### PR TITLE
Add trace-replay benchmark type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dev = [
     "ty",  # Astral's fast type checker (replaces mypy)
     "fastapi>=0.109.0",
     "httpx>=0.27.0",  # Required by FastAPI TestClient
+    "uvicorn>=0.27.0",  # Required for integration test mock server
+    "aiperf",  # Benchmark tool for trace replay integration tests
 ]
 
 # =============================================================================
@@ -77,7 +79,10 @@ testpaths = ["tests"]
 pythonpath = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not integration'"
+markers = [
+    "integration: slow tests that run real aiperf against a mock server",
+]
 
 # =============================================================================
 # ty - Astral's fast type checker (10-100x faster than mypy)

--- a/src/srtctl/benchmarks/__init__.py
+++ b/src/srtctl/benchmarks/__init__.py
@@ -4,7 +4,17 @@
 """Benchmark runners for srtctl."""
 
 # Import runners to trigger registration
-from srtctl.benchmarks import gpqa, gsm8k, longbenchv2, mmlu, mooncake_router, router, sa_bench, sglang_bench
+from srtctl.benchmarks import (
+    gpqa,
+    gsm8k,
+    longbenchv2,
+    mmlu,
+    mooncake_router,
+    router,
+    sa_bench,
+    sglang_bench,
+    trace_replay,
+)
 from srtctl.benchmarks.base import (
     BenchmarkRunner,
     get_runner,
@@ -26,4 +36,5 @@ __all__ = [
     "longbenchv2",
     "router",
     "mooncake_router",
+    "trace_replay",
 ]

--- a/src/srtctl/benchmarks/scripts/mooncake-router/bench.sh
+++ b/src/srtctl/benchmarks/scripts/mooncake-router/bench.sh
@@ -26,10 +26,10 @@ if [ -n "${AIPERF_SERVER_METRICS_URLS:-}" ]; then
     fi
 fi
 
-# Setup directories
-BASE_DIR="/logs"
-TRACE_DIR="${BASE_DIR}/traces"
-ARTIFACT_DIR="${BASE_DIR}/artifacts"
+# Setup directories (BASE_DIR defaults to /logs inside container, overridable for testing)
+BASE_DIR="${BASE_DIR:-/logs}"
+TRACE_DIR="${TRACE_DIR:-${BASE_DIR}/traces}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${BASE_DIR}/artifacts}"
 mkdir -p "${TRACE_DIR}"
 mkdir -p "${ARTIFACT_DIR}"
 

--- a/src/srtctl/benchmarks/scripts/trace-replay/bench.sh
+++ b/src/srtctl/benchmarks/scripts/trace-replay/bench.sh
@@ -79,8 +79,6 @@ TIMESTAMP=$(date '+%Y%m%d_%H%M%S')
 # Parse concurrencies (comma-separated)
 IFS=',' read -r -a CONCURRENCY_LIST <<< "${CONCURRENCIES}"
 
-OVERALL_EXIT_CODE=0
-
 for C in "${CONCURRENCY_LIST[@]}"; do
     echo ""
     echo "=============================================="
@@ -91,9 +89,6 @@ for C in "${CONCURRENCY_LIST[@]}"; do
     RUN_ARTIFACT_DIR="${ARTIFACT_DIR}/${MODEL_BASE_NAME}_trace_c${C}_${TIMESTAMP}"
     mkdir -p "${RUN_ARTIFACT_DIR}"
 
-    # Disable set -e for aiperf so a failure at one concurrency level
-    # doesn't abort the entire sweep — we want to try all levels.
-    set +e
     aiperf profile \
         -m "${MODEL_NAME}" \
         --tokenizer "${TOKENIZER_PATH}" \
@@ -108,14 +103,8 @@ for C in "${CONCURRENCY_LIST[@]}"; do
         --artifact-dir "${RUN_ARTIFACT_DIR}" \
         "${SERVER_METRICS_ARGS[@]}" \
         --goodput "time_to_first_token:${TTFT_THRESHOLD} inter_token_latency:${ITL_THRESHOLD}"
-    BENCH_EXIT_CODE=$?
-    set -e
 
-    echo "$(date '+%Y-%m-%d %H:%M:%S') - Concurrency ${C} complete (exit code: ${BENCH_EXIT_CODE})"
-
-    if [ $BENCH_EXIT_CODE -ne 0 ]; then
-        OVERALL_EXIT_CODE=$BENCH_EXIT_CODE
-    fi
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Concurrency ${C} complete"
 
     # List artifacts
     ls -la "${RUN_ARTIFACT_DIR}" 2>/dev/null || true
@@ -126,5 +115,3 @@ echo "=============================================="
 echo "Trace Replay Benchmark Complete"
 echo "Results saved to: ${ARTIFACT_DIR}"
 echo "=============================================="
-
-exit $OVERALL_EXIT_CODE

--- a/src/srtctl/benchmarks/scripts/trace-replay/bench.sh
+++ b/src/srtctl/benchmarks/scripts/trace-replay/bench.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Trace Replay Benchmark using aiperf
+# Replays a user-provided JSONL trace dataset at configurable concurrency levels.
+# Uses aiperf with --custom-dataset-type mooncake_trace.
+#
+# Usage: bench.sh ENDPOINT MODEL_NAME TRACE_FILE CONCURRENCIES [TTFT_THRESHOLD] [ITL_THRESHOLD] [TOKENIZER_PATH]
+
+set -e
+
+ENDPOINT=$1
+MODEL_NAME=${2:-"test-model"}
+TRACE_FILE=$3
+CONCURRENCIES=${4:-"1"}
+TTFT_THRESHOLD=${5:-2000}
+ITL_THRESHOLD=${6:-25}
+TOKENIZER_PATH=${7:-"/model"}
+
+# Optional: extra Prometheus endpoints for AIPerf server metrics
+SERVER_METRICS_ARGS=()
+if [ -n "${AIPERF_SERVER_METRICS_URLS:-}" ]; then
+    IFS=',' read -r -a server_metrics_urls <<< "${AIPERF_SERVER_METRICS_URLS}"
+    if [ ${#server_metrics_urls[@]} -gt 0 ]; then
+        SERVER_METRICS_ARGS+=(--server-metrics "${server_metrics_urls[@]}")
+    fi
+fi
+
+# Setup directories (BASE_DIR defaults to /logs inside container, overridable for testing)
+BASE_DIR="${BASE_DIR:-/logs}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${BASE_DIR}/artifacts}"
+mkdir -p "${ARTIFACT_DIR}"
+
+# Increase aiperf HTTP timeout
+export AIPERF_HTTP_SO_RCVTIMEO=120
+
+echo "=============================================="
+echo "Trace Replay Benchmark (aiperf)"
+echo "=============================================="
+echo "Endpoint: ${ENDPOINT}"
+echo "Model: ${MODEL_NAME}"
+echo "Trace File: ${TRACE_FILE}"
+echo "Concurrencies: ${CONCURRENCIES}"
+echo "TTFT Threshold: ${TTFT_THRESHOLD}ms"
+echo "ITL Threshold: ${ITL_THRESHOLD}ms"
+echo "Tokenizer Path: ${TOKENIZER_PATH}"
+echo "=============================================="
+
+# Validate trace file exists
+if [ ! -f "${TRACE_FILE}" ]; then
+    echo "ERROR: Trace file not found: ${TRACE_FILE}"
+    exit 1
+fi
+
+# Install aiperf if not present
+if ! command -v aiperf &> /dev/null; then
+    echo "Installing aiperf..."
+    pip install aiperf
+fi
+
+# Run small benchmark for warmup
+echo "Running warmup..."
+aiperf profile \
+    -m "${MODEL_NAME}" \
+    --tokenizer "${TOKENIZER_PATH}" \
+    --url "${ENDPOINT}" \
+    --streaming \
+    --ui simple \
+    --concurrency 1 \
+    --request-count 5
+echo "Warmup complete"
+
+# Setup artifact directory
+MODEL_BASE_NAME="${MODEL_NAME##*/}"
+TIMESTAMP=$(date '+%Y%m%d_%H%M%S')
+
+# Parse concurrencies (comma-separated)
+IFS=',' read -r -a CONCURRENCY_LIST <<< "${CONCURRENCIES}"
+
+OVERALL_EXIT_CODE=0
+
+for C in "${CONCURRENCY_LIST[@]}"; do
+    echo ""
+    echo "=============================================="
+    echo "Running concurrency=${C}"
+    echo "=============================================="
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Starting benchmark at concurrency ${C}"
+
+    RUN_ARTIFACT_DIR="${ARTIFACT_DIR}/${MODEL_BASE_NAME}_trace_c${C}_${TIMESTAMP}"
+    mkdir -p "${RUN_ARTIFACT_DIR}"
+
+    aiperf profile \
+        -m "${MODEL_NAME}" \
+        --tokenizer "${TOKENIZER_PATH}" \
+        --input-file "${TRACE_FILE}" \
+        --custom-dataset-type mooncake_trace \
+        --url "${ENDPOINT}" \
+        --streaming \
+        --concurrency "${C}" \
+        --random-seed 42 \
+        --ui simple \
+        --artifact-dir "${RUN_ARTIFACT_DIR}" \
+        "${SERVER_METRICS_ARGS[@]}" \
+        --goodput "time_to_first_token:${TTFT_THRESHOLD} inter_token_latency:${ITL_THRESHOLD}"
+
+    BENCH_EXIT_CODE=$?
+
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - Concurrency ${C} complete (exit code: ${BENCH_EXIT_CODE})"
+
+    if [ $BENCH_EXIT_CODE -ne 0 ]; then
+        OVERALL_EXIT_CODE=$BENCH_EXIT_CODE
+    fi
+
+    # List artifacts
+    ls -la "${RUN_ARTIFACT_DIR}" 2>/dev/null || true
+done
+
+echo ""
+echo "=============================================="
+echo "Trace Replay Benchmark Complete"
+echo "Results saved to: ${ARTIFACT_DIR}"
+echo "=============================================="
+
+exit $OVERALL_EXIT_CODE

--- a/src/srtctl/benchmarks/scripts/trace-replay/bench.sh
+++ b/src/srtctl/benchmarks/scripts/trace-replay/bench.sh
@@ -67,6 +67,7 @@ aiperf profile \
     --url "${ENDPOINT}" \
     --streaming \
     --ui simple \
+    --extra-inputs ignore_eos:true \
     --concurrency 1 \
     --request-count 5
 echo "Warmup complete"
@@ -97,6 +98,7 @@ for C in "${CONCURRENCY_LIST[@]}"; do
         --custom-dataset-type mooncake_trace \
         --url "${ENDPOINT}" \
         --streaming \
+        --extra-inputs ignore_eos:true \
         --concurrency "${C}" \
         --random-seed 42 \
         --ui simple \

--- a/src/srtctl/benchmarks/scripts/trace-replay/bench.sh
+++ b/src/srtctl/benchmarks/scripts/trace-replay/bench.sh
@@ -91,6 +91,9 @@ for C in "${CONCURRENCY_LIST[@]}"; do
     RUN_ARTIFACT_DIR="${ARTIFACT_DIR}/${MODEL_BASE_NAME}_trace_c${C}_${TIMESTAMP}"
     mkdir -p "${RUN_ARTIFACT_DIR}"
 
+    # Disable set -e for aiperf so a failure at one concurrency level
+    # doesn't abort the entire sweep — we want to try all levels.
+    set +e
     aiperf profile \
         -m "${MODEL_NAME}" \
         --tokenizer "${TOKENIZER_PATH}" \
@@ -105,8 +108,8 @@ for C in "${CONCURRENCY_LIST[@]}"; do
         --artifact-dir "${RUN_ARTIFACT_DIR}" \
         "${SERVER_METRICS_ARGS[@]}" \
         --goodput "time_to_first_token:${TTFT_THRESHOLD} inter_token_latency:${ITL_THRESHOLD}"
-
     BENCH_EXIT_CODE=$?
+    set -e
 
     echo "$(date '+%Y-%m-%d %H:%M:%S') - Concurrency ${C} complete (exit code: ${BENCH_EXIT_CODE})"
 

--- a/src/srtctl/benchmarks/trace_replay.py
+++ b/src/srtctl/benchmarks/trace_replay.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trace replay benchmark runner using aiperf.
+
+Replays a user-provided JSONL trace dataset at configurable concurrency levels.
+Uses aiperf with --custom-dataset-type mooncake_trace for trace files in the
+mooncake format (session_id, input_length, output_length, hash_ids, delay).
+
+Unlike mooncake-router (which downloads a fixed trace and uses --fixed-schedule),
+trace-replay takes a user-provided file and sweeps concurrency levels.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from srtctl.benchmarks.base import SCRIPTS_DIR, AIPerfBenchmarkRunner, register_benchmark
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import SrtConfig
+
+
+@register_benchmark("trace-replay")
+class TraceReplayRunner(AIPerfBenchmarkRunner):
+    """Trace replay benchmark using aiperf with a user-provided dataset.
+
+    Replays a JSONL trace file at various concurrency levels to measure
+    serving performance with realistic request patterns.
+
+    Required config fields:
+        - benchmark.trace_file: Path to trace JSONL file (container path)
+        - benchmark.concurrencies: Concurrency levels to sweep
+
+    Optional config fields:
+        - benchmark.ttft_threshold_ms: Goodput TTFT threshold (default: 2000)
+        - benchmark.itl_threshold_ms: Goodput ITL threshold (default: 25)
+    """
+
+    @property
+    def name(self) -> str:
+        return "Trace Replay"
+
+    @property
+    def script_path(self) -> str:
+        return "/srtctl-benchmarks/trace-replay/bench.sh"
+
+    @property
+    def local_script_dir(self) -> str:
+        return str(SCRIPTS_DIR / "trace-replay")
+
+    def validate_config(self, config: SrtConfig) -> list[str]:
+        errors = []
+        b = config.benchmark
+
+        if not b.trace_file:
+            errors.append("benchmark.trace_file is required for trace-replay")
+
+        if b.concurrencies is None:
+            errors.append("benchmark.concurrencies is required for trace-replay")
+
+        return errors
+
+    def build_command(
+        self,
+        config: SrtConfig,
+        runtime: RuntimeContext,
+    ) -> list[str]:
+        b = config.benchmark
+        endpoint = f"http://localhost:{runtime.frontend_port}"
+
+        model_name = config.served_model_name or config.model.path
+
+        # Format concurrencies as comma-separated string
+        concurrencies = b.concurrencies
+        if isinstance(concurrencies, list):
+            concurrencies = ",".join(str(c) for c in concurrencies)
+
+        ttft_threshold = getattr(b, "ttft_threshold_ms", None) or 2000
+        itl_threshold = getattr(b, "itl_threshold_ms", None) or 25
+
+        tokenizer_path = str(runtime.model_path) if runtime.is_hf_model else "/model"
+
+        return [
+            "bash",
+            self.script_path,
+            endpoint,
+            model_name,
+            b.trace_file or "",
+            str(concurrencies) if concurrencies else "",
+            str(ttft_threshold),
+            str(itl_threshold),
+            tokenizer_path,
+        ]

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -223,6 +223,7 @@ class BenchmarkType(str, Enum):
     SA_BENCH = "sa-bench"
     ROUTER = "router"
     MOONCAKE_ROUTER = "mooncake-router"
+    TRACE_REPLAY = "trace-replay"
     MMLU = "mmlu"
     GPQA = "gpqa"
     LONGBENCHV2 = "longbenchv2"
@@ -541,6 +542,8 @@ class BenchmarkConfig:
     random_range_ratio: float | None = None  # Random input/output length range ratio (default: 0.8)
     num_prompts_mult: int | None = None  # Multiplier for num_prompts = concurrency * mult (default: 10)
     num_warmup_mult: int | None = None  # Multiplier for warmup prompts = concurrency * mult (default: 2)
+    # Trace replay benchmark fields (uses aiperf with mooncake_trace dataset type)
+    trace_file: str | None = None  # Path to trace JSONL file (container path, e.g., /traces/dataset.jsonl)
 
     def get_concurrency_list(self) -> list[int]:
         if self.concurrencies is None:

--- a/tests/fixtures/trace_replay_sample.jsonl
+++ b/tests/fixtures/trace_replay_sample.jsonl
@@ -1,0 +1,3 @@
+{"session_id":"test-sess-001","input_length":1200,"output_length":50,"hash_ids":[0,1,2],"timestamp":0.0,"group_id":0}
+{"session_id":"test-sess-001","input_length":512,"output_length":30,"hash_ids":[3],"delay":100.0}
+{"session_id":"test-sess-002","input_length":1500,"output_length":40,"hash_ids":[4,5,6],"timestamp":0.5,"group_id":1}

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -193,6 +193,169 @@ class TestMooncakeRouterRunner:
         assert cmd[7] == "/model"  # tokenizer path
 
 
+class TestTraceReplayRunner:
+    """Test Trace Replay benchmark runner."""
+
+    def test_in_registry(self):
+        """trace-replay is registered in benchmark list."""
+        benchmarks = list_benchmarks()
+        assert "trace-replay" in benchmarks
+
+    def test_get_runner(self):
+        """Can get runner for trace-replay."""
+        runner = get_runner("trace-replay")
+        assert runner.name == "Trace Replay"
+        assert "trace-replay" in runner.script_path
+
+    def test_validate_missing_trace_file(self):
+        """Validates that trace_file is required."""
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = TraceReplayRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(type="trace-replay", concurrencies=[4, 8]),
+        )
+        errors = runner.validate_config(config)
+        assert any("trace_file" in e for e in errors)
+
+    def test_validate_missing_concurrencies(self):
+        """Validates that concurrencies is required."""
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = TraceReplayRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(type="trace-replay", trace_file="/traces/dataset.jsonl"),
+        )
+        errors = runner.validate_config(config)
+        assert any("concurrencies" in e for e in errors)
+
+    def test_validate_valid(self):
+        """Valid config passes validation."""
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = TraceReplayRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(
+                type="trace-replay",
+                trace_file="/traces/dataset.jsonl",
+                concurrencies=[4, 8],
+            ),
+        )
+        errors = runner.validate_config(config)
+        assert errors == []
+
+    def test_build_command(self):
+        """Build command includes all expected arguments."""
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+
+        runner = TraceReplayRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        runtime.is_hf_model = False
+
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model/kimi-k25", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(
+                type="trace-replay",
+                trace_file="/traces/dataset.jsonl",
+                concurrencies=[4, 8],
+                ttft_threshold_ms=3000,
+                itl_threshold_ms=7,
+            ),
+        )
+
+        cmd = runner.build_command(config, runtime)
+
+        assert cmd[0] == "bash"
+        assert "trace-replay" in cmd[1]
+        assert cmd[2] == "http://localhost:8000"  # endpoint
+        assert cmd[3] == "kimi-k25"  # model name (from path)
+        assert cmd[4] == "/traces/dataset.jsonl"  # trace file
+        assert cmd[5] == "4,8"  # concurrencies
+        assert cmd[6] == "3000"  # ttft threshold
+        assert cmd[7] == "7"  # itl threshold
+        assert cmd[8] == "/model"  # tokenizer path (local model)
+
+    def test_build_command_default_thresholds(self):
+        """Build command uses default thresholds when not specified."""
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+
+        runner = TraceReplayRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        runtime.is_hf_model = False
+
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model/test", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(
+                type="trace-replay",
+                trace_file="/traces/dataset.jsonl",
+                concurrencies=[1],
+            ),
+        )
+
+        cmd = runner.build_command(config, runtime)
+        assert cmd[6] == "2000"  # default ttft
+        assert cmd[7] == "25"  # default itl
+
+    def test_config_roundtrip(self):
+        """Config with trace-replay loads correctly from YAML."""
+        import tempfile
+        from pathlib import Path
+
+        import yaml
+
+        from srtctl.core.schema import SrtConfig
+
+        config_data = {
+            "name": "trace-test",
+            "model": {"path": "/model", "container": "/image", "precision": "fp4"},
+            "resources": {"gpu_type": "gb200"},
+            "benchmark": {
+                "type": "trace-replay",
+                "trace_file": "/traces/dataset.jsonl",
+                "concurrencies": [4, 8],
+                "ttft_threshold_ms": 3000,
+                "itl_threshold_ms": 7,
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config_data, f)
+            tmp_path = Path(f.name)
+
+        config = SrtConfig.from_yaml(tmp_path)
+        assert config.benchmark.type == "trace-replay"
+        assert config.benchmark.trace_file == "/traces/dataset.jsonl"
+        assert config.benchmark.concurrencies == [4, 8]
+        assert config.benchmark.ttft_threshold_ms == 3000
+        assert config.benchmark.itl_threshold_ms == 7
+
+
 class TestScriptsExist:
     """Test that benchmark scripts exist."""
 

--- a/tests/test_trace_replay_integration.py
+++ b/tests/test_trace_replay_integration.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for trace-replay benchmark.
+
+Runs the actual bench.sh script with aiperf against a mock OpenAI-compatible server.
+These tests are slow and require aiperf to be installed, so they are marked with
+@pytest.mark.integration and skipped by default (use `uv run pytest -m integration`).
+"""
+
+import json
+import os
+import socket
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+SCRIPTS_DIR = Path(__file__).parent.parent / "src" / "srtctl" / "benchmarks" / "scripts"
+BENCH_SCRIPT = SCRIPTS_DIR / "trace-replay" / "bench.sh"
+
+
+def _find_free_port() -> int:
+    """Find a free port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _create_mock_server(port: int):
+    """Create a FastAPI mock server that mimics OpenAI API for aiperf.
+
+    Handles:
+    - GET /v1/models - model listing
+    - POST /v1/chat/completions - streaming and non-streaming completions
+    - GET /health - health check
+    - GET /metrics - Prometheus metrics (aiperf probes this)
+    """
+    from fastapi import FastAPI, Request
+    from fastapi.responses import PlainTextResponse, StreamingResponse
+
+    app = FastAPI()
+
+    @app.get("/v1/models")
+    def list_models():
+        return {
+            "object": "list",
+            "data": [{"id": "test-model", "object": "model", "owned_by": "test"}],
+        }
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.get("/metrics")
+    def metrics():
+        """Prometheus-style metrics endpoint (aiperf probes this)."""
+        return PlainTextResponse(
+            "# HELP up Server is up\n# TYPE up gauge\nup 1\n",
+            media_type="text/plain",
+        )
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        body = await request.json()
+        stream = body.get("stream", False)
+        # Try to respect max_tokens from request for realistic responses
+        max_tokens = body.get("max_tokens", 5)
+        # Cap at a reasonable number for test speed
+        num_tokens = min(max_tokens, 20)
+
+        if not stream:
+            content = " ".join(["word"] * num_tokens)
+            return {
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": num_tokens,
+                    "total_tokens": 10 + num_tokens,
+                },
+            }
+
+        def generate():
+            for i in range(num_tokens):
+                chunk = {
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion.chunk",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "word "},
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+            final_chunk = {
+                "id": "chatcmpl-test",
+                "object": "chat.completion.chunk",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": num_tokens,
+                    "total_tokens": 10 + num_tokens,
+                },
+            }
+            yield f"data: {json.dumps(final_chunk)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(generate(), media_type="text/event-stream")
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def mock_server():
+    """Start a mock OpenAI server for the test session."""
+    import uvicorn
+
+    port = _find_free_port()
+    app = _create_mock_server(port)
+
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning"))
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    # Wait for server to be ready
+    for _ in range(50):
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
+                break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        pytest.fail("Mock server did not start in time")
+
+    yield f"http://127.0.0.1:{port}"
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+@pytest.mark.integration
+class TestTraceReplayIntegration:
+    """Integration tests that run bench.sh with real aiperf against a mock server."""
+
+    def test_bench_script_exists(self):
+        """bench.sh exists."""
+        assert BENCH_SCRIPT.exists(), f"bench.sh not found at {BENCH_SCRIPT}"
+
+    def test_fixture_exists(self):
+        """Test fixture JSONL exists."""
+        fixture = FIXTURES_DIR / "trace_replay_sample.jsonl"
+        assert fixture.exists()
+
+    def test_aiperf_installed(self):
+        """aiperf is available."""
+        result = subprocess.run(["aiperf", "--version"], capture_output=True, text=True)
+        assert result.returncode == 0, f"aiperf not installed or broken: {result.stderr}"
+
+    def test_bench_script_rejects_missing_trace(self, tmp_path):
+        """bench.sh exits with error when trace file doesn't exist."""
+        env = os.environ.copy()
+        env["BASE_DIR"] = str(tmp_path)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(BENCH_SCRIPT),
+                "http://localhost:9999",
+                "test-model",
+                "/nonexistent/trace.jsonl",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert result.returncode != 0
+        assert "not found" in result.stdout.lower()
+
+    def test_full_trace_replay(self, mock_server, tmp_path):
+        """Run bench.sh end-to-end against the mock server."""
+        fixture = FIXTURES_DIR / "trace_replay_sample.jsonl"
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        env = os.environ.copy()
+        env["BASE_DIR"] = str(log_dir)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(BENCH_SCRIPT),
+                mock_server,             # ENDPOINT
+                "test-model",            # MODEL_NAME
+                str(fixture),            # TRACE_FILE
+                "1",                     # CONCURRENCIES
+                "5000",                  # TTFT_THRESHOLD
+                "100",                   # ITL_THRESHOLD
+                "test-model",            # TOKENIZER_PATH (aiperf resolves via HF)
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+
+        print("STDOUT:", result.stdout[-3000:] if len(result.stdout) > 3000 else result.stdout)
+        print("STDERR:", result.stderr[-3000:] if len(result.stderr) > 3000 else result.stderr)
+
+        assert result.returncode == 0, f"bench.sh failed (exit {result.returncode})"
+        assert "Trace Replay Benchmark Complete" in result.stdout
+
+        # Verify artifact directory was created with content
+        artifact_dir = log_dir / "artifacts"
+        assert artifact_dir.exists(), "artifacts/ directory not created"
+        artifact_runs = list(artifact_dir.iterdir())
+        assert len(artifact_runs) > 0, "No artifact subdirectories created"
+
+    def test_multi_concurrency_sweep(self, mock_server, tmp_path):
+        """bench.sh iterates over multiple concurrency levels."""
+        fixture = FIXTURES_DIR / "trace_replay_sample.jsonl"
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        env = os.environ.copy()
+        env["BASE_DIR"] = str(log_dir)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(BENCH_SCRIPT),
+                mock_server,
+                "test-model",
+                str(fixture),
+                "1,2",                   # two concurrency levels
+                "5000",
+                "100",
+                "test-model",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+
+        print("STDOUT:", result.stdout[-3000:] if len(result.stdout) > 3000 else result.stdout)
+        print("STDERR:", result.stderr[-3000:] if len(result.stderr) > 3000 else result.stderr)
+
+        assert result.returncode == 0, f"bench.sh failed (exit {result.returncode})"
+
+        # Should have run both concurrency levels
+        assert "Running concurrency=1" in result.stdout
+        assert "Running concurrency=2" in result.stdout
+
+        # Should have created artifact dirs for both
+        artifact_dir = log_dir / "artifacts"
+        artifact_runs = list(artifact_dir.iterdir())
+        assert len(artifact_runs) == 2, f"Expected 2 artifact dirs, got {len(artifact_runs)}: {artifact_runs}"


### PR DESCRIPTION
## Summary
- Adds `trace-replay` benchmark type that replays user-provided JSONL trace datasets at configurable concurrency levels using aiperf
- Unlike `mooncake-router` (fixed trace + `--fixed-schedule`), `trace-replay` takes a user-provided file and sweeps concurrency levels
- Uses `aiperf --custom-dataset-type mooncake_trace --input-file <path> --concurrency <N>` per sweep level

## Changes
- `TraceReplayRunner` extending `AIPerfBenchmarkRunner` with validation and command building
- `bench.sh` script: warmup → per-concurrency aiperf runs with goodput thresholds
- `trace_file` field on `BenchmarkConfig`, `TRACE_REPLAY` enum value
- Made `BASE_DIR` overridable in bench scripts for testability
- aiperf + uvicorn added as dev deps, `integration` pytest marker

## Test plan
- [x] 8 unit tests: registry, validation, command building, YAML round-trip
- [x] 6 integration tests: mock FastAPI OpenAI server + real aiperf + bench.sh end-to-end
- [x] Multi-concurrency sweep verified (artifact dirs created per level)
- [x] `make check` passes (379 passed, integration tests deselected by default)
- [x] `uv run pytest -m integration` passes (6/6 in ~56s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)