### PR TITLE
fix: Install maturin if not present

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -883,6 +883,7 @@ class DynamoConfig:
         sglang = (
             "apt-get update -qq && apt-get install -y -qq libclang-dev curl > /dev/null 2>&1 && "
             "if ! command -v cargo &>/dev/null; then curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable -q && source $HOME/.cargo/env; fi && "
+            "if ! command -v maturin &>/dev/null; then pip install --break-system-packages maturin; fi && "
             "cd /sgl-workspace/ && "
             "git clone https://github.com/ai-dynamo/dynamo.git && "
             "cd dynamo && "


### PR DESCRIPTION
Fixes `/usr/bin/bash: line 1: maturin: command not found`