### PR TITLE
Add lm-eval benchmark runner for evals

### DIFF
--- a/docs/accuracy.md
+++ b/docs/accuracy.md
@@ -1,6 +1,6 @@
 # Accuracy Benchmarks
 
-In srt-slurm, users can run different accuracy benchmarks by setting the benchmark section in the config yaml file. Supported benchmarks include `mmlu`, `gpqa` and `longbenchv2`.
+In srt-slurm, users can run different accuracy benchmarks by setting the benchmark section in the config yaml file. Supported benchmarks include `mmlu`, `gpqa`, `longbenchv2`, and `lm-eval`.
 
 ## Table of Contents
 
@@ -14,6 +14,7 @@ In srt-slurm, users can run different accuracy benchmarks by setting the benchma
   - [Example: Quick Validation](#example-quick-validation)
   - [Output](#output)
   - [Important Notes](#important-notes)
+- [lm-eval](#lm-eval)
 
 ---
 
@@ -191,3 +192,83 @@ The output includes per-category scores and aggregate metrics:
 4. **Categories**: Running specific categories is useful for targeted validation (e.g., just testing summarization capabilities)
 
 
+## lm-eval
+
+The `lm-eval` benchmark runner integrates [EleutherAI/lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) against the deployed OpenAI-compatible endpoint. By default, the runner invokes the `lm_eval` CLI directly (installing the `lm-eval` pip package on demand when it isn't already present in the container). An external eval workspace that exposes a compatible `benchmark_lib.sh` can be plugged in instead — see [External eval harness](#external-eval-harness) below.
+
+### How it works
+
+1. `do_sweep.py` starts infrastructure, workers, and the frontend for the normal recipe topology.
+2. For `EVAL_ONLY=true`, `do_sweep.py` skips the throughput benchmark stage and runs `_run_post_eval()` directly after frontend startup.
+3. `_run_post_eval()` waits for the OpenAI-compatible endpoint on port 8000 and, in eval-only mode, performs the full `wait_for_model()` health check for the configured prefill/decode or aggregated topology.
+4. `_run_post_eval()` launches the registered `lm-eval` runner on the head node.
+5. The runner script (`benchmarks/scripts/lm-eval/bench.sh`) uses `MODEL_NAME` from `do_sweep.py`, or auto-discovers the served model from `/v1/models` as a fallback.
+6. The runner calls `lm_eval --model local-chat-completions --model_args base_url=<endpoint>/v1/chat/completions,model=<MODEL_NAME>,num_concurrent=<EVAL_CONCURRENT_REQUESTS>,tokenized_requests=False --tasks <LM_EVAL_TASKS>` and writes results to `/logs/eval_results/`.
+
+### EVAL_ONLY mode
+
+srt-slurm supports an `EVAL_ONLY` mode for jobs that should only validate accuracy. It is controlled by environment variables:
+
+| Env var | Description |
+|---------|-------------|
+| `EVAL_ONLY` | Set to `true` to skip the throughput benchmark stage and run eval only |
+| `RUN_EVAL` | Set to `true` to run eval after the throughput benchmark completes |
+| `EVAL_CONC` | Concurrent requests for lm-eval; falls back to max of the recipe benchmark concurrency list |
+| `MODEL_NAME` | Served model alias for OpenAI-compatible requests; set by `do_sweep.py` from `config.served_model_name` |
+| `LM_EVAL_TASKS` | Comma-separated lm-evaluation-harness tasks (default: `gsm8k`) |
+| `LM_EVAL_MODEL` | lm-evaluation-harness model type (default: `local-chat-completions`) |
+| `LM_EVAL_EXTRA_ARGS` | Extra flags appended to the `lm_eval` command line |
+| `EVAL_OUTPUT_DIR` | Where eval artifacts are written inside the container (default: `/logs/eval_results`) |
+
+When `EVAL_ONLY=true`:
+- Stage 4 skips the throughput benchmark entirely. No throughput result JSON is expected from srt-slurm.
+- The eval path uses the full `wait_for_model()` health check before starting lm-eval.
+- `_run_post_eval()` launches the `lm-eval` runner and returns its exit code.
+- Eval failure is fatal because eval is the only purpose of the job.
+
+When `RUN_EVAL=true` (without `EVAL_ONLY`):
+- Throughput benchmark runs normally.
+- After benchmark completes successfully, eval runs as a post-step.
+- Eval failure is non-fatal; the benchmark job still succeeds if throughput passed.
+
+### Topology metadata passthrough
+
+`do_sweep.py` also forwards a set of topology/precision env vars to the eval container so downstream aggregation tooling can record them alongside the eval results:
+
+| Env var | Purpose |
+|---------|---------|
+| `RUN_EVAL`, `EVAL_ONLY`, `IS_MULTINODE` | Whether eval runs and how artifacts are classified |
+| `FRAMEWORK`, `PRECISION`, `MODEL_PREFIX`, `RUNNER_TYPE`, `SPEC_DECODING` | Benchmark identity metadata |
+| `ISL`, `OSL`, `RESULT_FILENAME` | Sequence length and result-file metadata |
+| `MODEL`, `MODEL_PATH`, `MODEL_NAME` | Model metadata and the served model alias |
+| `MAX_MODEL_LEN`, `EVAL_MAX_MODEL_LEN` | Context-length metadata |
+| `PREFILL_TP`, `PREFILL_EP`, `PREFILL_NUM_WORKERS`, `PREFILL_DP_ATTN` | Prefill-side topology metadata |
+| `DECODE_TP`, `DECODE_EP`, `DECODE_NUM_WORKERS`, `DECODE_DP_ATTN` | Decode-side topology metadata |
+| `EVAL_CONC`, `EVAL_CONCURRENT_REQUESTS` | Eval concurrency controls |
+
+These variables are optional: they are passed through only when the launcher sets them, and the default lm-eval path works without any of them.
+
+### Concurrency
+
+The runner exports `EVAL_CONCURRENT_REQUESTS`, preferring `EVAL_CONC` when set and falling back to `256`:
+
+```bash
+export EVAL_CONCURRENT_REQUESTS="${EVAL_CONC:-${EVAL_CONCURRENT_REQUESTS:-256}}"
+```
+
+When `EVAL_CONC` is not set, `do_sweep.py` defaults it to the max of the recipe benchmark concurrency list.
+
+### Output
+
+Eval artifacts are written to `/logs/eval_results/` inside the container (override with `EVAL_OUTPUT_DIR`):
+- `results*.json` - lm-eval scores per task
+- `sample*.jsonl` - per-sample outputs (when the harness emits them)
+
+### External eval harness
+
+If the launcher needs to drive lm-eval through an existing `benchmark_lib.sh` (for example, an internal evaluation library that also handles summary generation), mount that workspace into the container and point the runner at it with one of:
+
+- `LM_EVAL_LIB` - absolute container path to the `benchmark_lib.sh` file.
+- `LM_EVAL_WORKSPACE` - host path to a workspace; it is mounted at `/lm-eval-workspace` inside the container, and the runner sources `/lm-eval-workspace/benchmarks/benchmark_lib.sh`.
+
+When a `benchmark_lib.sh` is found, the runner sources it, calls `run_eval --framework lm-eval` and (if exported) `append_lm_eval_summary`, and copies `meta_env.json`, `results*.json`, and `sample*.jsonl` from the CWD into `EVAL_OUTPUT_DIR`. Otherwise, the default in-container `lm_eval` CLI path is used.

--- a/src/srtctl/benchmarks/__init__.py
+++ b/src/srtctl/benchmarks/__init__.py
@@ -8,6 +8,7 @@ from srtctl.benchmarks import (
     custom,
     gpqa,
     gsm8k,
+    lm_eval,
     longbenchv2,
     mmlu,
     mooncake_router,
@@ -30,6 +31,7 @@ __all__ = [
     "register_benchmark",
     # Runners
     "custom",
+    "lm_eval",
     "sa_bench",
     "sglang_bench",
     "mmlu",

--- a/src/srtctl/benchmarks/lm_eval.py
+++ b/src/srtctl/benchmarks/lm_eval.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 SemiAnalysis LLC. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""lm-eval benchmark runner.
+
+Runs the EleutherAI lm-evaluation-harness against the deployed OpenAI-compatible
+endpoint. An external harness that exposes ``benchmark_lib.sh`` is used instead
+when available — either via the ``LM_EVAL_LIB`` env var, or a workspace mounted
+at ``/lm-eval-workspace`` (set host-side with ``LM_EVAL_WORKSPACE``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import SrtConfig
+
+
+@register_benchmark("lm-eval")
+class LMEvalRunner(BenchmarkRunner):
+    """lm-eval accuracy evaluation runner."""
+
+    @property
+    def name(self) -> str:
+        return "lm-eval"
+
+    @property
+    def script_path(self) -> str:
+        return "/srtctl-benchmarks/lm-eval/bench.sh"
+
+    @property
+    def local_script_dir(self) -> str:
+        return str(SCRIPTS_DIR / "lm-eval")
+
+    def validate_config(self, config: SrtConfig) -> list[str]:
+        # lm-eval has sensible defaults.
+        return []
+
+    def build_command(
+        self,
+        config: SrtConfig,
+        runtime: RuntimeContext,
+    ) -> list[str]:
+        endpoint = f"http://localhost:{runtime.frontend_port}"
+        return [
+            "bash",
+            self.script_path,
+            endpoint,
+        ]

--- a/src/srtctl/benchmarks/scripts/lm-eval/bench.sh
+++ b/src/srtctl/benchmarks/scripts/lm-eval/bench.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 SemiAnalysis LLC. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# lm-eval accuracy evaluation.
+#
+# By default runs the EleutherAI lm-evaluation-harness CLI directly against
+# the OpenAI-compatible endpoint. If an external eval harness is mounted at
+# /lm-eval-workspace (or pointed to via LM_EVAL_LIB) and exposes a compatible
+# benchmark_lib.sh, that harness is sourced and used instead.
+#
+# Expects: endpoint
+
+set -e
+
+ENDPOINT=$1
+
+# Extract HOST and PORT from endpoint (e.g., http://localhost:8000)
+HOST=$(echo "$ENDPOINT" | sed -E 's|https?://||; s|:.*||')
+PORT=$(echo "$ENDPOINT" | sed -E 's|.*:([0-9]+).*|\1|')
+
+echo "lm-eval config: endpoint=${ENDPOINT}; host=${HOST}; port=${PORT}"
+
+# Auto-discover the served model name from /v1/models if MODEL_NAME is not set.
+# This ensures we use the exact name the server recognizes, regardless of what
+# $MODEL (a HuggingFace ID from the launcher) is set to.
+if [[ -z "${MODEL_NAME:-}" ]]; then
+    DISCOVERED_MODEL=$(curl -sf "${ENDPOINT}/v1/models" 2>/dev/null \
+        | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['data'][0]['id'])" 2>/dev/null || true)
+    if [[ -n "$DISCOVERED_MODEL" ]]; then
+        export MODEL_NAME="$DISCOVERED_MODEL"
+        echo "Auto-discovered MODEL_NAME from /v1/models: ${MODEL_NAME}"
+    else
+        echo "WARNING: Could not discover model name from /v1/models, using MODEL_NAME=${MODEL_NAME:-$MODEL}"
+    fi
+else
+    echo "Using MODEL_NAME from environment: ${MODEL_NAME}"
+fi
+
+# Output directory for eval artifacts. Override with EVAL_OUTPUT_DIR.
+EVAL_OUTPUT_DIR="${EVAL_OUTPUT_DIR:-/logs/eval_results}"
+mkdir -p "${EVAL_OUTPUT_DIR}"
+
+# Concurrency. Prefer EVAL_CONC (set by orchestration) over EVAL_CONCURRENT_REQUESTS.
+export EVAL_CONCURRENT_REQUESTS="${EVAL_CONC:-${EVAL_CONCURRENT_REQUESTS:-256}}"
+echo "Running lm-eval with concurrent-requests=${EVAL_CONCURRENT_REQUESTS}..."
+
+eval_rc=0
+
+# Let a host-provided harness take over if one is mounted. LM_EVAL_LIB points
+# at a benchmark_lib.sh directly; otherwise we look for one at the standard
+# /lm-eval-workspace mount point.
+EXT_LIB="${LM_EVAL_LIB:-}"
+if [[ -z "$EXT_LIB" && -f "/lm-eval-workspace/benchmarks/benchmark_lib.sh" ]]; then
+    EXT_LIB="/lm-eval-workspace/benchmarks/benchmark_lib.sh"
+fi
+
+if [[ -n "$EXT_LIB" && -f "$EXT_LIB" ]]; then
+    echo "Using external eval harness: $EXT_LIB"
+    # cd to the workspace root so relative paths (utils/evals/*.yaml) resolve.
+    cd "$(dirname "$(dirname "$EXT_LIB")")"
+    # shellcheck disable=SC1090
+    source "$EXT_LIB"
+    run_eval --framework lm-eval --port "$PORT" || eval_rc=$?
+
+    # Derive metadata env vars that append_lm_eval_summary expects but the
+    # launcher passes under different names.
+    export IS_MULTINODE="${IS_MULTINODE:-true}"
+    export TP="${TP:-${PREFILL_TP:-1}}"
+    export CONC="${CONC:-${EVAL_CONC:-${EVAL_CONCURRENT_REQUESTS:-1}}}"
+    export EP_SIZE="${EP_SIZE:-${PREFILL_EP:-1}}"
+    export DP_ATTENTION="${DP_ATTENTION:-${PREFILL_DP_ATTN:-false}}"
+    export PREFILL_DP_ATTENTION="${PREFILL_DP_ATTENTION:-${PREFILL_DP_ATTN:-${DP_ATTENTION:-false}}}"
+    export DECODE_DP_ATTENTION="${DECODE_DP_ATTENTION:-${DECODE_DP_ATTN:-${DP_ATTENTION:-false}}}"
+
+    if declare -F append_lm_eval_summary >/dev/null 2>&1; then
+        echo "Generating lm-eval summary..."
+        append_lm_eval_summary || true
+    fi
+
+    echo "Copying eval artifacts to ${EVAL_OUTPUT_DIR}/..."
+    cp -v meta_env.json "${EVAL_OUTPUT_DIR}/" 2>/dev/null || true
+    cp -v results*.json "${EVAL_OUTPUT_DIR}/" 2>/dev/null || true
+    cp -v sample*.jsonl "${EVAL_OUTPUT_DIR}/" 2>/dev/null || true
+else
+    # Default path: run the EleutherAI lm-evaluation-harness CLI directly.
+    if ! command -v lm_eval >/dev/null 2>&1; then
+        echo "lm_eval CLI not found; installing lm-evaluation-harness via pip..."
+        python3 -m pip install --quiet --upgrade lm-eval || {
+            echo "ERROR: lm_eval CLI is not available and pip install failed."
+            exit 127
+        }
+    fi
+
+    TASKS="${LM_EVAL_TASKS:-gsm8k}"
+    MODEL_TYPE="${LM_EVAL_MODEL:-local-chat-completions}"
+    BASE_URL="${ENDPOINT%/}/v1/chat/completions"
+
+    echo "Running lm_eval on tasks=${TASKS} (model=${MODEL_NAME}, model_type=${MODEL_TYPE})"
+
+    MODEL_ARGS="base_url=${BASE_URL},model=${MODEL_NAME},num_concurrent=${EVAL_CONCURRENT_REQUESTS},tokenized_requests=False"
+
+    # shellcheck disable=SC2086
+    lm_eval \
+        --model "${MODEL_TYPE}" \
+        --model_args "${MODEL_ARGS}" \
+        --tasks "${TASKS}" \
+        --apply_chat_template \
+        --output_path "${EVAL_OUTPUT_DIR}" \
+        ${LM_EVAL_EXTRA_ARGS:-} || eval_rc=$?
+fi
+
+if [[ "$eval_rc" -ne 0 ]]; then
+    echo "lm-eval evaluation failed with exit code ${eval_rc}"
+    exit "$eval_rc"
+fi
+
+echo "lm-eval evaluation complete"

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -194,6 +195,117 @@ class SweepOrchestrator(
 
         logger.info("=" * 60)
         logger.info("")
+
+    def _run_post_eval(self, stop_event: threading.Event) -> int:
+        """Run lm-eval after the main benchmark completes (or directly in eval-only mode)."""
+        from srtctl.benchmarks import get_runner
+        from srtctl.core.health import wait_for_model
+
+        # In eval-only mode the benchmark health check was skipped, so do the
+        # full model-ready wait here.  In post-benchmark mode a quick port
+        # check is sufficient since the server already served traffic.
+        if os.environ.get("EVAL_ONLY", "false").lower() == "true":
+            r = self.config.resources
+            n_prefill = 0 if r.num_agg > 0 else r.num_prefill
+            n_decode = r.num_agg if r.num_agg > 0 else r.num_decode
+            hc = self.config.health_check
+            logger.info("EVAL_ONLY: Waiting for server health before eval...")
+            if not wait_for_model(
+                host=self.runtime.nodes.head,
+                port=8000,
+                n_prefill=n_prefill,
+                n_decode=n_decode,
+                poll_interval=float(hc.interval_seconds),
+                timeout=float(hc.max_attempts * hc.interval_seconds),
+                report_every=60.0,
+                frontend_type=self.config.frontend.type,
+                stop_event=stop_event,
+            ):
+                logger.error("Server did not become healthy for eval")
+                return 1
+        else:
+            if not wait_for_port(self.runtime.nodes.head, 8000, timeout=30):
+                logger.error("Server health check failed before eval - skipping")
+                return 1
+
+        try:
+            runner = get_runner("lm-eval")
+        except ValueError as e:
+            logger.error("lm-eval runner not available: %s", e)
+            return 1
+
+        eval_log = self.runtime.log_dir / "eval.out"
+        cmd = runner.build_command(self.config, self.runtime)
+
+        logger.info("Eval command: %s", " ".join(cmd))
+        logger.info("Eval log: %s", eval_log)
+
+        # Pass through eval-related env vars so downstream tooling can record
+        # multi-node topology/precision metadata alongside the eval results.
+        env_to_set = {}
+        for var in [
+            "RUN_EVAL",
+            "EVAL_ONLY",
+            "IS_MULTINODE",
+            "FRAMEWORK",
+            "PRECISION",
+            "MODEL_PREFIX",
+            "RUNNER_TYPE",
+            "RESULT_FILENAME",
+            "SPEC_DECODING",
+            "ISL",
+            "OSL",
+            "MODEL",
+            "MODEL_PATH",
+            "MAX_MODEL_LEN",
+            "EVAL_MAX_MODEL_LEN",
+            "PREFILL_TP",
+            "PREFILL_EP",
+            "PREFILL_DP_ATTN",
+            "PREFILL_NUM_WORKERS",
+            "DECODE_TP",
+            "DECODE_EP",
+            "DECODE_DP_ATTN",
+            "DECODE_NUM_WORKERS",
+        ]:
+            val = os.environ.get(var)
+            if val:
+                env_to_set[var] = val
+
+        # Set MODEL_NAME to the served model name so lm-eval targets the exact
+        # alias the server recognizes, rather than the raw HuggingFace ID.
+        env_to_set["MODEL_NAME"] = self.config.served_model_name
+        logger.info("Eval MODEL_NAME: %s", env_to_set["MODEL_NAME"])
+
+        # Use EVAL_CONC from the launcher environment if set, otherwise fall
+        # back to the max of the benchmark concurrency list.
+        eval_conc = os.environ.get("EVAL_CONC")
+        if eval_conc:
+            env_to_set["EVAL_CONC"] = eval_conc
+            logger.info("Eval concurrency (from environment): %s", eval_conc)
+        else:
+            conc_list = self.config.benchmark.get_concurrency_list()
+            if conc_list:
+                env_to_set["EVAL_CONC"] = str(max(conc_list))
+                logger.info("Eval concurrency (max of %s): %s", conc_list, env_to_set["EVAL_CONC"])
+
+        proc = start_srun_process(
+            command=cmd,
+            nodelist=[self.runtime.nodes.head],
+            output=str(eval_log),
+            container_image=str(self.runtime.container_image),
+            container_mounts=self.runtime.container_mounts,
+            env_to_set=env_to_set,
+        )
+
+        while proc.poll() is None:
+            if stop_event.is_set():
+                logger.info("Stop requested, terminating eval")
+                proc.terminate()
+                return 1
+            time.sleep(1)
+
+        return proc.returncode or 0
 
     def _get_hf_home(self) -> str | None:
         """Get HF_HOME from backend environment config."""
@@ -419,8 +531,27 @@ class SweepOrchestrator(
 
             self._print_connection_info()
 
-            # Stage 4: Benchmark (status reported AFTER health check passes)
-            exit_code = self.run_benchmark(registry, stop_event, reporter)
+            if os.environ.get("EVAL_ONLY", "false").lower() == "true":
+                reporter.report(JobStatus.BENCHMARK, JobStage.BENCHMARK, "Running eval-only evaluation")
+                logger.info("EVAL_ONLY=true: Skipping benchmark stage and running lm-eval evaluation...")
+                exit_code = self._run_post_eval(stop_event)
+                if exit_code != 0:
+                    logger.error("Eval-only evaluation failed with exit code %d", exit_code)
+                else:
+                    logger.info("Eval-only evaluation completed successfully")
+            else:
+                # Stage 4: Benchmark (status reported AFTER health check passes)
+                exit_code = self.run_benchmark(registry, stop_event, reporter)
+
+                # Stage 5: Post-benchmark eval (optional, non-fatal)
+                if os.environ.get("RUN_EVAL", "false").lower() == "true" and exit_code == 0:
+                    reporter.report(JobStatus.BENCHMARK, JobStage.BENCHMARK, "Running post-benchmark evaluation")
+                    logger.info("RUN_EVAL=true: Running post-benchmark lm-eval evaluation...")
+                    eval_exit = self._run_post_eval(stop_event)
+                    if eval_exit != 0:
+                        logger.warning("Eval failed with exit code %d (benchmark result is still valid)", eval_exit)
+                    else:
+                        logger.info("Post-benchmark eval completed successfully")
 
         except Exception as e:
             logger.exception("Error during sweep: %s", e)

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -231,6 +231,13 @@ class RuntimeContext:
                 host_path, container_path = mount_spec.split(":", 1)
                 container_mounts[Path(host_path).resolve()] = Path(container_path)
 
+        # Optional external eval-harness mount (used by the lm-eval runner when
+        # present). Skip exists() here: the orchestrator runs on the SLURM head
+        # node where this path may live only on the compute-node shared FS.
+        eval_ws = os.environ.get("LM_EVAL_WORKSPACE")
+        if eval_ws:
+            container_mounts[Path(eval_ws)] = Path("/lm-eval-workspace")
+
         # Add FormattablePath mounts from config.container_mounts
         # These need to be expanded with the runtime context, so we create a
         # temporary context first and then update

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -560,6 +560,61 @@ class TestTraceReplayRunner:
         assert config.benchmark.itl_threshold_ms == 7
 
 
+class TestLMEvalRunner:
+    """Test LM-Eval runner."""
+
+    def test_registry_includes_lm_eval(self):
+        """lm-eval is in the benchmark registry."""
+        assert "lm-eval" in list_benchmarks()
+
+    def test_get_runner(self):
+        """Can get lm-eval runner."""
+        runner = get_runner("lm-eval")
+        assert runner.name == "lm-eval"
+
+    def test_script_path(self):
+        """Script path points to lm-eval bench.sh."""
+        runner = get_runner("lm-eval")
+        assert "lm-eval/bench.sh" in runner.script_path
+
+    def test_local_script_dir(self):
+        """Local script dir points to lm-eval scripts."""
+        runner = get_runner("lm-eval")
+        assert runner.local_script_dir.endswith("lm-eval")
+
+    def test_validate_config_always_valid(self):
+        """lm-eval accepts any config."""
+        from srtctl.benchmarks.lm_eval import LMEvalRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = LMEvalRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(type="sa-bench"),
+        )
+        assert runner.validate_config(config) == []
+
+    def test_build_command(self):
+        """build_command returns correct bash command."""
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.lm_eval import LMEvalRunner
+
+        runner = LMEvalRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+
+        config = MagicMock()
+        cmd = runner.build_command(config, runtime)
+        assert cmd == [
+            "bash",
+            "/srtctl-benchmarks/lm-eval/bench.sh",
+            "http://localhost:8000",
+        ]
+
+
 class TestScriptsExist:
     """Test that benchmark scripts exist."""
 
@@ -576,6 +631,368 @@ class TestScriptsExist:
         """MMLU script exists."""
         script = SCRIPTS_DIR / "mmlu" / "bench.sh"
         assert script.exists()
+
+
+class TestRunPostEval:
+    """Test SweepOrchestrator._run_post_eval method."""
+
+    @staticmethod
+    def _make_orchestrator():
+        """Create a SweepOrchestrator with mocked config/runtime."""
+        from pathlib import Path
+
+        from srtctl.cli.do_sweep import SweepOrchestrator
+        from srtctl.core.runtime import Nodes, RuntimeContext
+        from srtctl.core.schema import (
+            BenchmarkConfig,
+            FrontendConfig,
+            HealthCheckConfig,
+            ModelConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model/test-model", container="/image", precision="fp4"),
+            resources=ResourceConfig(
+                gpu_type="h100",
+                gpus_per_node=8,
+                prefill_nodes=1,
+                decode_nodes=2,
+                prefill_workers=1,
+                decode_workers=2,
+            ),
+            benchmark=BenchmarkConfig(type="sa-bench", isl=1024, osl=1024, concurrencies="128x256x512"),
+            health_check=HealthCheckConfig(max_attempts=3, interval_seconds=1),
+            frontend=FrontendConfig(type="dynamo"),
+        )
+        runtime = RuntimeContext(
+            job_id="12345",
+            run_name="test-run",
+            nodes=Nodes(head="node0", bench="node0", infra="node0", worker=("node0", "node1", "node2")),
+            head_node_ip="10.0.0.1",
+            infra_node_ip="10.0.0.1",
+            log_dir=Path("/tmp/logs"),
+            model_path=Path("/model/test-model"),
+            container_image=Path("/path/to/container.sqsh"),
+            gpus_per_node=8,
+            network_interface=None,
+            container_mounts={},
+            environment={},
+        )
+        return SweepOrchestrator(config=config, runtime=runtime)
+
+    def test_post_benchmark_port_check_fails(self):
+        """Returns 1 when port check fails in post-benchmark mode."""
+        import os
+        import threading
+        from unittest.mock import patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+        with patch.dict(os.environ, {"EVAL_ONLY": "false"}, clear=False):
+            with patch("srtctl.cli.do_sweep.wait_for_port", return_value=False):
+                result = orch._run_post_eval(stop)
+        assert result == 1
+
+    def test_eval_only_health_check_fails(self):
+        """Returns 1 when health check fails in eval-only mode."""
+        import os
+        import threading
+        from unittest.mock import patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+        with patch.dict(os.environ, {"EVAL_ONLY": "true"}, clear=False):
+            with patch("srtctl.core.health.wait_for_model", return_value=False):
+                result = orch._run_post_eval(stop)
+        assert result == 1
+
+    def test_runner_not_available(self):
+        """Returns 1 when lm-eval runner is not registered."""
+        import os
+        import threading
+        from unittest.mock import patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+        with patch.dict(os.environ, {"EVAL_ONLY": "false"}, clear=False):
+            with patch("srtctl.cli.do_sweep.wait_for_port", return_value=True):
+                with patch("srtctl.benchmarks.get_runner", side_effect=ValueError("not found")):
+                    result = orch._run_post_eval(stop)
+        assert result == 1
+
+    def test_successful_eval(self):
+        """Returns 0 when eval completes successfully."""
+        import os
+        import threading
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+
+        mock_proc = MagicMock()
+        mock_proc.poll.side_effect = [None, 0]
+        mock_proc.returncode = 0
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "false"}, clear=False):
+            with patch("srtctl.cli.do_sweep.wait_for_port", return_value=True):
+                with patch("srtctl.cli.do_sweep.start_srun_process", return_value=mock_proc):
+                    result = orch._run_post_eval(stop)
+        assert result == 0
+
+    def test_eval_only_successful(self):
+        """Returns 0 in eval-only mode when health check and eval succeed."""
+        import os
+        import threading
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+
+        mock_proc = MagicMock()
+        mock_proc.poll.side_effect = [None, 0]
+        mock_proc.returncode = 0
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "true"}, clear=False):
+            with patch("srtctl.core.health.wait_for_model", return_value=True):
+                with patch("srtctl.cli.do_sweep.start_srun_process", return_value=mock_proc):
+                    result = orch._run_post_eval(stop)
+        assert result == 0
+
+    def test_env_var_passthrough(self):
+        """Eval env vars are passed through to srun."""
+        import os
+        import threading
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 0
+        mock_proc.returncode = 0
+
+        env_vars = {
+            "EVAL_ONLY": "false",
+            "RUN_EVAL": "true",
+            "FRAMEWORK": "sglang",
+            "PRECISION": "fp4",
+            "MODEL": "test-model",
+        }
+
+        captured_kwargs = {}
+
+        def capture_srun(**kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_proc
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            with patch("srtctl.cli.do_sweep.wait_for_port", return_value=True):
+                with patch("srtctl.cli.do_sweep.start_srun_process", side_effect=capture_srun):
+                    orch._run_post_eval(stop)
+
+        env_to_set = captured_kwargs["env_to_set"]
+        assert env_to_set["RUN_EVAL"] == "true"
+        assert env_to_set["FRAMEWORK"] == "sglang"
+        assert env_to_set["PRECISION"] == "fp4"
+        assert env_to_set["MODEL"] == "test-model"
+        assert env_to_set["MODEL_NAME"] == "test-model"
+
+    def test_eval_conc_from_env(self):
+        """EVAL_CONC from env takes priority over benchmark concurrencies."""
+        import os
+        import threading
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 0
+        mock_proc.returncode = 0
+
+        captured_kwargs = {}
+
+        def capture_srun(**kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_proc
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "false", "EVAL_CONC": "64"}, clear=False):
+            with patch("srtctl.cli.do_sweep.wait_for_port", return_value=True):
+                with patch("srtctl.cli.do_sweep.start_srun_process", side_effect=capture_srun):
+                    orch._run_post_eval(stop)
+
+        assert captured_kwargs["env_to_set"]["EVAL_CONC"] == "64"
+
+    def test_eval_conc_fallback_to_max_concurrency(self):
+        """EVAL_CONC falls back to max of benchmark concurrencies."""
+        import os
+        import threading
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 0
+        mock_proc.returncode = 0
+
+        captured_kwargs = {}
+
+        def capture_srun(**kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_proc
+
+        env = {"EVAL_ONLY": "false"}
+        # Remove EVAL_CONC if present
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("EVAL_CONC", None)
+            with patch("srtctl.cli.do_sweep.wait_for_port", return_value=True):
+                with patch("srtctl.cli.do_sweep.start_srun_process", side_effect=capture_srun):
+                    orch._run_post_eval(stop)
+
+        # concurrencies="128x256x512", max is 512
+        assert captured_kwargs["env_to_set"]["EVAL_CONC"] == "512"
+
+    def test_stop_event_terminates_eval(self):
+        """Stop event terminates the eval process."""
+        import os
+        import threading
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+        stop = threading.Event()
+        stop.set()
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "false"}, clear=False):
+            with patch("srtctl.cli.do_sweep.wait_for_port", return_value=True):
+                with patch("srtctl.cli.do_sweep.start_srun_process", return_value=mock_proc):
+                    result = orch._run_post_eval(stop)
+
+        assert result == 1
+        mock_proc.terminate.assert_called_once()
+
+
+class TestSweepRunEvalIntegration:
+    """Test eval-related branches in SweepOrchestrator.run()."""
+
+    @staticmethod
+    def _make_orchestrator():
+        return TestRunPostEval._make_orchestrator()
+
+    def test_run_eval_only_mode(self):
+        """EVAL_ONLY=true skips benchmark and runs _run_post_eval."""
+        import os
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "true"}, clear=False):
+            with patch.object(orch, "start_head_infrastructure") as mock_head:
+                mock_head.return_value = MagicMock()
+                with patch.object(orch, "start_all_workers", return_value={}):
+                    with patch.object(orch, "start_frontend", return_value=[]):
+                        with patch.object(orch, "_run_post_eval", return_value=0) as mock_eval:
+                            with patch.object(orch, "run_benchmark") as mock_bench:
+                                with patch.object(orch, "run_postprocess"):
+                                    with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
+                                        mock_reporter_cls.from_config.return_value = MagicMock()
+                                        exit_code = orch.run()
+
+        mock_eval.assert_called_once()
+        mock_bench.assert_not_called()
+        assert exit_code == 0
+
+    def test_run_with_post_benchmark_eval(self):
+        """RUN_EVAL=true runs benchmark then _run_post_eval."""
+        import os
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False):
+            with patch.object(orch, "start_head_infrastructure") as mock_head:
+                mock_head.return_value = MagicMock()
+                with patch.object(orch, "start_all_workers", return_value={}):
+                    with patch.object(orch, "start_frontend", return_value=[]):
+                        with patch.object(orch, "run_benchmark", return_value=0) as mock_bench:
+                            with patch.object(orch, "_run_post_eval", return_value=0) as mock_eval:
+                                with patch.object(orch, "run_postprocess"):
+                                    with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
+                                        mock_reporter_cls.from_config.return_value = MagicMock()
+                                        exit_code = orch.run()
+
+        mock_bench.assert_called_once()
+        mock_eval.assert_called_once()
+        assert exit_code == 0
+
+    def test_run_eval_only_failure(self):
+        """EVAL_ONLY=true with eval failure returns non-zero exit code."""
+        import os
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "true"}, clear=False):
+            with patch.object(orch, "start_head_infrastructure") as mock_head:
+                mock_head.return_value = MagicMock()
+                with patch.object(orch, "start_all_workers", return_value={}):
+                    with patch.object(orch, "start_frontend", return_value=[]):
+                        with patch.object(orch, "_run_post_eval", return_value=1):
+                            with patch.object(orch, "run_postprocess"):
+                                with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
+                                    mock_reporter_cls.from_config.return_value = MagicMock()
+                                    exit_code = orch.run()
+
+        assert exit_code == 1
+
+    def test_run_post_benchmark_eval_failure_nonfatal(self):
+        """RUN_EVAL=true with eval failure still returns benchmark exit code 0."""
+        import os
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False):
+            with patch.object(orch, "start_head_infrastructure") as mock_head:
+                mock_head.return_value = MagicMock()
+                with patch.object(orch, "start_all_workers", return_value={}):
+                    with patch.object(orch, "start_frontend", return_value=[]):
+                        with patch.object(orch, "run_benchmark", return_value=0):
+                            with patch.object(orch, "_run_post_eval", return_value=1):
+                                with patch.object(orch, "run_postprocess"):
+                                    with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
+                                        mock_reporter_cls.from_config.return_value = MagicMock()
+                                        exit_code = orch.run()
+
+        assert exit_code == 0
+
+    def test_run_eval_skipped_when_benchmark_fails(self):
+        """RUN_EVAL=true but benchmark fails: eval is skipped."""
+        import os
+        from unittest.mock import MagicMock, patch
+
+        orch = self._make_orchestrator()
+
+        with patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False):
+            with patch.object(orch, "start_head_infrastructure") as mock_head:
+                mock_head.return_value = MagicMock()
+                with patch.object(orch, "start_all_workers", return_value={}):
+                    with patch.object(orch, "start_frontend", return_value=[]):
+                        with patch.object(orch, "run_benchmark", return_value=1):
+                            with patch.object(orch, "_run_post_eval") as mock_eval:
+                                with patch.object(orch, "run_postprocess"):
+                                    with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
+                                        mock_reporter_cls.from_config.return_value = MagicMock()
+                                        exit_code = orch.run()
+
+        mock_eval.assert_not_called()
+        assert exit_code == 1
 
 
 class TestCustomDatasetLoader:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1603,3 +1603,84 @@ class TestHuggingFaceModelSupport:
 
         idx = cmd.index("--model-path")
         assert cmd[idx + 1] == "/model"
+
+
+class TestLMEvalWorkspaceMount:
+    """Test that LM_EVAL_WORKSPACE creates a container mount."""
+
+    @staticmethod
+    def _mock_scontrol(cmd, **kwargs):
+        import subprocess
+        from unittest.mock import MagicMock
+
+        if cmd[0] == "scontrol" and "hostnames" in cmd:
+            result = MagicMock()
+            result.stdout = "gpu-01\ngpu-02"
+            result.returncode = 0
+            return result
+        raise subprocess.CalledProcessError(1, cmd)
+
+    @staticmethod
+    def _make_config(tmp_path):
+        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        container_path = tmp_path / "container.sqsh"
+        container_path.touch()
+        return SrtConfig(
+            name="test",
+            model=ModelConfig(
+                path=str(model_path),
+                container=str(container_path),
+                precision="fp8",
+            ),
+            resources=ResourceConfig(
+                gpu_type="h100",
+                gpus_per_node=8,
+                prefill_nodes=1,
+                decode_nodes=1,
+            ),
+        )
+
+    @staticmethod
+    def _slurm_env():
+        from pathlib import Path
+
+        return {
+            "SLURM_JOB_ID": "12345",
+            "SLURM_JOBID": "12345",
+            "SLURM_NODELIST": "gpu-[01-02]",
+            "SLURM_JOB_NUM_NODES": "2",
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+        }
+
+    def test_lm_eval_workspace_mount_added(self, tmp_path):
+        """RuntimeContext includes /lm-eval-workspace mount when LM_EVAL_WORKSPACE is set."""
+        import os
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import RuntimeContext
+
+        env = {**self._slurm_env(), "LM_EVAL_WORKSPACE": "/host/eval-workspace"}
+        with patch.dict(os.environ, env):
+            with patch("subprocess.run", self._mock_scontrol):
+                with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+                    runtime = RuntimeContext.from_config(self._make_config(tmp_path), job_id="12345")
+                    assert Path("/lm-eval-workspace") in runtime.container_mounts.values()
+
+    def test_workspace_mount_not_added_without_env(self, tmp_path):
+        """No workspace mount when LM_EVAL_WORKSPACE is unset."""
+        import os
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import RuntimeContext
+
+        with patch.dict(os.environ, self._slurm_env()):
+            os.environ.pop("LM_EVAL_WORKSPACE", None)
+            with patch("subprocess.run", self._mock_scontrol):
+                with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+                    runtime = RuntimeContext.from_config(self._make_config(tmp_path), job_id="12345")
+                    assert Path("/lm-eval-workspace") not in runtime.container_mounts.values()


### PR DESCRIPTION
## Summary
Add InferenceX multi-node eval support through an `lm-eval` benchmark runner and eval-only orchestration path. Lets InferenceX run accuracy-only jobs against existing srt-slurm multi-node disaggregated recipes without running the throughput benchmark stage.

Copied from https://github.com/ishandhanani/srt-slurm/pull/245

## How
- Add an `lm-eval` benchmark runner that sources InferenceX's `benchmarks/benchmark_lib.sh` from a mounted `/infmax-workspace`.
- Mount `INFMAX_WORKSPACE` into the container as `/infmax-workspace` when provided.
- Add `EVAL_ONLY=true` handling in `do_sweep.py` so eval-only jobs start infra/workers/frontend, run
  the full model health check, skip throughput, and launch `lm-eval` directly.
- Keep `RUN_EVAL=true` behavior as a post-benchmark eval path for normal throughput jobs.
- Pass model/framework/topology metadata into the eval container, including served `MODEL_NAME`, prefill/decode TP/EP/DPA/worker counts, sequence length, precision, runner type, and eval concurrency. 
- Map srt-slurm `PREFILL_DP_ATTN` / `DECODE_DP_ATTN` env vars to the InferenceX `PREFILL_DP_ATTENTION` /`DECODE_DP_ATTENTION` names expected by `append_lm_eval_summary`.
- Copy eval outputs (`meta_env.json`, `results*.json`, `sample*.jsonl`) into `/logs/eval_results/` for launcher-side artifact pickup.
- Preserve partial eval artifacts on lm-eval failure while still returning the original eval failure
  code.
- Document the InferenceX lm-eval integration in `docs/accuracy.md`.

## What

For `EVAL_ONLY=true`:
- srt-slurm still starts the normal deployment topology.
- The throughput benchmark runner is skipped.
- `wait_for_model()` verifies the configured prefill/decode or aggregated worker counts.
- `lm-eval` runs against the OpenAI-compatible endpoint.
- Eval failure is fatal.
- Low score leads to failure

For `RUN_EVAL=true` without `EVAL_ONLY=true`:
- The normal benchmark runs first.
- `lm-eval` runs as a post-step if throughput succeeds.
- Eval failure is non-fatal to the benchmark result.
- Low score leads to failure

### Validation run
https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24059388771

### InferenceX PR
https://github.com/SemiAnalysisAI/InferenceX/pull/1000