### PR TITLE
feat: use pre-generated custom dataset for benchmarking MTP with chat template

### DIFF
--- a/src/srtctl/benchmarks/sa_bench.py
+++ b/src/srtctl/benchmarks/sa_bench.py
@@ -21,12 +21,13 @@ class SABenchRunner(BenchmarkRunner):
     Tests serving throughput at various concurrency levels.
 
     Required config fields:
-        - benchmark.isl: Input sequence length
-        - benchmark.osl: Output sequence length
         - benchmark.concurrencies: Concurrency levels (e.g., "4x8x16x32")
+        - benchmark.isl / benchmark.osl: Required when dataset_name is "random" (default)
 
     Optional:
         - benchmark.req_rate: Request rate (default: "inf")
+        - benchmark.dataset_name: "random" (default) or "custom"
+        - benchmark.dataset_path: Container path to dataset file (required when dataset_name="custom")
     """
 
     @property
@@ -45,12 +46,17 @@ class SABenchRunner(BenchmarkRunner):
         errors = []
         b = config.benchmark
 
-        if b.isl is None:
-            errors.append("benchmark.isl is required for sa-bench")
-        if b.osl is None:
-            errors.append("benchmark.osl is required for sa-bench")
+        is_custom = b.dataset_name == "custom"
+
+        if not is_custom:
+            if b.isl is None:
+                errors.append("benchmark.isl is required for sa-bench (when dataset_name is not 'custom')")
+            if b.osl is None:
+                errors.append("benchmark.osl is required for sa-bench (when dataset_name is not 'custom')")
         if b.concurrencies is None:
             errors.append("benchmark.concurrencies is required for sa-bench")
+        if is_custom and not b.dataset_path:
+            errors.append("benchmark.dataset_path is required when dataset_name='custom'")
 
         return errors
 
@@ -82,12 +88,14 @@ class SABenchRunner(BenchmarkRunner):
         # Tokenizer path: HF model ID or container mount path
         tokenizer_path = str(runtime.model_path) if runtime.is_hf_model else "/model"
 
+        dataset_name = b.dataset_name or "random"
+
         cmd = [
             "bash",
             self.script_path,
             endpoint,
-            str(b.isl),
-            str(b.osl),
+            str(b.isl or 0),
+            str(b.osl or 0),
             str(concurrencies) if concurrencies else "",
             str(b.req_rate) if b.req_rate else "inf",
             tokenizer_path,
@@ -101,5 +109,7 @@ class SABenchRunner(BenchmarkRunner):
             str(b.num_warmup_mult) if b.num_warmup_mult is not None else "2",
             b.custom_tokenizer or "",
             str(b.use_chat_template).lower(),
+            dataset_name,
+            b.dataset_path or "",
         ]
         return cmd

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -64,6 +64,8 @@ NUM_PROMPTS_MULT=${13:-10}
 NUM_WARMUP_MULT=${14:-2}
 CUSTOM_TOKENIZER=${15:-}
 USE_CHAT_TEMPLATE=${16:-true}
+DATASET_NAME=${17:-random}
+DATASET_PATH=${18:-}
 
 # Build optional custom tokenizer args
 CUSTOM_TOKENIZER_ARGS=()
@@ -77,13 +79,29 @@ if [ "$USE_CHAT_TEMPLATE" = "true" ]; then
     CHAT_TEMPLATE_ARGS=(--use-chat-template)
 fi
 
+# Build dataset args
+DATASET_ARGS=(--dataset-name "$DATASET_NAME")
+if [ -n "$DATASET_PATH" ]; then
+    DATASET_ARGS+=(--dataset-path "$DATASET_PATH")
+fi
+
+# Random-length args only apply to random dataset
+RANDOM_LEN_ARGS=()
+if [ "$DATASET_NAME" = "random" ]; then
+    RANDOM_LEN_ARGS=(
+        --random-input-len "$ISL"
+        --random-output-len "$OSL"
+        --random-range-ratio "${RANDOM_RANGE_RATIO}"
+    )
+fi
+
 # Parse endpoint into host:port
 HOST=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f1)
 PORT=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f2 | cut -d/ -f1)
 
 WORK_DIR="$(dirname "$0")"
 
-echo "SA-Bench Config: endpoint=${ENDPOINT}; isl=${ISL}; osl=${OSL}; concurrencies=${CONCURRENCIES}; req_rate=${REQ_RATE}; model=${MODEL_NAME}"
+echo "SA-Bench Config: endpoint=${ENDPOINT}; isl=${ISL}; osl=${OSL}; concurrencies=${CONCURRENCIES}; req_rate=${REQ_RATE}; model=${MODEL_NAME}; dataset=${DATASET_NAME}; dataset_path=${DATASET_PATH}"
 
 # Profiling shared helpers
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -112,7 +130,12 @@ echo ""
 ulimit -n 65536 2>/dev/null || true  # May fail in containers without CAP_SYS_RESOURCE
 
 # Benchmark
-result_dir="/logs/sa-bench_isl_${ISL}_osl_${OSL}"
+if [ "$DATASET_NAME" = "custom" ]; then
+    dataset_label=$(basename "${DATASET_PATH%.*}")
+    result_dir="/logs/sa-bench_custom_${dataset_label}"
+else
+    result_dir="/logs/sa-bench_isl_${ISL}_osl_${OSL}"
+fi
 mkdir -p "$result_dir"
 
 # Start profiling before benchmark
@@ -126,11 +149,9 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --host "$HOST" --port "$PORT" \
         --backend "dynamo" --endpoint /v1/completions \
         --disable-tqdm \
-        --dataset-name random \
+        "${DATASET_ARGS[@]}" \
         --num-prompts "$num_warmup_prompts" \
-        --random-input-len "$ISL" \
-        --random-output-len "$OSL" \
-        --random-range-ratio "${RANDOM_RANGE_RATIO}" \
+        "${RANDOM_LEN_ARGS[@]}" \
         --ignore-eos \
         --request-rate 250 \
         --percentile-metrics ttft,tpot,itl,e2el \
@@ -138,15 +159,15 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --trust-remote-code \
         "${CUSTOM_TOKENIZER_ARGS[@]}"
 
-    num_prompts=$((concurrency * 10))
-    
+    num_prompts=$((concurrency * NUM_PROMPTS_MULT))
+
     # Generate result filename based on mode
     if [ "$IS_DISAGGREGATED" = "true" ]; then
         result_filename="results_concurrency_${concurrency}_gpus_${TOTAL_GPUS}_ctx_${PREFILL_GPUS}_gen_${DECODE_GPUS}.json"
     else
         result_filename="results_concurrency_${concurrency}_gpus_${TOTAL_GPUS}.json"
     fi
-    
+
     echo "Running benchmark with concurrency: $concurrency"
     echo "$(date '+%Y-%m-%d %H:%M:%S')"
 
@@ -156,11 +177,9 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --host "$HOST" --port "$PORT" \
         --backend "dynamo" --endpoint /v1/completions \
         --disable-tqdm \
-        --dataset-name random \
+        "${DATASET_ARGS[@]}" \
         --num-prompts "$num_prompts" \
-        --random-input-len "$ISL" \
-        --random-output-len "$OSL" \
-        --random-range-ratio "${RANDOM_RANGE_RATIO}" \
+        "${RANDOM_LEN_ARGS[@]}" \
         --ignore-eos \
         --request-rate "${REQ_RATE}" \
         --percentile-metrics ttft,tpot,itl,e2el \

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_dataset.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_dataset.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Custom dataset loader for SA-Bench.
+
+Loads a JSONL dataset file where each line is a JSON object describing one request.
+No tokenizer is required — prompt lengths are either read from the dataset or
+estimated from the raw text length.
+
+Supported formats:
+
+1. TRT-LLM / OpenAI-style (messages array):
+   {"input": {"messages": [{"role": "user", "content": "..."}], "max_tokens": 2048}}
+   {"input": {"messages": [{"role": "user", "content": "..."}], "max_tokens": 2048, "num_tokens": 512}}
+
+2. Flat format (prompt string):
+   {"prompt": "...", "expected_output_len": 128}
+   {"prompt": "...", "expected_output_len": 128, "prompt_len": 64}
+"""
+
+from __future__ import annotations
+
+import json
+import random
+
+
+def sample_custom_requests(
+    dataset_path: str,
+    num_requests: int,
+) -> list[tuple[str, int, int, None]]:
+    """Load and sample requests from a custom JSONL dataset.
+
+    Args:
+        dataset_path: Path to JSONL file.
+        num_requests: Maximum number of requests to return.
+
+    Returns:
+        List of (prompt, prompt_len, output_len, None) tuples.
+    """
+    with open(dataset_path, encoding="utf-8") as f:
+        data = [json.loads(line) for line in f if line.strip()]
+
+    random.shuffle(data)
+
+    results: list[tuple[str, int, int, None]] = []
+
+    for entry in data:
+        if len(results) >= num_requests:
+            break
+
+        if "input" in entry:
+            messages = entry["input"].get("messages", [])
+            prompt = _extract_prompt_from_messages(messages)
+            output_len = int(entry["input"].get("max_tokens", 128))
+            prompt_len = entry["input"].get("num_tokens")
+        elif "prompt" in entry:
+            prompt = entry["prompt"]
+            output_len = int(entry.get("expected_output_len") or entry.get("max_tokens") or 128)
+            prompt_len = entry.get("prompt_len")
+        else:
+            continue
+
+        if not prompt:
+            continue
+
+        if not isinstance(prompt_len, int) or prompt_len <= 0:
+            prompt_len = len(prompt) // 4
+
+        results.append((prompt, prompt_len, output_len, None))
+
+    return results
+
+
+def _extract_prompt_from_messages(messages: list[dict]) -> str:
+    """Extract the user prompt from an OpenAI-style messages array."""
+    for msg in reversed(messages):
+        if msg.get("role") == "user" and msg.get("content"):
+            return msg["content"]
+    if messages and messages[-1].get("content"):
+        return messages[-1]["content"]
+    return ""

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -840,92 +840,101 @@ def main(args: argparse.Namespace):
         custom_tokenizer=args.custom_tokenizer,
     )
 
-    if args.dataset is not None:
-        warnings.warn(
-            "The '--dataset' argument will be deprecated in the next "
-            "release. Please use '--dataset-name' and "
-            "'--dataset-path' in the future runs.",
-            stacklevel=2,
-        )
-        input_requests = sample_sharegpt_requests(
-            dataset_path=args.dataset,
-            num_requests=args.num_prompts,
-            tokenizer=tokenizer,
-            fixed_output_len=args.sharegpt_output_len,
-        )
+    if args.dataset_name == "custom":
+        from benchmark_dataset import sample_custom_requests
 
-    elif args.dataset_name == "sharegpt":
-        input_requests = sample_sharegpt_requests(
+        input_requests = sample_custom_requests(
             dataset_path=args.dataset_path,
             num_requests=args.num_prompts,
-            tokenizer=tokenizer,
-            fixed_output_len=args.sharegpt_output_len,
         )
-
-    elif args.dataset_name == "burstgpt":
-        input_requests = sample_burstgpt_requests(
-            dataset_path=args.dataset_path,
-            num_requests=args.num_prompts,
-            random_seed=args.seed,
-            tokenizer=tokenizer,
-        )
-
-    elif args.dataset_name == "sonnet":
-        # Do not format the prompt, pass to message directly
-        if args.backend == "openai-chat":
-            input_requests = sample_sonnet_requests(
-                dataset_path=args.dataset_path,
-                num_requests=args.num_prompts,
-                input_len=args.sonnet_input_len,
-                output_len=args.sonnet_output_len,
-                prefix_len=args.sonnet_prefix_len,
-                tokenizer=tokenizer,
-            )
-            input_requests = [
-                (prompt, prompt_len, output_len, None)
-                for prompt, prompt_formatted, prompt_len, output_len, _ in input_requests
-            ]
-        else:
-            assert (
-                tokenizer.chat_template or tokenizer.default_chat_template
-            ), "Tokenizer/model must have chat template for sonnet dataset."
-            input_requests = sample_sonnet_requests(
-                dataset_path=args.dataset_path,
-                num_requests=args.num_prompts,
-                input_len=args.sonnet_input_len,
-                output_len=args.sonnet_output_len,
-                prefix_len=args.sonnet_prefix_len,
-                tokenizer=tokenizer,
-            )
-            input_requests = [
-                (prompt_formatted, prompt_len, output_len, None)
-                for prompt, prompt_formatted, prompt_len, output_len, _ in input_requests
-            ]
-
-    elif args.dataset_name == "hf":
-        input_requests = sample_hf_requests(
-            dataset_path=args.dataset_path,
-            dataset_subset=args.hf_subset,
-            dataset_split=args.hf_split,
-            num_requests=args.num_prompts,
-            tokenizer=tokenizer,
-            random_seed=args.seed,
-            fixed_output_len=args.hf_output_len,
-        )
-
-    elif args.dataset_name == "random":
-        input_requests = sample_random_requests(
-            prefix_len=args.random_prefix_len,
-            input_len=args.random_input_len,
-            output_len=args.random_output_len,
-            num_prompts=args.num_prompts,
-            range_ratio=args.random_range_ratio,
-            tokenizer=tokenizer,
-            use_chat_template=args.use_chat_template,
-        )
-
     else:
-        raise ValueError(f"Unknown dataset: {args.dataset_name}")
+
+        if args.dataset is not None:
+            warnings.warn(
+                "The '--dataset' argument will be deprecated in the next "
+                "release. Please use '--dataset-name' and "
+                "'--dataset-path' in the future runs.",
+                stacklevel=2,
+            )
+            input_requests = sample_sharegpt_requests(
+                dataset_path=args.dataset,
+                num_requests=args.num_prompts,
+                tokenizer=tokenizer,
+                fixed_output_len=args.sharegpt_output_len,
+            )
+
+        elif args.dataset_name == "sharegpt":
+            input_requests = sample_sharegpt_requests(
+                dataset_path=args.dataset_path,
+                num_requests=args.num_prompts,
+                tokenizer=tokenizer,
+                fixed_output_len=args.sharegpt_output_len,
+            )
+
+        elif args.dataset_name == "burstgpt":
+            input_requests = sample_burstgpt_requests(
+                dataset_path=args.dataset_path,
+                num_requests=args.num_prompts,
+                random_seed=args.seed,
+                tokenizer=tokenizer,
+            )
+
+        elif args.dataset_name == "sonnet":
+            # Do not format the prompt, pass to message directly
+            if args.backend == "openai-chat":
+                input_requests = sample_sonnet_requests(
+                    dataset_path=args.dataset_path,
+                    num_requests=args.num_prompts,
+                    input_len=args.sonnet_input_len,
+                    output_len=args.sonnet_output_len,
+                    prefix_len=args.sonnet_prefix_len,
+                    tokenizer=tokenizer,
+                )
+                input_requests = [
+                    (prompt, prompt_len, output_len, None)
+                    for prompt, prompt_formatted, prompt_len, output_len, _ in input_requests
+                ]
+            else:
+                assert (
+                    tokenizer.chat_template or tokenizer.default_chat_template
+                ), "Tokenizer/model must have chat template for sonnet dataset."
+                input_requests = sample_sonnet_requests(
+                    dataset_path=args.dataset_path,
+                    num_requests=args.num_prompts,
+                    input_len=args.sonnet_input_len,
+                    output_len=args.sonnet_output_len,
+                    prefix_len=args.sonnet_prefix_len,
+                    tokenizer=tokenizer,
+                )
+                input_requests = [
+                    (prompt_formatted, prompt_len, output_len, None)
+                    for prompt, prompt_formatted, prompt_len, output_len, _ in input_requests
+                ]
+
+        elif args.dataset_name == "hf":
+            input_requests = sample_hf_requests(
+                dataset_path=args.dataset_path,
+                dataset_subset=args.hf_subset,
+                dataset_split=args.hf_split,
+                num_requests=args.num_prompts,
+                tokenizer=tokenizer,
+                random_seed=args.seed,
+                fixed_output_len=args.hf_output_len,
+            )
+
+        elif args.dataset_name == "random":
+            input_requests = sample_random_requests(
+                prefix_len=args.random_prefix_len,
+                input_len=args.random_input_len,
+                output_len=args.random_output_len,
+                num_prompts=args.num_prompts,
+                range_ratio=args.random_range_ratio,
+                tokenizer=tokenizer,
+                use_chat_template=args.use_chat_template,
+            )
+
+        else:
+            raise ValueError(f"Unknown dataset: {args.dataset_name}")
 
     goodput_config_dict = check_goodput_args(args)
 
@@ -1033,7 +1042,7 @@ if __name__ == "__main__":
         "--dataset-name",
         type=str,
         default="sharegpt",
-        choices=["sharegpt", "burstgpt", "sonnet", "random", "hf"],
+        choices=["sharegpt", "burstgpt", "sonnet", "random", "hf", "custom"],
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument(

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -541,6 +541,9 @@ class BenchmarkConfig:
     random_range_ratio: float | None = None  # Random input/output length range ratio (default: 0.8)
     num_prompts_mult: int | None = None  # Multiplier for num_prompts = concurrency * mult (default: 10)
     num_warmup_mult: int | None = None  # Multiplier for warmup prompts = concurrency * mult (default: 2)
+    # Custom dataset fields (sa-bench)
+    dataset_name: str | None = None  # "random" (default) or "custom"
+    dataset_path: str | None = None  # Container path to dataset file (mount via extra_mount)
     # Trace replay benchmark fields (uses aiperf with mooncake_trace dataset type)
     trace_file: str | None = None  # Path to trace JSONL file (container path, e.g., /traces/dataset.jsonl)
     custom_tokenizer: str | None = None  # Custom tokenizer class (e.g., "module.path.ClassName")

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -77,6 +77,90 @@ class TestSABenchRunner:
         errors = runner.validate_config(config)
         assert errors == []
 
+    def test_validate_custom_dataset_requires_path(self):
+        """Custom dataset requires dataset_path."""
+        from srtctl.benchmarks.sa_bench import SABenchRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = SABenchRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(type="sa-bench", dataset_name="custom", concurrencies="4x8"),
+        )
+        errors = runner.validate_config(config)
+        assert any("dataset_path" in e for e in errors)
+        assert not any("isl" in e for e in errors)
+
+    def test_validate_custom_dataset_valid(self):
+        """Custom dataset with path passes validation (isl/osl not required)."""
+        from srtctl.benchmarks.sa_bench import SABenchRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = SABenchRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(
+                type="sa-bench", dataset_name="custom", dataset_path="/data/bench.jsonl", concurrencies="4x8"
+            ),
+        )
+        errors = runner.validate_config(config)
+        assert errors == []
+
+    def test_build_command_custom_dataset(self):
+        """build_command passes dataset_path through as container path."""
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.sa_bench import SABenchRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = SABenchRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        runtime.model_path = "/model"
+        runtime.is_hf_model = False
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(
+                type="sa-bench",
+                dataset_name="custom",
+                dataset_path="/glm5_datasets/bench.jsonl",
+                concurrencies="4x8",
+            ),
+        )
+        cmd = runner.build_command(config, runtime)
+        assert "custom" in cmd
+        assert "/glm5_datasets/bench.jsonl" in cmd
+
+    def test_build_command_default_dataset_random(self):
+        """Default dataset_name is 'random' when not specified."""
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.sa_bench import SABenchRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = SABenchRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        runtime.model_path = "/model"
+        runtime.is_hf_model = False
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(type="sa-bench", isl=1024, osl=128, concurrencies="4x8"),
+        )
+        cmd = runner.build_command(config, runtime)
+        assert "random" in cmd
+        assert cmd[-1] == ""  # empty dataset path
+
 
 class TestSGLangBenchRunner:
     """Test SGLang-Bench runner."""
@@ -627,3 +711,138 @@ class TestSweepRunEvalIntegration:
 
         mock_eval.assert_not_called()
         assert exit_code == 1
+
+
+class TestCustomDatasetLoader:
+    """Test benchmark_dataset.py custom JSONL loader."""
+
+    def test_trtllm_format(self, tmp_path):
+        """Loads TRT-LLM OpenAI-style JSONL."""
+        import sys
+
+        scripts_dir = str(SCRIPTS_DIR / "sa-bench")
+        sys.path.insert(0, scripts_dir)
+        try:
+            from benchmark_dataset import sample_custom_requests
+        finally:
+            sys.path.pop(0)
+
+        dataset_file = tmp_path / "data.jsonl"
+        dataset_file.write_text(
+            '{"input": {"messages": [{"role": "user", "content": "Hello world"}], "max_tokens": 64}}\n'
+            '{"input": {"messages": [{"role": "user", "content": "How are you?"}], "max_tokens": 128}}\n'
+        )
+
+        results = sample_custom_requests(str(dataset_file), num_requests=10)
+        assert len(results) == 2
+        assert all(len(r) == 4 for r in results)
+        assert results[0][3] is None
+
+    def test_flat_format(self, tmp_path):
+        """Loads flat prompt/output_len JSONL."""
+        import sys
+
+        scripts_dir = str(SCRIPTS_DIR / "sa-bench")
+        sys.path.insert(0, scripts_dir)
+        try:
+            from benchmark_dataset import sample_custom_requests
+        finally:
+            sys.path.pop(0)
+
+        dataset_file = tmp_path / "data.jsonl"
+        dataset_file.write_text(
+            '{"prompt": "Summarize this article", "expected_output_len": 256}\n'
+            '{"prompt": "Translate to French", "max_tokens": 100}\n'
+        )
+
+        results = sample_custom_requests(str(dataset_file), num_requests=10)
+        assert len(results) == 2
+        output_lens = {r[2] for r in results}
+        assert 256 in output_lens
+        assert 100 in output_lens
+
+    def test_num_requests_limit(self, tmp_path):
+        """Respects num_requests cap."""
+        import sys
+
+        scripts_dir = str(SCRIPTS_DIR / "sa-bench")
+        sys.path.insert(0, scripts_dir)
+        try:
+            from benchmark_dataset import sample_custom_requests
+        finally:
+            sys.path.pop(0)
+
+        lines = [f'{{"prompt": "request {i}", "expected_output_len": 64}}\n' for i in range(50)]
+        dataset_file = tmp_path / "data.jsonl"
+        dataset_file.write_text("".join(lines))
+
+        results = sample_custom_requests(str(dataset_file), num_requests=5)
+        assert len(results) == 5
+
+    def test_precomputed_token_lengths(self, tmp_path):
+        """Uses precomputed num_tokens when available in TRT-LLM format."""
+        import sys
+
+        scripts_dir = str(SCRIPTS_DIR / "sa-bench")
+        sys.path.insert(0, scripts_dir)
+        try:
+            from benchmark_dataset import sample_custom_requests
+        finally:
+            sys.path.pop(0)
+
+        dataset_file = tmp_path / "data.jsonl"
+        dataset_file.write_text(
+            '{"input": {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 64, "num_tokens": 42}}\n'
+        )
+
+        results = sample_custom_requests(str(dataset_file), num_requests=10)
+        assert len(results) == 1
+        assert results[0][1] == 42
+
+    def test_prompt_len_estimated_when_missing(self, tmp_path):
+        """Estimates prompt_len from text length when not provided."""
+        import sys
+
+        scripts_dir = str(SCRIPTS_DIR / "sa-bench")
+        sys.path.insert(0, scripts_dir)
+        try:
+            from benchmark_dataset import sample_custom_requests
+        finally:
+            sys.path.pop(0)
+
+        dataset_file = tmp_path / "data.jsonl"
+        dataset_file.write_text('{"prompt": "abcdefghijklmnop", "expected_output_len": 64}\n')
+
+        results = sample_custom_requests(str(dataset_file), num_requests=10)
+        assert len(results) == 1
+        assert results[0][1] == 4  # len("abcdefghijklmnop") // 4
+
+    def test_config_roundtrip_custom_dataset(self):
+        """Config with custom dataset loads correctly from YAML."""
+        import tempfile
+        from pathlib import Path
+
+        import yaml
+
+        from srtctl.core.schema import SrtConfig
+
+        config_data = {
+            "name": "custom-dataset-test",
+            "model": {"path": "/model", "container": "/image", "precision": "fp4"},
+            "resources": {"gpu_type": "h100"},
+            "benchmark": {
+                "type": "sa-bench",
+                "dataset_name": "custom",
+                "dataset_path": "/data/my_dataset.jsonl",
+                "concurrencies": [4, 8],
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config_data, f)
+            tmp_path = Path(f.name)
+
+        config = SrtConfig.from_yaml(tmp_path)
+        assert config.benchmark.dataset_name == "custom"
+        assert config.benchmark.dataset_path == "/data/my_dataset.jsonl"
+        assert config.benchmark.concurrencies == [4, 8]


### PR DESCRIPTION
This is a workaround for adding the chat template for MTP based benchmarking for GLM-5 model.

GLM-5 is using a custom tokenizer, invoking it multiple times will cause pmix failure at runtime. 

Workaround is pre-generate the dataset with chat template and use it for MTP based benchmarking.

The config is like this:
```
benchmark:
  type: "sa-bench"
  isl: 1024
  osl: 1024
  concurrencies: "8192"
  req_rate: "inf"
  dataset_name: "custom"
  dataset_path: "/glm5_datasets/glm5-1024-1024-100000-ratio-1_for_serve.json"
  custom_tokenizer: "glm_moe_dsa"

extra_mount:
  - "/lustre/fsw/core_dlfw_ci/rihuo/glm5_dataset:/glm5_datasets"
```
