### PR TITLE
fix(dynamo-install): repair maturin entry-script in regressed sgl images + add protoc

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -949,9 +949,9 @@ class DynamoConfig:
 
         # Original SGLang container path
         sglang = (
-            "apt-get update -qq && apt-get install -y -qq libclang-dev curl > /dev/null 2>&1 && "
+            "apt-get update -qq && apt-get install -y -qq libclang-dev curl protobuf-compiler > /dev/null 2>&1 && "
             "if ! command -v cargo &>/dev/null; then curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable -q && source $HOME/.cargo/env; fi && "
-            "if ! command -v maturin &>/dev/null; then pip install --break-system-packages maturin; fi && "
+            "if ! command -v maturin &>/dev/null; then pip install --break-system-packages --force-reinstall --no-deps maturin; fi && "
             "cd /sgl-workspace/ && "
             "git clone https://github.com/ai-dynamo/dynamo.git && "
             "cd dynamo && "
@@ -973,7 +973,7 @@ class DynamoConfig:
             "if ! command -v cargo &> /dev/null; then "
             "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env; fi && "
             "if ! command -v maturin &> /dev/null; then "
-            "pip install --break-system-packages maturin; fi; fi && "
+            "pip install --break-system-packages --force-reinstall --no-deps maturin; fi; fi && "
             "ORIG_DIR=$(pwd) && rm -rf /tmp/dynamo_build && mkdir -p /tmp/dynamo_build && cd /tmp/dynamo_build && "
             "git clone https://github.com/ai-dynamo/dynamo.git && "
             "cd dynamo && "


### PR DESCRIPTION
## Summary

The `lmsysorg/sglang/deepseek-v4-grace-blackwell` sqsh image was rebuilt on **2026-04-25 ~15:42 UTC** and shipped a regressed `maturin` pip install: the package directory under `dist-packages/maturin/` is present but `RECORD` / `entry_points.txt` is incomplete, so `/usr/local/bin/maturin` is **not** created. The previous gate

```bash
if ! command -v maturin; then pip install --break-system-packages maturin; fi
```

correctly detected the missing console-script, but `pip install maturin` saw the broken-but-importable `maturin/` package and short-circuited with **`Requirement already satisfied`** — the entry-script never got written. Result on the new image: `bash: maturin: command not found` followed by a cargo `Could not find protoc` once that was unmasked.

This PR makes the **smallest possible** change to recover the dynamo source-install path on the regressed image while staying a no-op on healthy images.

## Root cause (verified by `srun --container-image` probe on lyris)

Inside the new sqsh:

```
$ ls /usr/local/lib/python3.12/dist-packages/maturin/
__init__.py  __main__.py  bootstrap.py
$ ls /usr/local/lib/python3.12/dist-packages/maturin-*.dist-info/entry_points.txt
ls: No such file or directory
$ which maturin
(nothing)
$ python3 -m maturin --version
Unable to find `maturin` script
```

The maturin wheel ships a precompiled Rust binary that pip installs into `/usr/local/bin/maturin` via its console-script entry-point. With `entry_points.txt` missing, the script is never recreated by a plain `pip install` (because metadata says "already satisfied"). The fix is to force the gate's install to actually re-extract the wheel:

```bash
if ! command -v maturin; then
  pip install --break-system-packages --force-reinstall --no-deps maturin
fi
```

The pre-rebuild image (jobs 1582102 / 1582870 ran fine) had a working entry-script; on those (and any image where maturin is on `PATH`) the gate is `false` and **no install runs** — identical behavior to before.

## Changes

`src/srtctl/core/schema.py` — three minimal substitutions, fully symmetric across the `sglang` and `portable` branches:

1. **`sglang` branch**: `apt-get install` adds `protobuf-compiler` (the `modelexpress-common` cargo crate needs `protoc` at build-time; the `portable` branch already had it).
2. **`sglang` branch**: maturin gate's installer becomes `pip install --break-system-packages --force-reinstall --no-deps maturin`.
3. **`portable` branch**: same `--force-reinstall --no-deps` change.

Diff:

```diff
-"apt-get update -qq && apt-get install -y -qq libclang-dev curl > /dev/null 2>&1 && "
+"apt-get update -qq && apt-get install -y -qq libclang-dev curl protobuf-compiler > /dev/null 2>&1 && "
 ...
-"if ! command -v maturin &>/dev/null; then pip install --break-system-packages maturin; fi && "
+"if ! command -v maturin &>/dev/null; then pip install --break-system-packages --force-reinstall --no-deps maturin; fi && "
```

(plus the symmetric portable-branch line)

## Backward-compatibility

- **Pre-2026-04-25 sgl image** and any image with `maturin` already on `PATH`: gate is `false`, no install runs, **byte-identical behavior**.
- **Images that already have `protoc`**: `apt-get install protobuf-compiler` is a no-op.
- `--force-reinstall` only runs **inside** the gate, so the cost is paid exactly once on regressed images.
- `--no-deps` is safe because the maturin wheel has no Python deps (it ships a self-contained Rust binary).

## Test plan

- [x] Reproduced the failure on the rebuilt sqsh: `bash: maturin: command not found` (job 1583718).
- [x] Identified root cause via `srun --container-image` shell probe: `entry_points.txt` missing, `__main__.py` falls back to script-search and exits 1.
- [x] Verified inside the same container that `if ! command -v maturin; then pip install --force-reinstall --no-deps maturin; fi` writes `/usr/local/bin/maturin` and `maturin --version` works.
- [x] Verified the gate is correctly skipped when `maturin` is on `PATH` (no-op on healthy images).
- [x] End-to-end: applied patch on lyris, submitted disagg-1p1d-dep4-mega-moe (job **1584579**) — all 3 workers reach `Dynamo installed from source`, sa-bench is sweeping concurrencies.
- [ ] Verify on the old (pre-rebuild) sgl image if anyone still has it cached, just to double-confirm zero behavior change.

## Notes for reviewers

This PR replaces the previous version that unconditionally `--force-reinstall`-ed maturin on every job. After more careful root-causing it became clear the lazy gate was actually correct — only the installer command needed strengthening. The PR is now 3 lines (`+3 -3`) and preserves the original lazy semantics on every image where maturin is healthy.