### PR TITLE
Add Kimi K2.5 disagg STP and MTP recipes for GB200 NVfp4 (ISL8K_OSL1K…

### DIFF
--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
@@ -115,7 +115,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
@@ -1,0 +1,138 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp3"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=32
+# MTP (Eagle speculative decoding, max_draft_len=3)
+# concurrency: 666
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 32
+      max_num_tokens: 128
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.7
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "666"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -115,7 +115,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep16_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -117,7 +115,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch16_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch16_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -115,7 +113,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -113,7 +113,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch16_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -113,7 +113,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -1,0 +1,136 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch16_eplb0_mtp3"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=16
+# MTP (Eagle speculative decoding, max_draft_len=3)
+# concurrency: 666
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 64
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "666"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
@@ -175,7 +175,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep8_batch512_eplb0_mtp1"
 # concurrency: 4301
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -177,7 +175,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep8_batch512_eplb0_mtp1"
 # concurrency: 4301
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
@@ -1,0 +1,198 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep8_batch512_eplb0_mtp1"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 1 decode worker, TP8/EP8, enable_attention_dp=true, max_batch=512
+# MTP (Eagle speculative decoding, max_draft_len=1)
+# concurrency: 4301
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 2
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 512
+      max_num_tokens: 1024
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+          - 264
+          - 272
+          - 280
+          - 288
+          - 296
+          - 304
+          - 312
+          - 320
+          - 328
+          - 336
+          - 344
+          - 352
+          - 360
+          - 368
+          - 376
+          - 384
+          - 392
+          - 400
+          - 408
+          - 416
+          - 424
+          - 432
+          - 440
+          - 448
+          - 456
+          - 464
+          - 472
+          - 480
+          - 488
+          - 496
+          - 504
+          - 512
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "4301"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep8_batch512_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep8_batch512_eplb0_mtp1"
 # concurrency: 4301
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -175,7 +175,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3"
 # Covers all gen4tep8 concurrencies: 8, 48, 92, 192, 336
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -120,7 +120,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3"
 # Covers all gen4tep8 concurrencies: 8, 48, 92, 192, 336
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -122,13 +120,13 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "8 48 92 192 336"
+  concurrencies: "8x48x92x192x336"
   req_rate: "inf"
 
 frontend:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
@@ -120,7 +120,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3"
 # Covers all gen4tep8 concurrencies: 8, 48, 92, 192, 336
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3.yaml
@@ -1,0 +1,143 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch64_allconc_eplb0_mtp3"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 4 decode workers, TP8/EP8, allreduce_strategy=MNNVL, max_batch=64
+# MTP (Eagle speculative decoding, max_draft_len=3)
+# Covers all gen4tep8 concurrencies: 8, 48, 92, 192, 336
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 4
+  decode_nodes: 8
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      allreduce_strategy: MNNVL
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 64
+      max_num_tokens: 256
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "8 48 92 192 336"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3"
 # Covers all gen5tep4 concurrencies: 10, 15
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
@@ -111,7 +111,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3"
 # Covers all gen5tep4 concurrencies: 10, 15
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -113,13 +111,13 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "10 15"
+  concurrencies: "10x15"
   req_rate: "inf"
 
 frontend:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3"
 # Covers all gen5tep4 concurrencies: 10, 15
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -111,7 +111,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3.yaml
@@ -1,0 +1,134 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch2_allconc_eplb0_mtp3"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 5 decode workers, TP4/EP4, max_batch=2
+# MTP (Eagle speculative decoding, max_draft_len=3)
+# Covers all gen5tep4 concurrencies: 10, 15
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 8
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "10 15"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch128_eplb0_mtp1"
 # concurrency: 2253
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -127,7 +127,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
@@ -127,7 +127,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch128_eplb0_mtp1"
 # concurrency: 2253
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch128_eplb0_mtp1"
 # concurrency: 2253
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -129,7 +127,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep16_batch128_eplb0_mtp1.yaml
@@ -1,0 +1,150 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch128_eplb0_mtp1"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=128
+# MTP (Eagle speculative decoding, max_draft_len=1)
+# concurrency: 2253
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 128
+      max_num_tokens: 256
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.7
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "2253"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
@@ -1,0 +1,142 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch64_eplb0_mtp1"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=64
+# MTP (Eagle speculative decoding, max_draft_len=1)
+# concurrency: 2253
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 64
+      max_num_tokens: 128
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.6
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "2253"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
@@ -119,7 +119,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch64_eplb0_mtp1"
 # concurrency: 2253
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -121,7 +119,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch64_eplb0_mtp1"
 # concurrency: 2253
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -119,7 +119,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch64_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch64_eplb0_mtp1"
 # concurrency: 2253
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen3dep8_batch256_eplb0_mtp1"
 # concurrency: 6759
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -143,7 +143,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
@@ -1,0 +1,166 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen3dep8_batch256_eplb0_mtp1"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 3 decode workers, TP8/EP8, enable_attention_dp=true, max_batch=256
+# MTP (Eagle speculative decoding, max_draft_len=1)
+# concurrency: 6759
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 3
+  decode_nodes: 6
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 256
+      max_num_tokens: 512
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "6759"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen3dep8_batch256_eplb0_mtp1"
 # concurrency: 6759
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen3dep8_batch256_eplb0_mtp1"
 # concurrency: 6759
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -145,7 +143,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen3dep8_batch256_eplb0_mtp1.yaml
@@ -143,7 +143,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep16_batch32_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp0"
 # concurrency: 666
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep16_batch32_eplb0_mtp0.yaml
@@ -1,0 +1,127 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=32
+# STP (no speculative decoding)
+# concurrency: 666
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.75
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "666"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep16_batch32_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp0"
 # concurrency: 666
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep16_batch32_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep16_batch32_eplb0_mtp0"
 # concurrency: 666
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch64_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch64_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch64_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -121,7 +119,7 @@ benchmark:
 
 frontend:
   type: "dynamo"
-  enable_multiple_frontends: false
+  enable_multiple_frontends: true
 
 health_check:
   max_attempts: 360

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch64_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch64_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch64_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch64_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch64_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch64_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch64_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch64_eplb0_mtp0.yaml
@@ -1,0 +1,131 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep32_batch64_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=64
+# STP (no speculative decoding)
+# concurrency: 2253
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 64
+      max_num_tokens: 64
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.7
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "2253"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,219 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 1 decode worker, TP8/EP8, enable_attention_dp=true, max_batch=768
+# STP (no speculative decoding)
+# Covers all dep8 concurrencies: 4301, 6452
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 2
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 768
+      max_num_tokens: 768
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+          - 264
+          - 272
+          - 280
+          - 288
+          - 296
+          - 304
+          - 312
+          - 320
+          - 328
+          - 336
+          - 344
+          - 352
+          - 360
+          - 368
+          - 376
+          - 384
+          - 392
+          - 400
+          - 408
+          - 416
+          - 424
+          - 432
+          - 440
+          - 448
+          - 456
+          - 464
+          - 472
+          - 480
+          - 488
+          - 496
+          - 504
+          - 512
+          - 520
+          - 528
+          - 536
+          - 544
+          - 552
+          - 560
+          - 568
+          - 576
+          - 584
+          - 592
+          - 600
+          - 608
+          - 616
+          - 624
+          - 632
+          - 640
+          - 648
+          - 656
+          - 664
+          - 672
+          - 680
+          - 688
+          - 696
+          - 704
+          - 712
+          - 720
+          - 728
+          - 736
+          - 744
+          - 752
+          - 760
+          - 768
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "4301 6452"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0"
 # Covers all dep8 concurrencies: 4301, 6452
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0"
 # Covers all dep8 concurrencies: 4301, 6452
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen1dep8_batch768_allconc_eplb0_mtp0"
 # Covers all dep8 concurrencies: 4301, 6452
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -204,7 +202,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "4301 6452"
+  concurrencies: "4301x6452"
   req_rate: "inf"
 
 frontend:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0"
 # Covers all gen4tep8 concurrencies: 4, 192, 360, 668
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -125,7 +123,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "4 192 360 668"
+  concurrencies: "4x192x360x668"
   req_rate: "inf"
 
 frontend:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0"
 # Covers all gen4tep8 concurrencies: 4, 192, 360, 668
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0"
 # Covers all gen4tep8 concurrencies: 4, 192, 360, 668
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,140 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen4tep8_batch128_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 4 decode workers, TP8/EP8, allreduce_strategy=MNNVL, max_batch=128
+# STP (no speculative decoding)
+# Covers all gen4tep8 concurrencies: 4, 192, 360, 668
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 4
+  decode_nodes: 8
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      allreduce_strategy: MNNVL
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 128
+      max_num_tokens: 128
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "4 192 360 668"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,124 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 5 decode workers, TP4/EP4, max_batch=8
+# STP (no speculative decoding)
+# Covers all gen5tep4 concurrencies: 5, 15, 30, 55
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 8
+      max_num_tokens: 8
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "5 15 30 55"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0"
 # Covers all gen5tep4 concurrencies: 5, 15, 30, 55
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -109,7 +107,7 @@ benchmark:
   type: "sa-bench"
   isl: 1024
   osl: 1024
-  concurrencies: "5 15 30 55"
+  concurrencies: "5x15x30x55"
   req_rate: "inf"
 
 frontend:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0"
 # Covers all gen5tep4 concurrencies: 5, 15, 30, 55
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp0"
 # Covers all gen5tep4 concurrencies: 5, 15, 30, 55
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch256_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch256_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch256_eplb0_mtp0"
 # concurrency: 4301
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch256_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch256_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch256_eplb0_mtp0"
 # concurrency: 4301
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch256_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch256_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch256_eplb0_mtp0"
 # concurrency: 4301
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch256_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep16_batch256_eplb0_mtp0.yaml
@@ -1,0 +1,155 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep16_batch256_eplb0_mtp0"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=256
+# STP (no speculative decoding)
+# concurrency: 4301
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 256
+      max_num_tokens: 256
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.75
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "4301"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch128_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch128_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch128_eplb0_mtp0"
 # concurrency: 4301
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch128_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch128_eplb0_mtp0.yaml
@@ -1,0 +1,139 @@
+name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch128_eplb0_mtp0"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=128
+# STP (no speculative decoding)
+# concurrency: 4301
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16384
+      max_seq_len: 1064
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 128
+      max_num_tokens: 128
+      max_seq_len: 2088
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.7
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "4301"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch128_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch128_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch128_eplb0_mtp0"
 # concurrency: 4301
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch128_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch128_eplb0_mtp0.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL1K_OSL1K_ctx2dep4_gen1dep32_batch128_eplb0_mtp0"
 # concurrency: 4301
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen2tep8_batch32_eplb0_mtp3"
 # concurrency: 90
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen2tep8_batch32_eplb0_mtp3"
 # concurrency: 90
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -118,7 +116,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
@@ -116,7 +116,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen2tep8_batch32_eplb0_mtp3"
 # concurrency: 90
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -116,7 +116,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen2tep8_batch32_eplb0_mtp3.yaml
@@ -1,0 +1,139 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen2tep8_batch32_eplb0_mtp3"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 2 decode workers, TP8/EP8, allreduce_strategy=MNNVL, max_batch=32
+# MTP Eagle speculative decoding, max_draft_len=3
+# concurrency: 90
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 2
+  decode_nodes: 4
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      allreduce_strategy: MNNVL
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 32
+      max_num_tokens: 128
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "90"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
@@ -1,0 +1,135 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch1_eplb0_mtp3"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 4 decode workers, TP8/EP8, allreduce_strategy=MNNVL, max_batch=1
+# MTP Eagle speculative decoding, max_draft_len=3
+# concurrency: 8
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 4
+  decode_nodes: 8
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      allreduce_strategy: MNNVL
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 1
+      max_num_tokens: 4
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "8"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch1_eplb0_mtp3"
 # concurrency: 8
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch1_eplb0_mtp3"
 # concurrency: 8
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -112,7 +112,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
@@ -112,7 +112,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen4tep8_batch1_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch1_eplb0_mtp3"
 # concurrency: 8
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -114,7 +112,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3"
 # Covers all gen5tep4 concurrencies: 10, 15, 60
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -114,13 +112,13 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "10 15 60"
+  concurrencies: "10x15x60"
   req_rate: "inf"
 
 frontend:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
@@ -1,0 +1,135 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 5 decode workers, TP4/EP4, max_batch=8
+# MTP Eagle speculative decoding, max_draft_len=3
+# Covers all gen5tep4 concurrencies: 10, 15, 60
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 8
+      max_num_tokens: 32
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.85
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "10 15 60"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3"
 # Covers all gen5tep4 concurrencies: 10, 15, 60
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -112,7 +112,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
@@ -112,7 +112,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch8_allconc_eplb0_mtp3"
 # Covers all gen5tep4 concurrencies: 10, 15, 60
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
@@ -1,0 +1,135 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx2dep4_gen1dep16_batch8_eplb0_mtp3"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=8
+# MTP Eagle speculative decoding, max_draft_len=3
+# concurrency: 180
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 8
+      max_num_tokens: 32
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "180"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx2dep4_gen1dep16_batch8_eplb0_mtp3"
 # concurrency: 180
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -112,7 +112,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
@@ -112,7 +112,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx2dep4_gen1dep16_batch8_eplb0_mtp3"
 # concurrency: 180
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -114,7 +112,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep16_batch8_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx2dep4_gen1dep16_batch8_eplb0_mtp3"
 # concurrency: 180
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -1,0 +1,136 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep32_batch16_eplb0_mtp3"
+
+# ctx: 5 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=16
+# MTP Eagle speculative decoding, max_draft_len=3
+# concurrency: 666
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 5
+  prefill_workers: 5
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 64
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.75
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "666"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep32_batch16_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -115,7 +113,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -113,7 +113,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep32_batch16_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep32_batch16_eplb0_mtp3"
 # concurrency: 666
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -113,7 +113,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1"
 # Covers all dep8 mtp1 concurrencies: 1229, 2253
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -143,7 +143,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
@@ -1,0 +1,166 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1"
+
+# ctx: 5 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP8/EP8, enable_attention_dp=true, max_batch=256
+# MTP Eagle speculative decoding, max_draft_len=1
+# Covers all dep8 mtp1 concurrencies: 1229, 2253
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 5
+  prefill_workers: 5
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 2
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 256
+      max_num_tokens: 512
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 1
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "1229 2253"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1"
 # Covers all dep8 mtp1 concurrencies: 1229, 2253
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -145,13 +143,13 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "1229 2253"
+  concurrencies: "1229x2253"
   req_rate: "inf"
 
 frontend:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1"
 # Covers all dep8 mtp1 concurrencies: 1229, 2253
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp1.yaml
@@ -143,7 +143,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
@@ -1,0 +1,138 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx8dep4_gen1dep32_batch32_eplb0_mtp3"
+
+# ctx: 8 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP32/EP32, enable_attention_dp=true, max_batch=32
+# MTP Eagle speculative decoding, max_draft_len=3
+# concurrency: 1229
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  prefill_nodes: 8
+  prefill_workers: 8
+  gpus_per_prefill: 4
+
+  decode_workers: 1
+  decode_nodes: 8
+  gpus_per_decode: 32
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+    decode:
+      tensor_parallel_size: 32
+      moe_expert_parallel_size: 32
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: true
+      trust_remote_code: true
+      max_batch_size: 32
+      max_num_tokens: 128
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.75
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+      speculative_config:
+        decoding_type: Eagle
+        max_draft_len: 3
+        speculative_model_dir: "/eagle-model"
+
+extra_mount:
+  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "1229"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx8dep4_gen1dep32_batch32_eplb0_mtp3"
 # concurrency: 1229
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -33,7 +33,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -43,7 +42,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -117,7 +115,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
@@ -115,7 +115,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "/mnt/lustre01/users/slurm-shared/yeswanthk/models/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
+  - "kimi-k2.5-eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx8dep4_gen1dep32_batch32_eplb0_mtp3"
 # concurrency: 1229
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch32_eplb0_mtp3.yaml
@@ -6,8 +6,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx8dep4_gen1dep32_batch32_eplb0_mtp3"
 # concurrency: 1229
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:
@@ -115,7 +115,7 @@ backend:
         speculative_model_dir: "/eagle-model"
 
 extra_mount:
-  - "kimi-k2.5-eagle3:/eagle-model"
+  - "nvidia/Kimi-K2.5-Thinking-Eagle3:/eagle-model"
 
 benchmark:
   type: "sa-bench"

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0"
 # Single concurrency point: 156
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,128 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 4 decode workers, TP4/EP4, max_batch=32
+# Single concurrency point: 156
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  # Prefill: 1 worker x TP4 = 4 GPUs = 1 node
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  # Decode: 4 workers x TP4 = 16 GPUs = 4 nodes
+  decode_workers: 4
+  decode_nodes: 4
+  gpus_per_decode: 4
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "156"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0"
 # Single concurrency point: 156
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -34,7 +34,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -44,7 +43,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep4_batch32_allconc_eplb0_mtp0"
 # Single concurrency point: 156
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0"
 # Single concurrency point: 4
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -34,7 +34,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -44,7 +43,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0"
 # Single concurrency point: 4
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0"
 # Single concurrency point: 4
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,125 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen4tep8_batch1_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 4 decode workers, TP8/EP8, allreduce_strategy=MNNVL, max_batch=1
+# Single concurrency point: 4
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  # Prefill: 1 worker x TP4 = 4 GPUs = 1 node
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  # Decode: 4 workers x TP8 = 32 GPUs = 8 nodes
+  decode_workers: 4
+  decode_nodes: 8
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      allreduce_strategy: MNNVL
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 1
+      max_num_tokens: 1
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "4"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0"
 # Covers all concurrencies: 5, 15, 30, 60, 105
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -34,7 +34,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -44,7 +43,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:
@@ -113,7 +111,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "5 15 30 60 105"
+  concurrencies: "5x15x30x60x105"
   req_rate: "inf"
 
 frontend:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0"
 # Covers all concurrencies: 5, 15, 30, 60, 105
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,128 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0"
+
+# ctx: 1 prefill worker, TP4/EP4
+# gen: 5 decode workers, TP4/EP4, max_batch=16
+# Covers all concurrencies: 5, 15, 30, 60, 105
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  # Prefill: 1 worker x TP4 = 4 GPUs = 1 node
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 4
+
+  # Decode: 5 workers x TP4 = 20 GPUs = 5 nodes
+  decode_workers: 5
+  decode_nodes: 5
+  gpus_per_decode: 4
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      # max_batch_size=16 covers all concs: 5, 15, 30, 60, 105
+      # cuda_graph pre-compiles graphs for each batch size up to the max
+      max_batch_size: 16
+      max_num_tokens: 16
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "5 15 30 60 105"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx1dep4_gen5tep4_batch16_allconc_eplb0_mtp0"
 # Covers all concurrencies: 5, 15, 30, 60, 105
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep16_batch16_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep16_batch16_eplb0_mtp0.yaml
@@ -1,0 +1,126 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx2dep4_gen1dep16_batch16_eplb0_mtp0"
+
+# ctx: 2 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=16
+# concurrency: 333
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  # Prefill: 2 workers x TP4 = 8 GPUs = 2 nodes
+  prefill_nodes: 2
+  prefill_workers: 2
+  gpus_per_prefill: 4
+
+  # Decode: 1 worker x TP16 = 16 GPUs = 4 nodes
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 16
+      max_num_tokens: 16
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "333"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep16_batch16_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep16_batch16_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx2dep4_gen1dep16_batch16_eplb0_mtp0"
 # concurrency: 333
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep16_batch16_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep16_batch16_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx2dep4_gen1dep16_batch16_eplb0_mtp0"
 # concurrency: 333
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep16_batch16_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep16_batch16_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx2dep4_gen1dep16_batch16_eplb0_mtp0"
 # concurrency: 333
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -34,7 +34,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -44,7 +43,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx3dep4_gen1dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx3dep4_gen1dep16_batch32_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx3dep4_gen1dep16_batch32_eplb0_mtp0"
 # concurrency: 615
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx3dep4_gen1dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx3dep4_gen1dep16_batch32_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx3dep4_gen1dep16_batch32_eplb0_mtp0"
 # concurrency: 615
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx3dep4_gen1dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx3dep4_gen1dep16_batch32_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx3dep4_gen1dep16_batch32_eplb0_mtp0"
 # concurrency: 615
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -34,7 +34,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -44,7 +43,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx3dep4_gen1dep16_batch32_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx3dep4_gen1dep16_batch32_eplb0_mtp0.yaml
@@ -1,0 +1,128 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx3dep4_gen1dep16_batch32_eplb0_mtp0"
+
+# ctx: 3 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=32
+# concurrency: 615
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  # Prefill: 3 workers x TP4 = 12 GPUs = 3 nodes
+  prefill_nodes: 3
+  prefill_workers: 3
+  gpus_per_prefill: 4
+
+  # Decode: 1 worker x TP16 = 16 GPUs = 4 nodes
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "615"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0"
 # Single concurrency point: 2151
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0"
 # Single concurrency point: 2151
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0.yaml
@@ -1,0 +1,157 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0"
+
+# ctx: 5 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP8/EP8, enable_attention_dp=true, max_batch=256
+# Single concurrency point: 2151
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  # Prefill: 5 workers x TP4 = 20 GPUs = 5 nodes
+  prefill_nodes: 5
+  prefill_workers: 5
+  gpus_per_prefill: 4
+
+  # Decode: 1 worker x TP8 = 8 GPUs = 2 nodes
+  decode_workers: 1
+  decode_nodes: 2
+  gpus_per_decode: 8
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      # max_batch_size=256, cuda_graph pre-compiles graphs for all batch sizes up to 256
+      max_batch_size: 256
+      max_num_tokens: 256
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+          - 136
+          - 144
+          - 152
+          - 160
+          - 168
+          - 176
+          - 184
+          - 192
+          - 200
+          - 208
+          - 216
+          - 224
+          - 232
+          - 240
+          - 248
+          - 256
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "2151"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx5dep4_gen1dep8_batch256_allconc_eplb0_mtp0"
 # Single concurrency point: 2151
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -34,7 +34,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -44,7 +43,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx7dep4_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx7dep4_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -1,0 +1,140 @@
+name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx7dep4_gen1dep16_batch128_eplb0_mtp0"
+
+# ctx: 7 prefill workers, TP4/EP4
+# gen: 1 decode worker, TP16/EP16, enable_attention_dp=true, max_batch=128
+# concurrency: 2253
+
+model:
+  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
+  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  precision: "fp4"
+
+resources:
+  gpu_type: "gb200"
+
+  # Prefill: 7 workers x TP4 = 28 GPUs = 7 nodes
+  prefill_nodes: 7
+  prefill_workers: 7
+  gpus_per_prefill: 4
+
+  # Decode: 1 worker x TP16 = 16 GPUs = 4 nodes
+  decode_workers: 1
+  decode_nodes: 4
+  gpus_per_decode: 16
+
+  gpus_per_node: 4
+
+backend:
+  type: trtllm
+
+  prefill_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  decode_environment:
+    ENROOT_ALLOW_DEV: "yes"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
+
+  trtllm_config:
+    prefill:
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      disable_overlap_scheduler: true
+      trust_remote_code: true
+      max_batch_size: 2
+      max_num_tokens: 16384
+      max_seq_len: 8232
+      print_iter_log: true
+      cuda_graph_config: null
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.4
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+
+    decode:
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      enable_attention_dp: true
+      enable_lm_head_tp_in_adp: false
+      trust_remote_code: true
+      max_batch_size: 128
+      max_num_tokens: 128
+      max_seq_len: 9256
+      print_iter_log: true
+      stream_interval: 100
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+          - 1
+          - 2
+          - 4
+          - 8
+          - 16
+          - 24
+          - 32
+          - 40
+          - 48
+          - 56
+          - 64
+          - 72
+          - 80
+          - 88
+          - 96
+          - 104
+          - 112
+          - 120
+          - 128
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 16384
+      nvfp4_gemm_config:
+        allowed_backends:
+          - cutlass
+          - cublaslt
+          - cutedsl
+          - cuda_core
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "2253"
+  req_rate: "inf"
+
+frontend:
+  type: "dynamo"
+  enable_multiple_frontends: false
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+dynamo:
+  install: false

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx7dep4_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx7dep4_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx7dep4_gen1dep16_batch128_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "kimi-k2.5-nvfp4"
-  container: "tensorrtllm-runtime:1.1.0-dev.2"
+  path: "nvidia/Kimi-K2.5-NVFP4"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx7dep4_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx7dep4_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx7dep4_gen1dep16_batch128_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
-  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
+  path: "kimi-k2.5-nvfp4"
+  container: "tensorrtllm-runtime:1.1.0-dev.2"
   precision: "fp4"
 
 resources:

--- a/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx7dep4_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/kimi2.5/trtllm_dynamo/disagg/gb200Nvfp4/ISL8K_OSL1K/STP/ctx7dep4_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -5,8 +5,8 @@ name: "kimi_k25_nvfp4_ISL8K_OSL1K_ctx7dep4_gen1dep16_batch128_eplb0_mtp0"
 # concurrency: 2253
 
 model:
-  path: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/models/Kimi-K2.5-NVFP4"
-  container: "/lustre/fsw/infra_rd_gsw/users/yeswanthk/srt-slurm/squash/trtllm-main_aarch-46939060.sqsh"
+  path: "/mnt/lustre01/models/kimi-k2.5-nvfp4"
+  container: "/mnt/lustre01/users/slurm-shared/yeswanthk/squashs/tensorrtllm-runtime-1.1.0-dev.2.sqsh"
   precision: "fp4"
 
 resources:
@@ -34,7 +34,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   decode_environment:
     ENROOT_ALLOW_DEV: "yes"
@@ -44,7 +43,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     TRTLLM_SERVER_DISABLE_GC: "1"
     TRTLLM_WORKER_DISABLE_GC: "1"
-    HF_HOME: "/lustre/fsw/coreai_comparch_infbench/common/hf_cache"
 
   trtllm_config:
     prefill:

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -141,6 +141,20 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         config["reporting"] = cluster_config["reporting"]
         logger.debug("Applied cluster reporting config")
 
+    # Resolve extra_mount host path aliases through model_paths
+    extra_mounts = config.get("extra_mount", [])
+    if model_paths and extra_mounts:
+        resolved_mounts = []
+        for mount_spec in extra_mounts:
+            host_path, container_path = mount_spec.split(":", 1)
+            if host_path in model_paths:
+                resolved_host = model_paths[host_path]
+                resolved_mounts.append(f"{resolved_host}:{container_path}")
+                logger.debug(f"Resolved extra_mount alias '{host_path}' -> '{resolved_host}'")
+            else:
+                resolved_mounts.append(mount_spec)
+        config["extra_mount"] = resolved_mounts
+
     # Resolve frontend nginx_container alias
     frontend = config.get("frontend", {})
     nginx_container = frontend.get("nginx_container", "")


### PR DESCRIPTION
Add optimized disaggregated inference recipes for Kimi K2.5 model with NVfp4 precision on GB200 GPUs. Includes both STP and MTP configurations for ISL8K_OSL1K and ISL1K_OSL1K workloads covering concurrency points from 5 to 2253, with Eagle speculative decoding for MTP variants.