### PR TITLE
Sanitize srun output in node IP resolution

### DIFF
--- a/src/srtctl/core/ip_utils/get_node_ip.sh
+++ b/src/srtctl/core/ip_utils/get_node_ip.sh
@@ -175,7 +175,7 @@ get_node_ip() {
 
         exit 1
     "
-
+    # Execute the script on target node with single srun command
     local result
     result=$(srun --quiet --jobid "$slurm_job_id" --nodes=1 --ntasks=1 --nodelist="$node" bash -c "$ip_script" 2>&1)
     local rc=$?

--- a/src/srtctl/core/ip_utils/get_node_ip.sh
+++ b/src/srtctl/core/ip_utils/get_node_ip.sh
@@ -176,13 +176,14 @@ get_node_ip() {
         exit 1
     "
 
-    # Execute the script on target node with single srun command
     local result
-    result=$(srun --jobid $slurm_job_id --nodes=1 --ntasks=1 --nodelist=$node bash -c "$ip_script" 2>&1)
+    result=$(srun --quiet --jobid "$slurm_job_id" --nodes=1 --ntasks=1 --nodelist="$node" bash -c "$ip_script" 2>&1)
     local rc=$?
+    local ip
+    ip=$(printf '%s\n' "$result" | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' | tail -n 1)
 
-    if [ $rc -eq 0 ] && [ -n "$result" ]; then
-        echo "$result"
+    if [ $rc -eq 0 ] && [ -n "$ip" ]; then
+        echo "$ip"
         return 0
     else
         echo "Error: Could not retrieve IP address for node $node" >&2

--- a/src/srtctl/core/ip_utils/get_node_ip.sh
+++ b/src/srtctl/core/ip_utils/get_node_ip.sh
@@ -175,6 +175,7 @@ get_node_ip() {
 
         exit 1
     "
+
     # Execute the script on target node with single srun command
     local result
     result=$(srun --quiet --jobid "$slurm_job_id" --nodes=1 --ntasks=1 --nodelist="$node" bash -c "$ip_script" 2>&1)

--- a/tests/test_ip_utils.py
+++ b/tests/test_ip_utils.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for IP address resolution helpers."""
+
+import os
+
+from srtctl.core.ip_utils import get_node_ip
+
+
+def test_get_node_ip_ignores_srun_step_created_output(tmp_path, monkeypatch):
+    """get_node_ip() should ignore SLURM informational lines mixed into output."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    fake_srun = fake_bin / "srun"
+    fake_srun.write_text(
+        "#!/bin/bash\n"
+        "echo 'srun: Step created for StepId=2279904.27' >&2\n"
+        "echo '10.109.25.246'\n",
+        encoding="ascii",
+    )
+    fake_srun.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+
+    ip = get_node_ip("nvl72156-T15", slurm_job_id="2279904")
+
+    assert ip == "10.109.25.246"


### PR DESCRIPTION
• ## Summary
  - sanitize `srun` output when resolving remote node IPs
  - extract the resolved IPv4 address instead of returning the raw combined `stdout`/`stderr`
  - add a regression test for `srun: Step created ...` output contaminating IP resolution

  ## Root Cause
  Some SLURM environments emit informational lines like `srun: Step created for StepId=...` while resolving node IPs. That text was being returned verbatim from
  `get_node_ip()`, which then polluted distributed addresses such as `--dist-init-addr` and caused downstream ZMQ failures.
