### PR TITLE
[codex] Add generic telemetry and custom benchmark support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,110 @@ jobs:
           fail_ci_if_error: false
         continue-on-error: true
 
+  # Exercise the new mock + status-server surfaces end-to-end. These are
+  # covered by `pytest tests/` via the main `test` job, but we call them
+  # out here so a failure of the mock harness or the status-contract
+  # integration shows up as its own CI signal, and we run the full
+  # `srtctl apply --mock` CLI as a real subprocess to catch packaging or
+  # entry-point regressions that in-process tests can't.
+  mock-and-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.10
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run mock + status-server tests
+        run: |
+          uv run pytest -v \
+            tests/test_apply_json.py \
+            tests/test_apply_mock.py \
+            tests/test_mock_sweep.py \
+            tests/test_integration_status.py
+
+      - name: Smoke — srtctl apply --mock --json as a real CLI
+        run: |
+          set -euo pipefail
+          cat > /tmp/smoke.yaml <<'EOF'
+          name: ci-smoke
+          model:
+            path: hf:fake/mock-model
+            container: nvcr.io/fake:latest
+            precision: fp8
+          resources:
+            gpu_type: h100
+            gpus_per_node: 8
+            agg_nodes: 1
+            agg_workers: 1
+          benchmark:
+            type: custom
+            command: echo ci-smoke
+          EOF
+
+          mkdir -p /tmp/ci-outputs
+          uv run srtctl apply \
+            -f /tmp/smoke.yaml \
+            -o /tmp/ci-outputs \
+            --mock \
+            --mock-tick-s 0.1 \
+            --json \
+            > /tmp/submission.json
+
+          cat /tmp/submission.json
+
+          uv run python - <<'PY'
+          import json, pathlib, time
+          sub = json.loads(pathlib.Path("/tmp/submission.json").read_text().strip())
+          assert sub["status"] == "submitted", sub
+          output_dir = pathlib.Path(sub["output_dir"])
+          result_path = output_dir / "result.json"
+          # The detached mock worker keeps ticking in the background after
+          # apply returns. Give it a generous window to land result.json.
+          deadline = time.monotonic() + 45
+          while time.monotonic() < deadline:
+              if result_path.exists():
+                  break
+              time.sleep(0.25)
+          assert result_path.exists(), (
+              f"mock worker did not finish within window. output_dir contents: "
+              f"{sorted(p.name for p in output_dir.iterdir()) if output_dir.exists() else 'MISSING'}"
+          )
+          result = json.loads(result_path.read_text())
+          assert result["status"] == "completed", result
+          assert result["exit_code"] == 0, result
+          assert (output_dir / "status.json").exists()
+          assert (output_dir / "status_events.jsonl").exists()
+          assert (output_dir / "recipe.lock.yaml").exists()
+          print("CLI smoke passed:", {k: result.get(k) for k in ("job_id", "status", "score")})
+          PY
+
+      - name: Smoke — python -m srtctl.cli.mock_worker standalone
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/worker-out/54321
+          uv run python -m srtctl.cli.mock_worker \
+            --config /tmp/smoke.yaml \
+            --output-dir /tmp/worker-out/54321 \
+            --job-id 54321 \
+            --tick-s 0.1
+
+          test -f /tmp/worker-out/54321/result.json
+          uv run python -c "
+          import json
+          r = json.loads(open('/tmp/worker-out/54321/result.json').read())
+          assert r['status'] == 'completed' and r['exit_code'] == 0, r
+          print('worker standalone:', r)
+          "
+
   # Quick sanity check that recipes are valid
   validate-recipes:
     runs-on: ubuntu-latest

--- a/src/srtctl/benchmarks/__init__.py
+++ b/src/srtctl/benchmarks/__init__.py
@@ -5,6 +5,7 @@
 
 # Import runners to trigger registration
 from srtctl.benchmarks import (
+    custom,
     gpqa,
     gsm8k,
     longbenchv2,
@@ -28,6 +29,7 @@ __all__ = [
     "list_benchmarks",
     "register_benchmark",
     # Runners
+    "custom",
     "sa_bench",
     "sglang_bench",
     "mmlu",

--- a/src/srtctl/benchmarks/base.py
+++ b/src/srtctl/benchmarks/base.py
@@ -59,6 +59,18 @@ class BenchmarkRunner(ABC):
         """
         ...
 
+    def get_container_image(self, config: SrtConfig, runtime: RuntimeContext) -> str | Path:
+        """Get the container image used for the benchmark process."""
+        return runtime.container_image
+
+    def get_container_mounts(self, config: SrtConfig, runtime: RuntimeContext) -> dict[Path, Path]:
+        """Get mounts used for the benchmark process."""
+        return runtime.container_mounts
+
+    def get_environment(self, config: SrtConfig, runtime: RuntimeContext) -> dict[str, str]:
+        """Get benchmark-specific environment variables."""
+        return {}
+
 
 class AIPerfBenchmarkRunner(BenchmarkRunner):
     """Base class for AIPerf-driven benchmarks.

--- a/src/srtctl/benchmarks/custom.py
+++ b/src/srtctl/benchmarks/custom.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Custom benchmark runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from srtctl.benchmarks.base import BenchmarkRunner, register_benchmark
+from srtctl.core.runtime import RuntimeContext
+from srtctl.core.schema import SrtConfig
+
+
+@register_benchmark("custom")
+class CustomBenchmarkRunner(BenchmarkRunner):
+    """Run an arbitrary benchmark command inside a container."""
+
+    @property
+    def name(self) -> str:
+        return "Custom"
+
+    @property
+    def script_path(self) -> str:
+        return "<custom command>"
+
+    def validate_config(self, config: SrtConfig) -> list[str]:
+        if config.benchmark.command:
+            return []
+        return ["benchmark.command is required for benchmark.type=custom"]
+
+    def build_command(self, config: SrtConfig, runtime: RuntimeContext) -> list[str]:
+        del runtime
+        assert config.benchmark.command is not None
+        return ["bash", "-lc", config.benchmark.command]
+
+    def get_container_image(self, config: SrtConfig, runtime: RuntimeContext) -> str | Path:
+        return config.benchmark.container_image or runtime.container_image
+
+    def get_environment(self, config: SrtConfig, runtime: RuntimeContext) -> dict[str, str]:
+        del runtime
+        return dict(config.benchmark.env)

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -21,7 +21,13 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 
-from srtctl.cli.mixins import BenchmarkStageMixin, FrontendStageMixin, PostProcessStageMixin, WorkerStageMixin
+from srtctl.cli.mixins import (
+    BenchmarkStageMixin,
+    FrontendStageMixin,
+    PostProcessStageMixin,
+    TelemetryStageMixin,
+    WorkerStageMixin,
+)
 from srtctl.core.config import load_config
 from srtctl.core.health import wait_for_port
 from srtctl.core.lockfile import write_lockfile
@@ -42,7 +48,13 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixin, PostProcessStageMixin):
+class SweepOrchestrator(
+    WorkerStageMixin,
+    FrontendStageMixin,
+    TelemetryStageMixin,
+    BenchmarkStageMixin,
+    PostProcessStageMixin,
+):
     """Main orchestrator for benchmark sweeps.
 
     Usage:
@@ -223,6 +235,10 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
             reporter.report(JobStatus.FRONTEND, JobStage.FRONTEND, "Starting frontend")
             frontend_procs = self.start_frontend(registry)
             for proc in frontend_procs:
+                registry.add_process(proc)
+
+            telemetry_procs = self.start_telemetry()
+            for proc in telemetry_procs:
                 registry.add_process(proc)
 
             self._print_connection_info()

--- a/src/srtctl/cli/mixins/__init__.py
+++ b/src/srtctl/cli/mixins/__init__.py
@@ -14,11 +14,13 @@ Each mixin handles one stage of the sweep orchestration:
 from srtctl.cli.mixins.benchmark_stage import BenchmarkStageMixin
 from srtctl.cli.mixins.frontend_stage import FrontendStageMixin
 from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
+from srtctl.cli.mixins.telemetry_stage import TelemetryStageMixin
 from srtctl.cli.mixins.worker_stage import WorkerStageMixin
 
 __all__ = [
     "WorkerStageMixin",
     "FrontendStageMixin",
+    "TelemetryStageMixin",
     "BenchmarkStageMixin",
     "PostProcessStageMixin",
 ]

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -179,6 +179,9 @@ class BenchmarkStageMixin:
 
         cmd = runner.build_command(self.config, self.runtime)
         env_to_set = self._get_benchmark_env(runner)
+        env_to_set.update(runner.get_environment(self.config, self.runtime))
+        container_image = runner.get_container_image(self.config, self.runtime)
+        container_mounts = runner.get_container_mounts(self.config, self.runtime)
 
         logger.info("Script: %s", runner.script_path)
         logger.info("Command: %s", shlex.join(cmd))
@@ -188,8 +191,8 @@ class BenchmarkStageMixin:
             command=cmd,
             nodelist=[self.runtime.nodes.head],
             output=str(log_file),
-            container_image=str(self.runtime.container_image),
-            container_mounts=self.runtime.container_mounts,
+            container_image=str(container_image),
+            container_mounts=container_mounts,
             env_to_set=env_to_set,
         )
 

--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+POSTPROCESS_PARSE_FAILED_EXIT = 20
+POSTPROCESS_UPLOAD_FAILED_EXIT = 11
+
 
 class PostProcessStageMixin:
     """Mixin for post-process stage after benchmark completion.
@@ -301,34 +304,7 @@ class PostProcessStageMixin:
         endpoint_flag = f"--endpoint-url {s3_config.endpoint_url}" if s3_config.endpoint_url else ""
 
         # Build the post-processing script
-        script = f"""
-set -e
-
-# Install uv, srtlog, and awscli
-echo "Installing uv..."
-pip install uv
-
-echo "Installing srtlog and awscli..."
-cd /tmp
-git clone --depth 1 https://github.com/ishandhanani/srtlog.git
-uv pip install --system ./srtlog awscli
-
-# Run srtlog to generate parquet
-echo "Running srtlog parse..."
-cd /logs
-srtlog parse .
-
-# Upload entire log directory to S3
-echo "Uploading entire log directory to S3..."
-aws s3 sync /logs {s3_url} {endpoint_flag}
-echo "Upload complete: {s3_url}"
-
-# Report what was uploaded
-echo ""
-echo "Uploaded files:"
-find /logs -type f | wc -l
-echo "files total"
-"""
+        script = self._build_postprocess_script(s3_url, endpoint_flag)
 
         # Build env for AWS credentials
         env: dict[str, str] = {}
@@ -358,6 +334,9 @@ echo "files total"
             if proc.returncode == 0:
                 logger.info("Post-processing complete: %s", s3_url)
                 return parquet_path if parquet_path.exists() else None, s3_url
+            if proc.returncode == POSTPROCESS_PARSE_FAILED_EXIT:
+                logger.warning("srtlog parsing failed, but raw logs were still uploaded to %s", s3_url)
+                return parquet_path if parquet_path.exists() else None, s3_url
             else:
                 logger.warning("Post-processing failed (exit code: %s)", proc.returncode)
                 return parquet_path if parquet_path.exists() else None, None
@@ -369,6 +348,58 @@ echo "files total"
         except Exception as e:
             logger.warning("Post-processing container failed: %s", e)
             return None, None
+
+    def _build_postprocess_script(self, s3_url: str, endpoint_flag: str) -> str:
+        """Build the post-processing shell script.
+
+        Upload is always attempted if awscli installs successfully. Parsing is
+        best-effort so raw logs survive parser/tooling failures.
+        """
+        return f"""
+set -u
+set -o pipefail
+
+PARSE_STATUS=0
+UPLOAD_STATUS=0
+
+echo "Installing uv and awscli..."
+if ! pip install uv awscli; then
+  echo "Failed to install uv/awscli"
+  exit {POSTPROCESS_UPLOAD_FAILED_EXIT}
+fi
+
+echo "Installing srtlog..."
+if cd /tmp && git clone --depth 1 https://github.com/ishandhanani/srtlog.git && uv pip install --system ./srtlog; then
+  echo "Running srtlog parse..."
+  cd /logs
+  srtlog parse . || PARSE_STATUS=$?
+else
+  echo "Failed to install srtlog; continuing with raw log upload"
+  PARSE_STATUS=1
+fi
+
+cat > /logs/postprocess-status.json <<EOF
+{{"parse_status": $PARSE_STATUS, "s3_url": "{s3_url}"}}
+EOF
+
+echo "Uploading entire log directory to S3..."
+aws s3 sync /logs {s3_url} {endpoint_flag} || UPLOAD_STATUS=$?
+
+if [ "$UPLOAD_STATUS" -ne 0 ]; then
+  echo "Upload failed with status $UPLOAD_STATUS"
+  exit {POSTPROCESS_UPLOAD_FAILED_EXIT}
+fi
+
+echo "Upload complete: {s3_url}"
+echo ""
+echo "Uploaded files:"
+find /logs -type f | wc -l
+echo "files total"
+
+if [ "$PARSE_STATUS" -ne 0 ]; then
+  exit {POSTPROCESS_PARSE_FAILED_EXIT}
+fi
+"""
 
     def _report_metrics(self, benchmark_results: dict[str, Any] | None, s3_url: str | None, exit_code: int) -> None:
         """Report metrics to dashboard via status API.

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry stage mixin for SweepOrchestrator."""
+
+from __future__ import annotations
+
+import logging
+import shlex
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from srtctl.core.processes import ManagedProcess
+from srtctl.core.slurm import start_srun_process
+from srtctl.core.telemetry import generate_telemetry_config
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import SrtConfig, TelemetryExporterConfig
+    from srtctl.core.topology import Process
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryStageMixin:
+    """Mixin for telemetry startup stage."""
+
+    config: SrtConfig
+    runtime: RuntimeContext
+
+    @property
+    def backend_processes(self) -> list[Process]:
+        """Backend worker processes."""
+        raise NotImplementedError
+
+    def _compute_frontend_topology(self) -> Any:
+        """Frontend topology helper provided by FrontendStageMixin."""
+        raise NotImplementedError
+
+    def _start_exporter_container(
+        self,
+        *,
+        exporter_config: TelemetryExporterConfig,
+        name: str,
+        nodelist: list[str],
+        log_file: Path,
+        default_command_template: str,
+    ) -> ManagedProcess:
+        """Start one exporter container across the requested nodes."""
+        if exporter_config.command is None:
+            cmd_str = default_command_template.format(port=exporter_config.port)
+        elif "{port}" in exporter_config.command:
+            cmd_str = exporter_config.command.format(port=exporter_config.port)
+        else:
+            cmd_str = exporter_config.command
+
+        proc = start_srun_process(
+            command=shlex.split(cmd_str),
+            ntasks=len(nodelist),
+            nodelist=nodelist,
+            output=str(log_file),
+            container_image=exporter_config.container_image,
+            container_mounts=self.runtime.container_mounts,
+            srun_options=self.runtime.srun_options,
+        )
+        return ManagedProcess(
+            name=name,
+            popen=proc,
+            log_file=log_file,
+            node=",".join(nodelist),
+        )
+
+    def start_telemetry(self) -> list[ManagedProcess]:
+        """Start the configured telemetry provider."""
+        telemetry = self.config.telemetry
+        if not telemetry.enabled:
+            logger.info("Telemetry disabled")
+            return []
+        if telemetry.dcgm_exporter is None or telemetry.node_exporter is None or telemetry.container_image is None:
+            raise ValueError("Telemetry is enabled but required provider configuration is missing")
+
+        logger.info("Starting telemetry provider: %s", telemetry.provider.value)
+
+        topology = self._compute_frontend_topology()
+        config_path = self.runtime.log_dir / "telemetry_config.toml"
+        config_path.write_text(
+            generate_telemetry_config(
+                processes=self.backend_processes,
+                frontend_topology=topology,
+                runtime=self.runtime,
+                telemetry=telemetry,
+            )
+        )
+
+        telemetry_dir = self.runtime.log_dir / telemetry.storage_subdir
+        telemetry_dir.mkdir(parents=True, exist_ok=True)
+        local_dir = telemetry_dir / "local"
+        local_dir.mkdir(parents=True, exist_ok=True)
+
+        worker_nodes = sorted({process.node for process in self.backend_processes})
+        processes: list[ManagedProcess] = []
+        processes.append(
+            self._start_exporter_container(
+                exporter_config=telemetry.dcgm_exporter,
+                name="telemetry_dcgm_exporter",
+                nodelist=worker_nodes,
+                log_file=self.runtime.log_dir / "telemetry_dcgm_exporter.out",
+                default_command_template="dcgm-exporter --collect-interval=100 --address :{port}",
+            )
+        )
+        processes.append(
+            self._start_exporter_container(
+                exporter_config=telemetry.node_exporter,
+                name="telemetry_node_exporter",
+                nodelist=worker_nodes,
+                log_file=self.runtime.log_dir / "telemetry_node_exporter.out",
+                default_command_template=(
+                    "/bin/node_exporter --web.listen-address=:{port} "
+                    "--collector.disable-defaults --collector.cpu --collector.infiniband --collector.meminfo"
+                ),
+            )
+        )
+
+        cmd = [
+            telemetry.binary_path,
+            "--config",
+            "/telemetry_config.toml",
+            "--local-dir",
+            f"/logs/{telemetry.storage_subdir}/local",
+        ]
+        if telemetry.sync_interval_secs > 0:
+            cmd.extend(["--sync-interval", str(telemetry.sync_interval_secs)])
+
+        env_to_set: dict[str, str] = {}
+        if telemetry.compaction_threads > 0:
+            env_to_set["POLARS_MAX_THREADS"] = str(telemetry.compaction_threads)
+
+        scraper_mounts = self.runtime.container_mounts | {
+            config_path: Path("/telemetry_config.toml"),
+        }
+        processes.append(
+            ManagedProcess(
+                name="telemetry",
+                popen=start_srun_process(
+                    command=cmd,
+                    nodelist=[self.runtime.nodes.head],
+                    output=str(self.runtime.log_dir / "telemetry.out"),
+                    container_image=telemetry.container_image,
+                    container_mounts=scraper_mounts,
+                    env_to_set=env_to_set,
+                    srun_options=self.runtime.srun_options,
+                ),
+                log_file=self.runtime.log_dir / "telemetry.out",
+                node=self.runtime.nodes.head,
+            )
+        )
+        logger.info("Telemetry started with artifacts under %s", telemetry_dir)
+        return processes

--- a/src/srtctl/cli/mock_worker.py
+++ b/src/srtctl/cli/mock_worker.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI entry for the local mock sweep.
+
+    python -m srtctl.cli.mock_worker \\
+        --config cfg.yaml --output-dir ./out/42042 \\
+        --job-id 42042 [--tick-s 0.4] [--phase-pause-s 0.25] [--nodelist n1 n2]
+
+Runs the full SweepOrchestrator against patched infrastructure (see
+`srtctl.mock`). Intended to be spawned by tests and by higher-level harnesses
+that want a plausible sequence of srt-slurm artifacts without touching a real
+cluster.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from srtctl.mock import MockOptions, run_mock_sweep
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run a mock srtctl sweep (no real slurm involvement).",
+    )
+    parser.add_argument("--config", required=True, type=Path, help="YAML config path.")
+    parser.add_argument("--output-dir", required=True, type=Path, help="Per-job output directory.")
+    parser.add_argument("--job-id", required=True, help="Fake SLURM job id.")
+    parser.add_argument(
+        "--tick-s",
+        type=float,
+        default=0.4,
+        help="Wall time each fake srun child pretends to run.",
+    )
+    parser.add_argument(
+        "--phase-pause-s",
+        type=float,
+        default=0.25,
+        help="Pause between orchestrator phases (held by fake child durations).",
+    )
+    parser.add_argument(
+        "--nodelist",
+        nargs="+",
+        default=["mock-node-01"],
+        help="Fake SLURM nodelist.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    options = MockOptions(
+        child_duration_s=args.tick_s,
+        phase_pause_s=args.phase_pause_s,
+        nodelist=tuple(args.nodelist),
+    )
+    exit_code = run_mock_sweep(
+        config_path=args.config,
+        output_dir=args.output_dir,
+        job_id=args.job_id,
+        options=options,
+    )
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -136,6 +136,9 @@ def show_config_details(config: SrtConfig) -> None:
         if env:
             has_env = True
             mode_envs.append((mode_name, dict(env)))
+    if config.benchmark.env:
+        has_env = True
+        mode_envs.append(("benchmark", dict(config.benchmark.env)))
 
     if has_env:
         env_table = Table(title="Environment Variables", show_lines=False, pad_edge=False)
@@ -158,6 +161,27 @@ def show_config_details(config: SrtConfig) -> None:
     if config.srun_options:
         opts = " ".join(f"--{k} {v}" if v else f"--{k}" for k, v in config.srun_options.items())
         console.print(f"[dim]srun options:[/] {opts}")
+
+    if config.benchmark.type == "custom" or config.telemetry.enabled:
+        details = Table(title="Execution Extensions", show_lines=False, pad_edge=False)
+        details.add_column("Area", style="dim", width=14)
+        details.add_column("Setting", style="yellow")
+        details.add_column("Value", style="white")
+
+        if config.benchmark.type == "custom":
+            details.add_row("benchmark", "type", config.benchmark.type)
+            if config.benchmark.command:
+                details.add_row("benchmark", "command", config.benchmark.command)
+            if config.benchmark.container_image:
+                details.add_row("benchmark", "container_image", config.benchmark.container_image)
+
+        if config.telemetry.enabled:
+            details.add_row("telemetry", "provider", config.telemetry.provider.value)
+            details.add_row("telemetry", "container_image", config.telemetry.container_image or "<unset>")
+            details.add_row("telemetry", "storage_subdir", config.telemetry.storage_subdir)
+            details.add_row("telemetry", "frequency", str(config.telemetry.default_frequency))
+
+        console.print(Panel(details, border_style="blue"))
 
 
 def validate_setup(srtctl_source: Path) -> None:

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -56,6 +56,88 @@ from srtctl.core.status import create_job_record
 console = Console()
 logger = logging.getLogger(__name__)
 
+# Populated by submit_with_orchestrator on successful submission. Consumed by
+# main() when --json is set so callers get one JSON line per submitted job.
+_submissions: list[dict] = []
+
+
+def _record_submission(data: dict) -> None:
+    _submissions.append(data)
+
+
+def _install_mock_submit_patches() -> list:
+    """Stub the subset of `submit_with_orchestrator` that reaches real infra.
+
+    - `subprocess.run(["sbatch", ...])` is replaced with a fake that returns a
+      synthetic job id so the rest of the submit flow continues through the
+      real config write + metadata + _record_submission path.
+    - `validate_setup` and `create_job_record` are stubbed so mock runs do not
+      probe the cluster install or POST to a real status endpoint.
+    """
+    from unittest.mock import patch
+
+    original_run = subprocess.run
+
+    def _fake_subprocess_run(cmd, *args, **kwargs):
+        is_sbatch = (
+            isinstance(cmd, (list, tuple))
+            and len(cmd) > 0
+            and (cmd[0] == "sbatch" or (isinstance(cmd[0], str) and cmd[0].endswith("sbatch")))
+        )
+        if not is_sbatch:
+            return original_run(cmd, *args, **kwargs)
+        import time as _time
+
+        job_id = str(400_000 + int(_time.time() * 100) % 100_000)
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=f"Submitted batch job {job_id}\n",
+            stderr="",
+        )
+
+    patchers = [
+        patch("subprocess.run", _fake_subprocess_run),
+        patch("srtctl.cli.submit.validate_setup"),
+        patch("srtctl.cli.submit.create_job_record"),
+    ]
+    for p in patchers:
+        p.start()
+    return patchers
+
+
+def _spawn_mock_worker(submission: dict, tick_s: float) -> None:
+    """Detach a `srtctl.cli.mock_worker` subprocess to drive the full orchestrator.
+
+    Writes worker stdout+stderr to <output_dir>/mock_worker.log so the parent
+    process can exit cleanly while the child keeps ticking.
+    """
+    output_dir = Path(submission["output_dir"])
+    config_path = submission["config_path"]
+    job_id = submission["slurm_job_id"]
+    log_path = output_dir / "mock_worker.log"
+    log_fh = log_path.open("w")
+    subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "srtctl.cli.mock_worker",
+            "--config",
+            str(config_path),
+            "--output-dir",
+            str(output_dir),
+            "--job-id",
+            str(job_id),
+            "--tick-s",
+            str(tick_s),
+        ],
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+        close_fds=True,
+    )
+
 
 def get_job_name(config: SrtConfig) -> str:
     """Get job name, using RUNNER_NAME if available, otherwise config name.
@@ -514,6 +596,18 @@ def submit_with_orchestrator(
 
         with open(job_output_dir / f"{job_id}.json", "w") as f:
             json.dump(metadata, f, indent=2)
+
+        _record_submission(
+            {
+                "status": "submitted",
+                "slurm_job_id": job_id,
+                "job_name": job_name,
+                "output_dir": str(job_output_dir),
+                "metadata_path": str(job_output_dir / f"{job_id}.json"),
+                "config_path": str(config_path),
+                "tags": list(tags) if tags else None,
+            }
+        )
 
         # Report to status API (fire-and-forget, silent on failure)
         # Note: tags are already included in metadata dict above
@@ -1023,6 +1117,29 @@ def main():
     add_common_args(apply_parser)
     apply_parser.add_argument("--setup-script", type=str, help="Custom setup script in configs/")
     apply_parser.add_argument("--tags", type=str, help="Comma-separated tags")
+    apply_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit one JSON line per submission on stdout; prose output goes to stderr.",
+    )
+    apply_parser.add_argument(
+        "--mock",
+        action="store_true",
+        dest="mock_mode",
+        help=(
+            "Stub sbatch and spawn a detached mock worker that runs the full "
+            "SweepOrchestrator locally. For testing external harnesses (ibar) "
+            "without cluster access."
+        ),
+    )
+    apply_parser.add_argument(
+        "--mock-tick-s",
+        type=float,
+        default=0.2,
+        dest="mock_tick_s",
+        help="Per-phase wall time used by the detached mock worker.",
+    )
 
     dry_run_parser = subparsers.add_parser("dry-run", help="Validate without submitting")
     add_common_args(dry_run_parser)
@@ -1057,6 +1174,22 @@ def main():
     check_parser.add_argument("--json", action="store_true", dest="json_output", help="Output as JSON")
 
     args = parser.parse_args()
+
+    json_mode = bool(getattr(args, "json_output", False))
+    mock_mode = bool(getattr(args, "mock_mode", False))
+    # Always rebind the module console on each invocation so json-mode prose
+    # goes to stderr and non-json prose returns to stdout. Save the original
+    # so we can restore it on exit — direct library callers of submit_single /
+    # submit_override (tests, etc.) must not see a leaked stderr binding.
+    global console
+    _original_console = console
+    console = Console(file=sys.stderr) if json_mode else Console()
+    if json_mode:
+        _submissions.clear()
+
+    _mock_patch_teardowns: list = []
+    if mock_mode:
+        _mock_patch_teardowns = _install_mock_submit_patches()
 
     # Handle diff and check commands first (they don't use -f/config)
     if args.command == "diff":
@@ -1178,9 +1311,45 @@ def main():
                     output_dir=output_dir,
                 )
     except Exception as e:
+        # Restore subprocess.run etc. before we exit so in-process test
+        # invocations don't leak patches across runs.
+        for patcher in _mock_patch_teardowns:
+            with contextlib.suppress(Exception):
+                patcher.stop()
+        _mock_patch_teardowns = []
+        console = _original_console
+        if json_mode:
+            sys.stdout.write(json.dumps({"status": "error", "error": str(e)}) + "\n")
+            sys.stdout.flush()
+            logging.debug("Full traceback:", exc_info=True)
+            sys.exit(1)
         console.print(f"[bold red]Error:[/] {e}")
         logging.debug("Full traceback:", exc_info=True)
         sys.exit(1)
+
+    # Mock-mode post-submit: spawn the detached orchestrator worker so the
+    # real SweepOrchestrator runs against the output_dir that submit just
+    # wrote to. Tear down sbatch patches AFTER the spawn so the spawned
+    # subprocess inherits a clean environment (Popen itself isn't patched).
+    if mock_mode:
+        for submission in _submissions:
+            _spawn_mock_worker(submission, tick_s=float(args.mock_tick_s))
+        for patcher in _mock_patch_teardowns:
+            with contextlib.suppress(Exception):
+                patcher.stop()
+        _mock_patch_teardowns = []
+
+    if json_mode:
+        if not _submissions:
+            sys.stdout.write(json.dumps({"status": "no-submissions"}) + "\n")
+        else:
+            for record in _submissions:
+                sys.stdout.write(json.dumps(record) + "\n")
+        sys.stdout.flush()
+
+    # Restore the pre-main console binding so direct library callers aren't
+    # affected by this invocation's json-mode rebinding.
+    console = _original_console
 
 
 if __name__ == "__main__":

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -221,6 +221,7 @@ class Precision(str, Enum):
 
 class BenchmarkType(str, Enum):
     MANUAL = "manual"
+    CUSTOM = "custom"
     SA_BENCH = "sa-bench"
     ROUTER = "router"
     MOONCAKE_ROUTER = "mooncake-router"
@@ -234,6 +235,10 @@ class ProfilingType(str, Enum):
     NSYS = "nsys"
     TORCH = "torch"
     NONE = "none"
+
+
+class TelemetryProvider(str, Enum):
+    SCRAPER = "scraper"
 
 
 # ============================================================================
@@ -597,6 +602,10 @@ class BenchmarkConfig:
     trace_file: str | None = None  # Path to trace JSONL file (container path, e.g., /traces/dataset.jsonl)
     custom_tokenizer: str | None = None  # Custom tokenizer class (e.g., "module.path.ClassName")
     use_chat_template: bool = True  # Pass --use-chat-template to benchmark (default: true)
+    # Custom benchmark hook
+    command: str | None = None
+    container_image: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
     # aiperf pip install spec (e.g., "aiperf>=0.7.0", "aiperf @ git+https://...@commit")
     # If set, runs pip install <spec> before benchmarking. Upgrades if already installed.
     aiperf_package: str | None = None
@@ -832,6 +841,40 @@ class ObservabilityConfig:
     Schema: ClassVar[type[Schema]] = Schema
 
 
+@dataclass(frozen=True)
+class TelemetryExporterConfig:
+    """Configuration for telemetry exporters deployed on worker nodes."""
+
+    container_image: str
+    port: int
+    command: str | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
+class TelemetryConfig:
+    """Telemetry configuration for benchmark jobs.
+
+    The default provider bundles a scraper with dcgm_exporter and node_exporter.
+    Other providers can reuse the same top-level contract later.
+    """
+
+    enabled: bool = False
+    provider: TelemetryProvider = TelemetryProvider.SCRAPER
+    container_image: str | None = None
+    binary_path: str = "/usr/local/bin/telemetry-scraper"
+    default_frequency: float = 5.0
+    sync_interval_secs: int = 120
+    compaction_threads: int = 4
+    storage_subdir: str = "telemetry"
+    extra_metadata: dict[str, str] = field(default_factory=dict)
+    dcgm_exporter: TelemetryExporterConfig | None = None
+    node_exporter: TelemetryExporterConfig | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
 def build_otel_env(observability: ObservabilityConfig, component: str) -> dict[str, str]:
     """Build OTEL environment variables for a component.
 
@@ -1038,6 +1081,7 @@ class SrtConfig:
     health_check: HealthCheckConfig = field(default_factory=HealthCheckConfig)
     infra: InfraConfig = field(default_factory=InfraConfig)
     observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
 
     environment: dict[str, str] = field(default_factory=dict)
     container_mounts: dict[
@@ -1064,6 +1108,7 @@ class SrtConfig:
     def __post_init__(self):
         """Validate configuration after initialization."""
         self._validate_profiling()
+        self._validate_telemetry()
 
     def _validate_profiling(self):
         """Validate profiling configuration matches serving mode."""
@@ -1119,6 +1164,28 @@ class SrtConfig:
                 )
             if (r.agg_workers or 0) <= 0:
                 raise ValidationError("Aggregated mode requires agg_workers to be > 0.")
+
+    def _validate_telemetry(self):
+        """Validate telemetry configuration."""
+        telemetry = self.telemetry
+        if not telemetry.enabled:
+            return
+
+        if telemetry.provider != TelemetryProvider.SCRAPER:
+            raise ValidationError(f"Unsupported telemetry provider: {telemetry.provider}")
+
+        if not telemetry.container_image:
+            raise ValidationError("telemetry.container_image is required when telemetry is enabled")
+        if telemetry.dcgm_exporter is None:
+            raise ValidationError("telemetry.dcgm_exporter is required when telemetry is enabled")
+        if telemetry.node_exporter is None:
+            raise ValidationError("telemetry.node_exporter is required when telemetry is enabled")
+        if telemetry.default_frequency <= 0:
+            raise ValidationError("telemetry.default_frequency must be positive")
+        if telemetry.sync_interval_secs < 0:
+            raise ValidationError("telemetry.sync_interval_secs must be >= 0")
+        if telemetry.compaction_threads < 0:
+            raise ValidationError("telemetry.compaction_threads must be >= 0")
 
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry configuration helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from srtctl.core.slurm import get_hostname_ip
+
+if TYPE_CHECKING:
+    from srtctl.cli.mixins.frontend_stage import FrontendTopology
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import TelemetryConfig
+    from srtctl.core.topology import Process
+
+
+@dataclass(frozen=True)
+class TelemetryEndpoint:
+    """One telemetry endpoint entry in the scraper config."""
+
+    name: str
+    url: str
+    frequency: float
+    filter: str | None = None
+    node_metadata: dict[str, str] = field(default_factory=dict)
+    gpu_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
+
+
+def generate_telemetry_config(
+    *,
+    processes: list[Process],
+    frontend_topology: FrontendTopology,
+    runtime: RuntimeContext,
+    telemetry: TelemetryConfig,
+) -> str:
+    """Generate telemetry TOML from backend and frontend topology."""
+    dcgm_exporter = telemetry.dcgm_exporter
+    node_exporter = telemetry.node_exporter
+    if dcgm_exporter is None or node_exporter is None:
+        raise ValueError("Telemetry exporters must be configured before generating telemetry config")
+
+    endpoints: list[TelemetryEndpoint] = []
+    physical_nodes: dict[str, list[Process]] = {}
+    for process in processes:
+        physical_nodes.setdefault(process.node, []).append(process)
+
+    for node in sorted(physical_nodes):
+        node_processes = physical_nodes[node]
+        node_metadata = {"hostname": node, "job_id": runtime.job_id, "run_name": runtime.run_name}
+        node_metadata.update(telemetry.extra_metadata)
+
+        gpu_metadata: dict[str, dict[str, str]] = {}
+        for process in node_processes:
+            for gpu_idx in sorted(process.gpu_indices):
+                gpu_metadata[str(gpu_idx)] = {
+                    "worker_index": str(process.endpoint_index),
+                    "worker_process": str(process.node_rank),
+                    "worker_role": process.endpoint_mode,
+                }
+
+        endpoints.append(
+            TelemetryEndpoint(
+                name=f"dcgm_{node}",
+                url=f"http://{node}:{dcgm_exporter.port}/metrics",
+                frequency=telemetry.default_frequency,
+                filter="dcgm",
+                node_metadata=node_metadata,
+                gpu_metadata=gpu_metadata,
+            )
+        )
+        endpoints.append(
+            TelemetryEndpoint(
+                name=f"node_exporter_{node}",
+                url=f"http://{node}:{node_exporter.port}/metrics",
+                frequency=telemetry.default_frequency,
+                filter="node_exporter",
+                node_metadata=node_metadata,
+            )
+        )
+
+    for process in sorted(processes, key=lambda p: (p.endpoint_mode, p.endpoint_index, p.node_rank, p.node)):
+        node_ip = get_hostname_ip(process.node, runtime.network_interface)
+        node_metadata = {
+            "hostname": process.node,
+            "worker_index": str(process.endpoint_index),
+            "worker_process": str(process.node_rank),
+            "worker_role": process.endpoint_mode,
+        }
+        node_metadata.update(telemetry.extra_metadata)
+        endpoints.append(
+            TelemetryEndpoint(
+                name=f"backend_{process.endpoint_mode}{process.endpoint_index}_rank{process.node_rank}",
+                url=f"http://{node_ip}:{process.sys_port}/metrics",
+                frequency=telemetry.default_frequency,
+                filter="backend",
+                node_metadata=node_metadata,
+            )
+        )
+
+    for frontend_index, node in enumerate(frontend_topology.frontend_nodes):
+        node_ip = get_hostname_ip(node, runtime.network_interface)
+        node_metadata = {
+            "frontend_index": str(frontend_index),
+            "hostname": node,
+        }
+        node_metadata.update(telemetry.extra_metadata)
+        endpoints.append(
+            TelemetryEndpoint(
+                name=f"frontend{frontend_index}",
+                url=f"http://{node_ip}:{frontend_topology.frontend_port}/metrics",
+                frequency=telemetry.default_frequency,
+                filter="frontend",
+                node_metadata=node_metadata,
+            )
+        )
+
+    return _dump_toml(
+        endpoints=endpoints,
+        storage=f"/logs/{telemetry.storage_subdir}",
+    )
+
+
+def _dump_toml(*, endpoints: list[TelemetryEndpoint], storage: str) -> str:
+    """Render a compact TOML document without extra dependencies."""
+    lines = [f"storage = {json.dumps(storage)}", ""]
+    for endpoint in endpoints:
+        lines.append("[[endpoints]]")
+        lines.append(f"name = {json.dumps(endpoint.name)}")
+        lines.append(f"url = {json.dumps(endpoint.url)}")
+        lines.append(f"frequency = {endpoint.frequency}")
+        if endpoint.filter is not None:
+            lines.append(f"filter = {json.dumps(endpoint.filter)}")
+        if endpoint.node_metadata:
+            lines.append("[endpoints.node_metadata]")
+            for key, value in sorted(endpoint.node_metadata.items()):
+                lines.append(f"{json.dumps(key)} = {json.dumps(value)}")
+        if endpoint.gpu_metadata:
+            lines.append("[endpoints.gpu_metadata]")
+            for gpu_idx, metadata in sorted(endpoint.gpu_metadata.items(), key=lambda item: int(item[0])):
+                fields = ", ".join(f"{json.dumps(k)} = {json.dumps(v)}" for k, v in sorted(metadata.items()))
+                lines.append(f"{json.dumps(gpu_idx)} = {{ {fields} }}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/srtctl/mock.py
+++ b/src/srtctl/mock.py
@@ -1,0 +1,452 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Local mock runtime for srtctl.
+
+Runs the full SweepOrchestrator path — head infra, workers, frontend,
+telemetry, benchmark, postprocess — without launching any srun processes or
+touching real cluster infrastructure. Every external surface that would
+reach slurm, a network port, or a subprocess is swapped for a local fake
+while the orchestration code itself runs for real.
+
+Designed for end-to-end tests of upstream harnesses (ibar) that need to
+observe a plausible sequence of artifacts appearing under an output_dir.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+import threading
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+__all__ = [
+    "FakePopen",
+    "MockOptions",
+    "mock_infrastructure",
+    "run_mock_sweep",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fake subprocess.Popen that drop-in replaces an srun child.
+# ---------------------------------------------------------------------------
+
+
+class FakePopen:
+    """subprocess.Popen stand-in for srun children.
+
+    Writes a small banner to the provided output file on construction, sleeps
+    `duration_s` in wall time (in the background), then reports exit 0. Fully
+    compatible with the subset of the Popen API that srtctl actually uses:
+    poll(), wait(), terminate(), kill(), returncode, pid, stdout/stderr/stdin
+    as None (since we never open pipes).
+    """
+
+    _next_pid = 42000
+    _pid_lock = threading.Lock()
+
+    def __init__(self, *, cmd: list[str], output: str | None, duration_s: float) -> None:
+        with FakePopen._pid_lock:
+            FakePopen._next_pid += 1
+            self.pid = FakePopen._next_pid
+        self.args = list(cmd)
+        self._output = Path(output) if output else None
+        self._duration = max(0.0, duration_s)
+        self._start = time.monotonic()
+        self._returncode: int | None = None
+        self.stdout = None
+        self.stderr = None
+        self.stdin = None
+
+    @property
+    def returncode(self) -> int | None:
+        # Match subprocess.Popen — .poll() sets returncode as a side effect,
+        # so force one poll before the attribute is read.
+        self.poll()
+        return self._returncode
+
+        if self._output is not None:
+            self._output.parent.mkdir(parents=True, exist_ok=True)
+            header = (
+                f"[mock-srun pid={self.pid}] started at {time.strftime('%H:%M:%S')}\n"
+                f"[mock-srun pid={self.pid}] cmd: {' '.join(self.args[:6])}"
+                + ("..." if len(self.args) > 6 else "")
+                + "\n"
+            )
+            self._output.write_text(header)
+
+    def _finalize(self) -> None:
+        if self._returncode is not None:
+            return
+        self._returncode = 0
+        if self._output is not None:
+            with self._output.open("a") as f:
+                f.write(f"[mock-srun pid={self.pid}] exit=0\n")
+
+    def poll(self) -> int | None:
+        if self._returncode is not None:
+            return self._returncode
+        if (time.monotonic() - self._start) >= self._duration:
+            self._finalize()
+        return self._returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while self.poll() is None:
+            if deadline is not None and time.monotonic() >= deadline:
+                raise subprocess.TimeoutExpired(cmd=self.args, timeout=timeout)
+            time.sleep(0.02)
+        assert self._returncode is not None
+        return self._returncode
+
+    def terminate(self) -> None:
+        if self._returncode is None:
+            self._returncode = -15
+
+    def kill(self) -> None:
+        if self._returncode is None:
+            self._returncode = -9
+
+    def communicate(self, input: Any = None, timeout: float | None = None):  # noqa: A002
+        self.wait(timeout=timeout)
+        return (b"", b"")
+
+    def send_signal(self, sig: int) -> None:
+        if self._returncode is None:
+            self._returncode = -abs(sig)
+
+
+# ---------------------------------------------------------------------------
+# MockOptions and the fake srun factory.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockOptions:
+    """Tunables for a single mock run."""
+
+    # How long each fake srun child pretends to run. Kept small for tests.
+    child_duration_s: float = 0.4
+    # Pause inserted between major phases (head_infra, workers, frontend,
+    # benchmark, postprocess) so watchers observe distinct transitions.
+    phase_pause_s: float = 0.25
+    # Fake nodelist used by RuntimeContext.
+    nodelist: tuple[str, ...] = ("mock-node-01",)
+    # Fake IP returned for every hostname lookup.
+    hostname_ip: str = "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Status sink: replaces requests.put/post so status reports land on disk.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StatusSink:
+    status_file: Path
+    events_file: Path
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def write(self, payload: dict) -> None:
+        with self._lock:
+            self.events_file.parent.mkdir(parents=True, exist_ok=True)
+            with self.events_file.open("a") as f:
+                f.write(json.dumps(payload) + "\n")
+
+            current: dict = {}
+            if self.status_file.exists():
+                try:
+                    current = json.loads(self.status_file.read_text())
+                except Exception:
+                    current = {}
+            merged = {**current, **payload}
+            # Keep a tally of updates for debugging.
+            merged["update_count"] = int(current.get("update_count", 0)) + 1
+            self.status_file.write_text(json.dumps(merged, indent=2) + "\n")
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# The infrastructure patch context.
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def mock_infrastructure(*, options: MockOptions, output_dir: Path):
+    """Patch every external call so SweepOrchestrator runs fully in-process.
+
+    Parameters
+    ----------
+    options: MockOptions
+        Tunables for the mock run (child durations, phase pauses, nodelist).
+    output_dir: Path
+        The per-job output directory (.../outputs/<job_id>). The mock writes
+        status.json and status_events.jsonl directly under this path so
+        external watchers have a canonical source of truth.
+    """
+
+    log_dir = output_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    status_sink = _StatusSink(
+        status_file=output_dir / "status.json",
+        events_file=output_dir / "status_events.jsonl",
+    )
+
+    # Seed status.json with an initial "pending" row so watchers see a file
+    # the moment the mock starts.
+    status_sink.write(
+        {
+            "status": "pending",
+            "phase": "created",
+            "ts": time.time(),
+            "message": "mock sweep starting",
+        }
+    )
+
+    def _fake_srun(*args, **kwargs) -> FakePopen:
+        cmd = kwargs.get("command") or (args[0] if args else [])
+        if not isinstance(cmd, list):
+            cmd = [str(cmd)]
+        return FakePopen(
+            cmd=cmd,
+            output=kwargs.get("output"),
+            duration_s=options.child_duration_s,
+        )
+
+    def _fake_wait_for_port(*_args, **_kwargs) -> bool:
+        return True
+
+    def _fake_wait_for_model(*_args, **_kwargs) -> bool:
+        return True
+
+    def _fake_hostname_ip(*_args, **_kwargs) -> str:
+        return options.hostname_ip
+
+    def _fake_nodelist() -> list[str]:
+        return list(options.nodelist)
+
+    def _fake_put(url, json=None, timeout=None, **_kwargs):  # noqa: A002
+        payload = dict(json or {})
+        payload["_sink"] = "put"
+        payload["_url"] = url
+        status_sink.write(payload)
+        return _FakeResponse(200)
+
+    def _fake_post(url, json=None, timeout=None, **_kwargs):  # noqa: A002
+        payload = dict(json or {})
+        payload["_sink"] = "post"
+        payload["_url"] = url
+        status_sink.write(payload)
+        return _FakeResponse(201)
+
+    # Patches go onto every module that imported these symbols by name.
+    patch_targets: list[tuple[str, Any]] = [
+        # srun process starters.
+        ("srtctl.core.slurm.start_srun_process", _fake_srun),
+        ("srtctl.cli.do_sweep.start_srun_process", _fake_srun),
+        ("srtctl.cli.mixins.worker_stage.start_srun_process", _fake_srun),
+        ("srtctl.cli.mixins.frontend_stage.start_srun_process", _fake_srun),
+        ("srtctl.cli.mixins.telemetry_stage.start_srun_process", _fake_srun),
+        ("srtctl.cli.mixins.benchmark_stage.start_srun_process", _fake_srun),
+        ("srtctl.cli.mixins.postprocess_stage.start_srun_process", _fake_srun),
+        ("srtctl.frontends.dynamo.start_srun_process", _fake_srun),
+        ("srtctl.frontends.sglang.start_srun_process", _fake_srun),
+        # Hostname / IP resolution.
+        ("srtctl.core.slurm.get_hostname_ip", _fake_hostname_ip),
+        ("srtctl.core.slurm.get_slurm_nodelist", _fake_nodelist),
+        ("srtctl.core.runtime.get_hostname_ip", _fake_hostname_ip),
+        ("srtctl.core.runtime.get_slurm_nodelist", _fake_nodelist),
+        ("srtctl.core.telemetry.get_hostname_ip", _fake_hostname_ip),
+        ("srtctl.cli.mixins.frontend_stage.get_hostname_ip", _fake_hostname_ip),
+        ("srtctl.cli.mixins.benchmark_stage.get_hostname_ip", _fake_hostname_ip),
+        ("srtctl.frontends.sglang.get_hostname_ip", _fake_hostname_ip),
+        # Port / model readiness checks.
+        ("srtctl.core.health.wait_for_port", _fake_wait_for_port),
+        ("srtctl.cli.do_sweep.wait_for_port", _fake_wait_for_port),
+        ("srtctl.core.health.wait_for_model", _fake_wait_for_model),
+        ("srtctl.cli.mixins.benchmark_stage.wait_for_model", _fake_wait_for_model),
+        # Status POST/PUT — redirect to the on-disk sink so external watchers
+        # have a concrete artifact to poll.
+        ("srtctl.core.status.requests.put", _fake_put),
+        ("srtctl.core.status.requests.post", _fake_post),
+    ]
+
+    started: list = []
+    try:
+        for target, replacement in patch_targets:
+            try:
+                p = patch(target, replacement)
+                p.start()
+                started.append(p)
+            except (AttributeError, ImportError, ModuleNotFoundError):
+                # Symbol isn't imported by that module — nothing to patch
+                # there, which is fine. Skip quietly.
+                continue
+
+        # Make the status reporter believe it is enabled so .report*() paths
+        # actually hit our patched requests.put. from_config() is the entry
+        # that sets enabled=True iff endpoints are configured.
+        from srtctl.core.status import StatusReporter
+
+        original_from_config = StatusReporter.from_config
+
+        def _enabled_from_config(reporting, job_id, _orig=original_from_config):
+            reporter = _orig(reporting, job_id)
+            if reporter.enabled:
+                return reporter
+            # Rebuild with a sentinel endpoint so _put fires; requests.put is
+            # already patched so the endpoint URL is irrelevant.
+            return StatusReporter(
+                job_id=job_id,
+                api_endpoints=("http://mock-status.local",),
+            )
+
+        p = patch.object(StatusReporter, "from_config", _enabled_from_config)
+        p.start()
+        started.append(p)
+
+        yield status_sink
+    finally:
+        for p in reversed(started):
+            with contextlib.suppress(Exception):
+                p.stop()
+
+
+# ---------------------------------------------------------------------------
+# High-level entrypoint: run the full mock sweep.
+# ---------------------------------------------------------------------------
+
+
+def _write_final_result(output_dir: Path, *, job_id: str, exit_code: int) -> None:
+    """Write a stable result.json artifact at the end of the mock run."""
+    import hashlib
+
+    h = int(hashlib.sha1(f"result-{job_id}".encode()).hexdigest(), 16)
+    score = 0.75 + ((h % 100) - 50) / 1000.0
+    loss = max(0.01, 1.0 - score + ((h >> 8) % 50) / 2000.0)
+    payload = {
+        "job_id": job_id,
+        "status": "completed" if exit_code == 0 else "failed",
+        "exit_code": exit_code,
+        "final_loss": round(loss, 4),
+        "score": round(score, 4),
+        "param_count": 100_000,
+        "generated_at": time.time(),
+    }
+    (output_dir / "result.json").write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _set_slurm_env(job_id: str, nodelist: Iterable[str]) -> dict[str, str | None]:
+    """Set SLURM_* env vars for the duration of the mock run.
+
+    Returns a snapshot so callers can restore the prior values.
+    """
+    keys = ["SLURM_JOB_ID", "SLURM_JOBID", "SLURM_NODELIST", "SLURM_NNODES"]
+    prior = {k: os.environ.get(k) for k in keys}
+    os.environ["SLURM_JOB_ID"] = job_id
+    os.environ["SLURM_JOBID"] = job_id
+    nodes_csv = ",".join(nodelist)
+    os.environ["SLURM_NODELIST"] = nodes_csv
+    os.environ["SLURM_NNODES"] = str(len(nodes_csv.split(",")))
+    return prior
+
+
+def _restore_env(prior: dict[str, str | None]) -> None:
+    for k, v in prior.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def run_mock_sweep(
+    *,
+    config_path: Path,
+    output_dir: Path,
+    job_id: str,
+    options: MockOptions | None = None,
+) -> int:
+    """Execute `SweepOrchestrator.run()` under the full mock infrastructure.
+
+    Parameters
+    ----------
+    config_path: Path
+        Resolved YAML config. Used via `load_config` exactly like production.
+    output_dir: Path
+        The per-job output directory. Must match what submit_with_orchestrator
+        would have written to so artifacts collocate.
+    job_id: str
+        SLURM-style job id to pretend is ours.
+    options: MockOptions | None
+        Tunables; defaults to short waits suitable for tests.
+
+    Returns
+    -------
+    int
+        Exit code from the orchestrator.
+    """
+    from srtctl.cli.do_sweep import SweepOrchestrator
+    from srtctl.core.config import load_config
+    from srtctl.core.runtime import RuntimeContext
+
+    opts = options or MockOptions()
+    log_dir = output_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # SweepOrchestrator reads SRTCTL_OUTPUT_DIR to place log_dir; point it at
+    # the real output_dir so artifacts land where ibar expects them.
+    prior_output = os.environ.get("SRTCTL_OUTPUT_DIR")
+    os.environ["SRTCTL_OUTPUT_DIR"] = str(output_dir)
+    prior_slurm = _set_slurm_env(job_id, opts.nodelist)
+
+    try:
+        with mock_infrastructure(options=opts, output_dir=output_dir) as sink:
+            config = load_config(config_path)
+            runtime = RuntimeContext.from_config(config, job_id=job_id)
+            orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+            # Run the orchestrator in a thread so we can insert explicit phase
+            # pauses from the outside (the orchestrator itself is synchronous
+            # and would otherwise race through every phase in microseconds).
+            # We block on orchestrator.run() normally; the phase pauses happen
+            # inside the fake srun children (child_duration_s).
+            sink.write(
+                {
+                    "status": "running",
+                    "phase": "orchestrator-starting",
+                    "ts": time.time(),
+                }
+            )
+            exit_code = orchestrator.run()
+            sink.write(
+                {
+                    "status": "completed" if exit_code == 0 else "failed",
+                    "phase": "orchestrator-exited",
+                    "exit_code": exit_code,
+                    "ts": time.time(),
+                }
+            )
+        _write_final_result(output_dir, job_id=job_id, exit_code=exit_code)
+        return exit_code
+    finally:
+        _restore_env(prior_slurm)
+        if prior_output is None:
+            os.environ.pop("SRTCTL_OUTPUT_DIR", None)
+        else:
+            os.environ["SRTCTL_OUTPUT_DIR"] = prior_output

--- a/tests/test_apply_json.py
+++ b/tests/test_apply_json.py
@@ -51,6 +51,10 @@ def test_apply_json_emits_single_line_on_stdout(
     mock_sbatch = MagicMock()
     mock_sbatch.stdout = "Submitted batch job 42042"
 
+    # Unset RUNNER_NAME so get_job_name() falls through to config.name. On
+    # GitHub Actions runners RUNNER_NAME is auto-set and would otherwise
+    # override the configured job name.
+    monkeypatch.delenv("RUNNER_NAME", raising=False)
     monkeypatch.setattr(
         sys,
         "argv",

--- a/tests/test_apply_json.py
+++ b/tests/test_apply_json.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `srtctl apply --json` stdout contract.
+
+`--json` redirects prose output to stderr and emits one JSON line per
+submission on stdout so external harnesses can parse submission metadata
+without scraping Rich output.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from srtctl.cli import submit as submit_cli
+
+MINIMAL_CONFIG = {
+    "name": "test-job",
+    "model": {
+        "path": "/models/test-model",
+        "container": "test-container.sqsh",
+        "precision": "fp8",
+    },
+    "resources": {
+        "gpu_type": "h100",
+        "gpus_per_node": 8,
+        "prefill_nodes": 1,
+        "decode_nodes": 1,
+        "prefill_workers": 1,
+        "decode_workers": 1,
+    },
+    "benchmark": {"type": "manual"},
+}
+
+
+def _write_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(yaml.dump(MINIMAL_CONFIG))
+    return cfg
+
+
+def test_apply_json_emits_single_line_on_stdout(
+    monkeypatch, tmp_path: Path, capsys: Any
+) -> None:
+    cfg = _write_config(tmp_path)
+    mock_sbatch = MagicMock()
+    mock_sbatch.stdout = "Submitted batch job 42042"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["srtctl", "apply", "-f", str(cfg), "-o", str(tmp_path), "--json"],
+    )
+    with (
+        patch("subprocess.run", return_value=mock_sbatch),
+        patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+        patch("srtctl.cli.submit.create_job_record"),
+        patch("srtctl.cli.submit.validate_setup"),
+    ):
+        submit_cli.main()
+
+    captured = capsys.readouterr()
+    stdout = captured.out.strip()
+
+    # Exactly one line on stdout, valid JSON.
+    assert "\n" not in stdout
+    record = json.loads(stdout)
+    assert record["status"] == "submitted"
+    assert record["slurm_job_id"] == "42042"
+    assert record["job_name"] == "test-job"
+    assert record["config_path"] == str(cfg)
+    assert record["output_dir"].endswith("42042")
+    assert record["metadata_path"].endswith("42042.json")
+
+
+def test_apply_json_emits_error_line_on_failure(
+    monkeypatch, tmp_path: Path, capsys: Any
+) -> None:
+    cfg = _write_config(tmp_path)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("sbatch is on fire")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["srtctl", "apply", "-f", str(cfg), "-o", str(tmp_path), "--json"],
+    )
+    with (
+        patch("subprocess.run", side_effect=boom),
+        patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+        patch("srtctl.cli.submit.validate_setup"),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        submit_cli.main()
+
+    assert excinfo.value.code == 1
+    stdout = capsys.readouterr().out.strip()
+    record = json.loads(stdout)
+    assert record["status"] == "error"
+    assert "on fire" in record["error"]
+
+
+def test_apply_without_json_emits_prose_only(
+    monkeypatch, tmp_path: Path, capsys: Any
+) -> None:
+    cfg = _write_config(tmp_path)
+    mock_sbatch = MagicMock()
+    mock_sbatch.stdout = "Submitted batch job 99999"
+
+    monkeypatch.setattr(
+        sys, "argv", ["srtctl", "apply", "-f", str(cfg), "-o", str(tmp_path)]
+    )
+    with (
+        patch("subprocess.run", return_value=mock_sbatch),
+        patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+        patch("srtctl.cli.submit.create_job_record"),
+        patch("srtctl.cli.submit.validate_setup"),
+    ):
+        submit_cli.main()
+
+    stdout = capsys.readouterr().out
+    # Prose path stays as before; should NOT be machine-parseable JSON.
+    assert "Job 99999" in stdout
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
+            pytest.fail(f"Unexpected JSON in non-json stdout: {line!r}")

--- a/tests/test_apply_mock.py
+++ b/tests/test_apply_mock.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `srtctl apply --mock`.
+
+The `--mock` flag stubs sbatch in the submit flow, so submit_with_orchestrator
+runs end-to-end (config load → script generation → metadata write → JSON
+submission record), and then spawns a detached `srtctl.cli.mock_worker` that
+drives the real SweepOrchestrator under `srtctl.mock`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import yaml
+
+from srtctl.cli import submit as submit_cli
+
+MINIMAL_CONFIG = {
+    "name": "apply-mock-smoke",
+    "model": {
+        "path": "hf:fake/mock-model",
+        "container": "nvcr.io/fake:latest",
+        "precision": "fp8",
+    },
+    "resources": {
+        "gpu_type": "h100",
+        "gpus_per_node": 8,
+        "agg_nodes": 1,
+        "agg_workers": 1,
+    },
+    "benchmark": {"type": "custom", "command": "echo apply-mock"},
+}
+
+
+def _write_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(yaml.dump(MINIMAL_CONFIG))
+    return cfg
+
+
+def _wait_for(path: Path, *, timeout: float = 30.0, interval: float = 0.1) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists() and path.stat().st_size > 0:
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_apply_mock_emits_submission_json_and_spawns_worker(
+    monkeypatch, tmp_path: Path, capsys: Any
+) -> None:
+    cfg = _write_config(tmp_path)
+    output_base = tmp_path / "outputs"
+    output_base.mkdir()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "srtctl",
+            "apply",
+            "-f",
+            str(cfg),
+            "-o",
+            str(output_base),
+            "--mock",
+            "--mock-tick-s",
+            "0.1",
+            "--json",
+        ],
+    )
+    # get_srtslurm_setting returns cluster info; None is fine for the mock.
+    with patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None):
+        submit_cli.main()
+
+    stdout = capsys.readouterr().out.strip()
+    assert "\n" not in stdout
+    record = json.loads(stdout)
+    assert record["status"] == "submitted"
+    slurm_job_id = record["slurm_job_id"]
+    assert slurm_job_id and slurm_job_id.isdigit()
+    output_dir = Path(record["output_dir"])
+    assert output_dir.exists()
+    assert output_dir.name == slurm_job_id
+
+    # Real submit flow wrote <job_id>.json metadata before the worker even started.
+    metadata_path = Path(record["metadata_path"])
+    assert metadata_path.exists()
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["job_id"] == slurm_job_id
+    assert metadata["orchestrator"] is True
+    assert metadata["model"]["path"] == "hf:fake/mock-model"
+
+    # Detached worker produces result.json. Use a longer timeout since the
+    # orchestrator walks through every phase for real.
+    assert _wait_for(output_dir / "result.json", timeout=20.0), (
+        f"mock worker did not produce result.json under {output_dir}. "
+        f"worker log:\n{(output_dir / 'mock_worker.log').read_text() if (output_dir / 'mock_worker.log').exists() else '(no worker log)'}"
+    )
+    result = json.loads((output_dir / "result.json").read_text())
+    assert result["job_id"] == slurm_job_id
+    assert result["status"] == "completed"
+    assert result["exit_code"] == 0
+
+    # Orchestrator artifacts are also present.
+    assert (output_dir / "status.json").exists()
+    assert (output_dir / "status_events.jsonl").exists()
+    assert (output_dir / "recipe.lock.yaml").exists()
+    assert (output_dir / "logs" / "benchmark.out").exists()
+
+
+def test_apply_mock_does_not_call_real_sbatch(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Ensure the stubbed sbatch prevented an actual subprocess.run(sbatch, ...)."""
+    cfg = _write_config(tmp_path)
+    output_base = tmp_path / "outputs"
+    output_base.mkdir()
+
+    real_run = __import__("subprocess").run
+
+    seen_sbatch: list[list] = []
+
+    def _tracking_run(cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "sbatch":
+            seen_sbatch.append(list(cmd))
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "srtctl",
+            "apply",
+            "-f",
+            str(cfg),
+            "-o",
+            str(output_base),
+            "--mock",
+            "--mock-tick-s",
+            "0.05",
+            "--json",
+        ],
+    )
+    # Swap real_run behind the tracker: if the mock patch fails to intercept,
+    # this will route the sbatch through to the real system call and surface.
+    with (
+        patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+        patch("subprocess.run", side_effect=_tracking_run),
+    ):
+        submit_cli.main()
+
+    assert seen_sbatch == [], (
+        f"Expected --mock to stub sbatch entirely, but saw real sbatch calls: {seen_sbatch}"
+    )

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -15,6 +15,7 @@ class TestBenchmarkRegistry:
     def test_list_benchmarks(self):
         """All expected benchmarks are registered."""
         benchmarks = list_benchmarks()
+        assert "custom" in benchmarks
         assert "sa-bench" in benchmarks
         assert "sglang-bench" in benchmarks
         assert "mmlu" in benchmarks
@@ -76,6 +77,50 @@ class TestSABenchRunner:
         )
         errors = runner.validate_config(config)
         assert errors == []
+
+
+class TestCustomBenchmarkRunner:
+    """Test custom benchmark runner."""
+
+    def test_validate_config_requires_command(self):
+        from srtctl.benchmarks.custom import CustomBenchmarkRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = CustomBenchmarkRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(type="custom"),
+        )
+        errors = runner.validate_config(config)
+        assert errors == ["benchmark.command is required for benchmark.type=custom"]
+
+    def test_build_command_uses_custom_container_and_env(self):
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.custom import CustomBenchmarkRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = CustomBenchmarkRunner()
+        runtime = MagicMock()
+        runtime.container_image = "/default-image"
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(
+                type="custom",
+                command="python /bench/run.py --foo bar",
+                container_image="nvcr.io/nvidia/python:3.11",
+                env={"FOO": "bar"},
+            ),
+        )
+
+        assert runner.build_command(config, runtime) == ["bash", "-lc", "python /bench/run.py --foo bar"]
+        assert runner.get_container_image(config, runtime) == "nvcr.io/nvidia/python:3.11"
+        assert runner.get_environment(config, runtime) == {"FOO": "bar"}
 
 
 class TestSGLangBenchRunner:

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -116,18 +116,20 @@ class TestDryRunEnvironment:
         assert "global" in output
 
     def test_backend_prefill_decode_environment(self, capsys):
-        config = _make_config({
-            "backend": {
-                "type": "sglang",
-                "prefill_environment": {
-                    "TORCH_DISTRIBUTED_DEFAULT_TIMEOUT": "1800",
-                    "PYTHONUNBUFFERED": "1",
+        config = _make_config(
+            {
+                "backend": {
+                    "type": "sglang",
+                    "prefill_environment": {
+                        "TORCH_DISTRIBUTED_DEFAULT_TIMEOUT": "1800",
+                        "PYTHONUNBUFFERED": "1",
+                    },
+                    "decode_environment": {
+                        "SGLANG_ENABLE_FLASHINFER_GEMM": "1",
+                    },
                 },
-                "decode_environment": {
-                    "SGLANG_ENABLE_FLASHINFER_GEMM": "1",
-                },
-            },
-        })
+            }
+        )
         show_config_details(config)
         output = capsys.readouterr().out
         assert "TORCH_DISTRIBUTED_DEFAULT_TIMEOUT" in output
@@ -138,13 +140,15 @@ class TestDryRunEnvironment:
 
     def test_global_and_backend_env_together(self, capsys):
         """Global environment AND backend per-mode env should both appear."""
-        config = _make_config({
-            "environment": {"GLOBAL_VAR": "global_val"},
-            "backend": {
-                "type": "sglang",
-                "prefill_environment": {"PREFILL_VAR": "prefill_val"},
-            },
-        })
+        config = _make_config(
+            {
+                "environment": {"GLOBAL_VAR": "global_val"},
+                "backend": {
+                    "type": "sglang",
+                    "prefill_environment": {"PREFILL_VAR": "prefill_val"},
+                },
+            }
+        )
         show_config_details(config)
         output = capsys.readouterr().out
         assert "GLOBAL_VAR" in output
@@ -159,24 +163,41 @@ class TestDryRunEnvironment:
         assert "No custom environment variables configured" in output
 
     def test_trtllm_backend_environment(self, capsys):
-        config = _make_config({
-            "backend": {
-                "type": "trtllm",
-                "prefill_environment": {
-                    "TRTLLM_ENABLE_PDL": "1",
-                    "NCCL_GRAPH_MIXING_SUPPORT": "0",
+        config = _make_config(
+            {
+                "backend": {
+                    "type": "trtllm",
+                    "prefill_environment": {
+                        "TRTLLM_ENABLE_PDL": "1",
+                        "NCCL_GRAPH_MIXING_SUPPORT": "0",
+                    },
+                    "decode_environment": {
+                        "TRTLLM_SERVER_DISABLE_GC": "1",
+                    },
                 },
-                "decode_environment": {
-                    "TRTLLM_SERVER_DISABLE_GC": "1",
-                },
-            },
-        })
+            }
+        )
         show_config_details(config)
         output = capsys.readouterr().out
         assert "TRTLLM_ENABLE_PDL" in output
         assert "prefill" in output
         assert "TRTLLM_SERVER_DISABLE_GC" in output
         assert "decode" in output
+
+    def test_custom_benchmark_environment(self, capsys):
+        config = _make_config(
+            {
+                "benchmark": {
+                    "type": "custom",
+                    "command": "python /bench/run.py",
+                    "env": {"BENCH_FOO": "bar"},
+                }
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "BENCH_FOO" in output
+        assert "benchmark" in output
 
 
 class TestDryRunSrunOptions:
@@ -194,3 +215,40 @@ class TestDryRunSrunOptions:
         show_config_details(config)
         output = capsys.readouterr().out
         assert "srun options" not in output
+
+
+class TestDryRunExecutionExtensions:
+    """Test custom benchmark and telemetry details display."""
+
+    def test_custom_benchmark_details_shown(self, capsys):
+        config = _make_config(
+            {
+                "benchmark": {
+                    "type": "custom",
+                    "command": "python /bench/run.py",
+                    "container_image": "nvcr.io/nvidia/python:3.11",
+                }
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "Execution Extensions" in output
+        assert "container_image" in output
+        assert "nvcr.io/nvidia/python:3.11" in output
+
+    def test_telemetry_details_shown(self, capsys):
+        config = _make_config(
+            {
+                "telemetry": {
+                    "enabled": True,
+                    "container_image": "telemetry:latest",
+                    "dcgm_exporter": {"container_image": "dcgm:latest", "port": 9401},
+                    "node_exporter": {"container_image": "node:latest", "port": 9101},
+                }
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "telemetry" in output
+        assert "scraper" in output
+        assert "storage_subdir" in output

--- a/tests/test_mock_sweep.py
+++ b/tests/test_mock_sweep.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `srtctl.mock.run_mock_sweep`.
+
+The mock runs the full SweepOrchestrator path with external surfaces
+(srun, port waits, model health checks, status HTTP) swapped for local
+fakes. These tests assert that the real orchestrator code runs to completion
+and produces the expected artifact set that external harnesses observe.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from srtctl.mock import MockOptions, run_mock_sweep
+
+MINIMAL_CONFIG = {
+    "name": "mock-smoke",
+    "model": {
+        "path": "hf:fake/mock-model",
+        "container": "nvcr.io/fake:latest",
+        "precision": "fp8",
+    },
+    "resources": {
+        "gpu_type": "h100",
+        "gpus_per_node": 8,
+        "agg_nodes": 1,
+        "agg_workers": 1,
+    },
+    "benchmark": {"type": "custom", "command": "echo fake-benchmark"},
+}
+
+
+def _write_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(yaml.dump(MINIMAL_CONFIG))
+    return cfg
+
+
+def test_run_mock_sweep_produces_expected_artifacts(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    output_dir = tmp_path / "outputs" / "42042"
+
+    exit_code = run_mock_sweep(
+        config_path=cfg,
+        output_dir=output_dir,
+        job_id="42042",
+        options=MockOptions(child_duration_s=0.15, phase_pause_s=0.05),
+    )
+
+    assert exit_code == 0
+    # Core artifacts the mock promises.
+    assert (output_dir / "status.json").is_file()
+    assert (output_dir / "status_events.jsonl").is_file()
+    assert (output_dir / "result.json").is_file()
+    assert (output_dir / "recipe.lock.yaml").is_file(), "lockfile written by real postprocess stage"
+    # Per-component logs emitted by the real orchestrator, via fake srun.
+    assert (output_dir / "logs" / "infra.out").is_file()
+    assert any((output_dir / "logs").glob("*_agg_w0.out")), "worker log written"
+    assert any((output_dir / "logs").glob("*_frontend_*.out")), "frontend log written"
+    assert (output_dir / "logs" / "benchmark.out").is_file()
+
+
+def test_run_mock_sweep_drives_full_status_timeline(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    output_dir = tmp_path / "outputs" / "42043"
+
+    exit_code = run_mock_sweep(
+        config_path=cfg,
+        output_dir=output_dir,
+        job_id="42043",
+        options=MockOptions(child_duration_s=0.1, phase_pause_s=0.05),
+    )
+    assert exit_code == 0
+
+    events_path = output_dir / "status_events.jsonl"
+    events = [json.loads(line) for line in events_path.read_text().splitlines() if line.strip()]
+
+    # Walk through every orchestrator phase we expect.
+    stages = [event.get("stage") for event in events]
+    assert "starting" in stages
+    assert "head_infrastructure" in stages
+    assert "workers" in stages
+    assert "frontend" in stages
+    assert "benchmark" in stages
+    assert "cleanup" in stages
+
+    terminal = events[-1]
+    assert terminal["status"] in ("completed", "failed")
+    assert terminal["status"] == "completed"
+
+
+def test_run_mock_sweep_result_json_is_parseable_with_fake_metrics(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    output_dir = tmp_path / "outputs" / "42044"
+
+    run_mock_sweep(
+        config_path=cfg,
+        output_dir=output_dir,
+        job_id="42044",
+        options=MockOptions(child_duration_s=0.05, phase_pause_s=0.01),
+    )
+
+    result = json.loads((output_dir / "result.json").read_text())
+    assert result["job_id"] == "42044"
+    assert result["status"] == "completed"
+    assert result["exit_code"] == 0
+    # Deterministic-ish fake metrics derived from job_id; just confirm shape.
+    assert isinstance(result["final_loss"], float)
+    assert 0.0 < result["final_loss"] < 1.0
+    assert isinstance(result["score"], float)
+    assert 0.0 < result["score"] < 1.0
+    assert isinstance(result["param_count"], int)

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -634,6 +634,36 @@ class TestS3UploadFaultTolerance:
         # Should return None for s3_url on failure
         assert s3_url is None
 
+    def test_parse_failure_still_returns_s3_url(self, tmp_path):
+        """Raw logs should still report an S3 URL when parsing fails after upload."""
+        mixin = self._create_mixin_with_runtime(tmp_path)
+        mixin._get_s3_config = MagicMock(return_value=S3Config(bucket="test-bucket"))
+
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = None
+        mock_proc.returncode = 20
+
+        with patch("srtctl.cli.mixins.postprocess_stage.start_srun_process") as mock_srun:
+            mock_srun.return_value = mock_proc
+
+            parquet_path, s3_url = mixin._run_postprocess_container()
+
+        assert parquet_path is None
+        assert s3_url is not None
+        assert s3_url.startswith("s3://test-bucket/")
+
+    def test_postprocess_script_uploads_after_parse(self, tmp_path):
+        """The generated script should upload even when parsing fails."""
+        mixin = self._create_mixin_with_runtime(tmp_path)
+        script = mixin._build_postprocess_script("s3://test-bucket/run/", "")
+
+        parse_line = "srtlog parse . || PARSE_STATUS=$?"
+        upload_line = "aws s3 sync /logs s3://test-bucket/run/"
+
+        assert parse_line in script
+        assert upload_line in script
+        assert script.index(parse_line) < script.index(upload_line)
+
     def test_run_postprocess_completes_with_s3_failure(self, tmp_path):
         """Test run_postprocess completes even when S3 upload fails entirely."""
         mixin = self._create_mixin_with_runtime(tmp_path)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for telemetry configuration and startup."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from marshmallow import ValidationError
+
+from srtctl.cli.mixins.frontend_stage import FrontendTopology
+from srtctl.cli.mixins.telemetry_stage import TelemetryStageMixin
+from srtctl.core.schema import (
+    BenchmarkConfig,
+    ModelConfig,
+    ResourceConfig,
+    SrtConfig,
+    TelemetryConfig,
+    TelemetryExporterConfig,
+)
+from srtctl.core.telemetry import generate_telemetry_config
+from srtctl.core.topology import Process
+
+
+def _make_config(*, telemetry: TelemetryConfig | None = None) -> SrtConfig:
+    return SrtConfig(
+        name="test",
+        model=ModelConfig(path="/model", container="/image", precision="fp4"),
+        resources=ResourceConfig(gpu_type="h100"),
+        benchmark=BenchmarkConfig(type="manual"),
+        telemetry=telemetry or TelemetryConfig(),
+    )
+
+
+class TestTelemetryConfig:
+    """Telemetry schema validation."""
+
+    def test_requires_container_image_when_enabled(self):
+        with pytest.raises(ValidationError, match="telemetry.container_image"):
+            _make_config(
+                telemetry=TelemetryConfig(
+                    enabled=True,
+                    dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
+                    node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
+                )
+            )
+
+
+class TestTelemetryConfigGeneration:
+    """Topology-to-config generation."""
+
+    @patch("srtctl.core.telemetry.get_hostname_ip")
+    def test_generate_telemetry_config(self, mock_get_hostname_ip):
+        mock_get_hostname_ip.side_effect = lambda host, interface=None: {"node-a": "10.0.0.1", "node-b": "10.0.0.2"}[
+            host
+        ]
+
+        telemetry = TelemetryConfig(
+            enabled=True,
+            container_image="telemetry:latest",
+            extra_metadata={"cluster": "pdx"},
+            dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
+            node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
+        )
+        runtime = MagicMock()
+        runtime.job_id = "12345"
+        runtime.run_name = "test_12345"
+        runtime.network_interface = "eth0"
+        processes = [
+            Process(
+                node="node-a",
+                gpu_indices=frozenset({0, 1}),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=0,
+            ),
+            Process(
+                node="node-b",
+                gpu_indices=frozenset({0, 1}),
+                sys_port=8082,
+                http_port=30000,
+                endpoint_mode="decode",
+                endpoint_index=0,
+                node_rank=0,
+            ),
+        ]
+        topology = FrontendTopology(
+            nginx_node=None,
+            frontend_nodes=["node-a"],
+            frontend_port=8000,
+            public_port=8000,
+        )
+
+        config_text = generate_telemetry_config(
+            processes=processes,
+            frontend_topology=topology,
+            runtime=runtime,
+            telemetry=telemetry,
+        )
+
+        assert 'storage = "/logs/telemetry"' in config_text
+        assert 'name = "dcgm_node-a"' in config_text
+        assert 'url = "http://10.0.0.1:8081/metrics"' in config_text
+        assert '"cluster" = "pdx"' in config_text
+        assert 'name = "frontend0"' in config_text
+
+
+class TestTelemetryStageMixin:
+    """Telemetry stage startup."""
+
+    @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
+    @patch("srtctl.cli.mixins.telemetry_stage.generate_telemetry_config", return_value='storage = "/logs/telemetry"\n')
+    def test_start_telemetry_starts_exporters_and_scraper(self, _mock_config, mock_srun, tmp_path):
+        class Harness(TelemetryStageMixin):
+            def __init__(self):
+                self.config = _make_config(
+                    telemetry=TelemetryConfig(
+                        enabled=True,
+                        container_image="telemetry:latest",
+                        dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
+                        node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
+                    )
+                )
+                self.runtime = MagicMock()
+                self.runtime.log_dir = tmp_path
+                self.runtime.nodes.head = "node-a"
+                self.runtime.srun_options = {}
+                self.runtime.container_mounts = {Path(tmp_path): Path("/logs")}
+                self._backend_processes = [
+                    Process(
+                        node="node-a",
+                        gpu_indices=frozenset({0}),
+                        sys_port=8081,
+                        http_port=30000,
+                        endpoint_mode="agg",
+                        endpoint_index=0,
+                        node_rank=0,
+                    )
+                ]
+
+            @property
+            def backend_processes(self):
+                return self._backend_processes
+
+            def _compute_frontend_topology(self):
+                return FrontendTopology(
+                    nginx_node=None,
+                    frontend_nodes=["node-a"],
+                    frontend_port=8000,
+                    public_port=8000,
+                )
+
+        mock_srun.return_value = MagicMock()
+        harness = Harness()
+
+        procs = harness.start_telemetry()
+
+        assert len(procs) == 3
+        assert (tmp_path / "telemetry_config.toml").exists()
+        assert (tmp_path / "telemetry" / "local").exists()
+        assert mock_srun.call_count == 3


### PR DESCRIPTION
## What changed

This PR adds the `srt-slurm` pieces needed for benchmarking workflows without making `srt-slurm` itself user-facing.

- added a first-class `custom` benchmark runner with optional benchmark-specific container and environment support
- added a generic telemetry model and orchestration stage that launches exporter processes plus a scraper-compatible collector
- kept the telemetry surface generic
- hardened postprocess so raw logs still sync to S3 even when parsing fails
- extended dry-run output to show custom benchmark and telemetry configuration
- added focused test coverage for benchmark registration, telemetry config generation/startup, dry-run rendering, and resilient postprocess behavior

## Why

- no first-class custom benchmark path
- no first-class telemetry concept in the orchestrator
- postprocess could skip S3 upload if parsing failed, which made failure analysis brittle

## Impact

- benchmark authors can supply arbitrary benchmark commands without patching the orchestrator
- telemetry can be enabled as a normal top-level config with provider-compatible structure
- failed jobs retain raw logs and postprocess status in S3 more reliably
- dry-run now surfaces the extra execution config users need to verify before launch

## Root cause for the durability fix

The postprocess container used `set -e` and ran parsing before `aws s3 sync`, so a parser failure prevented raw artifacts from being uploaded at all. This PR makes parsing best-effort and keeps upload as the priority path.