### PR TITLE
fix(sa-bench): auto-fallback when tokenizer has no chat template

### DIFF
--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -840,6 +840,29 @@ def main(args: argparse.Namespace):
         custom_tokenizer=args.custom_tokenizer,
     )
 
+    # Some models (e.g. DeepSeek-V4) ship NO Hugging Face chat template; the
+    # server-side rendering happens entirely inside the engine. If a user runs
+    # such a model without supplying a `custom_tokenizer` plugin, the default
+    # `use_chat_template=True` would cause `tokenizer.apply_chat_template(...)`
+    # to raise. Auto-fallback to raw-text mode and warn loudly so the run does
+    # not silently break.
+    if args.use_chat_template and not args.custom_tokenizer:
+        has_template = bool(getattr(tokenizer, "chat_template", None)) or bool(
+            getattr(tokenizer, "default_chat_template", None)
+        )
+        if not has_template:
+            warnings.warn(
+                f"Tokenizer for '{tokenizer_id}' has no chat_template and no "
+                "`custom_tokenizer` was provided; disabling --use-chat-template "
+                "and benchmarking against the raw text path. Token counts on the "
+                "client may diverge from the server's #new-token. To match the "
+                "server exactly, set `custom_tokenizer` in the recipe (e.g. "
+                "`sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer` "
+                "for DeepSeek-V4).",
+                stacklevel=2,
+            )
+            args.use_chat_template = False
+
     if args.dataset_name == "custom":
         from benchmark_dataset import sample_custom_requests
 


### PR DESCRIPTION
## Summary

Some models (e.g. **DeepSeek-V4**) ship **no Hugging Face chat template**; their rendering happens entirely inside the engine via a hard-coded encoder. With the project-wide default `use_chat_template: true` introduced in #20, recipes that don't also set `custom_tokenizer` end up calling `tokenizer.apply_chat_template(...)` directly and crash with:

```
ValueError: Cannot use apply_chat_template() because tokenizer.chat_template is not set ...
```

Reported by @ishandhanani while running the dsv4 sa-bench recipes against srt-slurm without the new flags from #73.

## Fix

In `benchmark_serving.main()`, right after `get_tokenizer` returns, detect the no-template case:

- if `use_chat_template` is on **and** no `custom_tokenizer` plugin is configured **and** the tokenizer exposes neither `chat_template` nor `default_chat_template`,
- emit a loud `warnings.warn(...)` pointing at `custom_tokenizer` (e.g. `SGLangDeepseekV4Tokenizer` added in #73),
- and force `args.use_chat_template = False` so the run completes against the raw-text path.

This way:

- DSv4 recipe **without** the plugin -> no longer crashes; runs in raw-text mode (input_tokens may diverge from server #new-token, but the user is told why).
- DSv4 recipe **with** `custom_tokenizer: sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer` -> unchanged: real DSML rendering, exact parity with sglang server.
- Models with HF chat templates (DSR1, K2, Qwen, GLM, ...) -> unchanged.

## Test plan

- [x] `python3 -m py_compile benchmark_serving.py`
- [ ] Re-run dsv4 recipe without `custom_tokenizer`/`use_chat_template` overrides; confirm warning + successful sa-bench completion.
- [ ] Re-run an existing dsv4 recipe (e.g. `recipes/gb300-fp4/1k1k-dsv4/agg-low-latency-chat.yaml`) with `custom_tokenizer` set; confirm no behavior change vs. main.
- [ ] Re-run a non-DSv4 recipe (DSR1 / Kimi-K2.6) and confirm chat template path is unaffected.

Made with [Cursor](https://cursor.com)