### PR TITLE
[codex] Keep MCP validation off host cluster config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,12 @@ When you run `srtctl apply -f config.yaml`, the tool:
 3. Generates a SLURM batch script and SGLang configuration files
 4. Submits to SLURM
 
+The `srtctl-mcp` server is different from `srtctl apply`: it is a schema and
+recipe-authoring helper. It does not use host-side `srtslurm.yaml` for cluster
+defaults, aliases, containers, model paths, filesystem checks, or dry-run
+behavior. Run `srtctl` on the compute side, or use an orchestrator remote
+preflight path, for those checks.
+
 Once allocated, workers launch inside containers, discover each other through ETCD and NATS, and begin serving. If you've configured a benchmark, it runs automatically against the serving endpoint and saves results to the log directory.
 
 ## Commands

--- a/src/srtctl/core/validation.py
+++ b/src/srtctl/core/validation.py
@@ -22,7 +22,6 @@ import requests
 
 from srtctl.core.config import (
     generate_override_configs,
-    load_cluster_config,
     resolve_config_with_defaults,
 )
 
@@ -233,13 +232,149 @@ def _preflight_container(
     )
 
 
+def validate_topology(resources: dict[str, Any] | None) -> list[PreflightIssue]:
+    """Catch semantically wrong resources blocks that pass the marshmallow schema.
+
+    The schema accepts any combination of prefill_*, decode_*, and agg_* fields,
+    so configs like ``prefill_workers: 0`` with ``decode_workers: 1`` look valid
+    but express "disaggregated with no prefill" — which is really aggregated and
+    should use agg_nodes/agg_workers instead.
+    """
+    if not resources:
+        return [
+            PreflightIssue(
+                code="topology-missing",
+                field="resources",
+                message=(
+                    "resources block is empty. Set either disaggregated "
+                    "(prefill_nodes/prefill_workers + decode_nodes/decode_workers) "
+                    "or aggregated (agg_nodes + agg_workers)."
+                ),
+            )
+        ]
+
+    prefill_nodes = resources.get("prefill_nodes")
+    decode_nodes = resources.get("decode_nodes")
+    prefill_workers = resources.get("prefill_workers")
+    decode_workers = resources.get("decode_workers")
+    agg_nodes = resources.get("agg_nodes")
+    agg_workers = resources.get("agg_workers")
+
+    disagg_fields = {
+        "prefill_nodes": prefill_nodes,
+        "decode_nodes": decode_nodes,
+        "prefill_workers": prefill_workers,
+        "decode_workers": decode_workers,
+    }
+    agg_fields = {"agg_nodes": agg_nodes, "agg_workers": agg_workers}
+
+    has_disagg = any(v is not None for v in disagg_fields.values())
+    has_agg = any(v is not None for v in agg_fields.values())
+
+    if has_disagg and has_agg:
+        set_disagg = sorted(k for k, v in disagg_fields.items() if v is not None)
+        set_agg = sorted(k for k, v in agg_fields.items() if v is not None)
+        return [
+            PreflightIssue(
+                code="topology-mixed",
+                field="resources",
+                message=(
+                    f"Mixes disaggregated fields ({', '.join(set_disagg)}) with aggregated fields "
+                    f"({', '.join(set_agg)}). Use disaggregated (prefill_*/decode_*) "
+                    "or aggregated (agg_*), not both."
+                ),
+            )
+        ]
+
+    issues: list[PreflightIssue] = []
+
+    if has_disagg:
+        pf_workers = prefill_workers or 0
+        dc_workers = decode_workers or 0
+        pf_nodes = prefill_nodes or 0
+        dc_nodes = decode_nodes or 0
+
+        if pf_workers == 0 and dc_workers == 0:
+            issues.append(
+                PreflightIssue(
+                    code="topology-no-workers",
+                    field="resources",
+                    message=(
+                        "Disaggregated resources block has no workers: prefill_workers and "
+                        "decode_workers are both 0/null. Set both, or switch to aggregated "
+                        "mode with agg_nodes + agg_workers."
+                    ),
+                )
+            )
+        elif pf_workers == 0:
+            issues.append(
+                PreflightIssue(
+                    code="topology-aggregated-style",
+                    field="resources.prefill_workers",
+                    message=(
+                        "prefill_workers is 0 in a disaggregated-style resources block. "
+                        f"For a single-side topology on {dc_nodes} node(s) with {dc_workers} "
+                        f"worker(s), use aggregated mode: `agg_nodes: {dc_nodes}, "
+                        f"agg_workers: {dc_workers}` (remove prefill_*/decode_*)."
+                    ),
+                )
+            )
+        elif dc_workers == 0:
+            issues.append(
+                PreflightIssue(
+                    code="topology-aggregated-style",
+                    field="resources.decode_workers",
+                    message=(
+                        "decode_workers is 0 in a disaggregated-style resources block. "
+                        f"For a single-side topology on {pf_nodes} node(s) with {pf_workers} "
+                        f"worker(s), use aggregated mode: `agg_nodes: {pf_nodes}, "
+                        f"agg_workers: {pf_workers}` (remove prefill_*/decode_*)."
+                    ),
+                )
+            )
+        return issues
+
+    if has_agg:
+        ag_workers = agg_workers or 0
+        ag_nodes = agg_nodes or 0
+        if ag_workers == 0:
+            issues.append(
+                PreflightIssue(
+                    code="topology-no-workers",
+                    field="resources.agg_workers",
+                    message="agg_workers must be > 0 in aggregated mode.",
+                )
+            )
+        if ag_nodes == 0:
+            issues.append(
+                PreflightIssue(
+                    code="topology-no-nodes",
+                    field="resources.agg_nodes",
+                    message="agg_nodes must be > 0 in aggregated mode.",
+                )
+            )
+        return issues
+
+    return [
+        PreflightIssue(
+            code="topology-missing",
+            field="resources",
+            message=(
+                "No topology set. Set either disaggregated "
+                "(prefill_nodes/prefill_workers + decode_nodes/decode_workers) "
+                "or aggregated (agg_nodes + agg_workers)."
+            ),
+        )
+    ]
+
+
 def preflight_config_variants(
     raw_config: dict[str, Any],
     *,
     cluster_config: dict[str, Any] | None = None,
     selector: str | None = None,
 ) -> list[PreflightResult]:
-    active_cluster_config = load_cluster_config() if cluster_config is None else cluster_config
+    active_cluster_config = cluster_config
     variants = (
         generate_override_configs(raw_config, selector=selector) if "base" in raw_config else [("base", raw_config)]
     )
@@ -248,7 +383,8 @@ def preflight_config_variants(
         resolved = resolve_config_with_defaults(variant, active_cluster_config)
         model, model_issues = _preflight_model(variant, resolved, active_cluster_config)
         container, container_issues = _preflight_container(variant, resolved, active_cluster_config)
-        issues = [*model_issues, *container_issues]
+        topology_issues = validate_topology(variant.get("resources"))
+        issues = [*model_issues, *container_issues, *topology_issues]
         results.append(
             PreflightResult(
                 variant=suffix,

--- a/src/srtctl/mcp/server.py
+++ b/src/srtctl/mcp/server.py
@@ -64,7 +64,7 @@ def validate_config(
     config_yaml: str | None = None,
     apply_cluster_defaults: bool = False,
 ) -> dict[str, Any]:
-    """Validate recipe structure against the SrtConfig schema without assuming target-cluster state."""
+    """Validate recipe structure only; never read host-side srtslurm.yaml."""
     return validate_config_impl(
         config=config,
         config_yaml=config_yaml,
@@ -78,7 +78,7 @@ def preflight_config(
     config_yaml: str | None = None,
     apply_cluster_defaults: bool = False,
 ) -> dict[str, Any]:
-    """Run local-only validation for explicit paths or optionally this MCP host's srtslurm.yaml."""
+    """Check explicit local paths only; run cluster checks compute-side."""
     return preflight_config_impl(
         config=config,
         config_yaml=config_yaml,
@@ -92,7 +92,7 @@ def resolve_config(
     config_yaml: str | None = None,
     apply_cluster_defaults: bool = False,
 ) -> dict[str, Any]:
-    """Resolve schema defaults for recipe authoring without assuming target-cluster aliases."""
+    """Resolve schema-only defaults without reading host-side srtslurm.yaml."""
     return resolve_config_impl(
         config=config,
         config_yaml=config_yaml,

--- a/src/srtctl/mcp/spec_tools.py
+++ b/src/srtctl/mcp/spec_tools.py
@@ -11,15 +11,19 @@ from typing import Any, get_args, get_origin, get_type_hints
 import yaml
 
 from srtctl.core.config import (
-    find_cluster_config_path,
     generate_override_configs,
-    load_cluster_config,
     resolve_config_with_defaults,
 )
 from srtctl.core.schema import SrtConfig
-from srtctl.core.validation import preflight_config_variants
+from srtctl.core.validation import preflight_config_variants, validate_topology
 
 DOC_PATH = Path(__file__).resolve().parents[3] / "docs" / "config-reference.md"
+COMPUTE_SIDE_HINT = (
+    "Host-side srtslurm.yaml is not used by srtctl MCP. For cluster defaults, "
+    "aliases, containers, model paths, filesystem checks, or dry-run behavior, "
+    "run srtctl on the compute side or use IBAR remote_preflight/remote_dry_run/"
+    "cluster_aliases with the target compute profile."
+)
 
 
 def schema_summary() -> dict[str, Any]:
@@ -97,12 +101,10 @@ def validate_config(
     apply_cluster_defaults: bool = False,
 ) -> dict[str, Any]:
     """Validate one plain config or an override config against the real schema."""
+    _reject_cluster_defaults(apply_cluster_defaults)
     raw = _load_raw_config(config=config, config_yaml=config_yaml)
-    cluster_config = load_cluster_config() if apply_cluster_defaults else None
-    context = _cluster_context(
-        cluster_config=cluster_config,
-        apply_cluster_defaults=apply_cluster_defaults,
-    )
+    cluster_config = None
+    context = _cluster_context()
     schema = SrtConfig.Schema()
 
     variants: list[tuple[str, dict[str, Any]]] = generate_override_configs(raw) if "base" in raw else [("base", raw)]
@@ -116,6 +118,9 @@ def validate_config(
             normalized.append({"variant": suffix, "config": schema.dump(loaded)})
         except Exception as exc:
             errors.append(f"{suffix}: {exc}")
+            continue
+        for issue in validate_topology(variant.get("resources")):
+            errors.append(f"{suffix}: {issue.field}: {issue.message}")
 
     return {
         "valid": not errors,
@@ -132,24 +137,18 @@ def preflight_config(
     config_yaml: str | None = None,
     apply_cluster_defaults: bool = False,
 ) -> dict[str, Any]:
-    """Check that model and container references are resolvable on this MCP host."""
+    """Check explicit local paths only; cluster state must be checked compute-side."""
+    _reject_cluster_defaults(apply_cluster_defaults)
     raw = _load_raw_config(config=config, config_yaml=config_yaml)
-    cluster_config = load_cluster_config() if apply_cluster_defaults else None
-    context = _cluster_context(
-        cluster_config=cluster_config,
-        apply_cluster_defaults=apply_cluster_defaults,
-    )
+    cluster_config = None
+    context = _cluster_context()
     results = preflight_config_variants(raw, cluster_config=cluster_config)
     return {
-        "scope": "local",
+        "scope": "explicit-local-paths",
         "ok": all(result.ok for result in results),
         "variant_count": len(results),
         "variants": [result.as_dict() for result in results],
-        "operator_hint": (
-            "This preflight only reflects the srtslurm.yaml visible to this MCP host. "
-            "For cluster-aware operator flows through IBAR, prefer IBAR remote preflight "
-            "or IBAR remote dry-run with a compute profile."
-        ),
+        "operator_hint": COMPUTE_SIDE_HINT,
         **context,
     }
 
@@ -160,13 +159,11 @@ def resolve_config(
     config_yaml: str | None = None,
     apply_cluster_defaults: bool = False,
 ) -> dict[str, Any]:
-    """Resolve config defaults without requiring the caller to understand srtslurm.yaml."""
+    """Resolve schema-only defaults without reading host-side srtslurm.yaml."""
+    _reject_cluster_defaults(apply_cluster_defaults)
     raw = _load_raw_config(config=config, config_yaml=config_yaml)
-    cluster_config = load_cluster_config() if apply_cluster_defaults else None
-    context = _cluster_context(
-        cluster_config=cluster_config,
-        apply_cluster_defaults=apply_cluster_defaults,
-    )
+    cluster_config = None
+    context = _cluster_context()
     if "base" in raw:
         resolved_variants = [
             {
@@ -176,13 +173,13 @@ def resolve_config(
             for suffix, variant in generate_override_configs(raw)
         ]
         return {
-            "scope": "local",
+            "scope": "schema-only",
             "variant_count": len(resolved_variants),
             "variants": resolved_variants,
             **context,
         }
     return {
-        "scope": "local",
+        "scope": "schema-only",
         "variant_count": 1,
         "variants": [{"variant": "base", "config": resolve_config_with_defaults(raw, cluster_config)}],
         **context,
@@ -200,22 +197,17 @@ def _load_raw_config(*, config: dict[str, Any] | None = None, config_yaml: str |
     return loaded
 
 
-def _cluster_context(
-    *,
-    cluster_config: dict[str, Any] | None,
-    apply_cluster_defaults: bool,
-) -> dict[str, Any]:
-    path = find_cluster_config_path() if apply_cluster_defaults else None
-    if not apply_cluster_defaults:
-        source = "disabled"
-    elif cluster_config is None:
-        source = "none"
-    else:
-        source = "local-srtslurm.yaml"
+def _reject_cluster_defaults(apply_cluster_defaults: bool) -> None:
+    if apply_cluster_defaults:
+        raise ValueError(COMPUTE_SIDE_HINT)
+
+
+def _cluster_context() -> dict[str, Any]:
     return {
-        "cluster_defaults_applied": apply_cluster_defaults and cluster_config is not None,
-        "cluster_defaults_source": source,
-        "cluster_config_path": str(path) if path is not None else None,
+        "cluster_defaults_applied": False,
+        "cluster_defaults_source": "not-used-by-mcp",
+        "cluster_config_path": None,
+        "operator_boundary": COMPUTE_SIDE_HINT,
     }
 
 

--- a/tests/test_mcp_spec.py
+++ b/tests/test_mcp_spec.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from srtctl.mcp.spec_tools import (
     explain_field,
     get_config_reference,
@@ -58,12 +60,15 @@ def test_validate_config_accepts_minimal_recipe() -> None:
                 "gpus_per_node": 8,
                 "prefill_nodes": 1,
                 "decode_nodes": 1,
+                "prefill_workers": 1,
+                "decode_workers": 1,
             },
         },
     )
     assert result["valid"] is True
     assert result["normalized"][0]["config"]["name"] == "mcp-test"
-    assert result["cluster_defaults_source"] == "disabled"
+    assert result["cluster_defaults_source"] == "not-used-by-mcp"
+    assert "Host-side srtslurm.yaml is not used" in result["operator_boundary"]
 
 
 def test_preflight_config_reports_missing_container(tmp_path) -> None:
@@ -88,10 +93,81 @@ def test_preflight_config_reports_missing_container(tmp_path) -> None:
     )
 
     assert result["ok"] is False
-    assert result["scope"] == "local"
-    assert result["cluster_defaults_source"] == "disabled"
-    assert "IBAR remote preflight" in result["operator_hint"]
+    assert result["scope"] == "explicit-local-paths"
+    assert result["cluster_defaults_source"] == "not-used-by-mcp"
+    assert "compute side" in result["operator_hint"]
     assert result["variants"][0]["errors"][0]["field"] == "model.container"
+
+
+def test_validate_config_rejects_disagg_with_zero_prefill_workers() -> None:
+    """Reproduces the reported bad config: disagg-style block that should be aggregated."""
+    result = validate_config(
+        config={
+            "name": "mcp-test",
+            "model": {
+                "path": "/tmp/model",
+                "container": "/tmp/container.sqsh",
+                "precision": "bf16",
+            },
+            "resources": {
+                "gpu_type": "gb200",
+                "prefill_nodes": 0,
+                "decode_nodes": 1,
+                "prefill_workers": 0,
+                "decode_workers": 1,
+                "gpus_per_node": 4,
+            },
+        },
+    )
+    assert result["valid"] is False
+    assert len(result["errors"]) == 1
+    message = result["errors"][0]
+    assert "prefill_workers" in message
+    assert "agg_nodes: 1" in message
+    assert "agg_workers: 1" in message
+
+
+def test_validate_config_accepts_correct_aggregated_form() -> None:
+    result = validate_config(
+        config={
+            "name": "mcp-test",
+            "model": {
+                "path": "/tmp/model",
+                "container": "/tmp/container.sqsh",
+                "precision": "bf16",
+            },
+            "resources": {
+                "gpu_type": "gb200",
+                "gpus_per_node": 4,
+                "agg_nodes": 1,
+                "agg_workers": 1,
+            },
+        },
+    )
+    assert result["valid"] is True
+
+
+def test_validate_config_rejects_mixed_disagg_and_agg() -> None:
+    result = validate_config(
+        config={
+            "name": "mcp-test",
+            "model": {
+                "path": "/tmp/model",
+                "container": "/tmp/container.sqsh",
+                "precision": "bf16",
+            },
+            "resources": {
+                "gpu_type": "gb200",
+                "gpus_per_node": 4,
+                "prefill_nodes": 1,
+                "decode_nodes": 1,
+                "agg_nodes": 1,
+                "agg_workers": 1,
+            },
+        },
+    )
+    assert result["valid"] is False
+    assert "Mixes disaggregated fields" in result["errors"][0]
 
 
 def test_resolve_config_returns_variants() -> None:
@@ -119,6 +195,27 @@ def test_resolve_config_returns_variants() -> None:
         },
     )
     assert result["variant_count"] == 1
-    assert result["scope"] == "local"
-    assert result["cluster_defaults_source"] == "disabled"
+    assert result["scope"] == "schema-only"
+    assert result["cluster_defaults_source"] == "not-used-by-mcp"
     assert result["variants"][0]["variant"] == "alt"
+
+
+def test_mcp_tools_reject_host_side_cluster_defaults() -> None:
+    config = {
+        "name": "mcp-test",
+        "model": {
+            "path": "model-alias",
+            "container": "container-alias",
+            "precision": "bf16",
+        },
+        "resources": {
+            "gpu_type": "h100",
+            "gpus_per_node": 8,
+            "agg_nodes": 1,
+            "agg_workers": 1,
+        },
+    }
+
+    for tool in (validate_config, preflight_config, resolve_config):
+        with pytest.raises(ValueError, match="Host-side srtslurm.yaml is not used"):
+            tool(config=config, apply_cluster_defaults=True)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -242,6 +242,40 @@ class TestBackgroundValidation:
 
 
 class TestPreflightConfigVariants:
+    def test_does_not_load_host_side_srtslurm_yaml_by_default(self, tmp_path, monkeypatch):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        container_file = tmp_path / "container.sqsh"
+        container_file.write_text("sqsh")
+        (tmp_path / "srtslurm.yaml").write_text(
+            "model_paths:\n"
+            f"  qwen32b: {model_dir}\n"
+            "containers:\n"
+            f"  sglang-latest: {container_file}\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        results = preflight_config_variants(
+            {
+                "name": "host-side-ignored",
+                "model": {
+                    "path": "qwen32b",
+                    "container": "sglang-latest",
+                    "precision": "bf16",
+                },
+                "resources": {
+                    "gpu_type": "gb200",
+                    "gpus_per_node": 4,
+                    "agg_nodes": 1,
+                    "agg_workers": 1,
+                },
+            },
+        )
+
+        assert results[0].ok is False
+        assert results[0].model.source == "literal"
+        assert results[0].container.source == "literal"
+
     def test_aliases_pass_when_paths_exist(self, tmp_path):
         model_dir = tmp_path / "model"
         model_dir.mkdir()
@@ -261,6 +295,8 @@ class TestPreflightConfigVariants:
                     "gpus_per_node": 4,
                     "prefill_nodes": 1,
                     "decode_nodes": 1,
+                    "prefill_workers": 1,
+                    "decode_workers": 1,
                 },
             },
             cluster_config={


### PR DESCRIPTION
## Summary
- make srtctl MCP reject host-side cluster defaults
- stop MCP preflight from implicitly loading host-side srtslurm.yaml
- clarify MCP responses and docs that cluster defaults, aliases, paths, containers, filesystem checks, and dry-run behavior must run compute-side
- keep structural topology validation in MCP schema validation

## Validation
- uv run pytest tests/test_mcp_spec.py tests/test_validation.py -q