### PR TITLE
Yeswanthk/GLM5_NVFP4

### DIFF
--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp2.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp2"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=32
+# concurrency: 666
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -17,8 +17,8 @@ resources:
   gpus_per_prefill: 4
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
       max_batch_size: 32
-      max_num_tokens: 32
+      max_num_tokens: 96
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -107,12 +110,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "666"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch64_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch64_eplb0_mtp1.yaml
@@ -1,7 +1,7 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch64_eplb0_mtp1"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=64
 # concurrency: 1229
 
 model:
@@ -17,8 +17,8 @@ resources:
   gpus_per_prefill: 4
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 64
+      max_num_tokens: 128
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,6 +94,10 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
@@ -107,6 +114,9 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_allconc_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_allconc_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch16_allconc_eplb0_mtp3"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=16
+# concurrencies: 333 (batch8), 666 (batch16)
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 16
+      max_num_tokens: 64
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -89,15 +92,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +108,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "333x666"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch16_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch16_eplb0_mtp2.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch16_eplb0_mtp2"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# gen: 4 decode workers, TP8/EP8, enable_attention_dp=false, max_batch=16
+# concurrency: 96
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -16,9 +16,9 @@ resources:
   prefill_workers: 1
   gpus_per_prefill: 4
 
-  decode_workers: 1
+  decode_workers: 4
   decode_nodes: 8
-  gpus_per_decode: 32
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -66,17 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 16
+      max_num_tokens: 48
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -89,15 +93,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +109,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "96"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch32_allconc_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch32_allconc_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch32_allconc_eplb0_mtp3"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# gen: 4 decode workers, TP8/EP8, enable_attention_dp=false, max_batch=32
+# concurrencies: 8 (batch1), 44 (batch8), 192 (batch32)
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -16,9 +16,9 @@ resources:
   prefill_workers: 1
   gpus_per_prefill: 4
 
-  decode_workers: 1
+  decode_workers: 4
   decode_nodes: 8
-  gpus_per_decode: 32
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -66,17 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
       max_batch_size: 32
-      max_num_tokens: 32
+      max_num_tokens: 128
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -92,12 +96,12 @@ backend:
           - 24
           - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +111,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "8x44x192"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch1_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch1_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch1_eplb0_mtp3"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# gen: 5 decode workers, TP4/EP4, enable_attention_dp=false, max_batch=1
+# concurrency: 10
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -16,9 +16,9 @@ resources:
   prefill_workers: 1
   gpus_per_prefill: 4
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
 
   gpus_per_node: 4
 
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 1
+      max_num_tokens: 4
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -87,17 +90,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.85
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +106,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "10"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch256_eplb256_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch256_eplb256_mtp1.yaml
@@ -1,8 +1,9 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch256_eplb256_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=256
+# EPLB: num_slots=256
+# concurrency: 4301
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -12,13 +13,13 @@ model:
 resources:
   gpu_type: "gb200"
 
-  prefill_nodes: 1
-  prefill_workers: 1
+  prefill_nodes: 2
+  prefill_workers: 2
   gpus_per_prefill: 4
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -66,17 +67,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 256
+      max_num_tokens: 512
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,9 +95,40 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
+        load_balancer:
+          layer_updates_per_iter: 1
+          num_slots: 256
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
@@ -107,12 +142,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "4301"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx3dep4_gen1dep32_batch128_eplb288_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/MTP/ctx3dep4_gen1dep32_batch128_eplb288_mtp1.yaml
@@ -1,8 +1,9 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx3dep4_gen1dep32_batch128_eplb288_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 3 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=128
+# EPLB: num_slots=288
+# concurrency: 4301
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -12,8 +13,8 @@ model:
 resources:
   gpu_type: "gb200"
 
-  prefill_nodes: 1
-  prefill_workers: 1
+  prefill_nodes: 3
+  prefill_workers: 3
   gpus_per_prefill: 4
 
   decode_workers: 1
@@ -66,17 +67,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 128
+      max_num_tokens: 256
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,13 +95,28 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
+        load_balancer:
+          layer_updates_per_iter: 1
+          num_slots: 288
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +126,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "4301"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch32_eplb0_mtp0.yaml
@@ -1,0 +1,127 @@
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
+# concurrency: 1229
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.7
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "1229"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0"
 # Merged concurrencies: batch1(4), batch32(180), batch64(360), batch128(616)
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -125,8 +125,10 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "4 180 360 616"
+  concurrencies: "4x180x360x616"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,140 @@
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 4 decode workers, TP8/EP8, enable_attention_dp=false, max_batch=128
+# Merged concurrencies: batch1(4), batch32(180), batch64(360), batch128(616)
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 4
+  decode_nodes: 8
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 128
+      max_num_tokens: 128
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "4 180 360 616"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0"
 # Merged concurrencies: batch1(5), batch2(15), batch4(30), batch8(50)
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -109,8 +109,10 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "5 15 30 50"
+  concurrencies: "5x15x30x50"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,124 @@
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 5 decode workers, TP4/EP4, enable_attention_dp=false, max_batch=8
+# Merged concurrencies: batch1(5), batch2(15), batch4(30), batch8(50)
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 8
+      max_num_tokens: 8
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "5 15 30 50"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -1,0 +1,139 @@
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch128_eplb0_mtp0"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=128
+# concurrency: 2253
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 128
+      max_num_tokens: 128
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.75
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "2253"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch128_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -126,6 +126,8 @@ benchmark:
   osl: 1024
   concurrencies: "2253"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch512_eplb256_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch512_eplb256_mtp0.yaml
@@ -1,0 +1,191 @@
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch512_eplb256_mtp0"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=512
+# EPLB: num_slots=256
+# concurrency: 8192
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 512
+      max_num_tokens: 512
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+          - 264
+          - 272
+          - 280
+          - 288
+          - 296
+          - 304
+          - 312
+          - 320
+          - 328
+          - 336
+          - 344
+          - 352
+          - 360
+          - 368
+          - 376
+          - 384
+          - 392
+          - 400
+          - 408
+          - 416
+          - 424
+          - 432
+          - 440
+          - 448
+          - 456
+          - 464
+          - 472
+          - 480
+          - 488
+          - 496
+          - 504
+          - 512
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+        load_balancer:
+          layer_updates_per_iter: 1
+          num_slots: 256
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.75
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "8192"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch512_eplb256_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch512_eplb256_mtp0.yaml
@@ -6,8 +6,8 @@ name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch512_eplb256_mtp0"
 # concurrency: 8192
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -178,6 +178,8 @@ benchmark:
   osl: 1024
   concurrencies: "8192"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch64_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch64_eplb0_mtp0.yaml
@@ -1,0 +1,131 @@
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch64_eplb0_mtp0"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=64
+# concurrency: 2253
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 64
+      max_num_tokens: 64
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.7
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "2253"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch64_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch64_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch64_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -118,6 +118,8 @@ benchmark:
   osl: 1024
   concurrencies: "2253"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx4dep4_gen1dep32_batch256_eplb288_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx4dep4_gen1dep32_batch256_eplb288_mtp0.yaml
@@ -1,0 +1,159 @@
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx4dep4_gen1dep32_batch256_eplb288_mtp0"
+
+# ctx: 4 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=256
+# EPLB: num_slots=288
+# concurrency: 8192
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 4
+  prefill_workers: 4
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 256
+      max_num_tokens: 256
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+        load_balancer:
+          layer_updates_per_iter: 1
+          num_slots: 288
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.7
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "8192"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx4dep4_gen1dep32_batch256_eplb288_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/STP/ctx4dep4_gen1dep32_batch256_eplb288_mtp0.yaml
@@ -6,8 +6,8 @@ name: "glm5_nvfp4_ISL1K_OSL1K_ctx4dep4_gen1dep32_batch256_eplb288_mtp0"
 # concurrency: 8192
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -146,6 +146,8 @@ benchmark:
   osl: 1024
   concurrencies: "8192"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx10dep4_gen1dep16_batch64_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx10dep4_gen1dep16_batch64_eplb0_mtp1.yaml
@@ -1,7 +1,7 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx10dep4_gen1dep16_batch64_eplb0_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
+# ctx: 10 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=64
 # concurrency: 1229
 
 model:
@@ -12,13 +12,13 @@ model:
 resources:
   gpu_type: "gb200"
 
-  prefill_nodes: 1
-  prefill_workers: 1
+  prefill_nodes: 10
+  prefill_workers: 10
   gpus_per_prefill: 4
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -52,9 +52,9 @@ backend:
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 64
+      max_num_tokens: 128
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -91,6 +94,10 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
@@ -107,10 +114,13 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch16_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch16_eplb0_mtp3.yaml
@@ -1,8 +1,7 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen2tep8_batch16_eplb0_mtp3"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# gen: 2 decode workers, TP8/EP8, max_batch=16, concurrency: 46
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -16,9 +15,9 @@ resources:
   prefill_workers: 1
   gpus_per_prefill: 4
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 2
+  decode_nodes: 4
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -52,9 +51,9 @@ backend:
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +65,22 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 16
+      max_num_tokens: 64
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -89,15 +92,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +108,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "46"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch8_allconc_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch8_allconc_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch8_allconc_eplb0_mtp3"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# gen: 4 decode workers, TP8/EP8, max_batch=8
+# concurrencies: 4 (batch1), 48 (batch8)
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -16,9 +16,9 @@ resources:
   prefill_workers: 1
   gpus_per_prefill: 4
 
-  decode_workers: 1
+  decode_workers: 4
   decode_nodes: 8
-  gpus_per_decode: 32
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -52,9 +52,9 @@ backend:
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,22 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
+      max_batch_size: 8
       max_num_tokens: 32
-      max_seq_len: 2088
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -88,16 +92,13 @@ backend:
           - 2
           - 4
           - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +108,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "4x48"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch1_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch1_eplb0_mtp3.yaml
@@ -1,8 +1,7 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch1_eplb0_mtp3"
 
 # ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# gen: 5 decode workers, TP4/EP4, max_batch=1, concurrency: 5
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -16,9 +15,9 @@ resources:
   prefill_workers: 1
   gpus_per_prefill: 4
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
 
   gpus_per_node: 4
 
@@ -52,9 +51,9 @@ backend:
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +65,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 1
+      max_num_tokens: 4
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -87,17 +89,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.85
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +105,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "5"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx3dep4_gen1dep32_batch4_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx3dep4_gen1dep32_batch4_eplb0_mtp3.yaml
@@ -1,8 +1,7 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx3dep4_gen1dep32_batch4_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 3 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, max_batch=4, concurrency: 167
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -12,8 +11,8 @@ model:
 resources:
   gpu_type: "gb200"
 
-  prefill_nodes: 1
-  prefill_workers: 1
+  prefill_nodes: 3
+  prefill_workers: 3
   gpus_per_prefill: 4
 
   decode_workers: 1
@@ -52,9 +51,9 @@ backend:
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +65,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 4
+      max_num_tokens: 16
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -87,17 +89,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +105,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "167"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch8_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch8_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep32_batch8_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 5 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=8
+# concurrency: 333
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -12,8 +12,8 @@ model:
 resources:
   gpu_type: "gb200"
 
-  prefill_nodes: 1
-  prefill_workers: 1
+  prefill_nodes: 5
+  prefill_workers: 5
   gpus_per_prefill: 4
 
   decode_workers: 1
@@ -52,9 +52,9 @@ backend:
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
+      max_batch_size: 8
       max_num_tokens: 32
-      max_seq_len: 2088
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -88,16 +91,13 @@ backend:
           - 2
           - 4
           - 8
-          - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +107,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "333"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx7dep4_gen1dep16_batch32_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx7dep4_gen1dep16_batch32_eplb0_mtp2.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx7dep4_gen1dep16_batch32_eplb0_mtp2"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 7 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=32
+# concurrency: 615
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -12,13 +12,13 @@ model:
 resources:
   gpu_type: "gb200"
 
-  prefill_nodes: 1
-  prefill_workers: 1
+  prefill_nodes: 7
+  prefill_workers: 7
   gpus_per_prefill: 4
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -52,9 +52,9 @@ backend:
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
       max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_num_tokens: 96
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -107,12 +110,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "615"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx7dep4_gen1dep8_batch128_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/MTP/ctx7dep4_gen1dep8_batch128_eplb0_mtp1.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx7dep4_gen1dep8_batch128_eplb0_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 7 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP8/EP8, enable_attention_dp=true, max_batch=128
+# concurrency: 1076
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -12,13 +12,13 @@ model:
 resources:
   gpu_type: "gb200"
 
-  prefill_nodes: 1
-  prefill_workers: 1
+  prefill_nodes: 7
+  prefill_workers: 7
   gpus_per_prefill: 4
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 2
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -52,9 +52,9 @@ backend:
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 128
+      max_num_tokens: 256
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -91,13 +94,25 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.8
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +122,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "1076"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx10dep4_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx10dep4_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -1,0 +1,139 @@
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx10dep4_gen1dep16_batch128_eplb0_mtp0"
+
+# ctx: 10 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=128
+# concurrency: 2253
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 10
+  prefill_workers: 10
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 128
+      max_num_tokens: 128
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "2253"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx10dep4_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx10dep4_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL8K_OSL1K_ctx10dep4_gen1dep16_batch128_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -126,6 +126,8 @@ benchmark:
   osl: 1024
   concurrencies: "2253"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen2tep8_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen2tep8_batch32_eplb0_mtp0.yaml
@@ -1,0 +1,128 @@
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen2tep8_batch32_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 2 decode workers, TP8/EP8, enable_attention_dp=false, max_batch=32
+# concurrency: 84
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 2
+  decode_nodes: 4
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "84"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen2tep8_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen2tep8_batch32_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen2tep8_batch32_eplb0_mtp0"
 # concurrency: 84
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -115,6 +115,8 @@ benchmark:
   osl: 1024
   concurrencies: "84"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen3tep4_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen3tep4_batch32_eplb0_mtp0.yaml
@@ -1,0 +1,127 @@
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen3tep4_batch32_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 3 decode workers, TP4/EP4, enable_attention_dp=false, max_batch=32
+# concurrency: 117
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 3
+  decode_nodes: 3
+  gpus_per_decode: 4
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "117"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen3tep4_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen3tep4_batch32_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen3tep4_batch32_eplb0_mtp0"
 # concurrency: 117
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -114,6 +114,8 @@ benchmark:
   osl: 1024
   concurrencies: "117"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,124 @@
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 5 decode workers, TP4/EP4, enable_attention_dp=false, max_batch=8
+# Merged concurrencies: batch1(5), batch2(10), batch4(25), batch8(50)
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 8
+      max_num_tokens: 8
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "5 10 25 50"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0"
 # Merged concurrencies: batch1(5), batch2(10), batch4(25), batch8(50)
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -109,8 +109,10 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "5 10 25 50"
+  concurrencies: "5x10x25x50"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep32_batch16_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep32_batch16_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep32_batch16_eplb0_mtp0"
 # concurrency: 615
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -112,6 +112,8 @@ benchmark:
   osl: 1024
   concurrencies: "615"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep32_batch16_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep32_batch16_eplb0_mtp0.yaml
@@ -1,0 +1,125 @@
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep32_batch16_eplb0_mtp0"
+
+# ctx: 5 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=16
+# concurrency: 615
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 5
+  prefill_workers: 5
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 16
+      max_num_tokens: 16
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.75
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "615"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx8dep4_gen1dep32_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx8dep4_gen1dep32_batch32_eplb0_mtp0.yaml
@@ -1,0 +1,127 @@
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx8dep4_gen1dep32_batch32_eplb0_mtp0"
+
+# ctx: 8 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
+# concurrency: 1229
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 8
+  prefill_workers: 8
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    MIMALLOC_PURGE_DELAY: "0"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      custom_tokenizer: "glm_moe_dsa"
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.75
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "1229"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx8dep4_gen1dep32_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb200_nvfp4/ISL8K_OSL1K/STP/ctx8dep4_gen1dep32_batch32_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "glm5_nvfp4_ISL8K_OSL1K_ctx8dep4_gen1dep32_batch32_eplb0_mtp0"
 # concurrency: 1229
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/GLM-5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-glm5-xqiao-main3-aarch64-20260402.sqsh"
+  path: "/mnt/lustre01/models/glm-5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh"
   precision: "fp4"
 
 resources:
@@ -114,6 +114,8 @@ benchmark:
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"
+  custom_tokenizer: "glm_moe_dsa"
+  use_chat_template: false
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen1dep32_batch8_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen1dep32_batch8_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep2_gen1dep32_batch8_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=8
+# concurrency: 333
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,16 +66,19 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
+      max_batch_size: 8
       max_num_tokens: 32
       max_seq_len: 2088
       print_iter_log: true
@@ -88,16 +91,13 @@ backend:
           - 2
           - 4
           - 8
-          - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +107,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "333"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen4tep8_batch16_allconc_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen4tep8_batch16_allconc_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep2_gen4tep8_batch16_allconc_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 4 decode workers, TP8/EP8, enable_attention_dp=false, max_batch=16
+# concurrencies: 24 (batch4), 44 (batch8), 92 (batch16)
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
+  decode_workers: 4
   decode_nodes: 8
-  gpus_per_decode: 32
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 16
+      max_num_tokens: 64
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -89,15 +93,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +109,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "24x44x92"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen4tep8_batch32_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen4tep8_batch32_eplb0_mtp2.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep2_gen4tep8_batch32_eplb0_mtp2"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 4 decode workers, TP8/EP8, enable_attention_dp=false, max_batch=32
+# concurrency: 180
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
+  decode_workers: 4
   decode_nodes: 8
-  gpus_per_decode: 32
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
       max_batch_size: 32
-      max_num_tokens: 32
+      max_num_tokens: 96
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -92,12 +96,12 @@ backend:
           - 24
           - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +111,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "180"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen5tep4_batch1_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen5tep4_batch1_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep2_gen5tep4_batch1_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 5 decode workers, TP4/EP4, enable_attention_dp=false, max_batch=1
+# concurrency: 10
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
 
   gpus_per_node: 4
 
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 1
+      max_num_tokens: 4
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -87,17 +90,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.85
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +106,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "10"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx2dep2_gen1dep16_batch64_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx2dep2_gen1dep16_batch64_eplb0_mtp2.yaml
@@ -1,7 +1,7 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep2_gen1dep16_batch64_eplb0_mtp2"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
+# ctx: 2 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=64
 # concurrency: 1229
 
 model:
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_workers: 2
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 64
+      max_num_tokens: 192
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,6 +94,10 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
@@ -107,6 +114,9 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
 benchmark:
   type: "sa-bench"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx2dep2_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx2dep2_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep2_gen1dep32_batch16_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 2 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=16
+# concurrency: 666
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_workers: 2
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 16
+      max_num_tokens: 64
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -89,15 +92,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +108,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "666"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx3dep2_gen1dep32_batch32_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx3dep2_gen1dep32_batch32_eplb0_mtp2.yaml
@@ -1,6 +1,6 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx3dep2_gen1dep32_batch32_eplb0_mtp2"
 
-# ctx: 1 prefill worker, TP4/EP4
+# ctx: 3 prefill workers, TP2/EP2
 # gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
 # concurrency: 1229
 
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 2
+  prefill_workers: 3
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
       max_batch_size: 32
-      max_num_tokens: 32
+      max_num_tokens: 96
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -97,7 +100,7 @@ backend:
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,6 +110,9 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
 benchmark:
   type: "sa-bench"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx4dep2_gen1dep16_batch256_eplb256_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx4dep2_gen1dep16_batch256_eplb256_mtp1.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx4dep2_gen1dep16_batch256_eplb256_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 4 prefill workers, TP2/EP2, EPLB: num_slots=256, max_batch=256
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=256
+# concurrency: 4301
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 256
+      max_num_tokens: 512
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,9 +94,40 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
+        load_balancer:
+          layer_updates_per_iter: 1
+          num_slots: 256
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
@@ -107,12 +141,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "4301"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx5dep2_gen2dep8_batch512_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx5dep2_gen2dep8_batch512_eplb0_mtp1.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx5dep2_gen2dep8_batch512_eplb0_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 5 prefill workers, TP2/EP2
+# gen: 2 decode workers, TP8/EP8, enable_attention_dp=true, max_batch=512
+# concurrency: 8602
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 3
+  prefill_workers: 5
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 2
+  decode_nodes: 4
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 512
+      max_num_tokens: 1024
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,13 +94,73 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+          - 264
+          - 272
+          - 280
+          - 288
+          - 296
+          - 304
+          - 312
+          - 320
+          - 328
+          - 336
+          - 344
+          - 352
+          - 360
+          - 368
+          - 376
+          - 384
+          - 392
+          - 400
+          - 408
+          - 416
+          - 424
+          - 432
+          - 440
+          - 448
+          - 456
+          - 464
+          - 472
+          - 480
+          - 488
+          - 496
+          - 504
+          - 512
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.8
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +170,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "8602"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx6dep2_gen1dep32_batch128_eplb288_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx6dep2_gen1dep32_batch128_eplb288_mtp1.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx6dep2_gen1dep32_batch128_eplb288_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 6 prefill workers, TP2/EP2, EPLB: num_slots=288, max_batch=128
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=128
+# concurrency: 4301
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 3
+  prefill_workers: 6
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -66,17 +66,20 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 128
+      max_num_tokens: 256
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,13 +94,28 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
+        load_balancer:
+          layer_updates_per_iter: 1
+          num_slots: 288
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +125,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "4301"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen1dep32_batch16_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen1dep32_batch16_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep2_gen1dep32_batch16_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=16
+# concurrency: 615
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -75,8 +75,8 @@ backend:
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 16
+      max_num_tokens: 16
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -89,8 +89,6 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
@@ -112,7 +110,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "615"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen4tep8_batch64_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen4tep8_batch64_allconc_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep2_gen4tep8_batch64_allconc_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 4 decode workers, TP8/EP8, enable_attention_dp=false, max_batch=64
+# Merged concurrencies: batch16(84), batch32(180), batch64(336)
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
+  decode_workers: 4
   decode_nodes: 8
-  gpus_per_decode: 32
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -68,15 +68,16 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 64
+      max_num_tokens: 64
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,13 +92,17 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -112,7 +117,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "84x180x336"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 5 decode workers, TP4/EP4, enable_attention_dp=false, max_batch=4
+# Merged concurrencies: batch1(5), batch2(10), batch4(25)
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
 
   gpus_per_node: 4
 
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -68,15 +68,15 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 4
+      max_num_tokens: 4
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -87,17 +87,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -112,7 +108,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "5x10x25"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx2dep2_gen1dep32_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx2dep2_gen1dep32_batch32_eplb0_mtp0.yaml
@@ -1,6 +1,6 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx2dep2_gen1dep32_batch32_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
+# ctx: 2 prefill workers, TP2/EP2, max_batch=32
 # gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
 # concurrency: 1229
 
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_workers: 2
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx3dep2_gen1dep32_batch64_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx3dep2_gen1dep32_batch64_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx3dep2_gen1dep32_batch64_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 3 prefill workers, TP2/EP2, max_batch=64
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=64
+# concurrency: 2253
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 2
+  prefill_workers: 3
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -75,8 +75,8 @@ backend:
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 64
+      max_num_tokens: 64
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,6 +91,10 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
@@ -112,7 +116,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "2253"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx4dep2_gen1dep16_batch512_eplb256_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx4dep2_gen1dep16_batch512_eplb256_mtp0.yaml
@@ -1,8 +1,7 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx4dep2_gen1dep16_batch512_eplb256_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 4 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP16/EP16, EPLB: num_slots=256, max_batch=512, concurrency: 8192
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +9,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -45,8 +44,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -68,15 +67,15 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 512
+      max_num_tokens: 512
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,13 +90,76 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+          - 264
+          - 272
+          - 280
+          - 288
+          - 296
+          - 304
+          - 312
+          - 320
+          - 328
+          - 336
+          - 344
+          - 352
+          - 360
+          - 368
+          - 376
+          - 384
+          - 392
+          - 400
+          - 408
+          - 416
+          - 424
+          - 432
+          - 440
+          - 448
+          - 456
+          - 464
+          - 472
+          - 480
+          - 488
+          - 496
+          - 504
+          - 512
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
+        load_balancer:
+          layer_updates_per_iter: 1
+          num_slots: 256
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.75
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -112,7 +174,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "8192"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx4dep2_gen1dep32_batch128_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx4dep2_gen1dep32_batch128_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx4dep2_gen1dep32_batch128_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 4 prefill workers, TP2/EP2, max_batch=128
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=128
+# concurrency: 4301
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -75,8 +75,8 @@ backend:
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 128
+      max_num_tokens: 128
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,6 +91,18 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
@@ -112,7 +124,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "4301"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx6dep2_gen1dep32_batch256_eplb288_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx6dep2_gen1dep32_batch256_eplb288_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL1K_OSL1K_ctx6dep2_gen1dep32_batch256_eplb288_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 6 prefill workers, EPLB: num_slots=288, TP2/EP2, max_batch=256
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=256
+# concurrency: 8192
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 3
+  prefill_workers: 6
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,8 +45,8 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
@@ -75,8 +75,8 @@ backend:
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
+      max_batch_size: 256
+      max_num_tokens: 256
       max_seq_len: 2088
       print_iter_log: true
       stream_interval: 100
@@ -91,9 +91,40 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
+        load_balancer:
+          layer_updates_per_iter: 1
+          num_slots: 288
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
@@ -112,7 +143,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "8192"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx12dep2_gen1dep16_batch32_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx12dep2_gen1dep16_batch32_eplb0_mtp2.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx12dep2_gen1dep16_batch32_eplb0_mtp2"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 12 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=32
+# concurrency: 666
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 6
+  prefill_workers: 12
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
       max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_num_tokens: 96
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -107,12 +110,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 2
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "666"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx13dep2_gen1dep8_batch128_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx13dep2_gen1dep8_batch128_eplb0_mtp1.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx13dep2_gen1dep8_batch128_eplb0_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 13 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP8/EP8, enable_attention_dp=true, max_batch=128
+# concurrency: 1076
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 7
+  prefill_workers: 13
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 2
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 128
+      max_num_tokens: 256
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -91,13 +94,25 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.8
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +122,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "1076"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx15dep2_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx15dep2_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx15dep2_gen1dep32_batch16_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 15 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=16
+# concurrency: 666
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 8
+  prefill_workers: 15
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 16
+      max_num_tokens: 64
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -89,15 +92,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +108,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "666"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx18dep2_gen1dep16_batch64_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx18dep2_gen1dep16_batch64_eplb0_mtp1.yaml
@@ -1,7 +1,7 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx18dep2_gen1dep16_batch64_eplb0_mtp1"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
+# ctx: 18 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=64
 # concurrency: 1229
 
 model:
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 9
+  prefill_workers: 18
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 64
+      max_num_tokens: 128
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -91,6 +94,10 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
@@ -107,10 +114,13 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 1
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen1tep8_batch16_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen1tep8_batch16_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep2_gen1tep8_batch16_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 1 decode worker, TP8/EP8 (MNNVL), max_batch=16
+# concurrency: 24
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 2
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,22 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 16
+      max_num_tokens: 64
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -89,15 +93,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +109,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "24"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen2tep8_batch8_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen2tep8_batch8_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep2_gen2tep8_batch8_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 2 decode workers, TP8/EP8 (MNNVL), max_batch=8
+# concurrency: 22
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 2
+  decode_nodes: 4
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,22 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
+      max_batch_size: 8
       max_num_tokens: 32
-      max_seq_len: 2088
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -88,16 +92,13 @@ backend:
           - 2
           - 4
           - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +108,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "22"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen4tep8_batch4_allconc_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen4tep8_batch4_allconc_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep2_gen4tep8_batch4_allconc_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 4 decode workers, TP8/EP8 (MNNVL), max_batch=4
+# concurrencies: 4 (batch1), 24 (batch4)
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
+  decode_workers: 4
   decode_nodes: 8
-  gpus_per_decode: 32
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,22 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 4
+      max_num_tokens: 16
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -87,17 +91,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +107,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "4x24"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen5tep4_batch1_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen5tep4_batch1_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep2_gen5tep4_batch1_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 5 decode workers, TP4/EP4, max_batch=1
+# concurrency: 5
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 1
+      max_num_tokens: 4
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -87,17 +90,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.85
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +106,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "5"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx5dep2_gen1dep32_batch4_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx5dep2_gen1dep32_batch4_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx5dep2_gen1dep32_batch4_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 5 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, enable_lm_head_tp_in_adp=true, max_batch=4
+# concurrency: 180
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 3
+  prefill_workers: 5
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 4
+      max_num_tokens: 16
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -87,17 +90,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +106,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "180"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx9dep2_gen1dep32_batch8_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx9dep2_gen1dep32_batch8_eplb0_mtp3.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx9dep2_gen1dep32_batch8_eplb0_mtp3"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 9 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=8
+# concurrency: 333
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 5
+  prefill_workers: 9
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -66,18 +66,21 @@ backend:
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
     decode:
       tensor_parallel_size: 32
       moe_expert_parallel_size: 32
       pipeline_parallel_size: 1
       enable_attention_dp: true
-      enable_lm_head_tp_in_adp: false
+      enable_lm_head_tp_in_adp: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
+      max_batch_size: 8
       max_num_tokens: 32
-      max_seq_len: 2088
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -88,16 +91,13 @@ backend:
           - 2
           - 4
           - 8
-          - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.6
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -107,12 +107,15 @@ backend:
           - cublaslt
           - cutedsl
           - cuda_core
+      speculative_config:
+        decoding_type: MTP
+        num_nextn_predict_layers: 3
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "333"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx12dep2_gen1dep16_batch64_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx12dep2_gen1dep16_batch64_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx12dep2_gen1dep16_batch64_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 12 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=64
+# concurrency: 1127
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 6
+  prefill_workers: 12
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -68,16 +68,16 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 64
+      max_num_tokens: 64
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -91,13 +91,17 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.8
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,9 +114,9 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "1127"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx15dep2_gen1dep32_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx15dep2_gen1dep32_batch32_eplb0_mtp0.yaml
@@ -1,6 +1,6 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx15dep2_gen1dep32_batch32_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
+# ctx: 15 prefill workers, TP2/EP2
 # gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
 # concurrency: 1229
 
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 8
+  prefill_workers: 15
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -77,7 +77,7 @@ backend:
       custom_tokenizer: "glm_moe_dsa"
       max_batch_size: 32
       max_num_tokens: 32
-      max_seq_len: 2088
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -97,7 +97,7 @@ backend:
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.75
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,7 +110,7 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen2tep8_batch16_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen2tep8_batch16_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep2_gen2tep8_batch16_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 2 decode workers, TP8/EP8 (MNNVL), max_batch=16
+# concurrency: 42
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 2
+  decode_nodes: 4
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -68,16 +68,17 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 16
+      max_num_tokens: 16
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -89,15 +90,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,9 +109,9 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "42"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen4tep8_batch1_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen4tep8_batch1_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep2_gen4tep8_batch1_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 4 decode workers, TP8/EP8 (MNNVL), max_batch=1
+# concurrency: 4
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
+  decode_workers: 4
   decode_nodes: 8
-  gpus_per_decode: 32
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -68,16 +68,17 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 1
+      max_num_tokens: 1
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -87,17 +88,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,9 +107,9 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "4"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 1 prefill worker, TP2/EP2
+# gen: 5 decode workers, TP4/EP4, max_batch=4
+# concurrencies: 5 (batch1), 10 (batch2), 25 (batch4) — merged as 5x10x25
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
   prefill_workers: 1
-  gpus_per_prefill: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -68,16 +68,16 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 4
+      max_num_tokens: 4
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -87,17 +87,13 @@ backend:
           - 1
           - 2
           - 4
-          - 8
-          - 16
-          - 24
-          - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,9 +106,9 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "5x10x25"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx20dep2_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx20dep2_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx20dep2_gen1dep16_batch128_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 20 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=128
+# concurrency: 2151
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 10
+  prefill_workers: 20
+  gpus_per_prefill: 2
 
   decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_nodes: 4
+  gpus_per_decode: 16
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -68,16 +68,16 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
       pipeline_parallel_size: 1
       enable_attention_dp: true
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 128
+      max_num_tokens: 128
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -91,13 +91,25 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.8
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,9 +122,9 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "2151"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx2dep2_gen3tep8_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx2dep2_gen3tep8_batch32_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx2dep2_gen3tep8_batch32_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 2 prefill workers, TP2/EP2
+# gen: 3 decode workers, TP8/EP8 (MNNVL), max_batch=32
+# concurrency: 117
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
   prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_workers: 2
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 3
+  decode_nodes: 6
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -68,16 +68,17 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
       max_batch_size: 32
       max_num_tokens: 32
-      max_seq_len: 2088
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -92,12 +93,12 @@ backend:
           - 24
           - 32
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,9 +111,9 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "117"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx4dep2_gen3tep8_batch64_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx4dep2_gen3tep8_batch64_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx4dep2_gen3tep8_batch64_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 4 prefill workers, TP2/EP2
+# gen: 3 decode workers, TP8/EP8 (MNNVL), max_batch=64
+# concurrency: 231
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,15 +10,15 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
 
-  decode_workers: 1
-  decode_nodes: 8
-  gpus_per_decode: 32
+  decode_workers: 3
+  decode_nodes: 6
+  gpus_per_decode: 8
 
   gpus_per_node: 4
 
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -68,16 +68,17 @@ backend:
         max_tokens_in_buffer: 16384
 
     decode:
-      tensor_parallel_size: 32
-      moe_expert_parallel_size: 32
+      allreduce_strategy: MNNVL
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
       pipeline_parallel_size: 1
-      enable_attention_dp: true
+      enable_attention_dp: false
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 64
+      max_num_tokens: 64
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -91,13 +92,17 @@ backend:
           - 16
           - 24
           - 32
+          - 40
+          - 48
+          - 56
+          - 64
       moe_config:
-        backend: CUTEDSL
+        backend: TRTLLM
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.9
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,9 +115,9 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "231"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx9dep2_gen1dep32_batch16_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx9dep2_gen1dep32_batch16_eplb0_mtp0.yaml
@@ -1,8 +1,8 @@
-name: "glm5_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch32_eplb0_mtp0"
+name: "glm5_nvfp4_ISL8K_OSL1K_ctx9dep2_gen1dep32_batch16_eplb0_mtp0"
 
-# ctx: 1 prefill worker, TP4/EP4
-# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
-# concurrency: 1229
+# ctx: 9 prefill workers, TP2/EP2
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=16
+# concurrency: 615
 
 model:
   path: "/mnt/lustre01/models/glm-5-nvfp4"
@@ -10,11 +10,11 @@ model:
   precision: "fp4"
 
 resources:
-  gpu_type: "gb200"
+  gpu_type: "gb300"
 
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 4
+  prefill_nodes: 5
+  prefill_workers: 9
+  gpus_per_prefill: 2
 
   decode_workers: 1
   decode_nodes: 8
@@ -45,16 +45,16 @@ backend:
 
   trtllm_config:
     prefill:
-      tensor_parallel_size: 4
-      moe_expert_parallel_size: 4
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 2
       pipeline_parallel_size: 1
       enable_attention_dp: true
       disable_overlap_scheduler: true
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 16
-      max_num_tokens: 16384
-      max_seq_len: 1064
+      max_batch_size: 2
+      max_num_tokens: 16640
+      max_seq_len: 8232
       print_iter_log: true
       cuda_graph_config: null
       moe_config:
@@ -75,9 +75,9 @@ backend:
       enable_lm_head_tp_in_adp: false
       trust_remote_code: true
       custom_tokenizer: "glm_moe_dsa"
-      max_batch_size: 32
-      max_num_tokens: 32
-      max_seq_len: 2088
+      max_batch_size: 16
+      max_num_tokens: 16
+      max_seq_len: 9256
       print_iter_log: true
       stream_interval: 100
       num_postprocess_workers: 4
@@ -89,15 +89,13 @@ backend:
           - 4
           - 8
           - 16
-          - 24
-          - 32
       moe_config:
         backend: CUTEDSL
         use_low_precision_moe_combine: true
       kv_cache_config:
         dtype: fp8
         enable_block_reuse: false
-        free_gpu_memory_fraction: 0.7
+        free_gpu_memory_fraction: 0.75
       cache_transceiver_config:
         backend: UCX
         max_tokens_in_buffer: 16384
@@ -110,9 +108,9 @@ backend:
 
 benchmark:
   type: "sa-bench"
-  isl: 1024
+  isl: 8192
   osl: 1024
-  concurrencies: "1229"
+  concurrencies: "615"
   req_rate: "inf"
   custom_tokenizer: "glm_moe_dsa"
   use_chat_template: false

--- a/src/srtctl/benchmarks/sa_bench.py
+++ b/src/srtctl/benchmarks/sa_bench.py
@@ -97,5 +97,7 @@ class SABenchRunner(BenchmarkRunner):
             str(prefill_gpus),
             str(decode_gpus),
             str(b.random_range_ratio) if b.random_range_ratio is not None else "0.8",
+            b.custom_tokenizer or "",
+            str(b.use_chat_template).lower(),
         ]
         return cmd

--- a/src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py
@@ -515,6 +515,7 @@ def get_tokenizer(
     pretrained_model_name_or_path: str,
     tokenizer_mode: str = "auto",
     trust_remote_code: bool = False,
+    custom_tokenizer: str = None,
     **kwargs,
 ) -> PreTrainedTokenizer | PreTrainedTokenizerFast:
     if pretrained_model_name_or_path is not None and not os.path.exists(pretrained_model_name_or_path):
@@ -533,6 +534,25 @@ def get_tokenizer(
                 "to use mistral tokenizer mode."
             ) from e
         return MistralTokenizer.from_pretrained(str(pretrained_model_name_or_path))
+    if custom_tokenizer:
+        from tensorrt_llm.llmapi.llm_args import TOKENIZER_ALIASES
+
+        tokenizer_path = TOKENIZER_ALIASES.get(custom_tokenizer,
+                                               custom_tokenizer)
+        from importlib import import_module
+        try:
+            module_path, class_name = tokenizer_path.rsplit('.', 1)
+            module = import_module(module_path)
+            tokenizer_class = getattr(module, class_name)
+            return tokenizer_class.from_pretrained(
+                pretrained_model_name_or_path,
+                trust_remote_code=trust_remote_code,
+                **kwargs,
+            )
+        except (ValueError, ImportError, AttributeError) as e:
+            raise ValueError(
+                f"Failed to load custom_tokenizer '{custom_tokenizer}'. "
+                "Expected alias or 'module.path.ClassName'.") from e
     else:
         return AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path,

--- a/src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py
@@ -511,6 +511,47 @@ def get_model(pretrained_model_name_or_path: str) -> str:
     return pretrained_model_name_or_path
 
 
+def _load_glm_moe_dsa_tokenizer(pretrained_model_name_or_path: str) -> "PreTrainedTokenizerFast":
+    """Load GLM-Moe-Dsa / GLM-5 tokenizer directly from tokenizer.json.
+
+    Works around incompatibilities when the checkpoint was saved with
+    transformers 5.x (TokenizersBackend / list-style extra_special_tokens).
+    """
+    import json
+    from pathlib import Path
+
+    from tokenizers import Tokenizer as RustTokenizer
+    from transformers import PreTrainedTokenizerFast
+
+    _SAFE_CONFIG_KEYS = (
+        "pad_token", "pad_token_id", "eos_token", "eos_token_id",
+        "bos_token", "bos_token_id", "unk_token", "unk_token_id",
+        "model_max_length", "padding_side", "truncation_side",
+    )
+
+    path = Path(pretrained_model_name_or_path)
+    tokenizer_json = path / "tokenizer.json"
+    if not tokenizer_json.exists():
+        raise FileNotFoundError(
+            f"Expected tokenizer.json at {tokenizer_json}. "
+            "GlmMoeDsaTokenizer loads from tokenizer.json only."
+        )
+
+    rust_tok = RustTokenizer.from_file(str(tokenizer_json))
+    init_kwargs = {}
+    config_path = path / "tokenizer_config.json"
+    if config_path.exists():
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+        for key in _SAFE_CONFIG_KEYS:
+            if key in config:
+                init_kwargs[key] = config[key]
+        if "extra_special_tokens" in config:
+            init_kwargs["additional_special_tokens"] = config["extra_special_tokens"]
+
+    return PreTrainedTokenizerFast(tokenizer_object=rust_tok, **init_kwargs)
+
+
 def get_tokenizer(
     pretrained_model_name_or_path: str,
     tokenizer_mode: str = "auto",
@@ -535,13 +576,11 @@ def get_tokenizer(
             ) from e
         return MistralTokenizer.from_pretrained(str(pretrained_model_name_or_path))
     if custom_tokenizer:
-        from tensorrt_llm.llmapi.llm_args import TOKENIZER_ALIASES
-
-        tokenizer_path = TOKENIZER_ALIASES.get(custom_tokenizer,
-                                               custom_tokenizer)
+        if custom_tokenizer == "glm_moe_dsa":
+            return _load_glm_moe_dsa_tokenizer(pretrained_model_name_or_path)
         from importlib import import_module
         try:
-            module_path, class_name = tokenizer_path.rsplit('.', 1)
+            module_path, class_name = custom_tokenizer.rsplit('.', 1)
             module = import_module(module_path)
             tokenizer_class = getattr(module, class_name)
             return tokenizer_class.from_pretrained(
@@ -552,7 +591,7 @@ def get_tokenizer(
         except (ValueError, ImportError, AttributeError) as e:
             raise ValueError(
                 f"Failed to load custom_tokenizer '{custom_tokenizer}'. "
-                "Expected alias or 'module.path.ClassName'.") from e
+                "Expected 'glm_moe_dsa' or 'module.path.ClassName'.") from e
     else:
         return AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path,

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -60,6 +60,20 @@ TOTAL_GPUS=${9:-0}
 PREFILL_GPUS=${10:-0}
 DECODE_GPUS=${11:-0}
 RANDOM_RANGE_RATIO=${12:-0.8}
+CUSTOM_TOKENIZER=${13:-}
+USE_CHAT_TEMPLATE=${14:-true}
+
+# Build optional custom tokenizer args
+CUSTOM_TOKENIZER_ARGS=()
+if [ -n "$CUSTOM_TOKENIZER" ]; then
+    CUSTOM_TOKENIZER_ARGS=(--custom-tokenizer "$CUSTOM_TOKENIZER")
+fi
+
+# Build optional chat template args
+CHAT_TEMPLATE_ARGS=()
+if [ "$USE_CHAT_TEMPLATE" = "true" ]; then
+    CHAT_TEMPLATE_ARGS=(--use-chat-template)
+fi
 
 # Parse endpoint into host:port
 HOST=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f1)
@@ -119,7 +133,8 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --request-rate 250 \
         --percentile-metrics ttft,tpot,itl,e2el \
         --max-concurrency "$concurrency" \
-        --trust-remote-code
+        --trust-remote-code \
+        "${CUSTOM_TOKENIZER_ARGS[@]}"
 
     num_prompts=$((concurrency * 10))
     
@@ -149,7 +164,8 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --percentile-metrics ttft,tpot,itl,e2el \
         --max-concurrency "$concurrency" \
         --trust-remote-code \
-        --use-chat-template \
+        "${CHAT_TEMPLATE_ARGS[@]}" \
+        "${CUSTOM_TOKENIZER_ARGS[@]}" \
         --save-result --result-dir "$result_dir" --result-filename "$result_filename"
     set +x
 

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -837,6 +837,7 @@ def main(args: argparse.Namespace):
         tokenizer_id,
         tokenizer_mode=tokenizer_mode,
         trust_remote_code=args.trust_remote_code,
+        custom_tokenizer=args.custom_tokenizer,
     )
 
     if args.dataset is not None:
@@ -1277,6 +1278,14 @@ if __name__ == "__main__":
         "always use the slow tokenizer. \n* "
         '"mistral" will always use the `mistral_common` tokenizer. \n*'
         '"custom" will use --tokenizer to select the preregistered tokenizer.',
+    )
+
+    parser.add_argument(
+        "--custom-tokenizer",
+        type=str,
+        default=None,
+        help="Custom tokenizer class to use (e.g., 'module.path.ClassName'). "
+        "When set, overrides the default tokenizer loading.",
     )
 
     parser.add_argument(

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -167,6 +167,7 @@ class BenchmarkStageMixin:
             container_image=str(self.runtime.container_image),
             container_mounts=self.runtime.container_mounts,
             env_to_set=env_to_set,
+            mpi="pmix",
         )
 
         # Wait for benchmark to complete

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -167,7 +167,6 @@ class BenchmarkStageMixin:
             container_image=str(self.runtime.container_image),
             container_mounts=self.runtime.container_mounts,
             env_to_set=env_to_set,
-            mpi="pmix",
         )
 
         # Wait for benchmark to complete

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -539,6 +539,8 @@ class BenchmarkConfig:
     ttft_threshold_ms: int | None = None  # Goodput TTFT threshold in ms (default: 2000)
     itl_threshold_ms: int | None = None  # Goodput ITL threshold in ms (default: 25)
     random_range_ratio: float | None = None  # Random input/output length range ratio (default: 0.8)
+    custom_tokenizer: str | None = None  # Custom tokenizer class (e.g., "module.path.ClassName")
+    use_chat_template: bool = True  # Whether to use chat template in sa-bench
 
     def get_concurrency_list(self) -> list[int]:
         if self.concurrencies is None:


### PR DESCRIPTION
## Summary

Add optimized disaggregated inference recipes for GLM-5 model with NVfp4 precision on GB200 and GB300 GPUs, along with sa-bench GLM5 tokenizer support.

### Recipes Added (66 YAML configs)

**GB200 NVfp4:**
- ISL1K_OSL1K STP: 7 configs | ISL1K_OSL1K MTP: 8 configs
- ISL8K_OSL1K STP: 6 configs | ISL8K_OSL1K MTP: 8 configs

**GB300 NVfp4:**
- ISL1K_OSL1K STP: 8 configs | ISL1K_OSL1K MTP: 10 configs
- ISL8K_OSL1K STP: 9 configs | ISL8K_OSL1K MTP: 10 configs

### sa-bench Changes (from richardhuo-nv)
- Add `custom_tokenizer` and `use_chat_template` support for GLM5 tokenization
- Workaround for trtllm + GLM5 tokenizer loading issue (transformers v4 compatibility)

### Config Details
- All configs use `dynamo` frontend with `trtllm` backend
- Benchmark type: `sa-bench` with `custom_tokenizer: glm_moe_dsa`
- Container: `dynamo-trtllm-rihuo-glm5-2.0-arm64.sqsh`
- Configs with identical topology consolidated into `allconc` files
- All configs validated against source data tables

## Test plan
- [x] GB200 STP recipes validated - throughput curves match baseline
- [ ] GB200 MTP recipes pending benchmark validation
- [ ] GB300 STP/MTP recipes pending benchmark validation