### PR TITLE
Update README to include TensorRT LLM and vLLM in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # srtctl
 
-Command-line tool for distributed LLM inference benchmarks on SLURM clusters using TensorRT LLM, SGLang & vLLM. Replace complex shell scripts and 50+ CLI flags with declarative YAML configuration.
+Command-line tool for distributed LLM inference benchmarks on SLURM clusters using TensorRT LLM, SGLang and vLLM. Replace complex shell scripts and 50+ CLI flags with declarative YAML configuration.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # srtctl
 
-Command-line tool for distributed LLM inference benchmarks on SLURM clusters using SGLang. Replace complex shell scripts and 50+ CLI flags with declarative YAML configuration.
+Command-line tool for distributed LLM inference benchmarks on SLURM clusters using TensorRT LLM, SGLang & vLLM. Replace complex shell scripts and 50+ CLI flags with declarative YAML configuration.
 
 ## Quick Start
 


### PR DESCRIPTION
Updated project description to reflect that srtctl supports TensorRT LLM and  
  vLLM in addition to SGLang.  