### PR TITLE
fix: support cross-arch clusters (x86_64 login, aarch64 compute)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ Thumbs.db
 srtslurm.yaml
 srtslurm.toml
 
+# Compute-arch uv binary (installed by make setup)
+bin/
+
 # Configs - ignore downloaded files but keep deepep_config.json
 configs/nats-server
 configs/etcd

--- a/Makefile
+++ b/Makefile
@@ -45,43 +45,66 @@ setup:
 	@mkdir -p logs
 	@echo "🖥️  Using architecture: $(ARCH)"
 	@case "$(ARCH)" in \
-		x86_64)  ARCH_SHORT="amd64" ;; \
-		aarch64) ARCH_SHORT="arm64" ;; \
+		x86_64)  ARCH_SHORT="amd64"; ARCH_FILE_PATTERN="x86-64" ;; \
+		aarch64) ARCH_SHORT="arm64"; ARCH_FILE_PATTERN="aarch64" ;; \
 		*) echo "❌ Unsupported architecture: $(ARCH)"; exit 1 ;; \
 	esac; \
-	echo "ℹ️  Dynamo 0.8.0 will be installed from PyPI when workers start"; \
-	echo "⬇️  Downloading NATS ($(NATS_VERSION)) for $$ARCH_SHORT..."; \
-	NATS_DEB="nats-server-$(NATS_VERSION)-$$ARCH_SHORT.deb"; \
-	NATS_URL="https://github.com/nats-io/nats-server/releases/download/$(NATS_VERSION)/$$NATS_DEB"; \
-	wget -q --show-progress --tries=3 --waitretry=5 "$$NATS_URL" -O "configs/$$NATS_DEB"; \
-	echo "📁 Extracting NATS binary..."; \
-	TMP_DIR=$$(mktemp -d); \
-	dpkg-deb -x "configs/$$NATS_DEB" "$$TMP_DIR"; \
-	if [ -f "$$TMP_DIR/usr/local/bin/nats-server" ]; then \
-		cp "$$TMP_DIR/usr/local/bin/nats-server" configs/; \
-	elif [ -f "$$TMP_DIR/usr/bin/nats-server" ]; then \
-		cp "$$TMP_DIR/usr/bin/nats-server" configs/; \
-	else \
-		echo "❌ Could not find nats-server binary inside the .deb package"; \
-		ls -R "$$TMP_DIR" | head -n 50; \
-		exit 1; \
-	fi; \
-	chmod +x configs/nats-server; \
-	rm -rf "$$TMP_DIR" "configs/$$NATS_DEB"; \
-	echo "⬇️  Downloading ETCD ($(ETCD_VERSION)) for $$ARCH_SHORT..."; \
-	ETCD_TAR="etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT.tar.gz"; \
-	ETCD_URL="https://github.com/etcd-io/etcd/releases/download/$(ETCD_VERSION)/$$ETCD_TAR"; \
-	wget -q --show-progress --tries=3 --waitretry=5 "$$ETCD_URL" -O "configs/$$ETCD_TAR"; \
-	echo "📁 Extracting ETCD binaries..."; \
-	tar -xzf "configs/$$ETCD_TAR" --strip-components=1 -C configs etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT/etcd etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT/etcdctl; \
-	chmod +x configs/etcd configs/etcdctl; \
-	rm "configs/$$ETCD_TAR"; \
-	echo "✅ Done. Contents of configs directory:"; \
-	ls -lh configs/; \
 	echo ""; \
-	echo "⚙️  Setting up srtslurm.yaml..."; \
+	echo "--- NATS $(NATS_VERSION) ---"; \
+	if [ -f configs/nats-server ] && file configs/nats-server | grep -q "$$ARCH_FILE_PATTERN"; then \
+		echo "✅ NATS already installed at configs/nats-server ($(ARCH))"; \
+	else \
+		echo "⬇️  Downloading NATS ($(NATS_VERSION)) for $$ARCH_SHORT..."; \
+		NATS_DEB="nats-server-$(NATS_VERSION)-$$ARCH_SHORT.deb"; \
+		NATS_URL="https://github.com/nats-io/nats-server/releases/download/$(NATS_VERSION)/$$NATS_DEB"; \
+		wget -q --show-progress --tries=3 --waitretry=5 "$$NATS_URL" -O "configs/$$NATS_DEB"; \
+		echo "📁 Extracting NATS binary..."; \
+		TMP_DIR=$$(mktemp -d); \
+		dpkg-deb -x "configs/$$NATS_DEB" "$$TMP_DIR"; \
+		if [ -f "$$TMP_DIR/usr/local/bin/nats-server" ]; then \
+			cp "$$TMP_DIR/usr/local/bin/nats-server" configs/; \
+		elif [ -f "$$TMP_DIR/usr/bin/nats-server" ]; then \
+			cp "$$TMP_DIR/usr/bin/nats-server" configs/; \
+		else \
+			echo "❌ Could not find nats-server binary inside the .deb package"; \
+			ls -R "$$TMP_DIR" | head -n 50; \
+			exit 1; \
+		fi; \
+		chmod +x configs/nats-server; \
+		rm -rf "$$TMP_DIR" "configs/$$NATS_DEB"; \
+		echo "✅ NATS installed to configs/nats-server"; \
+	fi; \
+	echo ""; \
+	echo "--- ETCD $(ETCD_VERSION) ---"; \
+	if [ -f configs/etcd ] && [ -f configs/etcdctl ] && file configs/etcd | grep -q "$$ARCH_FILE_PATTERN"; then \
+		echo "✅ ETCD already installed at configs/etcd ($(ARCH))"; \
+	else \
+		echo "⬇️  Downloading ETCD ($(ETCD_VERSION)) for $$ARCH_SHORT..."; \
+		ETCD_TAR="etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT.tar.gz"; \
+		ETCD_URL="https://github.com/etcd-io/etcd/releases/download/$(ETCD_VERSION)/$$ETCD_TAR"; \
+		wget -q --show-progress --tries=3 --waitretry=5 "$$ETCD_URL" -O "configs/$$ETCD_TAR"; \
+		echo "📁 Extracting ETCD binaries..."; \
+		tar -xzf "configs/$$ETCD_TAR" --strip-components=1 -C configs etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT/etcd etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT/etcdctl; \
+		chmod +x configs/etcd configs/etcdctl; \
+		rm "configs/$$ETCD_TAR"; \
+		echo "✅ ETCD installed to configs/etcd"; \
+	fi; \
+	echo ""; \
+	echo "--- uv (compute node arch: $(ARCH)) ---"; \
+	if [ -f bin/uv ] && file bin/uv | grep -q "$$ARCH_FILE_PATTERN"; then \
+		echo "✅ uv already installed at bin/uv ($(ARCH))"; \
+	else \
+		echo "⬇️  Downloading uv for $(ARCH)..."; \
+		mkdir -p bin; \
+		UV_URL="https://github.com/astral-sh/uv/releases/latest/download/uv-$(ARCH)-unknown-linux-gnu.tar.gz"; \
+		curl -LsSf "$$UV_URL" | tar -xz --strip-components=1 -C bin; \
+		chmod +x bin/uv bin/uvx 2>/dev/null; \
+		echo "✅ uv installed to bin/uv ($$(file bin/uv | grep -o 'ARM aarch64\|x86-64'))"; \
+	fi; \
+	echo ""; \
+	echo "--- srtslurm.yaml ---"; \
 	if [ -f srtslurm.yaml ]; then \
-		echo "ℹ️  srtslurm.yaml already exists, skipping..."; \
+		echo "✅ srtslurm.yaml already exists"; \
 	else \
 		echo "Creating srtslurm.yaml with your cluster settings..."; \
 		echo ""; \

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -151,6 +151,33 @@ def show_config_details(config: SrtConfig) -> None:
         console.print(f"[dim]srun options:[/] {opts}")
 
 
+def validate_setup(srtctl_source: Path) -> None:
+    """Validate that make setup has been run and required binaries exist.
+
+    Checks for NATS, etcd, and compute-arch uv binaries. Raises SystemExit
+    with a clear error message if anything is missing.
+    """
+    missing = []
+
+    configs_dir = srtctl_source / "configs"
+    if not (configs_dir / "nats-server").exists():
+        missing.append("configs/nats-server")
+    if not (configs_dir / "etcd").exists():
+        missing.append("configs/etcd")
+    if not (srtctl_source / "bin" / "uv").exists():
+        missing.append("bin/uv (compute-arch uv)")
+
+    if missing:
+        console.print(f"\n[red bold]ERROR:[/] Required binaries not found in {srtctl_source}:")
+        for m in missing:
+            console.print(f"  [red]✗[/] {m}")
+        console.print("\nRun [bold]make setup ARCH=<compute_arch>[/] first:")
+        console.print(f"  cd {srtctl_source}")
+        console.print("  make setup ARCH=aarch64  [dim]# for GB200/Grace compute nodes[/]")
+        console.print("  make setup ARCH=x86_64   [dim]# for x86_64 compute nodes[/]\n")
+        raise SystemExit(1)
+
+
 def generate_minimal_sbatch_script(
     config: SrtConfig,
     config_path: Path,
@@ -299,6 +326,11 @@ def submit_with_orchestrator(
         console.print()
         show_config_details(config)
         return
+
+    # Validate setup before submitting (not during dry-run)
+    srtctl_root = get_srtslurm_setting("srtctl_root")
+    srtctl_source = Path(srtctl_root) if srtctl_root else Path(__file__).parent.parent.parent.parent
+    validate_setup(srtctl_source)
 
     # Write script to temp file
     fd, script_path = tempfile.mkstemp(suffix=".slurm", prefix="srtctl_", text=True)

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -78,16 +78,17 @@ export SRTCTL_SOURCE_DIR="${SRTCTL_SOURCE}"
 echo ""
 echo "Preparing srtctl environment..."
 
-# Ensure ~/.local/bin is in PATH (uv installs here)
-export PATH="$HOME/.local/bin:$PATH"
+# Use compute-arch uv from srt-slurm/bin (installed by make setup ARCH=<compute_arch>)
+# This avoids arch mismatch when login node (x86_64) != compute node (aarch64)
+export PATH="${SRTCTL_SOURCE}/bin:$HOME/.local/bin:$PATH"
 
-# Install uv if not present (single binary, no dependencies)
 if ! command -v uv &> /dev/null; then
-    echo "Installing uv package manager..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    echo "ERROR: uv not found. Run 'make setup ARCH=<compute_arch>' first."
+    echo "  e.g., make setup ARCH=aarch64  (for GB200/Grace compute nodes)"
+    exit 1
 fi
 
-echo "Using uv with Python 3.12..."
+echo "Using uv $(uv --version)..."
 
 {% if setup_script %}
 # Custom setup script override from CLI

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -391,6 +391,7 @@ class TestSubmitOverride:
                 patch("subprocess.run", return_value=mock_result) as mock_run,
                 patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
                 patch("srtctl.cli.submit.create_job_record"),
+                patch("srtctl.cli.submit.validate_setup"),
             ):
                 submit_override(cfg, selector=selector, output_dir=tmp_path)
             return sum(1 for c in mock_run.call_args_list if c[0][0][0] == "sbatch")
@@ -417,6 +418,7 @@ class TestSubmitOverride:
             patch("subprocess.run", return_value=mock_result),
             patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
             patch("srtctl.cli.submit.create_job_record"),
+            patch("srtctl.cli.submit.validate_setup"),
         ):
             submit_override(cfg, selector="zip_override_tp[1]", output_dir=tmp_path)
 
@@ -467,6 +469,7 @@ class TestSubmitOverride:
             patch("subprocess.run", return_value=mock_result),
             patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
             patch("srtctl.cli.submit.create_job_record"),
+            patch("srtctl.cli.submit.validate_setup"),
         ):
             submit_override(cfg, selector="override_lowmem", output_dir=tmp_path)
 
@@ -489,6 +492,7 @@ class TestSubmitSingleCompatibility:
             patch("subprocess.run", return_value=mock_result),
             patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
             patch("srtctl.cli.submit.create_job_record"),
+            patch("srtctl.cli.submit.validate_setup"),
         ):
             submit_single(config_path=cfg, output_dir=tmp_path)
 

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for validate_setup pre-flight check and Makefile arch detection."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from srtctl.cli.submit import validate_setup
+
+
+class TestValidateSetup:
+    """Tests for the validate_setup function."""
+
+    def test_passes_when_all_binaries_exist(self, tmp_path: Path):
+        """validate_setup succeeds when all required binaries are present."""
+        (tmp_path / "configs").mkdir()
+        (tmp_path / "configs" / "nats-server").touch()
+        (tmp_path / "configs" / "etcd").touch()
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "uv").touch()
+
+        # Should not raise
+        validate_setup(tmp_path)
+
+    def test_fails_when_nats_missing(self, tmp_path: Path):
+        """validate_setup fails when nats-server is missing."""
+        (tmp_path / "configs").mkdir()
+        (tmp_path / "configs" / "etcd").touch()
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "uv").touch()
+
+        with pytest.raises(SystemExit):
+            validate_setup(tmp_path)
+
+    def test_fails_when_etcd_missing(self, tmp_path: Path):
+        """validate_setup fails when etcd is missing."""
+        (tmp_path / "configs").mkdir()
+        (tmp_path / "configs" / "nats-server").touch()
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "uv").touch()
+
+        with pytest.raises(SystemExit):
+            validate_setup(tmp_path)
+
+    def test_fails_when_uv_missing(self, tmp_path: Path):
+        """validate_setup fails when bin/uv is missing."""
+        (tmp_path / "configs").mkdir()
+        (tmp_path / "configs" / "nats-server").touch()
+        (tmp_path / "configs" / "etcd").touch()
+
+        with pytest.raises(SystemExit):
+            validate_setup(tmp_path)
+
+    def test_fails_when_all_missing(self, tmp_path: Path):
+        """validate_setup fails when nothing has been set up."""
+        with pytest.raises(SystemExit):
+            validate_setup(tmp_path)
+
+
+class TestMakefileArchDetection:
+    """Test that the file | grep pattern used in Makefile matches correctly.
+
+    The Makefile uses `file <binary> | grep -q "$ARCH_FILE_PATTERN"` to check
+    if an existing binary matches the requested architecture. These tests verify
+    the pattern works by creating minimal ELF binaries and checking `file` output.
+    """
+
+    # Minimal ELF headers: just enough for `file` to identify the architecture
+    # ELF magic + class(64-bit) + data(little-endian) + version + OS/ABI + padding + type + machine
+    ELF_X86_64 = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8 + b"\x02\x00\x3e\x00"
+    ELF_AARCH64 = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8 + b"\x02\x00\xb7\x00"
+
+    @staticmethod
+    def _file_description(path: Path) -> str:
+        """Get just the description part of file(1) output (after the colon)."""
+        result = subprocess.run(["file", str(path)], capture_output=True, text=True)
+        return result.stdout.split(":", 1)[1] if ":" in result.stdout else result.stdout
+
+    def test_file_detects_x86_64(self, tmp_path: Path):
+        """file(1) description for x86_64 ELF contains 'x86-64' (hyphen, not underscore)."""
+        binary = tmp_path / "fake_bin"
+        binary.write_bytes(self.ELF_X86_64 + b"\x00" * 44)
+        desc = self._file_description(binary)
+        assert "x86-64" in desc, f"Expected 'x86-64' in: {desc}"
+        assert "x86_64" not in desc, f"file uses hyphen not underscore: {desc}"
+
+    def test_file_detects_aarch64(self, tmp_path: Path):
+        """file(1) description for aarch64 ELF contains 'aarch64'."""
+        binary = tmp_path / "fake_bin"
+        binary.write_bytes(self.ELF_AARCH64 + b"\x00" * 44)
+        desc = self._file_description(binary)
+        assert "aarch64" in desc, f"Expected 'aarch64' in: {desc}"
+
+    def test_x86_64_not_matched_by_aarch64_pattern(self, tmp_path: Path):
+        """An x86_64 binary must not match the aarch64 pattern."""
+        binary = tmp_path / "fake_bin"
+        binary.write_bytes(self.ELF_X86_64 + b"\x00" * 44)
+        desc = self._file_description(binary)
+        assert "aarch64" not in desc
+
+    def test_aarch64_not_matched_by_x86_pattern(self, tmp_path: Path):
+        """An aarch64 binary must not match the x86-64 pattern."""
+        binary = tmp_path / "fake_bin"
+        binary.write_bytes(self.ELF_AARCH64 + b"\x00" * 44)
+        desc = self._file_description(binary)
+        assert "x86-64" not in desc


### PR DESCRIPTION
## Summary

- Fix `uv run` failing with "Exec format error" on cross-arch clusters where login nodes are x86_64 but compute nodes are aarch64
- `make setup` now downloads a compute-arch `uv` binary to `bin/` alongside NATS/etcd
- sbatch template prepends `$SRTCTL_SOURCE/bin` to PATH so compute-arch uv takes precedence on compute nodes, while login node still uses `~/.local/bin/uv`
- `make setup` is now idempotent — skips downloads if binaries already present, shows clear status per component

## Context

Commit 452bb8d (PR #169) replaced the container `pip install --target` + `python3` approach with `uv run --python 3.12` in the sbatch template. This assumes `uv` in `~/.local/bin/` is the same arch on both login and compute nodes. On cross-arch clusters (Lyris: x86_64 login, aarch64 compute with shared NFS home), the x86_64 uv binary fails on aarch64 compute nodes.

## Test plan

- [x] Run `make setup ARCH=aarch64` on a cross-arch cluster — verify uv downloaded to `bin/` and all components show green checks
- [x] Run `make setup ARCH=aarch64` again — verify idempotent (all "already installed")
- [ ] Submit a job with `srtctl apply` from x86_64 login node — verify sbatch script uses `bin/uv` (aarch64) on compute node
- [ ] Verify same-arch clusters still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)