### PR TITLE
fix: add nvidia pypi as an extra index to be able to pip install the prerelease dynamo wheels

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -718,7 +718,7 @@ class DynamoConfig:
         if self.version is not None:
             return (
                 f"echo 'Installing dynamo {self.version}...' && "
-                f"pip install --break-system-packages --quiet ai-dynamo-runtime=={self.version} ai-dynamo=={self.version} && "
+                f"pip install --break-system-packages --quiet --extra-index-url https://pypi.nvidia.com ai-dynamo-runtime=={self.version} ai-dynamo=={self.version} && "
                 f"echo 'Dynamo {self.version} installed'"
             )
 


### PR DESCRIPTION
prerelease dynamo wheels are published into https://pypi.nvidia.com

add it as extra index so we can install them at runtime