### PR TITLE
[codex] Add asset materialization POC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,9 +32,10 @@ When you run `srtctl apply -f config.yaml`, the tool:
 
 The `srtctl-mcp` server is different from `srtctl apply`: it is a schema and
 recipe-authoring helper. It does not use host-side `srtslurm.yaml` for cluster
-defaults, aliases, containers, model paths, filesystem checks, or dry-run
-behavior. Run `srtctl` on the compute side, or use an orchestrator remote
-preflight path, for those checks.
+defaults, aliases, containers, model paths, filesystem checks, asset
+materialization, or dry-run behavior. Run `srtctl` on the compute side, or use
+an orchestrator remote path, for `srtctl ensure-assets`, preflight, and dry-run
+checks.
 
 Once allocated, workers launch inside containers, discover each other through ETCD and NATS, and begin serving. If you've configured a benchmark, it runs automatically against the serving endpoint and saves results to the log directory.
 
@@ -45,6 +46,7 @@ Once allocated, workers launch inside containers, discover each other through ET
 | `srtctl apply -f <config>`                         | Submit job(s) to SLURM                  |
 | `srtctl apply -f <config> --setup-script <script>` | Submit with custom setup script         |
 | `srtctl apply -f <config> --tags tag1,tag2`        | Submit with tags for filtering          |
+| `srtctl ensure-assets -f <config>`                 | Pull/import missing cluster aliases     |
 | `srtctl dry-run -f <config>`                       | Validate and preview without submitting |
 | `srtctl validate -f <config>`                      | Alias for dry-run                       |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,7 @@
 - [Commands](#commands)
   - [srtctl apply](#srtctl-apply)
   - [srtctl dry-run](#srtctl-dry-run)
+  - [srtctl ensure-assets](#srtctl-ensure-assets)
   - [srtctl resolve-override](#srtctl-resolve-override)
 - [Output](#output)
 - [Sweep Support](#sweep-support)
@@ -309,6 +310,69 @@ Dry-run output includes:
 - For sweeps: table of all jobs with parameters
 - Generated configs saved to `dry-runs/` folder
 
+### `srtctl ensure-assets`
+
+Materialize missing model and container aliases before submitting.
+
+```bash
+srtctl ensure-assets -f <config.yaml> [options]
+```
+
+`ensure-assets` is a cluster-side operation. It reads the target cluster's
+`srtslurm.yaml`, checks aliases referenced by `model.path` and
+`model.container`, and can run cluster-owned pull/import commands when those
+aliases are missing. It updates `srtslurm.yaml`; it does not rewrite the recipe
+YAML.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-f, --file` | YAML config file, or `file:selector` for overrides (required) |
+| `--dry-run` | Show planned materialization actions without running commands or editing `srtslurm.yaml` |
+| `--mode` | Override `asset_materialization.mode`; one of `auto`, `login`, or `srun` |
+| `--json` | Emit a machine-readable result for orchestrators |
+
+**Examples:**
+
+```bash
+# Preview missing assets and commands
+srtctl ensure-assets -f config.yaml --dry-run
+
+# Pull/import missing assets and register aliases
+srtctl ensure-assets -f config.yaml
+
+# Force materialization through srun for this invocation
+srtctl ensure-assets -f config.yaml --mode srun
+
+# JSON output for IBAR or other orchestrators
+srtctl ensure-assets -f config.yaml --json
+```
+
+`ensure-assets` uses the recipe `identity` block as provenance:
+
+```yaml
+model:
+  path: qwen32b
+  container: sglang-dev
+  precision: fp8
+
+identity:
+  model:
+    repo: Qwen/Qwen3-32B
+    revision: abc123
+  container:
+    image: nvcr.io/example/sglang:latest
+```
+
+If `qwen32b` is missing from `model_paths`, `ensure-assets` uses
+`identity.model.repo` and `identity.model.revision` with the configured
+`model_pull_template`. If `sglang-dev` is missing from `containers`, it uses
+`identity.container.image` with `container_pull_template`.
+
+Configure cluster behavior in `srtslurm.yaml` with `asset_materialization`.
+See [Configuration Reference — Asset Materialization](config-reference.md#asset-materialization).
+
 ### `srtctl resolve-override`
 
 Expand an override config and write the specialised YAML file(s) without submitting.
@@ -412,4 +476,3 @@ grep -E "Env:|Command:" outputs/<job_id>/logs/sweep_<job_id>.log
 - Use `srtctl apply -f` for scripting and CI pipelines
 - Always `dry-run` first for sweeps to check job count
 - Check `outputs/<job_id>/` for submitted configs and metadata
-

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -116,8 +116,97 @@ The `srtslurm.yaml` file can contain the following fields:
 | `model_paths`                   | dict   | Model path aliases                                    |
 | `containers`                    | dict   | Container image aliases                               |
 | `default_mounts`                | dict   | Cluster-wide container mounts                         |
+| `asset_materialization`         | dict   | Optional policy for `srtctl ensure-assets`            |
 
 **output_dir**: When set, job logs are written to `output_dir/{job_id}/logs` instead of `srtctl_root/outputs/{job_id}/logs`. Useful for CI/CD and ephemeral environments.
+
+### Asset Materialization
+
+`asset_materialization` configures the cluster-side `srtctl ensure-assets`
+command. It is optional and only used when `ensure-assets` is run explicitly.
+Normal `srtctl apply` does not pull models, import containers, or mutate
+`srtslurm.yaml` by itself.
+
+```yaml
+# In srtslurm.yaml
+asset_materialization:
+  mode: auto
+  models_root: "/shared/models"
+  containers_root: "/shared/containers"
+  lock_path: "/shared/srt-slurm/.asset-materialization.lock"
+  login_probe_command: "test -w /shared/models && test -w /shared/containers"
+  srun_template: "srun --partition=cpu --nodes=1 --ntasks=1 --cpus-per-task=8 --time=02:00:00 bash -lc {q_command}"
+  model_pull_template: "huggingface-cli download {q_source} --local-dir {q_target}"
+  container_pull_template: "enroot import -o {q_target} docker://{source}"
+```
+
+| Field | Type | Default | Description |
+| ----- | ---- | ------- | ----------- |
+| `mode` | string | `login` | Where to run materialization commands: `login`, `srun`, or `auto` |
+| `models_root` | string | null | Directory for new model aliases, e.g. `/shared/models/<alias>` |
+| `containers_root` | string | null | Directory for new container aliases, e.g. `/shared/containers/<alias>.sqsh` |
+| `lock_path` | string | `<srtslurm.yaml>.asset.lock` | File lock used to serialize alias updates |
+| `login_probe_command` | string | null | In `auto` mode, success selects `login`; failure selects `srun` |
+| `srun_template` | string | `srun --nodes=1 --ntasks=1 bash -lc {q_command}` | Wrapper used when selected mode is `srun` |
+| `model_pull_template` | string | null | Command template used to pull a missing model alias |
+| `container_pull_template` | string | null | Command template used to import a missing container alias |
+
+`ensure-assets` fills templates from the recipe alias and identity fields. For
+example:
+
+```yaml
+model:
+  path: qwen32b
+  container: sglang-dev
+  precision: fp8
+
+identity:
+  model:
+    repo: Qwen/Qwen3-32B
+    revision: abc123
+  container:
+    image: nvcr.io/example/sglang:latest
+```
+
+Available placeholders:
+
+| Placeholder | Description |
+| ----------- | ----------- |
+| `{alias}` | Raw alias from `model.path` or `model.container` |
+| `{source}` | Raw source: `identity.model.repo` or `identity.container.image` |
+| `{target}` | Raw target path under `models_root` or `containers_root` |
+| `{revision}` | `identity.model.revision`, or empty string |
+| `{q_alias}` / `{q_source}` / `{q_target}` / `{q_revision}` | Shell-quoted values for command templates |
+| `{py_alias}` / `{py_source}` / `{py_target}` / `{py_revision}` | Python-literal quoted values for inline Python snippets |
+| `{command}` | Unquoted inner command, available only to `srun_template` |
+| `{q_command}` | Shell-quoted inner command, available only to `srun_template` |
+
+Use the `q_` placeholders when interpolating shell arguments:
+
+```yaml
+model_pull_template: "huggingface-cli download {q_source} --local-dir {q_target}"
+```
+
+Use raw `{source}` when a tool expects the source to be part of a larger token,
+such as an enroot Docker URI:
+
+```yaml
+container_pull_template: "enroot import -o {q_target} docker://{source}"
+```
+
+The command updates only `srtslurm.yaml` aliases:
+
+```yaml
+model_paths:
+  qwen32b: "/shared/models/qwen32b"
+
+containers:
+  sglang-dev: "/shared/containers/sglang-dev.sqsh"
+```
+
+It does not rewrite the submitted recipe. Later runs resolve the aliases
+through normal config loading, and the recipe `identity` block remains available
+for runtime fingerprint verification.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -130,6 +130,17 @@ model_paths:
 containers:
   latest: "/containers/sglang-latest.sqsh"
   stable: "/containers/sglang-stable.sqsh"
+
+# Optional: allow srtctl ensure-assets to pull/import missing aliases
+asset_materialization:
+  mode: auto # login | srun | auto
+  models_root: "/models"
+  containers_root: "/containers"
+  lock_path: "/path/to/srtctl/.asset-materialization.lock"
+  login_probe_command: "test -w /models && test -w /containers"
+  srun_template: "srun --partition=cpu --nodes=1 --ntasks=1 --cpus-per-task=8 --time=02:00:00 bash -lc {q_command}"
+  model_pull_template: "huggingface-cli download {q_source} --local-dir {q_target}"
+  container_pull_template: "enroot import -o {q_target} docker://{source}"
 ```
 
 ## Create a Job Config

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -1148,6 +1148,7 @@ def main():
   srtctl apply -f ./configs/                     # Submit all YAMLs in directory
   srtctl apply -f config.yaml --sweep            # Submit sweep
   srtctl preflight -f config.yaml                # Check model/container availability
+  srtctl ensure-assets -f config.yaml            # Pull/register missing model/container aliases
   srtctl dry-run -f config.yaml                  # Dry run
   srtctl resolve-override -f config.yaml         # Resolve override YAML (no submit)
   srtctl resolve-override -f config.yaml --stdout  # Print to stdout
@@ -1212,6 +1213,35 @@ def main():
         required=True,
         dest="config",
         help="YAML config file, or file:selector for overrides",
+    )
+
+    ensure_assets_parser = subparsers.add_parser(
+        "ensure-assets",
+        help="Pull/register missing model and container aliases in srtslurm.yaml",
+    )
+    ensure_assets_parser.add_argument(
+        "-f",
+        "--file",
+        type=str,
+        required=True,
+        dest="config",
+        help="YAML config file, or file:selector for overrides",
+    )
+    ensure_assets_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show planned materialization actions without running commands or editing srtslurm.yaml",
+    )
+    ensure_assets_parser.add_argument(
+        "--mode",
+        choices=["auto", "login", "srun"],
+        help="Override asset_materialization.mode for this invocation",
+    )
+    ensure_assets_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit the ensure-assets result as JSON on stdout; prose output goes to stderr.",
     )
 
     resolve_parser = subparsers.add_parser(
@@ -1373,6 +1403,49 @@ def main():
                     )
                 restore_console()
                 return
+
+            if args.command == "ensure-assets":
+                from srtctl.core.assets import ensure_assets_for_config_variants
+
+                if effective_config_path.is_dir():
+                    raise ValueError("ensure-assets currently expects a file, not a directory")
+                with open(effective_config_path) as f:
+                    raw_config = yaml.safe_load(f)
+                if not isinstance(raw_config, dict):
+                    raise ValueError(f"Invalid config in {config_path}: top-level YAML must be a mapping")
+                result = ensure_assets_for_config_variants(
+                    raw_config,
+                    selector=selector,
+                    dry_run=bool(getattr(args, "dry_run", False)),
+                    mode=getattr(args, "mode", None),
+                )
+                if json_mode:
+                    sys.stdout.write(json.dumps(result.as_dict()) + "\n")
+                    sys.stdout.flush()
+                else:
+                    action_table = Table(title=f"Asset Materialization: {result.cluster_config_path}")
+                    action_table.add_column("Kind", style="cyan")
+                    action_table.add_column("Alias", style="green")
+                    action_table.add_column("Status", style="yellow")
+                    action_table.add_column("Mode", style="magenta")
+                    action_table.add_column("Target", style="white")
+                    action_table.add_column("Message", style="dim")
+                    for action in result.actions:
+                        action_table.add_row(
+                            action.kind,
+                            action.alias or "",
+                            action.status,
+                            action.mode,
+                            action.target or "",
+                            action.message,
+                        )
+                    console.print(action_table)
+                    if result.changed:
+                        console.print(f"[green]Updated:[/] {result.cluster_config_path}")
+                    elif not result.actions:
+                        console.print("[green]No model/container aliases needed materialization.[/]")
+                restore_console()
+                sys.exit(0 if result.ok else 1)
 
             setup_script = getattr(args, "setup_script", None)
             output_dir = getattr(args, "output_dir", None)

--- a/src/srtctl/core/assets.py
+++ b/src/srtctl/core/assets.py
@@ -1,0 +1,563 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cluster-side model and container materialization helpers."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml.comments import CommentedMap
+
+from srtctl.core.config import find_cluster_config_path, generate_override_configs
+from srtctl.core.yaml_utils import dump_yaml_with_comments, load_yaml_with_comments
+
+_DEFAULT_SRUN_TEMPLATE = "srun --nodes=1 --ntasks=1 bash -lc {q_command}"
+
+
+@dataclass(frozen=True)
+class AssetAction:
+    kind: str
+    alias: str | None
+    source: str | None
+    target: str | None
+    mode: str
+    status: str
+    message: str
+    command: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "alias": self.alias,
+            "source": self.source,
+            "target": self.target,
+            "mode": self.mode,
+            "status": self.status,
+            "message": self.message,
+            "command": self.command,
+        }
+
+
+@dataclass(frozen=True)
+class EnsureAssetsResult:
+    cluster_config_path: str
+    dry_run: bool
+    changed: bool
+    actions: list[AssetAction]
+    model_paths: dict[str, str]
+    containers: dict[str, str]
+
+    @property
+    def ok(self) -> bool:
+        failures = {"error", "missing-source", "missing-target-root", "missing-template"}
+        return all(action.status not in failures for action in self.actions)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "cluster_config_path": self.cluster_config_path,
+            "dry_run": self.dry_run,
+            "changed": self.changed,
+            "actions": [action.as_dict() for action in self.actions],
+            "model_paths": dict(self.model_paths),
+            "containers": dict(self.containers),
+        }
+
+
+def ensure_assets_for_config_variants(
+    raw_config: dict[str, Any],
+    *,
+    selector: str | None = None,
+    cluster_config_path: Path | None = None,
+    dry_run: bool = False,
+    mode: str | None = None,
+) -> EnsureAssetsResult:
+    """Ensure model/container aliases referenced by one recipe or override file."""
+    variants = (
+        generate_override_configs(raw_config, selector=selector) if "base" in raw_config else [("base", raw_config)]
+    )
+    return ensure_assets(
+        [variant for _suffix, variant in variants],
+        cluster_config_path=cluster_config_path,
+        dry_run=dry_run,
+        mode=mode,
+    )
+
+
+def ensure_assets(
+    configs: list[dict[str, Any]],
+    *,
+    cluster_config_path: Path | None = None,
+    dry_run: bool = False,
+    mode: str | None = None,
+) -> EnsureAssetsResult:
+    """Materialize missing aliases and update the cluster-owned srtslurm.yaml.
+
+    The recipe remains unchanged. If `model.path` or `model.container` names an
+    alias that is not present, this function infers the pull source from the
+    recipe `identity` block, chooses a target under the configured root, runs
+    the configured command template, and records the alias.
+    """
+    path = cluster_config_path or find_cluster_config_path()
+    if path is None:
+        raise FileNotFoundError("No srtslurm.yaml found. Set SRTSLURM_CONFIG or run from the repo/cluster config tree.")
+    path = Path(path)
+
+    with _asset_lock(path):
+        cluster_cm = load_yaml_with_comments(path)
+        cluster = _plain_mapping(cluster_cm)
+        policy = _plain_mapping(cluster.get("asset_materialization") or {})
+        selected_mode = _select_mode(str(mode or policy.get("mode") or "login"), policy)
+
+        model_paths = _string_mapping(cluster.get("model_paths"))
+        containers = _string_mapping(cluster.get("containers"))
+
+        actions: list[AssetAction] = []
+        changed = False
+        for config in configs:
+            model_action, model_changed = _ensure_model_alias(
+                config,
+                model_paths=model_paths,
+                policy=policy,
+                selected_mode=selected_mode,
+                dry_run=dry_run,
+            )
+            if model_action:
+                actions.append(model_action)
+                changed = changed or model_changed
+
+            container_action, container_changed = _ensure_container_alias(
+                config,
+                containers=containers,
+                policy=policy,
+                selected_mode=selected_mode,
+                dry_run=dry_run,
+            )
+            if container_action:
+                actions.append(container_action)
+                changed = changed or container_changed
+
+        if changed and not dry_run:
+            _set_mapping(cluster_cm, "model_paths", model_paths)
+            _set_mapping(cluster_cm, "containers", containers)
+            _atomic_write_yaml(path, cluster_cm)
+
+    return EnsureAssetsResult(
+        cluster_config_path=str(path),
+        dry_run=dry_run,
+        changed=changed,
+        actions=actions,
+        model_paths=model_paths,
+        containers=containers,
+    )
+
+
+def _ensure_model_alias(
+    config: dict[str, Any],
+    *,
+    model_paths: dict[str, str],
+    policy: dict[str, Any],
+    selected_mode: str,
+    dry_run: bool,
+) -> tuple[AssetAction | None, bool]:
+    model = _plain_mapping(config.get("model") or {})
+    raw = _string_or_none(model.get("path"))
+    if not raw or not _is_model_alias(raw):
+        return None, False
+
+    identity = _plain_mapping(config.get("identity") or {})
+    identity_model = _plain_mapping(identity.get("model") or {})
+    source = _string_or_none(identity_model.get("repo"))
+    revision = _string_or_none(identity_model.get("revision"))
+    if source is None and raw.startswith("hf:"):
+        source = raw[3:]
+
+    existing_target = model_paths.get(raw)
+    target = existing_target or _default_target(policy.get("models_root"), raw, suffix=None)
+    if target and Path(os.path.expandvars(target)).expanduser().exists():
+        if existing_target:
+            return (
+                AssetAction("model", raw, source, target, selected_mode, "exists", f"model alias {raw!r} exists"),
+                False,
+            )
+        model_paths[raw] = target
+        return (
+            AssetAction(
+                "model", raw, source, target, selected_mode, "registered", f"registered existing model {raw!r}"
+            ),
+            True,
+        )
+
+    if source is None:
+        return (
+            AssetAction(
+                "model",
+                raw,
+                None,
+                target,
+                selected_mode,
+                "missing-source",
+                f"model alias {raw!r} is missing and no identity.model.repo was provided",
+            ),
+            False,
+        )
+    if target is None:
+        return (
+            AssetAction(
+                "model",
+                raw,
+                source,
+                None,
+                selected_mode,
+                "missing-target-root",
+                "asset_materialization.models_root is required to create a new model alias",
+            ),
+            False,
+        )
+
+    command = _materialization_command(
+        template=_string_or_none(policy.get("model_pull_template")),
+        srun_template=_string_or_none(policy.get("srun_template")),
+        mode=selected_mode,
+        alias=raw,
+        source=source,
+        target=target,
+        revision=revision,
+    )
+    if command is None:
+        return (
+            AssetAction(
+                "model",
+                raw,
+                source,
+                target,
+                selected_mode,
+                "missing-template",
+                "asset_materialization.model_pull_template is required to pull missing models",
+            ),
+            False,
+        )
+    if dry_run:
+        return (
+            AssetAction(
+                "model", raw, source, target, selected_mode, "would-pull", "would pull and register model", command
+            ),
+            False,
+        )
+
+    _run_command(command)
+    if not Path(os.path.expandvars(target)).expanduser().is_dir():
+        return (
+            AssetAction(
+                "model",
+                raw,
+                source,
+                target,
+                selected_mode,
+                "error",
+                "model pull command completed but target directory does not exist",
+                command,
+            ),
+            False,
+        )
+    model_paths[raw] = target
+    return (
+        AssetAction("model", raw, source, target, selected_mode, "pulled", "pulled and registered model", command),
+        True,
+    )
+
+
+def _ensure_container_alias(
+    config: dict[str, Any],
+    *,
+    containers: dict[str, str],
+    policy: dict[str, Any],
+    selected_mode: str,
+    dry_run: bool,
+) -> tuple[AssetAction | None, bool]:
+    model = _plain_mapping(config.get("model") or {})
+    raw = _string_or_none(model.get("container"))
+    if not raw or not _is_container_alias(raw):
+        return None, False
+
+    identity = _plain_mapping(config.get("identity") or {})
+    identity_container = _plain_mapping(identity.get("container") or {})
+    source = _string_or_none(identity_container.get("image"))
+
+    existing_target = containers.get(raw)
+    target = existing_target or _default_target(policy.get("containers_root"), raw, suffix=".sqsh")
+    if target and Path(os.path.expandvars(target)).expanduser().exists():
+        if existing_target:
+            return (
+                AssetAction(
+                    "container", raw, source, target, selected_mode, "exists", f"container alias {raw!r} exists"
+                ),
+                False,
+            )
+        containers[raw] = target
+        return (
+            AssetAction(
+                "container",
+                raw,
+                source,
+                target,
+                selected_mode,
+                "registered",
+                f"registered existing container {raw!r}",
+            ),
+            True,
+        )
+
+    if source is None:
+        return (
+            AssetAction(
+                "container",
+                raw,
+                None,
+                target,
+                selected_mode,
+                "missing-source",
+                f"container alias {raw!r} is missing and no identity.container.image was provided",
+            ),
+            False,
+        )
+    if target is None:
+        return (
+            AssetAction(
+                "container",
+                raw,
+                source,
+                None,
+                selected_mode,
+                "missing-target-root",
+                "asset_materialization.containers_root is required to create a new container alias",
+            ),
+            False,
+        )
+
+    command = _materialization_command(
+        template=_string_or_none(policy.get("container_pull_template")),
+        srun_template=_string_or_none(policy.get("srun_template")),
+        mode=selected_mode,
+        alias=raw,
+        source=source,
+        target=target,
+        revision=None,
+    )
+    if command is None:
+        return (
+            AssetAction(
+                "container",
+                raw,
+                source,
+                target,
+                selected_mode,
+                "missing-template",
+                "asset_materialization.container_pull_template is required to pull missing containers",
+            ),
+            False,
+        )
+    if dry_run:
+        return (
+            AssetAction(
+                "container",
+                raw,
+                source,
+                target,
+                selected_mode,
+                "would-pull",
+                "would pull and register container",
+                command,
+            ),
+            False,
+        )
+
+    _run_command(command)
+    if not Path(os.path.expandvars(target)).expanduser().is_file():
+        return (
+            AssetAction(
+                "container",
+                raw,
+                source,
+                target,
+                selected_mode,
+                "error",
+                "container pull command completed but target file does not exist",
+                command,
+            ),
+            False,
+        )
+    containers[raw] = target
+    return (
+        AssetAction(
+            "container",
+            raw,
+            source,
+            target,
+            selected_mode,
+            "pulled",
+            "pulled and registered container",
+            command,
+        ),
+        True,
+    )
+
+
+def _materialization_command(
+    *,
+    template: str | None,
+    srun_template: str | None,
+    mode: str,
+    alias: str,
+    source: str,
+    target: str,
+    revision: str | None,
+) -> str | None:
+    if not template:
+        return None
+    values = _template_values(alias=alias, source=source, target=target, revision=revision)
+    command = template.format_map(values)
+    if mode != "srun":
+        return command
+    wrapper = srun_template or _DEFAULT_SRUN_TEMPLATE
+    wrapped_values = {**values, "command": command, "q_command": shlex.quote(command), "py_command": repr(command)}
+    return wrapper.format_map(wrapped_values)
+
+
+def _template_values(*, alias: str, source: str, target: str, revision: str | None) -> dict[str, str]:
+    values = {
+        "alias": alias,
+        "source": source,
+        "target": target,
+        "revision": revision or "",
+    }
+    quoted = {f"q_{key}": shlex.quote(value) for key, value in values.items()}
+    py_quoted = {f"py_{key}": repr(value) for key, value in values.items()}
+    return {**values, **quoted, **py_quoted}
+
+
+def _select_mode(mode: str, policy: dict[str, Any]) -> str:
+    normalized = mode.lower()
+    if normalized not in {"auto", "login", "srun"}:
+        raise ValueError("asset materialization mode must be one of: auto, login, srun")
+    if normalized != "auto":
+        return normalized
+
+    probe = _string_or_none(policy.get("login_probe_command"))
+    if probe is None:
+        return "login"
+    result = subprocess.run(probe, shell=True, capture_output=True, text=True, check=False)
+    return "login" if result.returncode == 0 else "srun"
+
+
+def _run_command(command: str) -> None:
+    result = subprocess.run(command, shell=True, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+        raise RuntimeError(f"asset materialization command failed: {details}")
+
+
+@contextlib.contextmanager
+def _asset_lock(cluster_config_path: Path) -> Iterator[None]:
+    raw = _load_raw_cluster_config(cluster_config_path)
+    policy = _plain_mapping(raw.get("asset_materialization") or {})
+    lock_path = _string_or_none(policy.get("lock_path")) or f"{cluster_config_path}.asset.lock"
+    lock_file = Path(os.path.expandvars(lock_path)).expanduser()
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_file, "w") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def _load_raw_cluster_config(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"srtslurm.yaml not found: {path}")
+    loaded = load_yaml_with_comments(path)
+    return _plain_mapping(loaded)
+
+
+def _atomic_write_yaml(path: Path, data: Any) -> None:
+    fd, temp_path = tempfile.mkstemp(suffix=".yaml", prefix=f".{path.name}.", dir=str(path.parent), text=True)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            dump_yaml_with_comments(data, handle)
+        os.replace(temp_path, path)
+    finally:
+        with contextlib.suppress(OSError):
+            os.remove(temp_path)
+
+
+def _set_mapping(data: CommentedMap, key: str, values: dict[str, str]) -> None:
+    existing = data.get(key)
+    if isinstance(existing, CommentedMap):
+        existing.clear()
+        for item_key in sorted(values):
+            existing[item_key] = values[item_key]
+        return
+    replacement = CommentedMap()
+    for item_key in sorted(values):
+        replacement[item_key] = values[item_key]
+    data[key] = replacement
+
+
+def _plain_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return dict(value)
+
+
+def _string_mapping(value: Any) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(k): str(v) for k, v in value.items() if v is not None}
+
+
+def _string_or_none(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _default_target(root: Any, alias: str, *, suffix: str | None) -> str | None:
+    root_str = _string_or_none(root)
+    if root_str is None:
+        return None
+    name = _safe_asset_name(alias)
+    if suffix and not name.endswith(suffix):
+        name = f"{name}{suffix}"
+    return str(Path(os.path.expandvars(root_str)).expanduser() / name)
+
+
+def _safe_asset_name(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-._")
+    return cleaned or "asset"
+
+
+def _is_model_alias(value: str) -> bool:
+    if value.startswith(("hf:", "/", "./", "../", "~")):
+        return False
+    return "/" not in value
+
+
+def _is_container_alias(value: str) -> bool:
+    if value.startswith(("/", "./", "../", "~")):
+        return False
+    if "://" in value:
+        return False
+    if "/" in value:
+        return False
+    return ":" not in value

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -175,6 +175,27 @@ class S3Config:
     Schema: ClassVar[type[Schema]] = Schema
 
 
+@dataclass(frozen=True)
+class AssetMaterializationConfig:
+    """Cluster policy for materializing model and container aliases.
+
+    This is intentionally command-template based for the first implementation:
+    clusters can decide whether downloads/imports run directly on the login
+    node or behind an srun wrapper, and can choose the local tools they trust.
+    """
+
+    mode: str = "login"  # login | srun | auto
+    models_root: str | None = None
+    containers_root: str | None = None
+    lock_path: str | None = None
+    srun_template: str | None = None
+    login_probe_command: str | None = None
+    model_pull_template: str | None = None
+    container_pull_template: str | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
 @dataclass
 class ClusterConfig:
     """Cluster configuration from srtslurm.yaml."""
@@ -196,6 +217,7 @@ class ClusterConfig:
     # Cluster-level container mounts (host_path -> container_path)
     # Applied to all jobs on this cluster, useful for cluster-specific paths
     default_mounts: dict[str, str] | None = None
+    asset_materialization: AssetMaterializationConfig | None = None
     reporting: ReportingConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema

--- a/src/srtctl/mcp/spec_tools.py
+++ b/src/srtctl/mcp/spec_tools.py
@@ -20,9 +20,10 @@ from srtctl.core.validation import preflight_config_variants, validate_topology
 DOC_PATH = Path(__file__).resolve().parents[3] / "docs" / "config-reference.md"
 COMPUTE_SIDE_HINT = (
     "Host-side srtslurm.yaml is not used by srtctl MCP. For cluster defaults, "
-    "aliases, containers, model paths, filesystem checks, or dry-run behavior, "
-    "run srtctl on the compute side or use IBAR remote_preflight/remote_dry_run/"
-    "cluster_aliases with the target compute profile."
+    "aliases, containers, model paths, asset materialization, filesystem checks, "
+    "or dry-run behavior, run srtctl on the compute side or use IBAR remote "
+    "lifecycle commands. For missing model/container aliases, run compute-side "
+    "`srtctl ensure-assets -f <recipe> --json` before remote preflight."
 )
 
 

--- a/srtslurm.yaml.example
+++ b/srtslurm.yaml.example
@@ -32,6 +32,23 @@ model_paths:
   llama-3-70b: "/shared/models/meta/llama-3-70b"
   llama-3-405b: "/shared/models/meta/llama-3-405b"
 
+# Optional POC: materialize missing model/container aliases.
+# Run explicitly with:
+#   srtctl ensure-assets -f recipe.yaml
+#
+# `mode` can be login, srun, or auto. In auto mode, login_probe_command decides:
+# success -> login, failure -> srun. Templates are cluster-owned because each
+# site uses different tools for HF downloads and container imports.
+# asset_materialization:
+#   mode: auto
+#   models_root: "/shared/models"
+#   containers_root: "/shared/containers"
+#   lock_path: "/shared/srt-slurm/.asset-materialization.lock"
+#   login_probe_command: "test -w /shared/models && test -w /shared/containers"
+#   srun_template: "srun --partition=cpu --nodes=1 --ntasks=1 --cpus-per-task=8 --time=02:00:00 bash -lc {q_command}"
+#   model_pull_template: "huggingface-cli download {q_source} --local-dir {q_target}"
+#   container_pull_template: "enroot import -o {q_target} docker://{source}"
+
 # AI-powered failure analysis (optional)
 # When enabled, Claude Code CLI analyzes benchmark failures and writes ai_analysis.md
 # Uses OpenRouter for authentication (works well in headless/automated environments)

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from srtctl.core.assets import ensure_assets_for_config_variants
+from srtctl.core.config import load_cluster_config, load_config
+
+
+def _write_cluster_config(tmp_path: Path, *, mode: str = "login", login_probe_command: str | None = None) -> Path:
+    cluster_config = {
+        "default_account": "acct",
+        "default_partition": "gpu",
+        "asset_materialization": {
+            "mode": mode,
+            "models_root": str(tmp_path / "models"),
+            "containers_root": str(tmp_path / "containers"),
+            "lock_path": str(tmp_path / "asset.lock"),
+            "model_pull_template": "mkdir -p {q_target}",
+            "container_pull_template": (
+                f"{sys.executable} -c "
+                '"from pathlib import Path; p=Path({py_target}); '
+                "p.parent.mkdir(parents=True, exist_ok=True); p.write_text('container')\""
+            ),
+        },
+    }
+    if login_probe_command is not None:
+        cluster_config["asset_materialization"]["login_probe_command"] = login_probe_command
+    path = tmp_path / "srtslurm.yaml"
+    path.write_text(yaml.safe_dump(cluster_config, sort_keys=False))
+    return path
+
+
+def _recipe() -> dict:
+    return {
+        "name": "asset-test",
+        "model": {
+            "path": "qwen32b",
+            "container": "sglang-dev",
+            "precision": "fp8",
+        },
+        "identity": {
+            "model": {"repo": "Qwen/Qwen3-32B", "revision": "abc123"},
+            "container": {"image": "nvcr.io/example/sglang:latest"},
+        },
+        "resources": {
+            "gpu_type": "h100",
+            "gpus_per_node": 8,
+            "agg_nodes": 1,
+            "agg_workers": 1,
+        },
+    }
+
+
+def test_ensure_assets_pulls_and_registers_missing_aliases(tmp_path, monkeypatch):
+    cluster_path = _write_cluster_config(tmp_path)
+    monkeypatch.setenv("SRTSLURM_CONFIG", str(cluster_path))
+
+    result = ensure_assets_for_config_variants(_recipe())
+
+    assert result.ok is True
+    assert result.changed is True
+    assert {action.status for action in result.actions} == {"pulled"}
+    assert Path(result.model_paths["qwen32b"]).is_dir()
+    assert Path(result.containers["sglang-dev"]).is_file()
+
+    updated = yaml.safe_load(cluster_path.read_text())
+    assert updated["model_paths"]["qwen32b"] == str(tmp_path / "models" / "qwen32b")
+    assert updated["containers"]["sglang-dev"] == str(tmp_path / "containers" / "sglang-dev.sqsh")
+
+    loaded = load_cluster_config()
+    assert loaded is not None
+    assert loaded["asset_materialization"]["mode"] == "login"
+
+
+def test_ensure_assets_preserves_recipe_identity_after_alias_resolution(tmp_path, monkeypatch):
+    cluster_path = _write_cluster_config(tmp_path)
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(yaml.safe_dump(_recipe(), sort_keys=False))
+    monkeypatch.setenv("SRTSLURM_CONFIG", str(cluster_path))
+
+    ensure_assets_for_config_variants(_recipe())
+    resolved = load_config(recipe_path)
+
+    assert resolved.model.path == str(tmp_path / "models" / "qwen32b")
+    assert resolved.model.container == str(tmp_path / "containers" / "sglang-dev.sqsh")
+    assert resolved.identity.model.repo == "Qwen/Qwen3-32B"
+    assert resolved.identity.model.revision == "abc123"
+    assert resolved.identity.container.image == "nvcr.io/example/sglang:latest"
+
+
+def test_ensure_assets_dry_run_does_not_mutate(tmp_path, monkeypatch):
+    cluster_path = _write_cluster_config(tmp_path)
+    monkeypatch.setenv("SRTSLURM_CONFIG", str(cluster_path))
+
+    result = ensure_assets_for_config_variants(_recipe(), dry_run=True)
+
+    assert result.ok is True
+    assert result.changed is False
+    assert {action.status for action in result.actions} == {"would-pull"}
+    assert not (tmp_path / "models").exists()
+    assert "model_paths" not in yaml.safe_load(cluster_path.read_text())
+
+
+def test_auto_mode_uses_srun_when_login_probe_fails(tmp_path, monkeypatch):
+    cluster_path = _write_cluster_config(tmp_path, mode="auto", login_probe_command="false")
+    monkeypatch.setenv("SRTSLURM_CONFIG", str(cluster_path))
+
+    result = ensure_assets_for_config_variants(_recipe(), dry_run=True)
+
+    assert result.ok is True
+    assert {action.mode for action in result.actions} == {"srun"}
+    assert all(action.command and action.command.startswith("srun ") for action in result.actions)
+
+
+def test_missing_target_root_is_not_ok(tmp_path, monkeypatch):
+    cluster_path = tmp_path / "srtslurm.yaml"
+    cluster_path.write_text(
+        yaml.safe_dump(
+            {
+                "asset_materialization": {
+                    "mode": "login",
+                    "containers_root": str(tmp_path / "containers"),
+                    "model_pull_template": "mkdir -p {q_target}",
+                    "container_pull_template": "touch {q_target}",
+                }
+            },
+            sort_keys=False,
+        )
+    )
+    monkeypatch.setenv("SRTSLURM_CONFIG", str(cluster_path))
+
+    result = ensure_assets_for_config_variants(_recipe(), dry_run=True)
+
+    assert result.ok is False
+    assert any(action.status == "missing-target-root" for action in result.actions)
+
+
+def test_ensure_assets_cli_json(tmp_path, monkeypatch):
+    cluster_path = _write_cluster_config(tmp_path)
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(yaml.safe_dump(_recipe(), sort_keys=False))
+    monkeypatch.setenv("SRTSLURM_CONFIG", str(cluster_path))
+
+    result = subprocess.run(
+        [sys.executable, "-m", "srtctl.cli.submit", "ensure-assets", "-f", str(recipe_path), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["changed"] is True
+    assert {action["status"] for action in payload["actions"]} == {"pulled"}


### PR DESCRIPTION
## Summary

Adds an explicit `srtctl ensure-assets` POC for cluster-side model and container alias materialization.

- Adds `asset_materialization` cluster config schema and example configuration.
- Adds core materialization logic that can run configured pull/import templates on the login node or through an `srun` wrapper, with `auto` mode driven by a login-node probe.
- Updates missing `model_paths` and `containers` aliases in `srtslurm.yaml` with locking and atomic writes.
- Adds JSON output for callers such as IBAR.

## Identity behavior

The materializer uses the recipe `identity` block as provenance:

- `identity.model.repo` and `identity.model.revision` feed model pull templates.
- `identity.container.image` feeds container import templates.

It does not rewrite the recipe or mutate identity fields. After aliases are registered, normal config loading resolves `model.path` and `model.container` to cluster paths while preserving identity for runtime fingerprint verification.

## Validation

- `uv run ruff format --check src/srtctl/core/assets.py src/srtctl/core/schema.py src/srtctl/cli/submit.py tests/test_assets.py`
- `uv run ruff check src/srtctl/core/assets.py src/srtctl/core/schema.py src/srtctl/cli/submit.py tests/test_assets.py`
- `uv run pytest -q`

Full test result: `603 passed, 2 skipped, 6 deselected`.
