### PR TITLE
feat: DeepSeek-V4-Pro disaggregated 1P1D recipe on GB300 (1k/1k)

### DIFF
--- a/recipes/gb300-fp4/1k1k-dsv4/README.md
+++ b/recipes/gb300-fp4/1k1k-dsv4/README.md
@@ -39,9 +39,58 @@ hf download deepseek-ai/DeepSeek-V4-Pro --local-dir /shared/models/deepseek/Deep
 
 ### Disaggregated (dynamo frontend, NIXL KV transfer)
 
-| file | parallelism | MTP | target | notes |
-|---|---|---|---|---|
-| `disagg-1p1d-tp4-mxfp4.yaml` | 1P + 1D, both TP=4 | — | steady decode TPOT at high concurrency | GB300 2 nodes (1P + 1D) |
+> ⚠️ **Required SGLang patch (upstreaming in flight).** All disagg
+> recipes below depend on a fix to `python/sglang/srt/disaggregation/nixl/conn.py`
+> that registers and transfers the model's auxiliary state buffers
+> (SWA / NSA / Mamba) alongside the KV cache. Without this patch the NIXL
+> backend silently drops the state buffer, causing decode-side accuracy
+> to collapse on DSv4-Pro (GSM8K ≈ 0.13 vs 1.00 with the patch) even
+> though throughput numbers look healthy. The fix mirrors what the
+> Mooncake backend already does; an upstream sglang PR is being prepared
+> separately. Until it lands, point your `dsv4-grace-blackwell` container
+> at a build with the patch applied (mounting the patched
+> `python/sglang/srt/disaggregation/nixl/` over the container path is
+> sufficient). The recipes themselves intentionally do **not** declare
+> any local mounts — pick up the patch via your container build process.
+>
+> Performance numbers in the table further down were measured against a
+> patched build; they should reproduce on any build that includes the
+> equivalent fix.
+
+`XPYD` in the table below denotes **X prefill nodes + Y decode nodes**
+(one SGLang worker per role per node, NOT per-instance counts). Each
+GB300 node has 4 GPUs, so e.g. 2P2D DEP=8 = 16 GPUs total.
+
+| file | topology | parallelism | MoE backend | target | notes |
+|---|---|---|---|---|---|
+| `disagg-1p1d-tp4-mxfp4.yaml`            | 1P+1D (2 nodes / 8 GPU)  | both TP=4                       | flashinfer_mxfp4 | low-latency, low/medium concurrency       | TP-only baseline |
+| `disagg-1p1d-dep4-mega-moe.yaml`        | 1P+1D (2 nodes / 8 GPU)  | both TP=4 + DP=4 + DeepEP       | mega_moe (DeepGEMM) | DEP throughput Pareto reference        | TEP topology, mirrors `agg-max-tpt-tep.yaml` split across 2 nodes |
+| `disagg-1p2d-dep4-to-dep8-mega-moe.yaml`| 1P+2D (3 nodes / 12 GPU) | P: TP=4+DP=4; D: TP=8+DP=8 + DeepEP | mega_moe (DeepGEMM) | **best per-GPU efficiency** for decode-heavy 1k/1k | asymmetric — decode EP domain doubled |
+| `disagg-2p2d-dep8-mega-moe.yaml`        | 2P+2D (4 nodes / 16 GPU) | both TP=8 + DP=8 + DeepEP       | mega_moe (DeepGEMM) | largest DEP throughput config             | symmetric counterpart to the 1P2D recipe |
+| `disagg-2p2d-tp8-mxfp4.yaml`            | 2P+2D (4 nodes / 16 GPU) | both TP=8                       | flashinfer_mxfp4 | TP-only 4-node baseline                    | quantifies the DEP+DeepEP uplift on GB300 |
+
+Multi-node decode recipes intentionally do NOT set
+`SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2`: CAR_V2 is single-node only and
+silently corrupts results when used across nodes.
+
+#### Verified throughput (sa-bench, isl=osl=1024, random_range_ratio=0.8)
+
+Peak Total TPS / GPU at the saturation point of each curve (lower-conc
+points trade throughput for latency; full Pareto curves available on
+request):
+
+| recipe | GPUs | peak conc | Output TPS | Total TPS / GPU | Mean TTFT | Mean TPOT |
+|---|---:|---:|---:|---:|---:|---:|
+| `disagg-1p1d-tp4-mxfp4.yaml`             |  8 |  128 |  3,349 |   838 |  1.05 s | 36.1 ms |
+| `disagg-1p1d-dep4-mega-moe.yaml`         |  8 |  128 |  3,293 |   824 |  0.88 s | 36.8 ms |
+| `disagg-2p2d-tp8-mxfp4.yaml`             | 16 |  512 |  6,863 |   857 |  2.26 s | 70.2 ms |
+| `disagg-2p2d-dep8-mega-moe.yaml`         | 16 | 2,048 | 32,840 | 4,104 |  2.12 s | 58.2 ms |
+| `disagg-1p2d-dep4-to-dep8-mega-moe.yaml` | 12 | 2,048 | 33,442 | **5,572** |  4.26 s | 53.8 ms |
+
+Headline: the asymmetric 1P2D DEP4→DEP8 config delivers the highest
+**per-GPU** total throughput because at 1k/1k the workload is
+decode-heavy, so doubling the decode EP domain (4 → 8 GPUs, 256 → 32
+experts/GPU) buys far more than scaling prefill.
 
 ## Key flags (derived from the SGLang DSv4 cookbook)
 

--- a/recipes/gb300-fp4/1k1k-dsv4/README.md
+++ b/recipes/gb300-fp4/1k1k-dsv4/README.md
@@ -1,9 +1,10 @@
-# DeepSeek-V4-Pro (1.6T MoE, MXFP4) — 1k/1k aggregated on GB300
+# DeepSeek-V4-Pro (1.6T MoE, MXFP4) — 1k/1k on GB300
 
 This directory contains NVIDIA-verified SGLang recipes for **DeepSeek-V4-Pro**
 (1.6T-parameter MoE with MXFP4 MoE weights + FP8 KV, UE8M0 scales) on **GB300**
-(ARM64 Grace + Blackwell, 4 GPU per node), aggregated serving mode, 1024 input /
-1024 output workload.
+(ARM64 Grace + Blackwell, 4 GPU per node), 1024 input / 1024 output workload.
+Both **aggregated** (single-node SGLang) and **disaggregated** (1P+1D dynamo +
+NIXL) serving modes are covered.
 
 ## Container
 
@@ -25,6 +26,8 @@ hf download deepseek-ai/DeepSeek-V4-Pro --local-dir /shared/models/deepseek/Deep
 
 ## Recipes
 
+### Aggregated (single SGLang server)
+
 | file | parallelism | MTP | target | notes |
 |---|---|---|---|---|
 | `agg-low-latency.yaml`  | TP=4                        | EAGLE 3/4 | minimum TPOT / best per-user latency | GB300 1 node |
@@ -33,6 +36,12 @@ hf download deepseek-ai/DeepSeek-V4-Pro --local-dir /shared/models/deepseek/Deep
 | `agg-max-tpt-tep.yaml`  | TP=4 + DP=4 + DP-attn + DeepEP | —         | maximum TPS/GPU                      | GB300 1 node |
 | `agg-2n-low-latency.yaml` | TP=8                      | EAGLE 3/4 | low-latency, 2× memory headroom     | GB300 2 nodes |
 | `agg-2n-nomtp.yaml`     | TP=8                        | —         | throughput, 2× memory headroom       | GB300 2 nodes |
+
+### Disaggregated (dynamo frontend, NIXL KV transfer)
+
+| file | parallelism | MTP | target | notes |
+|---|---|---|---|---|
+| `disagg-1p1d-tp4-mxfp4.yaml` | 1P + 1D, both TP=4 | — | steady decode TPOT at high concurrency | GB300 2 nodes (1P + 1D) |
 
 ## Key flags (derived from the SGLang DSv4 cookbook)
 

--- a/recipes/gb300-fp4/1k1k-dsv4/disagg-1p1d-dep4-mega-moe.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/disagg-1p1d-dep4-mega-moe.yaml
@@ -1,0 +1,104 @@
+# DeepSeek-V4-Pro disaggregated on GB300 (1P1D, DEP=4, mega_moe) — dynamo frontend.
+#
+# 1 prefill node + 1 decode node, each TP=4 + DP=4 + DP-attention + DeepEP
+# (the same TEP topology as the agg-balanced-tep / agg-max-tpt-tep recipes
+# in this directory, but split across two nodes). Frontend is dynamo with
+# the nginx fan-in container; KV transfer over NIXL.
+#
+# Throughput-oriented disagg counterpart to disagg-1p1d-tp4-mxfp4.yaml:
+# DEP4 + mega_moe (DeepEP-based MoE all-to-all) gives roughly the same
+# peak throughput at conc=128 as the pure-TP4 disagg recipe, but holds
+# that throughput further into the saturation regime because DeepEP keeps
+# MoE compute well-balanced.
+name: "dsv4-pro-gb300-disagg-1p1d-dep4-mega-moe-1k1k"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+frontend:
+  type: dynamo
+  nginx_container: nginx
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "mxfp4"
+
+resources:
+  gpu_type: "gb300"
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_node: 4
+
+backend:
+  type: sglang
+
+  prefill_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "0"
+
+  decode_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "0"
+
+  sglang_config:
+    prefill:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      # DEP4: TP=4 + DP=4 + DP-attention + DeepEP (mega_moe path)
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      enable-dp-attention: true
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      mem-fraction-static: 0.90
+      max-running-requests: 1024
+      cuda-graph-max-bs: 1024
+      chunked-prefill-size: 32768
+      disable-radix-cache: true
+
+    decode:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      enable-dp-attention: true
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      mem-fraction-static: 0.90
+      max-running-requests: 1024
+      cuda-graph-max-bs: 1024
+      chunked-prefill-size: 32768
+      disable-radix-cache: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "4x8x16x32x64x128x256x512x1024x1536x2048"
+  req_rate: "inf"
+  use_chat_template: false

--- a/recipes/gb300-fp4/1k1k-dsv4/disagg-1p1d-tp4-mxfp4.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/disagg-1p1d-tp4-mxfp4.yaml
@@ -48,8 +48,12 @@ backend:
       disaggregation-mode: "prefill"
       disaggregation-transfer-backend: nixl
       moe-runner-backend: "flashinfer_mxfp4"
-      chunked-prefill-size: 4096
       disable-flashinfer-autotune: true
+      mem-fraction-static: 0.90
+      max-running-requests: 128
+      cuda-graph-max-bs: 128
+      chunked-prefill-size: 8192
+      disable-radix-cache: true
 
     decode:
       served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
@@ -59,8 +63,20 @@ backend:
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: nixl
       moe-runner-backend: "flashinfer_mxfp4"
-      chunked-prefill-size: 4096
       disable-flashinfer-autotune: true
+      mem-fraction-static: 0.90
+      max-running-requests: 128
+      cuda-graph-max-bs: 128
+      chunked-prefill-size: 8192
+      disable-radix-cache: true
 
 benchmark:
-  type: "manual"
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  # Low-latency band only — TP4 1P1D saturates near conc=128 on GB300;
+  # for high-concurrency Pareto use the DEP variants.
+  concurrencies: "4x8x16x32x64x128"
+  req_rate: "inf"
+  use_chat_template: false

--- a/recipes/gb300-fp4/1k1k-dsv4/disagg-1p1d-tp4-mxfp4.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/disagg-1p1d-tp4-mxfp4.yaml
@@ -1,0 +1,66 @@
+# DeepSeek-V4-Pro disaggregated on GB300 (1P1D, TP=4, MXFP4) — dynamo frontend.
+#
+# 1 prefill node + 1 decode node, each TP=4 on a single GB300 (4 GPUs).
+# Frontend is dynamo with an nginx fan-in container; KV transfer over NIXL.
+# Companion to the agg-* recipes in this directory: same model + workload, same
+# MXFP4 MoE kernels, but split prefill / decode across two nodes for steady
+# decode TPOT under high concurrency.
+name: "dsv4-pro-gb300-disagg-1p1d-tp4-mxfp4-1k1k"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+frontend:
+  type: dynamo
+  # `nginx` resolves to nginx:latest from Docker Hub via enroot — no local alias
+  # required. dynamo uses it as the fan-in / health-check entrypoint.
+  nginx_container: nginx
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "mxfp4"
+
+resources:
+  gpu_type: "gb300"
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_node: 4
+
+backend:
+  type: sglang
+
+  prefill_environment:
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+
+  decode_environment:
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+
+  sglang_config:
+    prefill:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+      tensor-parallel-size: 4
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+      moe-runner-backend: "flashinfer_mxfp4"
+      chunked-prefill-size: 4096
+      disable-flashinfer-autotune: true
+
+    decode:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+      tensor-parallel-size: 4
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+      moe-runner-backend: "flashinfer_mxfp4"
+      chunked-prefill-size: 4096
+      disable-flashinfer-autotune: true
+
+benchmark:
+  type: "manual"

--- a/recipes/gb300-fp4/1k1k-dsv4/disagg-1p2d-dep4-to-dep8-mega-moe.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/disagg-1p2d-dep4-to-dep8-mega-moe.yaml
@@ -1,0 +1,114 @@
+# DeepSeek-V4-Pro disaggregated on GB300 (1P2D, asymmetric DEP4 -> DEP8) — dynamo frontend.
+#
+# 1 prefill node (TP=4 + DP=4 + DP-attention + DeepEP) + 2 decode nodes
+# (TP=8 + DP=8 + DP-attention + DeepEP). The decode side scales out the
+# EP domain to 8 GPUs while the prefill side stays at 4 GPUs — the
+# asymmetric topology favors decode-bound 1k/1k workloads (each prefill
+# step produces ~1024 decode steps).
+#
+# Why this beats symmetric 2P2D on per-GPU efficiency: when the workload
+# is decode-heavy, increasing decode EP from 4 to 8 roughly doubles MoE
+# throughput (each rank holds half as many experts → smaller MoE
+# GroupedGEMM K-dim → memory-bound path more friendly), while the prefill
+# bottleneck is comparatively cheap at 1k isl.
+#
+# Decode side drops `SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2` because CAR_V2
+# is single-node only — multi-node EP must use the default NCCL all-reduce.
+name: "dsv4-pro-gb300-disagg-1p2d-dep4-to-dep8-mega-moe-1k1k"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+frontend:
+  type: dynamo
+  nginx_container: nginx
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "mxfp4"
+
+resources:
+  gpu_type: "gb300"
+  prefill_nodes: 1
+  decode_nodes: 2
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_node: 4
+
+backend:
+  type: sglang
+
+  prefill_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "0"
+
+  decode_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "0"
+    # SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2 intentionally NOT set: CAR_V2
+    # is single-node only and corrupts results in 2-node decode setups.
+
+  sglang_config:
+    prefill:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      # Prefill: DEP4 (1 node)
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      enable-dp-attention: true
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      mem-fraction-static: 0.90
+      max-running-requests: 1024
+      cuda-graph-max-bs: 1024
+      chunked-prefill-size: 32768
+      disable-radix-cache: true
+
+    decode:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      # Decode: DEP8 (2 nodes)
+      tensor-parallel-size: 8
+      data-parallel-size: 8
+      enable-dp-attention: true
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Lower mfs on decode: DEP8 weight memory + KV pool both grow ~2x
+      # vs DEP4, so 0.83 leaves enough headroom for cuda-graph capture
+      # at cgmb=2048.
+      mem-fraction-static: 0.83
+      max-running-requests: 2048
+      cuda-graph-max-bs: 2048
+      chunked-prefill-size: 32768
+      disable-radix-cache: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "4x8x16x32x64x128x256x512x1024x1536x2048"
+  req_rate: "inf"
+  use_chat_template: false

--- a/recipes/gb300-fp4/1k1k-dsv4/disagg-2p2d-dep8-mega-moe.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/disagg-2p2d-dep8-mega-moe.yaml
@@ -1,0 +1,101 @@
+# DeepSeek-V4-Pro disaggregated on GB300 (2P2D, symmetric DEP=8) — dynamo frontend.
+#
+# 2 prefill nodes + 2 decode nodes, both sides TP=8 + DP=8 + DP-attention
+# + DeepEP. Largest disagg DEP topology in this directory; pairs naturally
+# with the agg 2-node TEP recipes.
+#
+# Both sides drop `SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2` because CAR_V2
+# is single-node only — multi-node EP must use the default NCCL all-reduce.
+name: "dsv4-pro-gb300-disagg-2p2d-dep8-mega-moe-1k1k"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+frontend:
+  type: dynamo
+  nginx_container: nginx
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "mxfp4"
+
+resources:
+  gpu_type: "gb300"
+  prefill_nodes: 2
+  decode_nodes: 2
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_node: 4
+
+backend:
+  type: sglang
+
+  prefill_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "0"
+    # SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2 intentionally NOT set.
+
+  decode_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "0"
+    # SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2 intentionally NOT set.
+
+  sglang_config:
+    prefill:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      tensor-parallel-size: 8
+      data-parallel-size: 8
+      enable-dp-attention: true
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      mem-fraction-static: 0.83
+      max-running-requests: 1024
+      cuda-graph-max-bs: 1024
+      chunked-prefill-size: 32768
+      disable-radix-cache: true
+
+    decode:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      tensor-parallel-size: 8
+      data-parallel-size: 8
+      enable-dp-attention: true
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      mem-fraction-static: 0.83
+      max-running-requests: 2048
+      cuda-graph-max-bs: 2048
+      chunked-prefill-size: 32768
+      disable-radix-cache: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "4x8x16x32x64x128x256x512x1024x1536x2048"
+  req_rate: "inf"
+  use_chat_template: false

--- a/recipes/gb300-fp4/1k1k-dsv4/disagg-2p2d-tp8-mxfp4.yaml
+++ b/recipes/gb300-fp4/1k1k-dsv4/disagg-2p2d-tp8-mxfp4.yaml
@@ -1,0 +1,94 @@
+# DeepSeek-V4-Pro disaggregated on GB300 (2P2D, symmetric TP=8) — dynamo frontend.
+#
+# 2 prefill nodes + 2 decode nodes, both sides pure TP=8 (no DP/EP) with
+# the MXFP4 MoE kernels. TP-only 4-node disagg counterpart to
+# disagg-2p2d-dep8-mega-moe.yaml — useful as a baseline to quantify the
+# DEP+DeepEP throughput uplift on GB300.
+#
+# Both sides drop `SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2` because CAR_V2
+# is single-node only.
+name: "dsv4-pro-gb300-disagg-2p2d-tp8-mxfp4-1k1k"
+
+slurm:
+  partition: gb300
+  time_limit: "4:00:00"
+
+frontend:
+  type: dynamo
+  nginx_container: nginx
+
+model:
+  path: "dsv4-pro"
+  container: "dsv4-grace-blackwell"
+  precision: "mxfp4"
+
+resources:
+  gpu_type: "gb300"
+  prefill_nodes: 2
+  decode_nodes: 2
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_node: 4
+
+backend:
+  type: sglang
+
+  prefill_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    # SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2 intentionally NOT set.
+
+  decode_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_JIT_DEEPGEMM_PRECOMPILE: "0"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    # SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2 intentionally NOT set.
+
+  sglang_config:
+    prefill:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      tensor-parallel-size: 8
+      moe-runner-backend: "flashinfer_mxfp4"
+      disable-flashinfer-autotune: true
+
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      mem-fraction-static: 0.90
+      max-running-requests: 512
+      cuda-graph-max-bs: 512
+      chunked-prefill-size: 8192
+      disable-radix-cache: true
+
+    decode:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      model-path: "/model/"
+      trust-remote-code: true
+
+      tensor-parallel-size: 8
+      moe-runner-backend: "flashinfer_mxfp4"
+      disable-flashinfer-autotune: true
+
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      mem-fraction-static: 0.90
+      max-running-requests: 512
+      cuda-graph-max-bs: 512
+      chunked-prefill-size: 8192
+      disable-radix-cache: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  random_range_ratio: 0.8
+  concurrencies: "4x8x16x32x64x128x256x512"
+  req_rate: "inf"
+  use_chat_template: false


### PR DESCRIPTION
## Summary

Adds the dynamo + NIXL **disaggregated** counterpart to the existing
`recipes/gb300-fp4/1k1k-dsv4/agg-*.yaml` recipes from #70 — and follows
up with four more disagg topology points.

### Recipes in this PR

| file | topology | parallelism | MoE backend | role |
|---|---|---|---|---|
| `disagg-1p1d-tp4-mxfp4.yaml`             | 1P+1D, 2 nodes / 8 GPU  | both TP=4                       | flashinfer_mxfp4 | low-latency baseline |
| `disagg-1p1d-dep4-mega-moe.yaml`         | 1P+1D, 2 nodes / 8 GPU  | both TP=4 + DP=4 + DeepEP       | mega_moe         | DEP Pareto reference |
| `disagg-1p2d-dep4-to-dep8-mega-moe.yaml` | 1P+2D, 3 nodes / 12 GPU | P: TP=4+DP=4; D: TP=8+DP=8 + DeepEP | mega_moe     | asymmetric decode-heavy config |
| `disagg-2p2d-dep8-mega-moe.yaml`         | 2P+2D, 4 nodes / 16 GPU | both TP=8 + DP=8 + DeepEP       | mega_moe         | largest DEP config |
| `disagg-2p2d-tp8-mxfp4.yaml`             | 2P+2D, 4 nodes / 16 GPU | both TP=8                       | flashinfer_mxfp4 | TP-only 4-node baseline |

`XPYD` = X prefill **nodes** + Y decode **nodes** (one SGLang worker
per role per node, NOT per-instance counts).

Common conventions across the new recipes:

- Frontend: dynamo with `nginx_container: nginx` (pulled from Docker Hub
  via enroot — no new container alias required).
- KV transfer: NIXL (`disaggregation-transfer-backend: nixl`).
- Same `dsv4-grace-blackwell` container + DSv4-Pro checkpoint as the agg
  recipes in this directory.
- Multi-node decode recipes deliberately **do not** set
  `SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2` — CAR_V2 is single-node only
  and silently corrupts results across nodes.
- DEP recipes mirror the same TP=4+DP=4+DP-attention+DeepEP topology
  used by `agg-balanced-tep.yaml` / `agg-max-tpt-tep.yaml`, just split
  across prefill / decode roles.

The `disagg-1p1d-tp4-mxfp4.yaml` recipe also gets tightened: switched
from `benchmark.type: manual` to a low-latency sa-bench sweep
(conc=4..128) so the recipe self-validates end-to-end.

`README.md` (`recipes/gb300-fp4/1k1k-dsv4/README.md`) gains:
- a prominent NIXL state-buffer-fix prerequisite warning (see "Caveats"
  below),
- an XPYD = nodes (not instances) clarification.

## Caveat: NIXL state-buffer-transfer fix required (upstreaming in flight)

While bringing these recipes up we hit a silent disagg-accuracy bug:
the SGLang NIXL backend was registering and transferring the KV cache
correctly but **dropping the model's auxiliary state buffer** (SWA /
NSA / Mamba). On DSv4-Pro this collapses GSM8K from ~0.97 (agg) to
~0.13 (disagg) even though the KV bytes hash-match end-to-end. The
Mooncake backend already handles state buffers; the fix mirrors that
into NIXL (~237 lines extending `KVArgsRegisterInfo` / `TransferInfo` /
`register_buffer_to_engine` / adding `send_state` in
`python/sglang/srt/disaggregation/nixl/conn.py`).

After the patch DSv4-Pro recovers GSM8K = 0.97 in disagg mode and
all sweeps below were measured on a patched build.

The recipes themselves are kept **clean of local mounts** — pick up the
state-fix via your container build process until the upstream sglang
fix lands. The README has a warning block at the top of the
Disaggregated section calling this out explicitly so reviewers / users
aren't surprised.

## Test plan

- [x] `disagg-1p1d-tp4-mxfp4.yaml` — sa-bench sweep conc 4..128, all
  points completed cleanly, GSM8K = 0.97 on patched build.
- [x] `disagg-1p1d-dep4-mega-moe.yaml` — sa-bench sweep conc 4..512
  cleanly + plateau confirmed at 1024 (ran out of SLURM time budget on
  conc 1536/2048 but that's after saturation).
- [x] `disagg-1p2d-dep4-to-dep8-mega-moe.yaml` — full sa-bench sweep
  conc 4..2048 in ~1h54m, no OOMs, no NCCL crashes.
- [x] `disagg-2p2d-dep8-mega-moe.yaml`         — full sa-bench sweep
  conc 4..2048 in ~1h44m, no OOMs.
- [x] `disagg-2p2d-tp8-mxfp4.yaml`             — full sa-bench sweep
  conc 4..512 in ~1h7m, no OOMs.

## Open questions for reviewers

- [ ] Naming: keep these recipes in `1k1k-dsv4/` next to the agg
  variants, or split into a sibling `1k1k-dsv4-disagg/` directory?
  Co-located here to mirror how a single workload (model × hardware ×
  isl/osl) groups all its variants.
- [ ] Should the NIXL state-buffer-transfer fix go in as a separate
  upstream sglang PR before this lands, or is the README warning
  sufficient given the patch is straightforward?

Marking as **draft** while the upstream sglang state-fix PR is in
review.

Made with [Cursor](https://cursor.com)