### PR TITLE
Built-in GPU performance monitoring during benchmarks

### DIFF
--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -16,7 +16,6 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from srtctl.core.config import get_srtslurm_setting
 from srtctl.core.health import wait_for_model
 from srtctl.core.slurm import get_hostname_ip, start_srun_process
 from srtctl.core.status import JobStage, JobStatus, StatusReporter
@@ -137,15 +136,15 @@ class BenchmarkStageMixin:
 
         logger.info("Running %s benchmark", runner.name)
 
-        # Start gweperf on all worker nodes (non-fatal if it fails)
-        perf_procs = self._start_gweperf()
+        # Start perf monitoring on all worker nodes (non-fatal if it fails)
+        perf_procs = self._start_perf_monitor()
 
         # Run the benchmark script
         benchmark_log = self.runtime.log_dir / "benchmark.out"
         exit_code = self._run_benchmark_script(runner, benchmark_log, stop_event)
 
-        # Stop gweperf regardless of benchmark outcome
-        self._stop_gweperf(perf_procs)
+        # Stop monitoring regardless of benchmark outcome
+        self._stop_perf_monitor(perf_procs)
 
         if exit_code != 0:
             logger.error("Benchmark failed with exit code %d", exit_code)
@@ -154,8 +153,8 @@ class BenchmarkStageMixin:
 
         return exit_code
 
-    def _start_gweperf(self) -> list[tuple[str, "subprocess.Popen"]]:
-        """Start one gweperf process per worker node (excluding head node).
+    def _start_perf_monitor(self) -> list[tuple[str, "subprocess.Popen"]]:
+        """Start one perfmon process per worker node (excluding head node).
 
         Failures are non-fatal: a warning is logged and that node is skipped.
 
@@ -166,44 +165,24 @@ class BenchmarkStageMixin:
         if m is None or not m.enabled:
             return []
 
-        gweperf_dir_str = get_srtslurm_setting("gweperf_path")
-        if not gweperf_dir_str:
-            logger.warning("monitoring.enabled=true but gweperf_path not set in srtslurm.yaml - skipping")
-            return []
-
-        gweperf_path = Path(gweperf_dir_str)
-        if not gweperf_path.exists():
-            logger.warning("gweperf directory not found: %s - skipping monitoring", gweperf_path)
-            return []
-
         # All worker nodes except the head (head runs nginx/benchmark client, not GPU workloads)
         worker_nodes = [n for n in self.runtime.nodes.worker if n != self.runtime.nodes.head]
         if not worker_nodes:
             logger.warning("No worker nodes to monitor (all nodes are head node)")
             return []
 
+        perfmon_script = Path(__file__).parent.parent.parent / "monitor" / "perfmon.py"
         mounts = dict(self.runtime.container_mounts)
-        mounts[gweperf_path.resolve()] = Path("/gweperf")
+        mounts[perfmon_script] = Path("/tmp/srt_perfmon.py")
 
         procs: list[tuple[str, subprocess.Popen]] = []
         for node in worker_nodes:
             cmd = [
-                "python3",
-                "/gweperf/gweperfmon.py",
-                "--sampleOutput", f"/logs/perf_samples_{node}.csv",
-                "--cumReportOutput", f"/logs/perf_summary_{node}.json",
-                "--sampleIntervalSec", str(m.sample_interval),
-                "--lifeTimeSec", "86400",
+                "python3", "/tmp/srt_perfmon.py",
+                "--output-csv", f"/logs/perf_samples_{node}.csv",
+                "--output-json", f"/logs/perf_summary_{node}.json",
+                "--interval", str(m.sample_interval),
             ]
-            if m.features.dcgm:
-                cmd.append("--dcgm")
-            if m.features.rapl:
-                cmd.append("--rapl")
-            if m.features.ipmi:
-                cmd.append("--ipmi")
-            if m.features.cpu_pmu:
-                cmd.append("--cpuPmu")
-
             perf_log = self.runtime.log_dir / f"perf_monitor_{node}.out"
             try:
                 proc = start_srun_process(
@@ -214,36 +193,36 @@ class BenchmarkStageMixin:
                     container_mounts=mounts,
                 )
                 procs.append((node, proc))
-                logger.info("gweperf started on %s (interval=%.1fs)", node, m.sample_interval)
+                logger.info("perf monitor started on %s (interval=%.1fs)", node, m.sample_interval)
             except Exception as e:
-                logger.warning("Failed to start gweperf on %s: %s - monitoring skipped for this node", node, e)
+                logger.warning("Failed to start perf monitor on %s: %s - monitoring skipped for this node", node, e)
 
         return procs
 
-    def _stop_gweperf(self, procs: list[tuple[str, "subprocess.Popen"]]) -> None:
-        """Stop all gweperf processes, allowing each to write its cumulative report.
+    def _stop_perf_monitor(self, procs: list[tuple[str, "subprocess.Popen"]]) -> None:
+        """Stop all perfmon processes, allowing each to write its summary JSON.
 
-        Sends SIGINT (triggering gweperf's cleanup handler) and waits up to 30s.
+        Sends SIGINT (triggers perfmon's exit handler) and waits up to 30s.
         Falls back to SIGKILL if the process does not exit cleanly.
         """
         if not procs:
             return
 
-        logger.info("Stopping gweperf monitoring on %d node(s)", len(procs))
+        logger.info("Stopping perf monitoring on %d node(s)", len(procs))
         for node, proc in procs:
             if proc.poll() is not None:
-                logger.warning("gweperf on %s already exited (code %d)", node, proc.returncode)
+                logger.warning("perf monitor on %s already exited (code %d)", node, proc.returncode)
                 continue
             try:
                 proc.send_signal(signal.SIGINT)
             except ProcessLookupError:
-                logger.warning("gweperf on %s vanished before SIGINT", node)
+                logger.warning("perf monitor on %s vanished before SIGINT", node)
                 continue
             try:
                 proc.wait(timeout=30)
-                logger.info("gweperf on %s stopped cleanly", node)
+                logger.info("perf monitor on %s stopped cleanly", node)
             except subprocess.TimeoutExpired:
-                logger.warning("gweperf on %s did not stop within 30s, killing", node)
+                logger.warning("perf monitor on %s did not stop within 30s, killing", node)
                 proc.kill()
                 proc.wait()
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -9,11 +9,14 @@ Handles benchmark execution and profiling.
 
 import logging
 import shlex
+import signal
+import subprocess
 import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from srtctl.core.config import get_srtslurm_setting
 from srtctl.core.health import wait_for_model
 from srtctl.core.slurm import get_hostname_ip, start_srun_process
 from srtctl.core.status import JobStage, JobStatus, StatusReporter
@@ -134,9 +137,15 @@ class BenchmarkStageMixin:
 
         logger.info("Running %s benchmark", runner.name)
 
+        # Start gweperf on all worker nodes (non-fatal if it fails)
+        perf_procs = self._start_gweperf()
+
         # Run the benchmark script
         benchmark_log = self.runtime.log_dir / "benchmark.out"
         exit_code = self._run_benchmark_script(runner, benchmark_log, stop_event)
+
+        # Stop gweperf regardless of benchmark outcome
+        self._stop_gweperf(perf_procs)
 
         if exit_code != 0:
             logger.error("Benchmark failed with exit code %d", exit_code)
@@ -144,6 +153,99 @@ class BenchmarkStageMixin:
             logger.info("Benchmark completed successfully")
 
         return exit_code
+
+    def _start_gweperf(self) -> list[tuple[str, "subprocess.Popen"]]:
+        """Start one gweperf process per worker node (excluding head node).
+
+        Failures are non-fatal: a warning is logged and that node is skipped.
+
+        Returns:
+            List of (node, Popen) pairs for processes that started successfully.
+        """
+        m = self.config.monitoring
+        if m is None or not m.enabled:
+            return []
+
+        gweperf_dir_str = get_srtslurm_setting("gweperf_path")
+        if not gweperf_dir_str:
+            logger.warning("monitoring.enabled=true but gweperf_path not set in srtslurm.yaml - skipping")
+            return []
+
+        gweperf_path = Path(gweperf_dir_str)
+        if not gweperf_path.exists():
+            logger.warning("gweperf directory not found: %s - skipping monitoring", gweperf_path)
+            return []
+
+        # All worker nodes except the head (head runs nginx/benchmark client, not GPU workloads)
+        worker_nodes = [n for n in self.runtime.nodes.worker if n != self.runtime.nodes.head]
+        if not worker_nodes:
+            logger.warning("No worker nodes to monitor (all nodes are head node)")
+            return []
+
+        mounts = dict(self.runtime.container_mounts)
+        mounts[gweperf_path.resolve()] = Path("/gweperf")
+
+        procs: list[tuple[str, subprocess.Popen]] = []
+        for node in worker_nodes:
+            cmd = [
+                "python3",
+                "/gweperf/gweperfmon.py",
+                "--sampleOutput", f"/logs/perf_samples_{node}.csv",
+                "--cumReportOutput", f"/logs/perf_summary_{node}.json",
+                "--sampleIntervalSec", str(m.sample_interval),
+                "--lifeTimeSec", "86400",
+            ]
+            if m.features.dcgm:
+                cmd.append("--dcgm")
+            if m.features.rapl:
+                cmd.append("--rapl")
+            if m.features.ipmi:
+                cmd.append("--ipmi")
+            if m.features.cpu_pmu:
+                cmd.append("--cpuPmu")
+
+            perf_log = self.runtime.log_dir / f"perf_monitor_{node}.out"
+            try:
+                proc = start_srun_process(
+                    command=cmd,
+                    nodelist=[node],
+                    output=str(perf_log),
+                    container_image=str(self.runtime.container_image),
+                    container_mounts=mounts,
+                )
+                procs.append((node, proc))
+                logger.info("gweperf started on %s (interval=%.1fs)", node, m.sample_interval)
+            except Exception as e:
+                logger.warning("Failed to start gweperf on %s: %s - monitoring skipped for this node", node, e)
+
+        return procs
+
+    def _stop_gweperf(self, procs: list[tuple[str, "subprocess.Popen"]]) -> None:
+        """Stop all gweperf processes, allowing each to write its cumulative report.
+
+        Sends SIGINT (triggering gweperf's cleanup handler) and waits up to 30s.
+        Falls back to SIGKILL if the process does not exit cleanly.
+        """
+        if not procs:
+            return
+
+        logger.info("Stopping gweperf monitoring on %d node(s)", len(procs))
+        for node, proc in procs:
+            if proc.poll() is not None:
+                logger.warning("gweperf on %s already exited (code %d)", node, proc.returncode)
+                continue
+            try:
+                proc.send_signal(signal.SIGINT)
+            except ProcessLookupError:
+                logger.warning("gweperf on %s vanished before SIGINT", node)
+                continue
+            try:
+                proc.wait(timeout=30)
+                logger.info("gweperf on %s stopped cleanly", node)
+            except subprocess.TimeoutExpired:
+                logger.warning("gweperf on %s did not stop within 30s, killing", node)
+                proc.kill()
+                proc.wait()
 
     def _run_benchmark_script(
         self,

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -154,7 +154,7 @@ class BenchmarkStageMixin:
         return exit_code
 
     def _start_perf_monitor(self) -> list[tuple[str, "subprocess.Popen"]]:
-        """Start one perfmon process per worker node (excluding head node).
+        """Start one perfmon process per worker node.
 
         Failures are non-fatal: a warning is logged and that node is skipped.
 
@@ -165,10 +165,9 @@ class BenchmarkStageMixin:
         if m is None or not m.enabled:
             return []
 
-        # All worker nodes except the head (head runs nginx/benchmark client, not GPU workloads)
-        worker_nodes = [n for n in self.runtime.nodes.worker if n != self.runtime.nodes.head]
+        worker_nodes = list(self.runtime.nodes.worker)
         if not worker_nodes:
-            logger.warning("No worker nodes to monitor (all nodes are head node)")
+            logger.warning("No worker nodes to monitor")
             return []
 
         perfmon_script = Path(__file__).parent.parent.parent / "monitor" / "perfmon.py"

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -196,6 +196,7 @@ class ClusterConfig:
     # Applied to all jobs on this cluster, useful for cluster-specific paths
     default_mounts: dict[str, str] | None = None
     reporting: ReportingConfig | None = None
+    gweperf_path: str | None = None  # Path to gweperf directory on this cluster
 
     Schema: ClassVar[type[Schema]] = Schema
 
@@ -802,6 +803,38 @@ class OutputConfig:
 
 
 @dataclass(frozen=True)
+class MonitoringFeaturesConfig:
+    """Optional gweperf feature flags (all require elevated privileges or specific hardware)."""
+
+    dcgm: bool = False      # GPU SM/tensor/engine activity (requires nv-hostengine)
+    rapl: bool = False      # CPU package power (requires root + MSR module)
+    ipmi: bool = False      # System-level sensors (requires root + ipmi-sensors)
+    cpu_pmu: bool = False   # CPU performance counters (requires root + Intel CPU)
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
+class MonitoringConfig:
+    """gweperf performance monitoring during benchmark execution.
+
+    When enabled, one gweperf process runs per worker node (excluding the head node)
+    and writes per-node output files to the job log directory:
+      - perf_samples_{node}.csv   per-second time-series (GPU/CPU/memory/network)
+      - perf_summary_{node}.json  aggregate statistics over the benchmark window
+
+    Requires gweperf_path to be set in srtslurm.yaml.
+    Failures are non-fatal: monitoring is skipped for affected nodes, benchmark continues.
+    """
+
+    enabled: bool = True
+    sample_interval: float = 1.0
+    features: MonitoringFeaturesConfig = field(default_factory=MonitoringFeaturesConfig)
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
 class HealthCheckConfig:
     """Health check configuration."""
 
@@ -871,6 +904,9 @@ class SrtConfig:
 
     # Reporting configuration (status API, future: logs to S3, etc.)
     reporting: ReportingConfig | None = None
+
+    # gweperf monitoring (runs on all worker nodes during benchmark)
+    monitoring: MonitoringConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -196,7 +196,6 @@ class ClusterConfig:
     # Applied to all jobs on this cluster, useful for cluster-specific paths
     default_mounts: dict[str, str] | None = None
     reporting: ReportingConfig | None = None
-    gweperf_path: str | None = None  # Path to gweperf directory on this cluster
 
     Schema: ClassVar[type[Schema]] = Schema
 
@@ -803,33 +802,20 @@ class OutputConfig:
 
 
 @dataclass(frozen=True)
-class MonitoringFeaturesConfig:
-    """Optional gweperf feature flags (all require elevated privileges or specific hardware)."""
-
-    dcgm: bool = False      # GPU SM/tensor/engine activity (requires nv-hostengine)
-    rapl: bool = False      # CPU package power (requires root + MSR module)
-    ipmi: bool = False      # System-level sensors (requires root + ipmi-sensors)
-    cpu_pmu: bool = False   # CPU performance counters (requires root + Intel CPU)
-
-    Schema: ClassVar[type[Schema]] = Schema
-
-
-@dataclass(frozen=True)
 class MonitoringConfig:
-    """gweperf performance monitoring during benchmark execution.
+    """Built-in GPU performance monitoring during benchmark execution.
 
-    When enabled, one gweperf process runs per worker node (excluding the head node)
+    When enabled, one perfmon process runs per worker node (excluding the head node)
     and writes per-node output files to the job log directory:
-      - perf_samples_{node}.csv   per-second time-series (GPU/CPU/memory/network)
+      - perf_samples_{node}.csv   per-second time-series (GPU util, memory, power, temp)
       - perf_summary_{node}.json  aggregate statistics over the benchmark window
 
-    Requires gweperf_path to be set in srtslurm.yaml.
+    Uses nvidia-smi — no external dependencies required.
     Failures are non-fatal: monitoring is skipped for affected nodes, benchmark continues.
     """
 
     enabled: bool = True
     sample_interval: float = 1.0
-    features: MonitoringFeaturesConfig = field(default_factory=MonitoringFeaturesConfig)
 
     Schema: ClassVar[type[Schema]] = Schema
 
@@ -905,7 +891,7 @@ class SrtConfig:
     # Reporting configuration (status API, future: logs to S3, etc.)
     reporting: ReportingConfig | None = None
 
-    # gweperf monitoring (runs on all worker nodes during benchmark)
+    # Built-in GPU performance monitoring (runs on all worker nodes during benchmark)
     monitoring: MonitoringConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema

--- a/src/srtctl/monitor/perfmon.py
+++ b/src/srtctl/monitor/perfmon.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight GPU performance monitor.
+
+Polls nvidia-smi at a fixed interval and writes:
+  - per-second CSV samples   (--output-csv)
+  - aggregate summary JSON   (--output-json, written on SIGINT/exit)
+
+Usage:
+    python3 perfmon.py --output-csv /logs/perf_samples_node1.csv \\
+                       --output-json /logs/perf_summary_node1.json \\
+                       --interval 1.0
+"""
+
+import argparse
+import csv
+import json
+import signal
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+_QUERY = "index,utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu"
+_FIELDS = ["gpu", "util_pct", "mem_used_mb", "mem_total_mb", "power_w", "temp_c"]
+
+
+def _sample() -> list[dict]:
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", f"--query-gpu={_QUERY}", "--format=csv,noheader,nounits"],
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+    rows = []
+    for line in out.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) == len(_FIELDS):
+            rows.append(dict(zip(_FIELDS, parts)))
+    return rows
+
+
+def _summarize(samples: list[dict]) -> dict:
+    by_gpu: dict[str, list[dict]] = {}
+    for s in samples:
+        by_gpu.setdefault(s["gpu"], []).append(s)
+
+    summary = {}
+    for gpu_idx, gpu_samples in by_gpu.items():
+
+        def avg(field: str, _s: list[dict] = gpu_samples) -> float | None:
+            vals = [float(s[field]) for s in _s if s.get(field, "").strip() not in ("", "[N/A]")]
+            return round(sum(vals) / len(vals), 2) if vals else None
+
+        summary[f"gpu_{gpu_idx}"] = {
+            "samples": len(gpu_samples),
+            "avg_util_pct": avg("util_pct"),
+            "avg_mem_used_mb": avg("mem_used_mb"),
+            "mem_total_mb": avg("mem_total_mb"),
+            "avg_power_w": avg("power_w"),
+            "avg_temp_c": avg("temp_c"),
+        }
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-csv", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--interval", type=float, default=1.0)
+    args = parser.parse_args()
+
+    samples: list[dict] = []
+    stop = False
+
+    def handle_sigint(sig, frame):
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGINT, handle_sigint)
+
+    with Path(args.output_csv).open("w", newline="") as f:
+        writer: csv.DictWriter | None = None
+        while not stop:
+            ts = datetime.now(timezone.utc).isoformat()
+            for row in _sample():
+                record = {"timestamp": ts, **row}
+                if writer is None:
+                    writer = csv.DictWriter(f, fieldnames=list(record.keys()))
+                    writer.writeheader()
+                writer.writerow(record)
+                samples.append(record)
+            f.flush()
+            time.sleep(args.interval)
+
+    if samples:
+        Path(args.output_json).write_text(json.dumps(_summarize(samples), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for gweperf monitoring configuration and benchmark stage integration."""
+
+import signal
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from srtctl.core.schema import (
+    BenchmarkConfig,
+    ModelConfig,
+    MonitoringConfig,
+    MonitoringFeaturesConfig,
+    ResourceConfig,
+    SrtConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestMonitoringFeaturesConfig:
+    def test_defaults(self):
+        f = MonitoringFeaturesConfig()
+        assert f.dcgm is False
+        assert f.rapl is False
+        assert f.ipmi is False
+        assert f.cpu_pmu is False
+
+    def test_dcgm_only(self):
+        f = MonitoringFeaturesConfig(dcgm=True)
+        assert f.dcgm is True
+        assert f.rapl is False
+
+
+class TestMonitoringConfig:
+    def test_defaults(self):
+        m = MonitoringConfig()
+        assert m.enabled is True
+        assert m.sample_interval == 1.0
+        assert isinstance(m.features, MonitoringFeaturesConfig)
+
+    def test_disabled(self):
+        m = MonitoringConfig(enabled=False)
+        assert m.enabled is False
+
+    def test_custom_interval(self):
+        m = MonitoringConfig(sample_interval=2.5)
+        assert m.sample_interval == 2.5
+
+    def test_yaml_roundtrip(self):
+        """MonitoringConfig round-trips through marshmallow schema."""
+        schema = MonitoringConfig.Schema()
+        data = {"enabled": True, "sample_interval": 0.5, "features": {"dcgm": True}}
+        result = schema.load(data)
+        assert result.enabled is True
+        assert result.sample_interval == 0.5
+        assert result.features.dcgm is True
+
+
+class TestSrtConfigMonitoringField:
+    """SrtConfig accepts monitoring=None (backward compat) and a MonitoringConfig."""
+
+    def _base_config(self, **kwargs) -> SrtConfig:
+        return SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image.sqsh", precision="fp8"),
+            resources=ResourceConfig(gpu_type="h100", agg_nodes=1, agg_workers=1),
+            benchmark=BenchmarkConfig(type="manual"),
+            **kwargs,
+        )
+
+    def test_monitoring_defaults_to_none(self):
+        config = self._base_config()
+        assert config.monitoring is None
+
+    def test_monitoring_accepted(self):
+        config = self._base_config(monitoring=MonitoringConfig())
+        assert config.monitoring is not None
+        assert config.monitoring.enabled is True
+
+    def test_monitoring_disabled(self):
+        config = self._base_config(monitoring=MonitoringConfig(enabled=False))
+        assert config.monitoring.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkStageMixin._start_gweperf / _stop_gweperf
+# ---------------------------------------------------------------------------
+
+
+def _make_orchestrator(monitoring=None):
+    """Build a minimal BenchmarkStageMixin instance for testing."""
+    from srtctl.cli.mixins.benchmark_stage import BenchmarkStageMixin
+    from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+    config = SrtConfig(
+        name="test",
+        model=ModelConfig(path="/model", container="/image.sqsh", precision="fp8"),
+        resources=ResourceConfig(gpu_type="h100", agg_nodes=2, agg_workers=2, gpus_per_node=8),
+        benchmark=BenchmarkConfig(type="sa-bench"),
+        monitoring=monitoring,
+    )
+
+    runtime = MagicMock()
+    runtime.nodes.head = "node0"
+    runtime.nodes.worker = ("node0", "node1", "node2")
+    runtime.container_image = Path("/image.sqsh")
+    runtime.container_mounts = {}
+    runtime.log_dir = Path("/logs/12345")
+
+    # Minimal concrete subclass
+    class Orchestrator(BenchmarkStageMixin):
+        @property
+        def endpoints(self):
+            return []
+
+        @property
+        def backend_processes(self):
+            return []
+
+    orch = Orchestrator.__new__(Orchestrator)
+    orch.config = config
+    orch.runtime = runtime
+    return orch
+
+
+class TestStartGweperf:
+    def test_returns_empty_when_monitoring_is_none(self):
+        orch = _make_orchestrator(monitoring=None)
+        assert orch._start_gweperf() == []
+
+    def test_returns_empty_when_disabled(self):
+        orch = _make_orchestrator(monitoring=MonitoringConfig(enabled=False))
+        assert orch._start_gweperf() == []
+
+    def test_returns_empty_when_gweperf_path_not_set(self):
+        orch = _make_orchestrator(monitoring=MonitoringConfig())
+        with patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=None):
+            result = orch._start_gweperf()
+        assert result == []
+
+    def test_returns_empty_when_gweperf_path_missing(self, tmp_path):
+        orch = _make_orchestrator(monitoring=MonitoringConfig())
+        missing = str(tmp_path / "nonexistent")
+        with patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=missing):
+            result = orch._start_gweperf()
+        assert result == []
+
+    def test_starts_one_proc_per_worker_node_excluding_head(self, tmp_path):
+        """Starts gweperf on node1 and node2 (not node0=head)."""
+        gweperf_dir = tmp_path / "gweperf"
+        gweperf_dir.mkdir()
+
+        orch = _make_orchestrator(monitoring=MonitoringConfig())
+        mock_proc = MagicMock()
+
+        with (
+            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
+            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun,
+        ):
+            result = orch._start_gweperf()
+
+        assert len(result) == 2
+        nodes = [node for node, _ in result]
+        assert "node0" not in nodes
+        assert "node1" in nodes
+        assert "node2" in nodes
+
+    def test_output_paths_keyed_by_hostname(self, tmp_path):
+        """perf_samples and perf_summary files are named with the node hostname."""
+        gweperf_dir = tmp_path / "gweperf"
+        gweperf_dir.mkdir()
+
+        orch = _make_orchestrator(monitoring=MonitoringConfig())
+        mock_proc = MagicMock()
+
+        with (
+            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
+            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun,
+        ):
+            orch._start_gweperf()
+
+        all_cmds = [c.kwargs["command"] for c in mock_srun.call_args_list]
+        for node in ("node1", "node2"):
+            node_cmds = [cmd for cmd in all_cmds if any(node in arg for arg in cmd)]
+            assert any(f"perf_samples_{node}.csv" in arg for arg in node_cmds[0])
+            assert any(f"perf_summary_{node}.json" in arg for arg in node_cmds[0])
+
+    def test_feature_flags_appended_to_command(self, tmp_path):
+        """dcgm/rapl/ipmi/cpu_pmu flags are passed to gweperfmon.py."""
+        gweperf_dir = tmp_path / "gweperf"
+        gweperf_dir.mkdir()
+
+        features = MonitoringFeaturesConfig(dcgm=True, rapl=True)
+        orch = _make_orchestrator(monitoring=MonitoringConfig(features=features))
+        mock_proc = MagicMock()
+
+        with (
+            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
+            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun,
+        ):
+            orch._start_gweperf()
+
+        for c in mock_srun.call_args_list:
+            cmd = c.kwargs["command"]
+            assert "--dcgm" in cmd
+            assert "--rapl" in cmd
+            assert "--ipmi" not in cmd
+            assert "--cpuPmu" not in cmd
+
+    def test_failed_node_is_skipped(self, tmp_path):
+        """If start_srun_process raises on one node, others still start."""
+        gweperf_dir = tmp_path / "gweperf"
+        gweperf_dir.mkdir()
+
+        orch = _make_orchestrator(monitoring=MonitoringConfig())
+        mock_proc = MagicMock()
+
+        def srun_side_effect(**kwargs):
+            if kwargs["nodelist"] == ["node1"]:
+                raise RuntimeError("srun failed")
+            return mock_proc
+
+        with (
+            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
+            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", side_effect=srun_side_effect),
+        ):
+            result = orch._start_gweperf()
+
+        assert len(result) == 1
+        assert result[0][0] == "node2"
+
+    def test_gweperf_mounted_in_container(self, tmp_path):
+        """gweperf directory is added to container mounts."""
+        gweperf_dir = tmp_path / "gweperf"
+        gweperf_dir.mkdir()
+
+        orch = _make_orchestrator(monitoring=MonitoringConfig())
+        mock_proc = MagicMock()
+
+        with (
+            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
+            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun,
+        ):
+            orch._start_gweperf()
+
+        for c in mock_srun.call_args_list:
+            mounts = c.kwargs["container_mounts"]
+            assert Path("/gweperf") in mounts.values()
+
+
+class TestStopGweperf:
+    def test_noop_on_empty_list(self):
+        orch = _make_orchestrator()
+        orch._stop_gweperf([])  # should not raise
+
+    def test_sends_sigint_to_running_process(self):
+        orch = _make_orchestrator()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # still running
+        mock_proc.wait.return_value = 0
+
+        orch._stop_gweperf([("node1", mock_proc)])
+
+        mock_proc.send_signal.assert_called_once_with(signal.SIGINT)
+        mock_proc.wait.assert_called_once_with(timeout=30)
+
+    def test_skips_already_exited_process(self):
+        orch = _make_orchestrator()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 0  # already done
+        mock_proc.returncode = 0
+
+        orch._stop_gweperf([("node1", mock_proc)])
+
+        mock_proc.send_signal.assert_not_called()
+
+    def test_kills_process_on_timeout(self):
+        orch = _make_orchestrator()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        # First call (with timeout=) raises; second call (bare wait after kill) returns normally
+        mock_proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="gweperf", timeout=30), None]
+
+        orch._stop_gweperf([("node1", mock_proc)])
+
+        mock_proc.kill.assert_called_once()
+
+    def test_handles_process_lookup_error(self):
+        """Process vanished between poll() and send_signal() — should not raise."""
+        orch = _make_orchestrator()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.send_signal.side_effect = ProcessLookupError
+
+        orch._stop_gweperf([("node1", mock_proc)])  # must not raise
+
+    def test_stops_all_nodes(self):
+        orch = _make_orchestrator()
+        procs = []
+        for node in ("node1", "node2", "node3"):
+            mock_proc = MagicMock()
+            mock_proc.poll.return_value = None
+            mock_proc.wait.return_value = 0
+            procs.append((node, mock_proc))
+
+        orch._stop_gweperf(procs)
+
+        for _, mock_proc in procs:
+            mock_proc.send_signal.assert_called_once_with(signal.SIGINT)

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -113,17 +113,17 @@ class TestStartPerfMonitor:
     def test_returns_empty_when_disabled(self):
         assert _make_orchestrator(monitoring=MonitoringConfig(enabled=False))._start_perf_monitor() == []
 
-    def test_starts_one_proc_per_worker_node_excluding_head(self):
-        """Starts perfmon on node1 and node2 (not node0=head)."""
+    def test_starts_one_proc_per_worker_node_including_head(self):
+        """Starts perfmon on all worker nodes including head (node0)."""
         orch = _make_orchestrator(monitoring=MonitoringConfig())
         mock_proc = MagicMock()
 
         with patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun:
             result = orch._start_perf_monitor()
 
-        assert len(result) == 2
+        assert len(result) == 3
         nodes = [node for node, _ in result]
-        assert "node0" not in nodes
+        assert "node0" in nodes
         assert "node1" in nodes
         assert "node2" in nodes
 
@@ -135,7 +135,7 @@ class TestStartPerfMonitor:
             orch._start_perf_monitor()
 
         all_cmds = [c.kwargs["command"] for c in mock_srun.call_args_list]
-        for node in ("node1", "node2"):
+        for node in ("node0", "node1", "node2"):
             node_cmds = [cmd for cmd in all_cmds if any(node in arg for arg in cmd)]
             assert any(f"perf_samples_{node}.csv" in arg for arg in node_cmds[0])
             assert any(f"perf_summary_{node}.json" in arg for arg in node_cmds[0])
@@ -163,8 +163,10 @@ class TestStartPerfMonitor:
         with patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", side_effect=srun_side_effect):
             result = orch._start_perf_monitor()
 
-        assert len(result) == 1
-        assert result[0][0] == "node2"
+        assert len(result) == 2
+        nodes = [node for node, _ in result]
+        assert "node0" in nodes
+        assert "node2" in nodes
 
 
 class TestStopPerfMonitor:

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for gweperf monitoring configuration and benchmark stage integration."""
+"""Tests for built-in GPU performance monitoring configuration and benchmark stage integration."""
 
 import signal
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -14,7 +14,6 @@ from srtctl.core.schema import (
     BenchmarkConfig,
     ModelConfig,
     MonitoringConfig,
-    MonitoringFeaturesConfig,
     ResourceConfig,
     SrtConfig,
 )
@@ -25,26 +24,11 @@ from srtctl.core.schema import (
 # ---------------------------------------------------------------------------
 
 
-class TestMonitoringFeaturesConfig:
-    def test_defaults(self):
-        f = MonitoringFeaturesConfig()
-        assert f.dcgm is False
-        assert f.rapl is False
-        assert f.ipmi is False
-        assert f.cpu_pmu is False
-
-    def test_dcgm_only(self):
-        f = MonitoringFeaturesConfig(dcgm=True)
-        assert f.dcgm is True
-        assert f.rapl is False
-
-
 class TestMonitoringConfig:
     def test_defaults(self):
         m = MonitoringConfig()
         assert m.enabled is True
         assert m.sample_interval == 1.0
-        assert isinstance(m.features, MonitoringFeaturesConfig)
 
     def test_disabled(self):
         m = MonitoringConfig(enabled=False)
@@ -55,18 +39,13 @@ class TestMonitoringConfig:
         assert m.sample_interval == 2.5
 
     def test_yaml_roundtrip(self):
-        """MonitoringConfig round-trips through marshmallow schema."""
         schema = MonitoringConfig.Schema()
-        data = {"enabled": True, "sample_interval": 0.5, "features": {"dcgm": True}}
-        result = schema.load(data)
+        result = schema.load({"enabled": True, "sample_interval": 0.5})
         assert result.enabled is True
         assert result.sample_interval == 0.5
-        assert result.features.dcgm is True
 
 
 class TestSrtConfigMonitoringField:
-    """SrtConfig accepts monitoring=None (backward compat) and a MonitoringConfig."""
-
     def _base_config(self, **kwargs) -> SrtConfig:
         return SrtConfig(
             name="test",
@@ -77,8 +56,7 @@ class TestSrtConfigMonitoringField:
         )
 
     def test_monitoring_defaults_to_none(self):
-        config = self._base_config()
-        assert config.monitoring is None
+        assert self._base_config().monitoring is None
 
     def test_monitoring_accepted(self):
         config = self._base_config(monitoring=MonitoringConfig())
@@ -91,14 +69,12 @@ class TestSrtConfigMonitoringField:
 
 
 # ---------------------------------------------------------------------------
-# BenchmarkStageMixin._start_gweperf / _stop_gweperf
+# BenchmarkStageMixin._start_perf_monitor / _stop_perf_monitor
 # ---------------------------------------------------------------------------
 
 
 def _make_orchestrator(monitoring=None):
-    """Build a minimal BenchmarkStageMixin instance for testing."""
     from srtctl.cli.mixins.benchmark_stage import BenchmarkStageMixin
-    from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
 
     config = SrtConfig(
         name="test",
@@ -115,7 +91,6 @@ def _make_orchestrator(monitoring=None):
     runtime.container_mounts = {}
     runtime.log_dir = Path("/logs/12345")
 
-    # Minimal concrete subclass
     class Orchestrator(BenchmarkStageMixin):
         @property
         def endpoints(self):
@@ -131,41 +106,20 @@ def _make_orchestrator(monitoring=None):
     return orch
 
 
-class TestStartGweperf:
+class TestStartPerfMonitor:
     def test_returns_empty_when_monitoring_is_none(self):
-        orch = _make_orchestrator(monitoring=None)
-        assert orch._start_gweperf() == []
+        assert _make_orchestrator(monitoring=None)._start_perf_monitor() == []
 
     def test_returns_empty_when_disabled(self):
-        orch = _make_orchestrator(monitoring=MonitoringConfig(enabled=False))
-        assert orch._start_gweperf() == []
+        assert _make_orchestrator(monitoring=MonitoringConfig(enabled=False))._start_perf_monitor() == []
 
-    def test_returns_empty_when_gweperf_path_not_set(self):
-        orch = _make_orchestrator(monitoring=MonitoringConfig())
-        with patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=None):
-            result = orch._start_gweperf()
-        assert result == []
-
-    def test_returns_empty_when_gweperf_path_missing(self, tmp_path):
-        orch = _make_orchestrator(monitoring=MonitoringConfig())
-        missing = str(tmp_path / "nonexistent")
-        with patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=missing):
-            result = orch._start_gweperf()
-        assert result == []
-
-    def test_starts_one_proc_per_worker_node_excluding_head(self, tmp_path):
-        """Starts gweperf on node1 and node2 (not node0=head)."""
-        gweperf_dir = tmp_path / "gweperf"
-        gweperf_dir.mkdir()
-
+    def test_starts_one_proc_per_worker_node_excluding_head(self):
+        """Starts perfmon on node1 and node2 (not node0=head)."""
         orch = _make_orchestrator(monitoring=MonitoringConfig())
         mock_proc = MagicMock()
 
-        with (
-            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
-            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun,
-        ):
-            result = orch._start_gweperf()
+        with patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun:
+            result = orch._start_perf_monitor()
 
         assert len(result) == 2
         nodes = [node for node, _ in result]
@@ -173,19 +127,12 @@ class TestStartGweperf:
         assert "node1" in nodes
         assert "node2" in nodes
 
-    def test_output_paths_keyed_by_hostname(self, tmp_path):
-        """perf_samples and perf_summary files are named with the node hostname."""
-        gweperf_dir = tmp_path / "gweperf"
-        gweperf_dir.mkdir()
-
+    def test_output_paths_keyed_by_hostname(self):
         orch = _make_orchestrator(monitoring=MonitoringConfig())
         mock_proc = MagicMock()
 
-        with (
-            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
-            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun,
-        ):
-            orch._start_gweperf()
+        with patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun:
+            orch._start_perf_monitor()
 
         all_cmds = [c.kwargs["command"] for c in mock_srun.call_args_list]
         for node in ("node1", "node2"):
@@ -193,33 +140,18 @@ class TestStartGweperf:
             assert any(f"perf_samples_{node}.csv" in arg for arg in node_cmds[0])
             assert any(f"perf_summary_{node}.json" in arg for arg in node_cmds[0])
 
-    def test_feature_flags_appended_to_command(self, tmp_path):
-        """dcgm/rapl/ipmi/cpu_pmu flags are passed to gweperfmon.py."""
-        gweperf_dir = tmp_path / "gweperf"
-        gweperf_dir.mkdir()
-
-        features = MonitoringFeaturesConfig(dcgm=True, rapl=True)
-        orch = _make_orchestrator(monitoring=MonitoringConfig(features=features))
+    def test_perfmon_script_mounted_in_container(self):
+        orch = _make_orchestrator(monitoring=MonitoringConfig())
         mock_proc = MagicMock()
 
-        with (
-            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
-            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun,
-        ):
-            orch._start_gweperf()
+        with patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun:
+            orch._start_perf_monitor()
 
         for c in mock_srun.call_args_list:
-            cmd = c.kwargs["command"]
-            assert "--dcgm" in cmd
-            assert "--rapl" in cmd
-            assert "--ipmi" not in cmd
-            assert "--cpuPmu" not in cmd
+            mounts = c.kwargs["container_mounts"]
+            assert Path("/tmp/srt_perfmon.py") in mounts.values()
 
-    def test_failed_node_is_skipped(self, tmp_path):
-        """If start_srun_process raises on one node, others still start."""
-        gweperf_dir = tmp_path / "gweperf"
-        gweperf_dir.mkdir()
-
+    def test_failed_node_is_skipped(self):
         orch = _make_orchestrator(monitoring=MonitoringConfig())
         mock_proc = MagicMock()
 
@@ -228,46 +160,24 @@ class TestStartGweperf:
                 raise RuntimeError("srun failed")
             return mock_proc
 
-        with (
-            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
-            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", side_effect=srun_side_effect),
-        ):
-            result = orch._start_gweperf()
+        with patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", side_effect=srun_side_effect):
+            result = orch._start_perf_monitor()
 
         assert len(result) == 1
         assert result[0][0] == "node2"
 
-    def test_gweperf_mounted_in_container(self, tmp_path):
-        """gweperf directory is added to container mounts."""
-        gweperf_dir = tmp_path / "gweperf"
-        gweperf_dir.mkdir()
 
-        orch = _make_orchestrator(monitoring=MonitoringConfig())
-        mock_proc = MagicMock()
-
-        with (
-            patch("srtctl.cli.mixins.benchmark_stage.get_srtslurm_setting", return_value=str(gweperf_dir)),
-            patch("srtctl.cli.mixins.benchmark_stage.start_srun_process", return_value=mock_proc) as mock_srun,
-        ):
-            orch._start_gweperf()
-
-        for c in mock_srun.call_args_list:
-            mounts = c.kwargs["container_mounts"]
-            assert Path("/gweperf") in mounts.values()
-
-
-class TestStopGweperf:
+class TestStopPerfMonitor:
     def test_noop_on_empty_list(self):
-        orch = _make_orchestrator()
-        orch._stop_gweperf([])  # should not raise
+        _make_orchestrator()._stop_perf_monitor([])
 
     def test_sends_sigint_to_running_process(self):
         orch = _make_orchestrator()
         mock_proc = MagicMock()
-        mock_proc.poll.return_value = None  # still running
+        mock_proc.poll.return_value = None
         mock_proc.wait.return_value = 0
 
-        orch._stop_gweperf([("node1", mock_proc)])
+        orch._stop_perf_monitor([("node1", mock_proc)])
 
         mock_proc.send_signal.assert_called_once_with(signal.SIGINT)
         mock_proc.wait.assert_called_once_with(timeout=30)
@@ -275,10 +185,10 @@ class TestStopGweperf:
     def test_skips_already_exited_process(self):
         orch = _make_orchestrator()
         mock_proc = MagicMock()
-        mock_proc.poll.return_value = 0  # already done
+        mock_proc.poll.return_value = 0
         mock_proc.returncode = 0
 
-        orch._stop_gweperf([("node1", mock_proc)])
+        orch._stop_perf_monitor([("node1", mock_proc)])
 
         mock_proc.send_signal.assert_not_called()
 
@@ -286,21 +196,19 @@ class TestStopGweperf:
         orch = _make_orchestrator()
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
-        # First call (with timeout=) raises; second call (bare wait after kill) returns normally
-        mock_proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="gweperf", timeout=30), None]
+        mock_proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="perfmon", timeout=30), None]
 
-        orch._stop_gweperf([("node1", mock_proc)])
+        orch._stop_perf_monitor([("node1", mock_proc)])
 
         mock_proc.kill.assert_called_once()
 
     def test_handles_process_lookup_error(self):
-        """Process vanished between poll() and send_signal() — should not raise."""
         orch = _make_orchestrator()
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
         mock_proc.send_signal.side_effect = ProcessLookupError
 
-        orch._stop_gweperf([("node1", mock_proc)])  # must not raise
+        orch._stop_perf_monitor([("node1", mock_proc)])  # must not raise
 
     def test_stops_all_nodes(self):
         orch = _make_orchestrator()
@@ -311,7 +219,7 @@ class TestStopGweperf:
             mock_proc.wait.return_value = 0
             procs.append((node, mock_proc))
 
-        orch._stop_gweperf(procs)
+        orch._stop_perf_monitor(procs)
 
         for _, mock_proc in procs:
             mock_proc.send_signal.assert_called_once_with(signal.SIGINT)


### PR DESCRIPTION
## Summary
- Add lightweight GPU performance monitor (`perfmon.py`) that polls nvidia-smi during benchmarks, writing per-node CSV time-series (util, memory, power, temp) and aggregate JSON summaries
- Monitor all worker nodes including the head node (head runs GPU workers in most topologies)
- Auto-resolve HF hub cache snapshot directories in sa-bench and mooncake-router benchmark scripts, fixing tokenizer loading when `model.path` points to a hub cache root with symlinked snapshots
## Test plan
- [x] `tests/test_monitoring.py` — 19 tests passing
- [ ] E2E: verify `perf_samples_{node}.csv` appears for all nodes including head
- [ ] Verify tokenizer resolution with HF hub cache model directories