### PR TITLE
Add CSV export for sa-bench rollup

### DIFF
--- a/src/srtctl/benchmarks/scripts/sa-bench/rollup.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/rollup.py
@@ -2,12 +2,37 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Generate benchmark-rollup.json from sa-bench results."""
+"""Generate benchmark-rollup.json and benchmark-rollup.csv from sa-bench results."""
 
+from __future__ import annotations
+
+import csv
 import json
+from collections import Counter
+import math
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
+
+
+OUTPUT_FIELDS = [
+    "Config",
+    "Total GPU Count",
+    "Decode GPU Count",
+    "Concurrency",
+    "Total Token Throughput",
+    "Output Token Throughput",
+    "Median TTFT",
+    "Median TPOT",
+    "Median ITL",
+    "P90 Decode Running Requests",
+    "Output Token Throughput per User",
+    "Total Token Throughput per GPU",
+]
+
+RUNNING_REQ_PATTERN = re.compile(r"#running-req:\s*(\d+)")
 
 
 def _get_percentile(percentiles: list, target: float) -> float | None:
@@ -20,24 +45,157 @@ def _get_percentile(percentiles: list, target: float) -> float | None:
     return None
 
 
+def _read_job_metadata(log_dir: Path) -> dict[str, Any] | None:
+    """Read submit metadata JSON from the output directory when available."""
+    output_dir = log_dir.parent
+    for metadata_path in sorted(output_dir.glob("*.json")):
+        try:
+            data = json.loads(metadata_path.read_text())
+        except Exception as exc:
+            print(f"Failed to parse {metadata_path}: {exc}", file=sys.stderr)
+            continue
+        if data:
+            return data
+    return None
+
+
+def _compute_gpu_counts(resources: dict[str, Any]) -> tuple[int | None, int | None]:
+    """Compute total and decode GPU counts from resource settings."""
+    gpus_per_node = int(resources.get("gpus_per_node", 0))
+    prefill_nodes = int(resources.get("prefill_nodes", 0))
+    decode_nodes = int(resources.get("decode_nodes", 0))
+    agg_nodes = int(resources.get("agg_nodes", 0))
+    if gpus_per_node <= 0:
+        return None, None
+
+    if prefill_nodes > 0 or decode_nodes > 0:
+        total_gpu_count = (prefill_nodes + decode_nodes) * gpus_per_node
+    elif agg_nodes > 0:
+        total_gpu_count = agg_nodes * gpus_per_node
+    else:
+        total_gpu_count = gpus_per_node
+
+    if decode_nodes > 0:
+        return total_gpu_count, decode_nodes * gpus_per_node
+
+    decode_workers = int(resources.get("decode_workers", 0))
+    gpus_per_decode = int(resources.get("gpus_per_decode", 0))
+    if decode_workers > 0 and gpus_per_decode > 0:
+        return total_gpu_count, decode_workers * gpus_per_decode
+
+    return total_gpu_count, None
+
+
+def _extract_p90_decode_running_requests(log_dir: Path, metadata: dict[str, Any] | None) -> int | None:
+    """Stream decode logs and compute the nearest-rank P90 of #running-req values."""
+    if not metadata or metadata.get("backend_type") != "sglang":
+        return None
+
+    resources = metadata.get("resources")
+    if resources is None:
+        return None
+    if not (int(resources.get("prefill_nodes", 0)) > 0 and int(resources.get("decode_nodes", 0)) > 0):
+        return None
+    if int(resources.get("agg_workers", 0)) > 0:
+        return None
+
+    counts: Counter[int] = Counter()
+    total = 0
+
+    for decode_log in sorted(log_dir.glob("*decode*.out")):
+        try:
+            with decode_log.open("r", errors="replace") as f:
+                for line in f:
+                    match = RUNNING_REQ_PATTERN.search(line)
+                    if not match:
+                        continue
+                    value = int(match.group(1))
+                    counts[value] += 1
+                    total += 1
+        except OSError as exc:
+            print(f"Failed to read {decode_log}: {exc}", file=sys.stderr)
+
+    if total == 0:
+        return None
+
+    rank = math.ceil(total * 0.9)
+    cumulative = 0
+    for value in sorted(counts):
+        cumulative += counts[value]
+        if cumulative >= rank:
+            return value
+
+    return None
+
+
+def _safe_ratio(numerator: float | int | None, denominator: float | int | None) -> float | None:
+    """Return numerator / denominator when both values are valid and denominator != 0."""
+    if numerator is None or denominator in (None, 0):
+        return None
+    return float(numerator) / float(denominator)
+
+
+def _format_csv_value(value: object) -> str:
+    """Format CSV values with at most three decimal places for numeric fields."""
+    if value is None:
+        return ""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.3f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
+def _build_csv_row(
+    data: dict[str, object],
+    config_name: str,
+    gpu_num: int | None,
+    decode_gpu_count: int | None,
+    p90_decode_running_requests: int | None,
+) -> dict[str, object]:
+    """Build one CSV row from a parsed sa-bench result."""
+    total_token_throughput = data.get("total_token_throughput")
+    median_tpot = data.get("median_tpot_ms")
+    row = {
+        "Config": config_name,
+        "Total GPU Count": gpu_num,
+        "Decode GPU Count": decode_gpu_count,
+        "Concurrency": data.get("max_concurrency"),
+        "Total Token Throughput": total_token_throughput,
+        "Output Token Throughput": data.get("output_throughput"),
+        "Median TTFT": data.get("median_ttft_ms"),
+        "Median TPOT": median_tpot,
+        "Median ITL": data.get("median_itl_ms"),
+        "P90 Decode Running Requests": p90_decode_running_requests,
+        "Output Token Throughput per User": _safe_ratio(1000.0, median_tpot),
+        "Total Token Throughput per GPU": _safe_ratio(total_token_throughput, gpu_num),
+    }
+    return {key: _format_csv_value(value) for key, value in row.items()}
+
+
 def main(log_dir: Path) -> None:
-    """Generate benchmark-rollup.json from sa-bench result files."""
+    """Generate benchmark-rollup.json and benchmark-rollup.csv from sa-bench result files."""
     result_files = sorted(log_dir.glob("sa-bench_*/results_*.json"))
     if not result_files:
         print("No sa-bench results found", file=sys.stderr)
         return
 
     runs = []
+    csv_rows = []
     config = {}
+    metadata = _read_job_metadata(log_dir)
+    config_name = metadata.get("job_name") if metadata else None
+    resources = metadata.get("resources") if metadata else None
+    total_gpu_count, decode_gpu_count = _compute_gpu_counts(resources) if resources else (None, None)
+    p90_decode_running_requests = _extract_p90_decode_running_requests(log_dir, metadata)
 
-    for f in result_files:
+    for result_file in result_files:
         try:
-            data = json.loads(f.read_text())
-        except json.JSONDecodeError as e:
-            print(f"Failed to parse {f}: {e}", file=sys.stderr)
+            data = json.loads(result_file.read_text())
+        except json.JSONDecodeError as exc:
+            print(f"Failed to parse {result_file}: {exc}", file=sys.stderr)
             continue
 
-        # Extract config from first file
         if not config:
             config = {
                 "model": data.get("model_id"),
@@ -61,6 +219,20 @@ def main(log_dir: Path) -> None:
             "total_output_tokens": data.get("total_output"),
         })
 
+        csv_rows.append(
+            _build_csv_row(
+                data=data,
+                config_name=config_name or str(data.get("model_id") or "unknown"),
+                gpu_num=total_gpu_count,
+                decode_gpu_count=decode_gpu_count,
+                p90_decode_running_requests=p90_decode_running_requests,
+            )
+        )
+
+    if not runs:
+        print("No valid sa-bench results found", file=sys.stderr)
+        return
+
     rollup = {
         "benchmark_type": "sa-bench",
         "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -68,9 +240,17 @@ def main(log_dir: Path) -> None:
         "runs": runs,
     }
 
-    output_path = log_dir / "benchmark-rollup.json"
-    output_path.write_text(json.dumps(rollup, indent=2))
-    print(f"Wrote {output_path}")
+    json_path = log_dir / "benchmark-rollup.json"
+    json_path.write_text(json.dumps(rollup, indent=2))
+    print(f"Wrote {json_path}")
+
+    csv_rows.sort(key=lambda row: int(row["Concurrency"]) if row["Concurrency"] else -1)
+    csv_path = log_dir / "benchmark-rollup.csv"
+    with csv_path.open("w", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=OUTPUT_FIELDS)
+        writer.writeheader()
+        writer.writerows(csv_rows)
+    print(f"Wrote {csv_path}")
 
 
 if __name__ == "__main__":

--- a/tests/test_sa_bench_rollup.py
+++ b/tests/test_sa_bench_rollup.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for SA-Bench rollup generation."""
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_rollup_module():
+    rollup_path = Path(__file__).parent.parent / "src/srtctl/benchmarks/scripts/sa-bench/rollup.py"
+    spec = importlib.util.spec_from_file_location("sa_bench_rollup", rollup_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def test_sa_bench_rollup_generates_json_and_csv_without_metadata(tmp_path):
+    """Rollup keeps legacy JSON and emits CSV even when metadata is absent."""
+    rollup = _load_rollup_module()
+
+    result_dir = tmp_path / "sa-bench_isl_8192_osl_1024"
+    result_dir.mkdir()
+
+    valid_low_concurrency = {
+        "model_id": "GLM-5-FP8",
+        "random_input_len": 8192,
+        "random_output_len": 1024,
+        "max_concurrency": 16,
+        "output_throughput": 1234.5,
+        "total_token_throughput": 9876.0,
+        "request_throughput": 1.25,
+        "mean_ttft_ms": 100.0,
+        "mean_tpot_ms": 10.0,
+        "mean_itl_ms": 20.0,
+        "mean_e2el_ms": 200.0,
+        "median_ttft_ms": 95.0,
+        "median_tpot_ms": 8.0,
+        "median_itl_ms": 12.5,
+        "completed": 160,
+        "total_input": None,
+        "total_output": None,
+        "percentiles_ttft_ms": [(99.0, 150.0)],
+        "percentiles_tpot_ms": [(99.0, 15.0)],
+        "percentiles_itl_ms": [(99.0, 30.0)],
+    }
+    valid_high_concurrency = {
+        "model_id": "GLM-5-FP8",
+        "random_input_len": 8192,
+        "random_output_len": 1024,
+        "max_concurrency": 32,
+        "output_throughput": 2222.25,
+        "total_token_throughput": 11111.0,
+        "request_throughput": 2.5,
+        "mean_ttft_ms": 110.0,
+        "mean_tpot_ms": 11.0,
+        "mean_itl_ms": 21.0,
+        "mean_e2el_ms": 210.0,
+        "median_ttft_ms": 96.0,
+        "median_tpot_ms": 9.5,
+        "median_itl_ms": 13.0,
+        "completed": 320,
+        "total_input": 1,
+        "total_output": 2,
+        "percentiles_ttft_ms": [(99.0, 151.0)],
+        "percentiles_tpot_ms": [(99.0, 16.0)],
+        "percentiles_itl_ms": [(99.0, 31.0)],
+    }
+
+    (result_dir / "results_concurrency_32_gpus_48_ctx_8_gen_40.json").write_text(json.dumps(valid_high_concurrency))
+    (result_dir / "results_concurrency_16_gpus_48_ctx_8_gen_40.json").write_text(json.dumps(valid_low_concurrency))
+    (result_dir / "results_concurrency_99_gpus_48_ctx_8_gen_40.json").write_text("{invalid json")
+
+    rollup.main(tmp_path)
+
+    json_rollup = tmp_path / "benchmark-rollup.json"
+    csv_rollup = tmp_path / "benchmark-rollup.csv"
+    assert json_rollup.exists()
+    assert csv_rollup.exists()
+
+    json_data = json.loads(json_rollup.read_text())
+    assert json_data["benchmark_type"] == "sa-bench"
+    assert [run["concurrency"] for run in json_data["runs"]] == [16, 32]
+    assert json_data["runs"][0]["ttft_mean_ms"] == 100.0
+    assert json_data["runs"][1]["ttft_p99_ms"] == 151.0
+
+    rows = _read_csv_rows(csv_rollup)
+    assert [row["Concurrency"] for row in rows] == ["16", "32"]
+
+    first = rows[0]
+    assert first["Config"] == "GLM-5-FP8"
+    assert first["Total GPU Count"] == ""
+    assert first["Decode GPU Count"] == ""
+    assert first["Total Token Throughput"] == "9876"
+    assert first["Output Token Throughput"] == "1234.5"
+    assert first["Median TTFT"] == "95"
+    assert first["Median TPOT"] == "8"
+    assert first["Median ITL"] == "12.5"
+    assert first["P90 Decode Running Requests"] == ""
+    assert first["Output Token Throughput per User"] == "125"
+    assert first["Total Token Throughput per GPU"] == ""
+
+
+def test_sa_bench_rollup_uses_metadata_for_name_gpu_counts_and_p90(tmp_path):
+    """Metadata-driven runs should use job_name, resource-derived GPU counts, and decode-log P90."""
+    rollup = _load_rollup_module()
+
+    logs_dir = tmp_path / "logs"
+    result_dir = logs_dir / "sa-bench_isl_8192_osl_1024"
+    result_dir.mkdir(parents=True)
+
+    (tmp_path / "4049.json").write_text(
+        json.dumps(
+            {
+                "job_name": "job-metadata-name",
+                "backend_type": "sglang",
+                "resources": {
+                    "gpus_per_node": 8,
+                    "prefill_nodes": 1,
+                    "decode_nodes": 2,
+                    "decode_workers": 2,
+                    "agg_workers": 0,
+                },
+            }
+        )
+    )
+    (logs_dir / "b300-003_decode_w0.out").write_text(
+        "\n".join(
+            [
+                "[x] Decode batch, #running-req: 4, #token: 100",
+                "[x] Decode batch, #running-req: 8, #token: 100",
+                "[x] Decode batch, #running-req: 8, #token: 100",
+                "[x] Decode batch, #running-req: 16, #token: 100",
+                "[x] Decode batch, #running-req: 32, #token: 100",
+                "[x] unrelated line",
+            ]
+        )
+    )
+
+    result = {
+        "model_id": "GLM-5-FP8",
+        "max_concurrency": 512,
+        "output_throughput": 100.0,
+        "total_token_throughput": 800.0,
+        "median_ttft_ms": 200.0,
+        "median_tpot_ms": 25.0,
+        "median_itl_ms": 10.0,
+    }
+    (result_dir / "results_concurrency_512_gpus_999_ctx_8_gen_56.json").write_text(json.dumps(result))
+
+    rollup.main(logs_dir)
+
+    rows = _read_csv_rows(logs_dir / "benchmark-rollup.csv")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["Config"] == "job-metadata-name"
+    assert row["Total GPU Count"] == "24"
+    assert row["Decode GPU Count"] == "16"
+    assert row["P90 Decode Running Requests"] == "32"
+    assert row["Output Token Throughput per User"] == "40"
+    assert row["Total Token Throughput per GPU"] == "33.333"


### PR DESCRIPTION
## Summary
- add a human-readable benchmark-rollup.csv alongside the existing JSON rollup. So that we don't need to extract data from benchmark log manually.
- keep benchmark-rollup.json and downstream postprocess behavior unchanged. It use mean instead of median.
- derive total and decode GPU counts from the resolved runtime resources when available, with a filename fallback for total GPU count
- include median-based CSV metrics and optional P90 decode running request data for sglang disaggregated runs

## CSV Example
```csv
Config,Total GPU Count,Decode GPU Count,Concurrency,Total Token Throughput,Output Token Throughput,Median TTFT,Median TPOT,Median ITL,P90 Decode Running Requests,Output Token Throughput per User,Total Token Throughput per GPU
b200-fp8-glm5-8k1k_lowlat_4,64,56,512,46343.14,5148.868,67510.52,21.541,644.745,21,46.423,724.112
```

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_sa_bench_rollup.py -q