### PR TITLE
docs: loud warnings on custom benchmark templating and nginx-off mode

### DIFF
--- a/src/srtctl/benchmarks/custom.py
+++ b/src/srtctl/benchmarks/custom.py
@@ -14,7 +14,29 @@ from srtctl.core.schema import SrtConfig
 
 @register_benchmark("custom")
 class CustomBenchmarkRunner(BenchmarkRunner):
-    """Run an arbitrary benchmark command inside a container."""
+    """Run an arbitrary benchmark command inside a container.
+
+    IMPORTANT — no templating on ``benchmark.command``.
+
+    The string in ``benchmark.command`` is passed to ``bash -lc`` verbatim.
+    srtctl does NOT substitute placeholders like ``{nginx_url}``,
+    ``{slurm_job_id}``, ``{log_dir}``, ``{target}``, etc. Any literal
+    ``{…}`` in the command will reach the shell unchanged and almost
+    certainly produce a confusing error (e.g. ``bash: {nginx_url}: not
+    found``).
+
+    Practical consequences:
+
+    * The benchmark runs inside the job's container with pyxis/enroot's
+      default networking, so services on the head node are reachable at
+      ``localhost``. Hit ``http://localhost:<port>`` directly.
+    * If ``frontend.enable_multiple_frontends`` is ``False`` there is no
+      nginx proxy; point the benchmark at the master router port (or a
+      worker) directly — again via ``localhost``.
+    * If you need to parameterize the command, render it yourself when
+      you generate the recipe and paste the final string into
+      ``benchmark.command``.
+    """
 
     @property
     def name(self) -> str:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -602,7 +602,11 @@ class BenchmarkConfig:
     trace_file: str | None = None  # Path to trace JSONL file (container path, e.g., /traces/dataset.jsonl)
     custom_tokenizer: str | None = None  # Custom tokenizer class (e.g., "module.path.ClassName")
     use_chat_template: bool = True  # Pass --use-chat-template to benchmark (default: true)
-    # Custom benchmark hook
+    # Custom benchmark hook.
+    # ``command`` is passed to ``bash -lc`` verbatim; srtctl does NOT
+    # substitute placeholders like ``{nginx_url}`` or ``{slurm_job_id}``.
+    # Render any parameters when generating the recipe. See
+    # srtctl.benchmarks.custom.CustomBenchmarkRunner for details.
     command: str | None = None
     container_image: str | None = None
     env: dict[str, str] = field(default_factory=dict)
@@ -996,7 +1000,13 @@ class FrontendConfig:
 
     Attributes:
         type: Frontend type - "dynamo" (default) or "sglang"
-        enable_multiple_frontends: Scale with nginx + multiple routers
+        enable_multiple_frontends: Scale with nginx + multiple routers.
+            When ``True`` (default), srtctl stands up nginx and fans out
+            to ``num_additional_frontends + 1`` router replicas. When
+            ``False``, there is NO nginx proxy — the benchmark must
+            target the single master router (or a worker) directly at
+            ``http://localhost:<port>``. ``benchmark.command`` has no
+            placeholder substitution, so write the URL out literally.
         num_additional_frontends: Additional routers beyond master (default: 9)
         nginx_container: Custom nginx container image (default: nginx:1.27.4)
         args: CLI arguments passed to the frontend/router process


### PR DESCRIPTION
## Summary

- `benchmarks/custom.py`: loud class-docstring warning that `benchmark.command` is passed to `bash -lc` verbatim — srtctl does **not** substitute `{nginx_url}`, `{slurm_job_id}`, `{log_dir}`, `{target}`, etc. If you need parameters, render them when generating the recipe and paste the final string in.
- `core/schema.py`: short companion comment on the `command` field pointing at the runner docstring.
- `core/schema.py`: `FrontendConfig` docstring expanded on `enable_multiple_frontends` — when `False`, there is no nginx proxy, and the benchmark must target `http://localhost:<port>` directly (and, again, literally — no templating).

## Motivation

Autoresearch session: agent wrote `benchmark.command: "aiperf ... --url {nginx_url}"` against a recipe that also had `enable_multiple_frontends: false`. The literal `{nginx_url}` hit `bash -lc` untouched, which produced a confusing `bash: {nginx_url}: ...` error. Coupled with the disabled multi-frontend mode (no nginx), the right answer was just `--url http://localhost:8000`. The schema and runner had no hint about either. Single-digit-lines fix, saves a whole iteration.

## Test plan

- [ ] `uv run pytest -x` (600 passed, 2 skipped locally)
- [ ] Read the updated docstrings as a user