### PR TITLE
fix: emit aggregated resources and harden sa-bench rollup

### DIFF
--- a/src/srtctl/benchmarks/scripts/sa-bench/rollup.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/rollup.py
@@ -59,12 +59,27 @@ def _read_job_metadata(log_dir: Path) -> dict[str, Any] | None:
     return None
 
 
+def _as_int(value: Any) -> int:
+    """Coerce to int, treating None / non-numeric as 0.
+
+    Submit metadata serializes optional ResourceConfig fields as JSON null, so
+    ``dict.get(key, 0)`` returns ``None`` (not 0) when the key is present but
+    unset. ``int(None)`` raises, so every field read here must go through this.
+    """
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _compute_gpu_counts(resources: dict[str, Any]) -> tuple[int | None, int | None]:
-    """Compute total and decode GPU counts from resource settings."""
-    gpus_per_node = int(resources.get("gpus_per_node", 0))
-    prefill_nodes = int(resources.get("prefill_nodes", 0))
-    decode_nodes = int(resources.get("decode_nodes", 0))
-    agg_nodes = int(resources.get("agg_nodes", 0))
+    """Compute total and decode-serving GPU counts from resource settings."""
+    gpus_per_node = _as_int(resources.get("gpus_per_node"))
+    prefill_nodes = _as_int(resources.get("prefill_nodes"))
+    decode_nodes = _as_int(resources.get("decode_nodes"))
+    agg_nodes = _as_int(resources.get("agg_nodes"))
     if gpus_per_node <= 0:
         return None, None
 
@@ -78,10 +93,18 @@ def _compute_gpu_counts(resources: dict[str, Any]) -> tuple[int | None, int | No
     if decode_nodes > 0:
         return total_gpu_count, decode_nodes * gpus_per_node
 
-    decode_workers = int(resources.get("decode_workers", 0))
-    gpus_per_decode = int(resources.get("gpus_per_decode", 0))
+    decode_workers = _as_int(resources.get("decode_workers"))
+    gpus_per_decode = _as_int(resources.get("gpus_per_decode"))
     if decode_workers > 0 and gpus_per_decode > 0:
         return total_gpu_count, decode_workers * gpus_per_decode
+
+    # Aggregated deployments: all provisioned GPUs serve both prefill and decode.
+    agg_workers = _as_int(resources.get("agg_workers"))
+    gpus_per_agg = _as_int(resources.get("gpus_per_agg"))
+    if agg_workers > 0 and gpus_per_agg > 0:
+        return total_gpu_count, agg_workers * gpus_per_agg
+    if agg_nodes > 0:
+        return total_gpu_count, total_gpu_count
 
     return total_gpu_count, None
 
@@ -94,9 +117,9 @@ def _extract_p90_decode_running_requests(log_dir: Path, metadata: dict[str, Any]
     resources = metadata.get("resources")
     if resources is None:
         return None
-    if not (int(resources.get("prefill_nodes", 0)) > 0 and int(resources.get("decode_nodes", 0)) > 0):
+    if not (_as_int(resources.get("prefill_nodes")) > 0 and _as_int(resources.get("decode_nodes")) > 0):
         return None
-    if int(resources.get("agg_workers", 0)) > 0:
+    if _as_int(resources.get("agg_workers")) > 0:
         return None
 
     counts: Counter[int] = Counter()

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -594,9 +594,13 @@ def submit_with_orchestrator(
                 "gpus_per_node": config.resources.gpus_per_node,
                 "prefill_nodes": config.resources.prefill_nodes,
                 "decode_nodes": config.resources.decode_nodes,
+                "agg_nodes": config.resources.agg_nodes,
                 "prefill_workers": config.resources.num_prefill,
                 "decode_workers": config.resources.num_decode,
                 "agg_workers": config.resources.num_agg,
+                "gpus_per_prefill": config.resources.gpus_per_prefill,
+                "gpus_per_decode": config.resources.gpus_per_decode,
+                "gpus_per_agg": config.resources.gpus_per_agg,
             },
             # Backend and frontend
             "backend_type": config.backend_type,

--- a/tests/test_sa_bench_rollup.py
+++ b/tests/test_sa_bench_rollup.py
@@ -167,3 +167,121 @@ def test_sa_bench_rollup_uses_metadata_for_name_gpu_counts_and_p90(tmp_path):
     assert row["P90 Decode Running Requests"] == "32"
     assert row["Output Token Throughput per User"] == "40"
     assert row["Total Token Throughput per GPU"] == "33.333"
+
+
+def test_sa_bench_rollup_aggregated_deployment_reports_all_gpus(tmp_path):
+    """Aggregated runs should report total and decode GPU counts from agg_* fields."""
+    rollup = _load_rollup_module()
+
+    logs_dir = tmp_path / "logs"
+    result_dir = logs_dir / "sa-bench_isl_1024_osl_1024"
+    result_dir.mkdir(parents=True)
+
+    (tmp_path / "4688.json").write_text(
+        json.dumps(
+            {
+                "job_name": "glm47flash-agg-tp4-baseline",
+                "backend_type": "sglang",
+                "resources": {
+                    "gpus_per_node": 4,
+                    "prefill_nodes": None,
+                    "decode_nodes": None,
+                    "agg_nodes": 1,
+                    "prefill_workers": 0,
+                    "decode_workers": 0,
+                    "agg_workers": 1,
+                    "gpus_per_agg": 4,
+                },
+            }
+        )
+    )
+
+    result = {
+        "model_id": "zai-org/GLM-4.7-Flash",
+        "max_concurrency": 512,
+        "output_throughput": 12617.0,
+        "total_token_throughput": 25230.0,
+        "median_ttft_ms": 1780.0,
+        "median_tpot_ms": 38.5,
+        "median_itl_ms": 38.5,
+    }
+    (result_dir / "results_concurrency_512_gpus_4.json").write_text(json.dumps(result))
+
+    rollup.main(logs_dir)
+
+    rows = _read_csv_rows(logs_dir / "benchmark-rollup.csv")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["Config"] == "glm47flash-agg-tp4-baseline"
+    assert row["Total GPU Count"] == "4"
+    assert row["Decode GPU Count"] == "4"
+    assert row["Total Token Throughput per GPU"] == "6307.5"
+
+
+def test_sa_bench_rollup_tolerates_null_resource_fields(tmp_path):
+    """Legacy metadata with null optional fields must not crash _compute_gpu_counts."""
+    rollup = _load_rollup_module()
+
+    logs_dir = tmp_path / "logs"
+    result_dir = logs_dir / "sa-bench_isl_1024_osl_1024"
+    result_dir.mkdir(parents=True)
+
+    # Pre-fix metadata shape: prefill/decode_nodes are JSON null, no agg_nodes
+    # key. Rollup used to crash with TypeError: int() argument must be ... not
+    # 'NoneType'.
+    (tmp_path / "4688.json").write_text(
+        json.dumps(
+            {
+                "job_name": "legacy-agg-run",
+                "backend_type": "sglang",
+                "resources": {
+                    "gpus_per_node": 4,
+                    "prefill_nodes": None,
+                    "decode_nodes": None,
+                    "prefill_workers": 0,
+                    "decode_workers": 0,
+                    "agg_workers": 1,
+                },
+            }
+        )
+    )
+
+    result = {
+        "model_id": "zai-org/GLM-4.7-Flash",
+        "max_concurrency": 128,
+        "output_throughput": 7130.0,
+        "total_token_throughput": 14278.0,
+        "median_ttft_ms": 138.0,
+        "median_tpot_ms": 17.4,
+        "median_itl_ms": 17.4,
+    }
+    (result_dir / "results_concurrency_128_gpus_4.json").write_text(json.dumps(result))
+
+    rollup.main(logs_dir)
+
+    rows = _read_csv_rows(logs_dir / "benchmark-rollup.csv")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["Config"] == "legacy-agg-run"
+    assert row["Total GPU Count"] == "4"
+
+
+def test_compute_gpu_counts_handles_none_values():
+    """_compute_gpu_counts should never raise on null-valued keys."""
+    rollup = _load_rollup_module()
+
+    assert rollup._compute_gpu_counts(
+        {
+            "gpus_per_node": 4,
+            "prefill_nodes": None,
+            "decode_nodes": None,
+            "agg_nodes": None,
+            "prefill_workers": None,
+            "decode_workers": None,
+            "agg_workers": None,
+            "gpus_per_agg": None,
+        }
+    ) == (4, None)
+
+    assert rollup._compute_gpu_counts({}) == (None, None)
+    assert rollup._compute_gpu_counts({"gpus_per_node": None}) == (None, None)


### PR DESCRIPTION
## Summary

- `cli/submit.py` now emits `agg_nodes` and `gpus_per_{prefill,decode,agg}` in the submit metadata JSON so the sa-bench rollup can compute correct counts for aggregated deployments.
- `sa-bench/rollup.py` is hardened against \`null\` resource fields (current metadata writes \`prefill_nodes: null\` for aggregated runs, and \`int(None)\` crashed the rollup) and gains an aggregated branch so `Decode GPU Count` / `Total Token Throughput per GPU` populate when only the \`agg_*\` fields are set.
- Tests extended: aggregated-deployment coverage, regression for legacy metadata with \`null\` optional fields, and a unit test for `_compute_gpu_counts`.

## Why

Aggregated sa-bench sweeps on sgl-gb200 were failing the rollup stage with:
\`\`\`
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
\`\`\`
traced to \`_compute_gpu_counts\` reading \`prefill_nodes\` as \`None\` (present in JSON with \`null\`, so \`.get(key, 0)\` returns \`None\`). Even with the None-crash fixed, the emitted metadata was missing \`agg_nodes\` and the resolved \`gpus_per_*\` values, so rollup had no way to compute the decode-serving GPU count for an aggregated run.

The raw \`results_concurrency_*.json\` files were always fine; only the rollup CSV/JSON was affected. This fix brings aggregated runs to parity with disaggregated runs.

## Test plan

- [x] \`pytest tests/test_sa_bench_rollup.py tests/test_submit_cli.py\` (8 passed, 3 new)
- [x] \`pytest -q\` (600 passed, 2 skipped, 6 deselected)
- [ ] Spot-check on next aggregated sa-bench submission that \`benchmark-rollup.csv\` has non-empty \`Total GPU Count\`, \`Decode GPU Count\`, and \`Total Token Throughput per GPU\` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)