### PR TITLE
feat: configurable NATS max_payload for disagg serving

### DIFF
--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -107,6 +107,8 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
             "--log-dir",
             str(self.runtime.log_dir),
         ]
+        if self.config.infra.nats_max_payload_mb is not None:
+            cmd += ["--nats-max-payload-mb", str(self.config.infra.nats_max_payload_mb)]
 
         mounts = dict(self.runtime.container_mounts)
         mounts[setup_script] = setup_script_container

--- a/src/srtctl/cli/setup_head.py
+++ b/src/srtctl/cli/setup_head.py
@@ -119,11 +119,13 @@ def setup_logging():
     )
 
 
-def start_nats(binary_path: str = "/configs/nats-server") -> subprocess.Popen:
+def start_nats(binary_path: str = "/configs/nats-server", max_payload_mb: int | None = None) -> subprocess.Popen:
     """Start NATS server.
 
     Args:
         binary_path: Path to nats-server binary
+        max_payload_mb: Maximum message payload size in MB, or None for NATS default (1MB).
+            Set to 24+ for disaggregated serving with long ISL (65K+ tokens).
 
     Returns:
         Popen object for the NATS process
@@ -132,14 +134,24 @@ def start_nats(binary_path: str = "/configs/nats-server") -> subprocess.Popen:
         raise FileNotFoundError(f"NATS binary not found: {binary_path}")
 
     # Use /tmp for JetStream storage - avoids "Temporary storage directory" warning
-    # and ensures we're using fast local storage'
+    # and ensures we're using fast local storage
     if os.path.exists("/tmp/nats"):
         shutil.rmtree("/tmp/nats")
     nats_store_dir = "/tmp/nats"
     os.makedirs(nats_store_dir, exist_ok=True)
 
-    logger.info("Starting NATS server...")
-    cmd = [binary_path, "-js", "-sd", nats_store_dir]
+    if max_payload_mb is not None:
+        # Write NATS config with custom max_payload
+        nats_config_path = "/tmp/nats.conf"
+        max_payload_bytes = max_payload_mb * 1024 * 1024
+        with open(nats_config_path, "w") as f:
+            f.write(f"max_payload: {max_payload_bytes}\n")
+            f.write(f"jetstream {{ store_dir: \"{nats_store_dir}\" }}\n")
+        logger.info("Starting NATS server (max_payload: %dMB)...", max_payload_mb)
+        cmd = [binary_path, "-c", nats_config_path]
+    else:
+        logger.info("Starting NATS server...")
+        cmd = [binary_path, "-js", "-sd", nats_store_dir]
 
     proc = subprocess.Popen(
         cmd,
@@ -246,6 +258,12 @@ def main():
         default="/configs/etcd",
         help="Path to etcd binary",
     )
+    parser.add_argument(
+        "--nats-max-payload-mb",
+        type=int,
+        default=None,
+        help="NATS max message payload in MB (default: NATS default 1MB)",
+    )
 
     args = parser.parse_args()
 
@@ -264,7 +282,7 @@ def main():
     etcd_proc = None
 
     try:
-        nats_proc = start_nats(args.nats_binary)
+        nats_proc = start_nats(args.nats_binary, max_payload_mb=args.nats_max_payload_mb)
         etcd_proc = start_etcd(host_ip, args.etcd_binary, log_dir)
 
         # Wait for services

--- a/src/srtctl/cli/setup_head.py
+++ b/src/srtctl/cli/setup_head.py
@@ -119,7 +119,10 @@ def setup_logging():
     )
 
 
-def start_nats(binary_path: str = "/configs/nats-server", max_payload_mb: int | None = None) -> subprocess.Popen:
+def start_nats(
+    binary_path: str = "/configs/nats-server",
+    max_payload_mb: int | None = None,
+) -> subprocess.Popen:
     """Start NATS server.
 
     Args:
@@ -146,7 +149,7 @@ def start_nats(binary_path: str = "/configs/nats-server", max_payload_mb: int | 
         max_payload_bytes = max_payload_mb * 1024 * 1024
         with open(nats_config_path, "w") as f:
             f.write(f"max_payload: {max_payload_bytes}\n")
-            f.write(f"jetstream {{ store_dir: \"{nats_store_dir}\" }}\n")
+            f.write(f'jetstream {{ store_dir: "{nats_store_dir}" }}\n')
         logger.info("Starting NATS server (max_payload: %dMB)...", max_payload_mb)
         cmd = [binary_path, "-c", nats_config_path]
     else:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -840,9 +840,13 @@ class InfraConfig:
         etcd_nats_dedicated_node: If True, run etcd and nats on a dedicated node
             instead of the head node. This reserves the first node exclusively
             for infrastructure services. Default: False.
+        nats_max_payload_mb: Maximum NATS message payload in MB. Default: None (uses
+            NATS default of 1MB). Set to 24+ for disaggregated serving with long ISL
+            (e.g. 65K+ tokens where prompt data exceeds 1MB in NATS messages).
     """
 
     etcd_nats_dedicated_node: bool = False
+    nats_max_payload_mb: int | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
 


### PR DESCRIPTION
## Summary
- Adds `infra.nats_max_payload_mb` config option to recipe YAML
- Default: None (NATS default 1MB). Set to 24+ for long-ISL disaggregated serving
- When set, writes a NATS config file with the custom `max_payload` before starting the server

## Problem
NATS default `max_payload` is 1MB. With disaggregated serving at long ISL (65K+ tokens), the prompt data in NATS messages exceeds 1MB, causing `NATS request timed out: deadline has elapsed` errors on the prefill worker. This was previously fixed in the GTC-2026 fork but never upstreamed.

## Usage
```yaml
infra:
  nats_max_payload_mb: 24  # for long-ISL disagg (65K+ tokens)
```

## Test plan
- [x] Verified NATS starts with `max_payload: 24MB` in job logs on Lyris
- [x] Running Kimi K2.5 disagg benchmark (1P+2D) with this fix — jobs 1454666/1454667

🤖 Generated with [Claude Code](https://claude.com/claude-code)