### PR TITLE
feat: DeepSeek-V4-Pro perf recipes for GB300 / GB200 (1k/1k agg)

### DIFF
--- a/recipes/gb200-fp4/1k1k-dsv4/README.md
+++ b/recipes/gb200-fp4/1k1k-dsv4/README.md
@@ -1,0 +1,21 @@
+# DeepSeek-V4-Pro (1.6T MoE, MXFP4) — 1k/1k aggregated on GB200
+
+NVIDIA-verified SGLang recipes for **DeepSeek-V4-Pro** (MXFP4) on **GB200**
+(ARM64 Grace + Blackwell, 4 GPU per node), aggregated mode, 1k / 1k workload.
+GB200 HBM per GPU is smaller than GB300, so the 1.6T MXFP4 checkpoint only fits
+across **2 nodes (8 GPUs) at TP=8**.
+
+## Container
+
+Same Grace+Blackwell aarch64 image as GB300 (shared enroot sqsh alias
+`dsv4-grace-blackwell` in `srtslurm.yaml.example`).
+
+## Recipes
+
+| file | parallelism | MTP | notes |
+|---|---|---|---|
+| `agg-2n-low-latency.yaml` | TP=8 | EAGLE 3/4 | low-latency, 2-node |
+| `agg-2n-nomtp.yaml`       | TP=8 | —         | throughput, 2-node  |
+
+See `recipes/gb300-fp4/1k1k-dsv4/README.md` for the full flag rationale —
+flags are identical to the GB300 2-node recipes apart from the partition.

--- a/recipes/gb200-fp4/1k1k-dsv4/agg-2n-low-latency.yaml
+++ b/recipes/gb200-fp4/1k1k-dsv4/agg-2n-low-latency.yaml
@@ -63,5 +63,3 @@ benchmark:
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
   req_rate: "inf"
-  warmup_multiplier: 2
-  formal_multiplier: 10

--- a/recipes/gb200-fp4/1k1k-dsv4/agg-2n-low-latency.yaml
+++ b/recipes/gb200-fp4/1k1k-dsv4/agg-2n-low-latency.yaml
@@ -1,0 +1,67 @@
+# DeepSeek-V4-Pro aggregated on GB300 2 nodes (TP=8) - MTP enabled
+name: "dsv4-pro-gb200-2n-agg-ll-1k1k-official"
+
+slurm:
+  partition: gb200
+  time_limit: "4:00:00"
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "fp4"
+
+frontend:
+  type: sglang
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+  agg_nodes: 2
+  agg_workers: 1
+
+backend:
+  type: sglang
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    # Persistent JIT caches (recommended for repeatable runs).
+    # Mount your own cache dirs into /configs/** via srt-slurm extra_mount
+    # or change these to any writable path inside the container.
+    SGLANG_DG_CACHE_DIR: "/configs/dsv4/gb200/deepgemm-cache"
+    FLASHINFER_WORKSPACE_BASE: "/configs/dsv4/gb200/flashinfer-cache"
+
+  sglang_config:
+    aggregated:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+      tensor-parallel-size: 8
+
+      moe-runner-backend: "flashinfer_mxfp4"
+      speculative-algo: "EAGLE"
+      speculative-num-steps: 3
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 4
+      chunked-prefill-size: 4096
+      disable-flashinfer-autotune: true
+      mem-fraction-static: 0.82
+
+      context-length: 2200
+      cuda-graph-max-bs: 1024
+      max-running-requests: 1024
+      disable-radix-cache: true
+      decode-log-interval: 1
+      stream-interval: 50
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
+  req_rate: "inf"
+  warmup_multiplier: 2
+  formal_multiplier: 10

--- a/recipes/gb200-fp4/1k1k-dsv4/agg-2n-nomtp.yaml
+++ b/recipes/gb200-fp4/1k1k-dsv4/agg-2n-nomtp.yaml
@@ -59,5 +59,3 @@ benchmark:
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
   req_rate: "inf"
-  warmup_multiplier: 2
-  formal_multiplier: 10

--- a/recipes/gb200-fp4/1k1k-dsv4/agg-2n-nomtp.yaml
+++ b/recipes/gb200-fp4/1k1k-dsv4/agg-2n-nomtp.yaml
@@ -1,0 +1,63 @@
+# DeepSeek-V4-Pro aggregated on GB300 2 nodes (TP=8) - MTP enabled
+name: "dsv4-pro-gb200-2n-agg-nomtp-1k1k-official"
+
+slurm:
+  partition: gb200
+  time_limit: "4:00:00"
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "fp4"
+
+frontend:
+  type: sglang
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+  agg_nodes: 2
+  agg_workers: 1
+
+backend:
+  type: sglang
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    # Persistent JIT caches (recommended for repeatable runs).
+    # Mount your own cache dirs into /configs/** via srt-slurm extra_mount
+    # or change these to any writable path inside the container.
+    SGLANG_DG_CACHE_DIR: "/configs/dsv4/gb200/deepgemm-cache"
+    FLASHINFER_WORKSPACE_BASE: "/configs/dsv4/gb200/flashinfer-cache"
+
+  sglang_config:
+    aggregated:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+      tensor-parallel-size: 8
+
+      moe-runner-backend: "flashinfer_mxfp4"
+      chunked-prefill-size: 4096
+      disable-flashinfer-autotune: true
+      mem-fraction-static: 0.82
+
+      context-length: 2200
+      cuda-graph-max-bs: 1024
+      max-running-requests: 1024
+      disable-radix-cache: true
+      decode-log-interval: 1
+      stream-interval: 50
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
+  req_rate: "inf"
+  warmup_multiplier: 2
+  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/README.md
+++ b/recipes/gb300-fp4/1k1k-dsv4/README.md
@@ -1,0 +1,53 @@
+# DeepSeek-V4-Pro (1.6T MoE, MXFP4) — 1k/1k aggregated on GB300
+
+This directory contains NVIDIA-verified SGLang recipes for **DeepSeek-V4-Pro**
+(1.6T-parameter MoE with MXFP4 MoE weights + FP8 KV, UE8M0 scales) on **GB300**
+(ARM64 Grace + Blackwell, 4 GPU per node), aggregated serving mode, 1024 input /
+1024 output workload.
+
+## Container
+
+All recipes reference the `dsv4-grace-blackwell` alias defined in
+`srtslurm.yaml.example`. Pull + convert:
+
+```bash
+enroot import --output sglang-deepseek-v4-grace-blackwell.sqsh \
+  docker://lmsysorg/sglang:deepseek-v4-grace-blackwell
+```
+
+(Use the `deepseek-v4-blackwell` image for B200 x86_64, or `deepseek-v4-hopper` for H200.)
+
+## Model checkpoint
+
+```bash
+hf download deepseek-ai/DeepSeek-V4-Pro --local-dir /shared/models/deepseek/DeepSeek-V4-Pro
+```
+
+## Recipes
+
+| file | parallelism | MTP | target | notes |
+|---|---|---|---|---|
+| `agg-low-latency.yaml`  | TP=4                        | EAGLE 3/4 | minimum TPOT / best per-user latency | GB300 1 node |
+| `agg-nomtp.yaml`        | TP=4                        | —         | baseline throughput, no spec decoding | GB300 1 node |
+| `agg-balanced-tep.yaml` | TP=4 + DP=4 + DP-attn + DeepEP | EAGLE 1/2 | Pareto mid-curve                     | GB300 1 node |
+| `agg-max-tpt-tep.yaml`  | TP=4 + DP=4 + DP-attn + DeepEP | —         | maximum TPS/GPU                      | GB300 1 node |
+| `agg-2n-low-latency.yaml` | TP=8                      | EAGLE 3/4 | low-latency, 2× memory headroom     | GB300 2 nodes |
+| `agg-2n-nomtp.yaml`     | TP=8                        | —         | throughput, 2× memory headroom       | GB300 2 nodes |
+
+## Key flags (derived from the SGLang DSv4 cookbook)
+
+- `moe-runner-backend: flashinfer_mxfp4` — MXFP4 MoE kernels (Blackwell only).
+- `chunked-prefill-size: 4096` + `disable-flashinfer-autotune: true` — cookbook recipe.
+- `disable-radix-cache: true` — synthetic benchmark best practice; also
+  reduces contiguous-allocator fragmentation at weight-reorder time.
+- `mem-fraction-static: 0.78` — leaves headroom for the MXFP4
+  `reorder_w1w3_to_w3w1` path (0.82 intermittently OOMs on GB300).
+- TEP recipes: `enable-dp-attention + moe-a2a-backend: deepep` plus
+  `deepep-config num_sms=96` (DeepEP `DEEPEP_LARGE_SMS_FLAG` for single-node
+  Blackwell per cookbook).
+
+## References
+
+- [SGLang cookbook: `docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx`](https://github.com/sgl-project/sglang/blob/main/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx)
+- [DeepSeek-V4-Pro model card](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro)
+- Upstream SGLang PR: sgl-project/sglang#23600

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-2n-low-latency.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-2n-low-latency.yaml
@@ -1,0 +1,68 @@
+# DeepSeek-V4-Pro aggregated on GB300 2 nodes (TP=8) - MTP enabled
+name: "dsv4-pro-gb300-2n-agg-ll-1k1k-official"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "fp4"
+
+frontend:
+  type: sglang
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 2
+  agg_workers: 1
+
+backend:
+  type: sglang
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    # Persistent JIT caches (recommended for repeatable runs).
+    # Mount your own cache dirs into /configs/** via srt-slurm extra_mount
+    # or change these to any writable path inside the container.
+    SGLANG_DG_CACHE_DIR: "/configs/dsv4/gb300/deepgemm-cache"
+    FLASHINFER_WORKSPACE_BASE: "/configs/dsv4/gb300/flashinfer-cache"
+
+  sglang_config:
+    aggregated:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+      tensor-parallel-size: 8
+
+      moe-runner-backend: "flashinfer_mxfp4"
+      speculative-algo: "EAGLE"
+      speculative-num-steps: 3
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 4
+      chunked-prefill-size: 4096
+      disable-flashinfer-autotune: true
+      mem-fraction-static: 0.82
+
+      context-length: 2200
+      cuda-graph-max-bs: 1024
+      max-running-requests: 1024
+      disable-radix-cache: true
+      decode-log-interval: 1
+      stream-interval: 50
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
+  req_rate: "inf"
+  warmup_multiplier: 2
+  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-2n-low-latency.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-2n-low-latency.yaml
@@ -64,5 +64,3 @@ benchmark:
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
   req_rate: "inf"
-  warmup_multiplier: 2
-  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-2n-nomtp.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-2n-nomtp.yaml
@@ -60,5 +60,3 @@ benchmark:
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
   req_rate: "inf"
-  warmup_multiplier: 2
-  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-2n-nomtp.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-2n-nomtp.yaml
@@ -1,0 +1,64 @@
+# DeepSeek-V4-Pro aggregated on GB300 2 nodes (TP=8) - MTP enabled
+name: "dsv4-pro-gb300-2n-agg-nomtp-1k1k-official"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "fp4"
+
+frontend:
+  type: sglang
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 2
+  agg_workers: 1
+
+backend:
+  type: sglang
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    # Persistent JIT caches (recommended for repeatable runs).
+    # Mount your own cache dirs into /configs/** via srt-slurm extra_mount
+    # or change these to any writable path inside the container.
+    SGLANG_DG_CACHE_DIR: "/configs/dsv4/gb300/deepgemm-cache"
+    FLASHINFER_WORKSPACE_BASE: "/configs/dsv4/gb300/flashinfer-cache"
+
+  sglang_config:
+    aggregated:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+      tensor-parallel-size: 8
+
+      moe-runner-backend: "flashinfer_mxfp4"
+      chunked-prefill-size: 4096
+      disable-flashinfer-autotune: true
+      mem-fraction-static: 0.82
+
+      context-length: 2200
+      cuda-graph-max-bs: 1024
+      max-running-requests: 1024
+      disable-radix-cache: true
+      decode-log-interval: 1
+      stream-interval: 50
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
+  req_rate: "inf"
+  warmup_multiplier: 2
+  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-balanced-tep.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-balanced-tep.yaml
@@ -1,0 +1,76 @@
+# DeepSeek-V4-Pro GB300 1n TEP 'balanced' recipe
+# From SGLang cookbook (DeepSeek-V4.mdx / deepseek-v4-deployment.jsx):
+#   TP=4 + DP=4 + DP-attention + DeepEP + MTP 1/2 + cg=128 max-run=256
+# Tests TEP vs pure-TP speedup at medium concurrency.
+name: "dsv4-pro-gb300-agg-balanced-1k1k-official"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "fp4"
+
+frontend:
+  type: sglang
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+
+backend:
+  type: sglang
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "1024"
+    # Persistent JIT caches (recommended for repeatable runs).
+    # Mount your own cache dirs into /configs/** via srt-slurm extra_mount
+    # or change these to any writable path inside the container.
+    SGLANG_DG_CACHE_DIR: "/configs/dsv4/gb300/deepgemm-cache"
+    FLASHINFER_WORKSPACE_BASE: "/configs/dsv4/gb300/flashinfer-cache"
+
+  sglang_config:
+    aggregated:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      # TEP: TP=DP=4 + dp-attention + deepep
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      enable-dp-attention: true
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+      # MTP 1/2 (balanced - gentler than 3/4)
+      speculative-algo: "EAGLE"
+      speculative-num-steps: 1
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 2
+
+      mem-fraction-static: 0.78
+      context-length: 2200
+      cuda-graph-max-bs: 128
+      max-running-requests: 256
+      disable-radix-cache: true
+      decode-log-interval: 1
+      stream-interval: 50
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "1x2x4x8x16x32x64x128x256"
+  req_rate: "inf"
+  warmup_multiplier: 2
+  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-balanced-tep.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-balanced-tep.yaml
@@ -72,5 +72,3 @@ benchmark:
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128x256"
   req_rate: "inf"
-  warmup_multiplier: 2
-  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-low-latency.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-low-latency.yaml
@@ -69,5 +69,3 @@ benchmark:
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
   req_rate: "inf"
-  warmup_multiplier: 2
-  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-low-latency.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-low-latency.yaml
@@ -1,0 +1,73 @@
+# DeepSeek-V4-Pro aggregated mode on GB300 (1 node 4 GPU, TP=4)
+# Based on SGLang upstream dsv4-docs cookbook (b200|big|low-latency verified)
+# Adapted to GB300 per DeepSeek-V4.mdx: "GB300 4 GPU" is the single-node config
+name: "dsv4-pro-gb300-agg-ll-1k1k"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "fp4"
+
+frontend:
+  type: sglang
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+
+backend:
+  type: sglang
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    # Persistent JIT caches (recommended for repeatable runs).
+    # Mount your own cache dirs into /configs/** via srt-slurm extra_mount
+    # or change these to any writable path inside the container.
+    SGLANG_DG_CACHE_DIR: "/configs/dsv4/gb300/deepgemm-cache"
+    FLASHINFER_WORKSPACE_BASE: "/configs/dsv4/gb300/flashinfer-cache"
+
+  sglang_config:
+    aggregated:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      tensor-parallel-size: 4
+
+      # V4 low-latency recipe: MXFP4 MoE + MTP 3/4 + chunked-prefill 4096
+      moe-runner-backend: "flashinfer_mxfp4"
+      speculative-algo: "EAGLE"
+      speculative-num-steps: 3
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 4
+      chunked-prefill-size: 4096
+      disable-flashinfer-autotune: true
+      mem-fraction-static: 0.78
+
+      # Generic knobs
+      context-length: 2200
+      cuda-graph-max-bs: 1024
+      max-running-requests: 1024
+      disable-radix-cache: true
+      decode-log-interval: 1
+      stream-interval: 50
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
+  req_rate: "inf"
+  warmup_multiplier: 2
+  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-max-tpt-tep.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-max-tpt-tep.yaml
@@ -68,5 +68,3 @@ benchmark:
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128x256"
   req_rate: "inf"
-  warmup_multiplier: 2
-  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-max-tpt-tep.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-max-tpt-tep.yaml
@@ -1,0 +1,72 @@
+# DeepSeek-V4-Pro GB300 1n TEP 'max-throughput' recipe
+# From SGLang cookbook (DeepSeek-V4.mdx / deepseek-v4-deployment.jsx):
+#   TP=4 + DP=4 + DP-attention + DeepEP, NO MTP + cg=128 max-run=256
+# Tests TEP peak throughput at high concurrency.
+name: "dsv4-pro-gb300-agg-maxtpt-1k1k-official"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "fp4"
+
+frontend:
+  type: sglang
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+
+backend:
+  type: sglang
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "1024"
+    # Persistent JIT caches (recommended for repeatable runs).
+    # Mount your own cache dirs into /configs/** via srt-slurm extra_mount
+    # or change these to any writable path inside the container.
+    SGLANG_DG_CACHE_DIR: "/configs/dsv4/gb300/deepgemm-cache"
+    FLASHINFER_WORKSPACE_BASE: "/configs/dsv4/gb300/flashinfer-cache"
+
+  sglang_config:
+    aggregated:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      # TEP: TP=DP=4 + dp-attention + deepep
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      enable-dp-attention: true
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+      # NO MTP for max-tpt
+
+      mem-fraction-static: 0.78
+      context-length: 2200
+      cuda-graph-max-bs: 128
+      max-running-requests: 256
+      disable-radix-cache: true
+      decode-log-interval: 1
+      stream-interval: 50
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "1x2x4x8x16x32x64x128x256"
+  req_rate: "inf"
+  warmup_multiplier: 2
+  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-nomtp.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-nomtp.yaml
@@ -1,0 +1,67 @@
+# DeepSeek-V4-Pro aggregated mode on GB300 (1 node 4 GPU, TP=4) - NO MTP
+# Baseline for comparison against MTP-enabled run (1567486)
+name: "dsv4-pro-gb300-agg-nomtp-1k1k-official"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "fp4"
+
+frontend:
+  type: sglang
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+
+backend:
+  type: sglang
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    # Persistent JIT caches (recommended for repeatable runs).
+    # Mount your own cache dirs into /configs/** via srt-slurm extra_mount
+    # or change these to any writable path inside the container.
+    SGLANG_DG_CACHE_DIR: "/configs/dsv4/gb300/deepgemm-cache"
+    FLASHINFER_WORKSPACE_BASE: "/configs/dsv4/gb300/flashinfer-cache"
+
+  sglang_config:
+    aggregated:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      tensor-parallel-size: 4
+
+      # No MTP - pure MXFP4 MoE baseline
+      moe-runner-backend: "flashinfer_mxfp4"
+      chunked-prefill-size: 4096
+      disable-flashinfer-autotune: true
+      mem-fraction-static: 0.78
+
+      context-length: 2200
+      cuda-graph-max-bs: 1024
+      max-running-requests: 1024
+      disable-radix-cache: true
+      decode-log-interval: 1
+      stream-interval: 50
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
+  req_rate: "inf"
+  warmup_multiplier: 2
+  formal_multiplier: 10

--- a/recipes/gb300-fp4/1k1k-dsv4/agg-nomtp.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/agg-nomtp.yaml
@@ -63,5 +63,3 @@ benchmark:
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128x256x512x1024"
   req_rate: "inf"
-  warmup_multiplier: 2
-  formal_multiplier: 10

--- a/srtslurm.yaml.example
+++ b/srtslurm.yaml.example
@@ -24,11 +24,21 @@ containers:
   sglang-latest: "/shared/containers/sglang-v0.4.sqsh"
   sglang-dev: "/shared/containers/sglang-dev.sqsh"
   sglang-fp4: "/shared/containers/sglang-fp4.sqsh"
+  # DeepSeek-V4 cookbook images (pull via enroot from Docker Hub lmsysorg/sglang):
+  #   lmsysorg/sglang:deepseek-v4-blackwell         (B200 / x86_64)
+  #   lmsysorg/sglang:deepseek-v4-grace-blackwell   (GB200 / GB300 / aarch64)
+  #   lmsysorg/sglang:deepseek-v4-hopper            (H200)
+  dsv4-blackwell: "/shared/containers/sglang-deepseek-v4-blackwell.sqsh"
+  dsv4-grace-blackwell: "/shared/containers/sglang-deepseek-v4-grace-blackwell.sqsh"
+  dsv4-hopper: "/shared/containers/sglang-deepseek-v4-hopper.sqsh"
 
 # Model path aliases
 model_paths:
   deepseek-r1: "/shared/models/deepseek/DeepSeek-R1"
   deepseek-r1-distill: "/shared/models/deepseek/DeepSeek-R1-Distill-Qwen-32B"
+  # DeepSeek-V4 checkpoints (huggingface.co/deepseek-ai/DeepSeek-V4-Pro, -V4-Flash):
+  dsv4-pro: "/shared/models/deepseek/DeepSeek-V4-Pro"
+  dsv4-flash: "/shared/models/deepseek/DeepSeek-V4-Flash"
   llama-3-70b: "/shared/models/meta/llama-3-70b"
   llama-3-405b: "/shared/models/meta/llama-3-405b"
 


### PR DESCRIPTION
## Summary

Adds eight SGLang aggregated-serving recipes for **DeepSeek-V4-Pro** (1.6T MXFP4 MoE) on Grace+Blackwell hardware, plus model / container aliases in `srtslurm.yaml.example`.

Draft PR — opening early for review of the flag choices and directory layout before I submit final benchmark numbers.

### New recipes

| file | hardware | parallelism | MTP |
|---|---|---|---|
| `recipes/gb300-fp4/1k1k-dsv4/agg-low-latency.yaml`     | GB300 1n | TP=4                         | EAGLE 3/4 |
| `recipes/gb300-fp4/1k1k-dsv4/agg-nomtp.yaml`           | GB300 1n | TP=4                         | —         |
| `recipes/gb300-fp4/1k1k-dsv4/agg-balanced-tep.yaml`    | GB300 1n | TP=4 + DP=4 + DP-attn + DeepEP | EAGLE 1/2 |
| `recipes/gb300-fp4/1k1k-dsv4/agg-max-tpt-tep.yaml`     | GB300 1n | TP=4 + DP=4 + DP-attn + DeepEP | —         |
| `recipes/gb300-fp4/1k1k-dsv4/agg-2n-low-latency.yaml`  | GB300 2n | TP=8                         | EAGLE 3/4 |
| `recipes/gb300-fp4/1k1k-dsv4/agg-2n-nomtp.yaml`        | GB300 2n | TP=8                         | —         |
| `recipes/gb200-fp4/1k1k-dsv4/agg-2n-low-latency.yaml`  | GB200 2n | TP=8                         | EAGLE 3/4 |
| `recipes/gb200-fp4/1k1k-dsv4/agg-2n-nomtp.yaml`        | GB200 2n | TP=8                         | —         |

## Source of truth for flags

All configurations are derived from the official SGLang DeepSeek-V4 cookbook:

- Structure generator: [`docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx`](https://github.com/sgl-project/sglang/blob/main/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx) (low-latency / balanced / max-throughput recipes)
- Prose doc: [`docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx`](https://github.com/sgl-project/sglang/blob/main/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx)
- Upstream SGLang PR: sgl-project/sglang#23600

Key cookbook-derived flags:

- \`moe-runner-backend: flashinfer_mxfp4\` — MXFP4 MoE kernels (Blackwell only)
- \`chunked-prefill-size: 4096\` + \`disable-flashinfer-autotune: true\`
- \`--speculative-num-steps/topk/draft-tokens 3 1 4\` for low-latency, \`1 1 2\` for balanced
- TEP recipes: \`--enable-dp-attention --moe-a2a-backend deepep\` plus \`--deepep-config '{\"normal_dispatch\":{\"num_sms\":96},\"normal_combine\":{\"num_sms\":96}}'\` (\`DEEPEP_LARGE_SMS_FLAG\` for single-node Blackwell per cookbook)

## Non-cookbook adjustments (documented in README)

- **\`disable-radix-cache: true\`** — sa-bench uses synthetic random prompts where radix prefix hits are accidental / non-representative. Also, on GB300 the default \`RadixCache\` path interacts badly with the MXFP4 \`reorder_w1w3_to_w3w1\` contiguous-allocation step and causes 20 MiB CUDA OOM despite ~4 GB free (fragmentation). \`ChunkCache\` path is more conservative here.
- **\`mem-fraction-static: 0.78\`** — Cookbook uses 0.82 for big MoE models; on GB300 single-node we observed \`reorder_w1w3_to_w3w1\` OOMing intermittently at 0.82. 0.78 gives ~4% contiguous headroom and is what the cookbook's \`cp\` recipe uses elsewhere.

## srtslurm.yaml.example changes

Added stock aliases for the three DSv4 cookbook container tags
(\`dsv4-blackwell\`, \`dsv4-grace-blackwell\`, \`dsv4-hopper\`) and the two
DSv4 checkpoints (\`dsv4-pro\`, \`dsv4-flash\`). These are examples — each
cluster deployment fills in their own paths.

## Test plan

- [ ] All 8 recipes pass \`srtctl apply -f <recipe>\` dry-run with schema validation
- [ ] Single-node GB300 recipes start healthily and complete a c=1→1024 sweep
- [ ] 2-node GB300 / GB200 recipes start healthily and complete a c=1→1024 sweep
- [ ] Pareto curves look sensible (monotone along the canonical TPS/User vs TPS/GPU frontier)
- [ ] TEP recipes don't regress vs pure-TP baseline at the concurrencies the cookbook targets
- [ ] Secondary pass: confirm no sensitive cluster paths / tokens / S3 creds leaked into committed YAML (I've grepped \`lustre/fsw\`, \`ghp_\`, \`s3://\`, \`secret\`, \`password\`, \`bearer\`)

Will flip to ready-for-review once I have completed sweep data to attach.

Made with [Cursor](https://cursor.com)