### PR TITLE
[codex] Port HF cache cleanup

### DIFF
--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -16,6 +16,7 @@ import argparse
 import functools
 import logging
 import os
+import subprocess
 import sys
 import threading
 from dataclasses import dataclass
@@ -194,6 +195,173 @@ class SweepOrchestrator(
         logger.info("=" * 60)
         logger.info("")
 
+    def _get_hf_home(self) -> str | None:
+        """Get HF_HOME from backend environment config."""
+        for mode in ("prefill", "decode", "agg"):
+            env = self.config.backend.get_environment_for_mode(mode)
+            if "HF_HOME" in env:
+                return env["HF_HOME"]
+        return None
+
+    def _get_hf_env(self) -> dict[str, str]:
+        """Collect HF-related environment variables from backend config.
+
+        Merges environment from all modes (prefill/decode/agg), keeping
+        only HuggingFace-relevant keys (HF_*, HUGGING_FACE_*) so the
+        pre-download srun runs with the same auth/endpoint context as workers.
+        """
+        hf_env: dict[str, str] = {}
+        for mode in ("prefill", "decode", "agg"):
+            for key, val in self.config.backend.get_environment_for_mode(mode).items():
+                if key.startswith(("HF_", "HUGGING_FACE_")):
+                    hf_env[key] = val
+        return hf_env
+
+    def _clean_stale_hf_locks(self) -> None:
+        """Clean stale HuggingFace download lock files from shared cache.
+
+        When multiple workers share a HF cache on a networked filesystem,
+        stale .lock files from crashed jobs block all future downloads with
+        "Lock acquisition failed". This removes locks older than 30 minutes
+        (no legitimate download takes that long).
+        """
+        hf_home = self._get_hf_home()
+        if not hf_home:
+            return
+
+        cache_dir = Path(hf_home)
+        if not cache_dir.is_dir():
+            return
+
+        import time
+
+        threshold = time.time() - 30 * 60  # 30 minutes ago
+        removed = 0
+        for lock_file in cache_dir.rglob("*.lock"):
+            try:
+                if lock_file.stat().st_mtime < threshold:
+                    lock_file.unlink()
+                    removed += 1
+            except OSError:
+                pass  # Permission denied or already deleted
+
+        if removed > 0:
+            logger.info("Cleaned %d stale .lock files from HF cache: %s", removed, hf_home)
+
+    def _ensure_model_cached(self) -> None:
+        """Pre-download HuggingFace model on a single node before starting workers.
+
+        srt-slurm launches multiple workers that each independently call
+        dynamo's fetch_model(). Without pre-caching, all workers race to
+        download the same model on the shared filesystem, causing lock
+        contention and "Lock acquisition failed" errors.
+
+        This method runs huggingface-cli download on ONE compute node
+        (synchronously, blocking) so the model is fully cached before
+        any worker starts. Subsequent worker startups find the model
+        in cache and skip downloading entirely - no locks created.
+        """
+        if not self.runtime.is_hf_model:
+            return
+
+        hf_home = self._get_hf_home()
+        if not hf_home:
+            logger.warning(
+                "HF model '%s' specified but HF_HOME is not set in backend environment config. "
+                "Workers will use the default HuggingFace cache (~/.cache/huggingface) which may not "
+                "be shared across nodes. Set HF_HOME in prefill_environment/decode_environment to use "
+                "a shared cache directory (e.g., HF_HOME: /lustre/fsw/.../common/cache).",
+                self.runtime.model_path,
+            )
+            return
+
+        model_id = str(self.runtime.model_path)
+
+        # Check if model is already fully cached using huggingface_hub API.
+        # snapshot_download with local_files_only=True succeeds only if every
+        # file in the model repo is already present in the local cache.
+        # Note: HF_HOME stores models in $HF_HOME/hub/, so we pass cache_dir=$HF_HOME/hub
+        # to match the actual storage location used by workers.
+        try:
+            from huggingface_hub import snapshot_download  # type: ignore[import-untyped]
+
+            snapshot_download(model_id, cache_dir=str(Path(hf_home) / "hub"), local_files_only=True)
+            logger.info("Model '%s' already cached at %s, skipping pre-download", model_id, hf_home)
+            return
+        except ImportError:
+            logger.debug("huggingface_hub not installed on host, will use container to check/download")
+        except Exception:
+            logger.debug("Model '%s' not fully cached, will pre-download", model_id)
+
+        download_node = self.runtime.nodes.worker[0]
+
+        logger.info("Ensuring model '%s' is cached on %s (cache: %s)", model_id, download_node, hf_home)
+
+        # The srun command uses HF_HOME (not --cache-dir) to match the exact
+        # cache path workers use ($HF_HOME/hub/models--*/).
+        # It first checks with HF_HUB_OFFLINE=1 (fast, no network). Only if
+        # that fails does it actually download.
+        # Uses 'hf download' (new CLI) with 'huggingface-cli download' as fallback.
+        import shlex
+
+        q_hf_home = shlex.quote(hf_home)
+        q_model_id = shlex.quote(model_id)
+        download_cmd = [
+            "bash",
+            "-c",
+            f"export HF_HOME={q_hf_home}; "
+            f"find {q_hf_home} -name '*.lock' -mmin +30 -delete 2>/dev/null; "
+            f"DL_CMD='hf download'; "
+            f"command -v hf >/dev/null 2>&1 || DL_CMD='huggingface-cli download'; "
+            f"if HF_HUB_OFFLINE=1 $DL_CMD {q_model_id} --quiet 2>/dev/null; then "
+            f"echo 'Model already cached'; "
+            f"else "
+            f"echo 'Downloading model...'; "
+            f"$DL_CMD {q_model_id} --quiet; "
+            f"fi",
+        ]
+
+        download_log = self.runtime.log_dir / "model_download.out"
+
+        # Pass all HF-related env vars (HF_TOKEN, HF_ENDPOINT, etc.) so the
+        # pre-download runs with the same auth/endpoint context as workers.
+        hf_env = self._get_hf_env()
+
+        try:
+            proc = start_srun_process(
+                command=download_cmd,
+                nodelist=[download_node],
+                output=str(download_log),
+                container_image=str(self.runtime.container_image),
+                container_mounts=self.runtime.container_mounts,
+                env_to_set=hf_env,
+                use_bash_wrapper=False,  # command is already bash -c
+            )
+
+            timeout_sec = 60 * 60  # 1 hour; large models can take a while
+            try:
+                rc = proc.wait(timeout=timeout_sec)
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "Model pre-download timed out after %d seconds, killing (workers will retry at startup). Log: %s",
+                    timeout_sec,
+                    download_log,
+                )
+                proc.kill()
+                proc.wait()
+                return
+
+            if rc != 0:
+                logger.warning(
+                    "Model pre-download exited with code %d (workers will retry at startup). Log: %s",
+                    rc,
+                    download_log,
+                )
+            else:
+                logger.info("Model pre-download complete")
+        except Exception:
+            logger.warning("Model pre-download failed (workers will retry at startup)", exc_info=True)
+
     def run(self) -> int:
         """Run the complete sweep."""
         # Create status reporter (fire-and-forget, no-op if not configured)
@@ -225,6 +393,14 @@ class SweepOrchestrator(
             reporter.report(JobStatus.STARTING, JobStage.HEAD_INFRASTRUCTURE, "Starting head infrastructure")
             head_proc = self.start_head_infrastructure(registry)
             registry.add_process(head_proc)
+
+            # Pre-worker: Ensure HF model is cached before starting workers.
+            # 1. Clean stale lock files from previous crashed downloads
+            # 2. Download model on a single node (blocks until complete)
+            # This prevents lock contention when multiple workers start.
+            if self.runtime.is_hf_model:
+                self._clean_stale_hf_locks()
+                self._ensure_model_cached()
 
             # Stage 2: Workers
             reporter.report(JobStatus.WORKERS, JobStage.WORKERS, "Starting workers")

--- a/tests/test_hf_cache.py
+++ b/tests/test_hf_cache.py
@@ -1,0 +1,643 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for HuggingFace cache management in SweepOrchestrator.
+
+Tests _get_hf_home(), _clean_stale_hf_locks(), and _ensure_model_cached().
+"""
+
+import os
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from srtctl.cli.do_sweep import SweepOrchestrator
+from srtctl.core.config import load_config
+from srtctl.core.runtime import RuntimeContext
+
+# Fixtures
+
+
+class TestCluster:
+    """Minimal cluster for testing."""
+
+    NUM_NODES = 5
+    GPUS_PER_NODE = 4
+
+    @classmethod
+    def nodes(cls) -> list[str]:
+        return [f"node-{i:02d}" for i in range(1, cls.NUM_NODES + 1)]
+
+    @classmethod
+    def slurm_env(cls) -> dict[str, str]:
+        return {
+            "SLURM_JOB_ID": "99999",
+            "SLURM_JOBID": "99999",
+            "SLURM_NODELIST": f"node-[01-{cls.NUM_NODES:02d}]",
+            "SLURM_JOB_NUM_NODES": str(cls.NUM_NODES),
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+        }
+
+    @classmethod
+    def mock_scontrol(cls):
+        def mock_run(cmd, **kwargs):
+            if cmd[0] == "scontrol" and "hostnames" in cmd:
+                result = MagicMock()
+                result.stdout = "\n".join(cls.nodes())
+                result.returncode = 0
+                return result
+            raise subprocess.CalledProcessError(1, cmd)
+
+        return mock_run
+
+
+def _make_orchestrator(config_path: str, hf_model: bool = True) -> SweepOrchestrator:
+    """Create a SweepOrchestrator with mocked SLURM environment."""
+    with (
+        patch.dict(os.environ, TestCluster.slurm_env()),
+        patch("subprocess.run", TestCluster.mock_scontrol()),
+    ):
+        config = load_config(Path(config_path))
+        runtime = RuntimeContext.from_config(config, "99999")
+        return SweepOrchestrator(config=config, runtime=runtime)
+
+
+# Tests for _get_hf_home
+
+
+class TestGetHfHome:
+    """Tests for _get_hf_home() method."""
+
+    def test_returns_hf_home_from_prefill_env(self, tmp_path: Path):
+        """HF_HOME set in prefill_environment should be returned."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            """
+name: test
+model:
+  path: "hf:nvidia/test-model"
+  container: "test-image:latest"
+  precision: fp16
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "/cache/hub"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+        assert orch._get_hf_home() == "/cache/hub"
+
+    def test_returns_none_when_not_set(self, tmp_path: Path):
+        """No HF_HOME in any environment config should return None."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            """
+name: test
+model:
+  path: "hf:nvidia/test-model"
+  container: "test-image:latest"
+  precision: fp16
+backend:
+  type: vllm
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+        assert orch._get_hf_home() is None
+
+
+# Tests for _clean_stale_hf_locks
+
+
+class TestCleanStaleHfLocks:
+    """Tests for _clean_stale_hf_locks() method."""
+
+    def test_removes_old_lock_files(self, tmp_path: Path):
+        """Lock files older than 30 minutes should be removed."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        blobs_dir = cache_dir / "hub" / "models--test" / "blobs"
+        blobs_dir.mkdir(parents=True)
+
+        # Create a stale lock (set mtime to 1 hour ago)
+        stale_lock = blobs_dir / "abc123.lock"
+        stale_lock.touch()
+        old_time = time.time() - 3600
+        os.utime(stale_lock, (old_time, old_time))
+
+        # Create a fresh lock (should NOT be removed)
+        fresh_lock = blobs_dir / "def456.lock"
+        fresh_lock.touch()
+
+        # Create a non-lock file (should NOT be removed)
+        data_file = blobs_dir / "abc123"
+        data_file.write_bytes(b"model data")
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "hf:nvidia/test-model"
+  container: "test-image:latest"
+  precision: fp16
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{cache_dir}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+        orch._clean_stale_hf_locks()
+
+        assert not stale_lock.exists(), "Stale lock should be removed"
+        assert fresh_lock.exists(), "Fresh lock should be kept"
+        assert data_file.exists(), "Non-lock files should be untouched"
+
+    def test_no_hf_home_is_noop(self, tmp_path: Path):
+        """No HF_HOME configured should silently do nothing."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            """
+name: test
+model:
+  path: "hf:nvidia/test-model"
+  container: "test-image:latest"
+  precision: fp16
+backend:
+  type: vllm
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+        # Should not raise
+        orch._clean_stale_hf_locks()
+
+    def test_nonexistent_cache_dir_is_noop(self, tmp_path: Path):
+        """HF_HOME pointing to nonexistent directory should silently do nothing."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "hf:nvidia/test-model"
+  container: "test-image:latest"
+  precision: fp16
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'nonexistent'}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+        # Should not raise
+        orch._clean_stale_hf_locks()
+
+
+# Tests for _ensure_model_cached
+
+
+class TestEnsureModelCached:
+    """Tests for _ensure_model_cached() method."""
+
+    def test_skips_local_models(self, tmp_path: Path):
+        """Local model paths (not hf:) should skip pre-download."""
+        model_dir = tmp_path / "local_model"
+        model_dir.mkdir()
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "{model_dir}"
+  container: "test-image:latest"
+  precision: fp16
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'cache'}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process") as mock_srun:
+            orch._ensure_model_cached()
+            mock_srun.assert_not_called()
+
+    def test_skips_and_warns_when_no_hf_home(self, tmp_path: Path, caplog):
+        """HF model without HF_HOME should skip pre-download and log a warning."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            """
+name: test
+model:
+  path: "hf:nvidia/test-model"
+  container: "test-image:latest"
+  precision: fp16
+backend:
+  type: vllm
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        import logging
+
+        with patch("srtctl.cli.do_sweep.start_srun_process") as mock_srun:
+            with caplog.at_level(logging.WARNING):
+                orch._ensure_model_cached()
+            mock_srun.assert_not_called()
+            assert "HF_HOME is not set" in caplog.text
+
+    def test_skips_when_model_already_cached(self, tmp_path: Path):
+        """Pre-download should skip if huggingface_hub reports model is cached."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "hf:nvidia/Kimi-K2.5-NVFP4"
+  container: "test-image:latest"
+  precision: fp4
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'cache'}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        # Mock huggingface_hub.snapshot_download to succeed (model is cached).
+        # The import happens inside _ensure_model_cached via "from huggingface_hub import ...",
+        # so we create a fake module and patch it into sys.modules.
+        import types
+
+        fake_hf_hub = types.ModuleType("huggingface_hub")
+        fake_hf_hub.snapshot_download = MagicMock(return_value="/fake/path")
+
+        import sys
+
+        with (
+            patch("srtctl.cli.do_sweep.start_srun_process") as mock_srun,
+            patch.dict(sys.modules, {"huggingface_hub": fake_hf_hub}),
+        ):
+            orch._ensure_model_cached()
+            mock_srun.assert_not_called()
+            fake_hf_hub.snapshot_download.assert_called_once()
+
+    def test_runs_srun_on_single_node(self, tmp_path: Path):
+        """Pre-download should run huggingface-cli on exactly one node."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "hf:nvidia/Kimi-K2.5-NVFP4"
+  container: "test-image:latest"
+  precision: fp4
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'cache'}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = 0
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=mock_proc) as mock_srun:
+            orch._ensure_model_cached()
+
+            mock_srun.assert_called_once()
+            kwargs = mock_srun.call_args.kwargs
+
+            # Should run on exactly one node (first worker node)
+            assert kwargs["nodelist"] == ["node-01"]
+
+            # Command should contain huggingface-cli download with model name
+            cmd_str = " ".join(kwargs["command"])
+            assert "huggingface-cli download" in cmd_str
+            assert "nvidia/Kimi-K2.5-NVFP4" in cmd_str
+            assert str(tmp_path / "cache") in cmd_str
+
+            # Should use the container image
+            assert kwargs["container_image"] == "test-image:latest"
+
+            # Should pass HF env vars to srun
+            assert "HF_HOME" in kwargs["env_to_set"]
+
+            # Should wait with a timeout
+            mock_proc.wait.assert_called_once()
+            assert mock_proc.wait.call_args.kwargs.get("timeout") is not None
+
+    def test_passes_hf_token_to_srun(self, tmp_path: Path):
+        """HF_TOKEN from backend env should be passed to the pre-download srun."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "hf:nvidia/Kimi-K2.5-NVFP4"
+  container: "test-image:latest"
+  precision: fp4
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'cache'}"
+    HF_TOKEN: "hf_secret_token_123"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = 0
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=mock_proc) as mock_srun:
+            orch._ensure_model_cached()
+
+            kwargs = mock_srun.call_args.kwargs
+            assert kwargs["env_to_set"]["HF_TOKEN"] == "hf_secret_token_123"
+
+    def test_handles_download_timeout_gracefully(self, tmp_path: Path):
+        """Timed-out pre-download should kill the process and continue."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "hf:nvidia/Kimi-K2.5-NVFP4"
+  container: "test-image:latest"
+  precision: fp4
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'cache'}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        mock_proc = MagicMock()
+        mock_proc.wait.side_effect = [subprocess.TimeoutExpired("srun", 3600), None]
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=mock_proc):
+            # Should NOT raise
+            orch._ensure_model_cached()
+            # Should have killed the process
+            mock_proc.kill.assert_called_once()
+
+    def test_handles_download_failure_gracefully(self, tmp_path: Path):
+        """Failed pre-download should warn but not raise."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "hf:nvidia/Kimi-K2.5-NVFP4"
+  container: "test-image:latest"
+  precision: fp4
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'cache'}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        mock_proc = MagicMock()
+        mock_proc.wait.return_value = 1  # Non-zero = failure
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=mock_proc):
+            # Should NOT raise, just log a warning
+            orch._ensure_model_cached()
+
+    def test_handles_srun_launch_exception_gracefully(self, tmp_path: Path):
+        """Exception from start_srun_process should be caught, not abort the sweep."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "hf:nvidia/Kimi-K2.5-NVFP4"
+  container: "test-image:latest"
+  precision: fp4
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'cache'}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", side_effect=OSError("srun not found")):
+            # Should NOT raise - best-effort pre-download
+            orch._ensure_model_cached()
+
+
+# Tests for run() guard on is_hf_model
+
+
+class TestRunHfModelGuard:
+    """Tests that run() only triggers HF cache operations for HF models."""
+
+    def test_local_model_skips_hf_cache_operations(self, tmp_path: Path):
+        """Local model paths should not trigger _clean_stale_hf_locks or _ensure_model_cached."""
+        model_dir = tmp_path / "local_model"
+        model_dir.mkdir()
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            f"""
+name: test
+model:
+  path: "{model_dir}"
+  container: "test-image:latest"
+  precision: fp16
+backend:
+  type: vllm
+  prefill_environment:
+    HF_HOME: "{tmp_path / 'cache'}"
+  vllm_config:
+    prefill:
+      tensor-parallel-size: 1
+    decode:
+      tensor-parallel-size: 1
+resources:
+  gpu_type: gb200
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_node: 4
+"""
+        )
+        orch = _make_orchestrator(str(config_file))
+
+        with (
+            patch.object(orch, "_clean_stale_hf_locks") as mock_clean,
+            patch.object(orch, "_ensure_model_cached") as mock_ensure,
+            patch.object(orch, "start_head_infrastructure"),
+            patch.object(orch, "start_all_workers", return_value=[]),
+            patch.object(orch, "start_frontend", return_value=[]),
+            patch.object(orch, "run_benchmark", return_value=0),
+            patch.object(orch, "run_postprocess"),
+            patch("srtctl.cli.do_sweep.StatusReporter"),
+        ):
+            orch.run()
+            mock_clean.assert_not_called()
+            mock_ensure.assert_not_called()


### PR DESCRIPTION
## Summary

Ports the HF cache cleanup and single-node model pre-download work from `ishandhanani/srt-slurm` PR #251 into `NVIDIA/srt-slurm`.

This adds pre-worker HuggingFace cache handling in `SweepOrchestrator`:
- collect `HF_*` and `HUGGING_FACE_*` env vars from backend mode environments
- remove stale `.lock` files from shared `HF_HOME`
- pre-download HF models on one worker node before starting all workers
- keep pre-download best-effort so workers can still retry at startup

## Why

HF-backed runs can start multiple workers that all try to populate the same shared model cache at once. That can leave stale locks or trigger lock contention. Pre-caching the model once before worker startup avoids the fan-out download race.

## Validation

- `uv run --with ruff ruff check src/srtctl tests/test_hf_cache.py`
- `uv run --with pytest pytest tests/test_hf_cache.py tests/test_configs.py::TestHuggingFaceModelSupport tests/test_benchmarks.py -q`
