### PR TITLE
fix(orchestrate): robust container bootstrap (maturin/protoc/venv-race)

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -949,9 +949,14 @@ class DynamoConfig:
 
         # Original SGLang container path
         sglang = (
-            "apt-get update -qq && apt-get install -y -qq libclang-dev curl > /dev/null 2>&1 && "
+            # protobuf-compiler is required by modelexpress-common's build.rs (prost-build).
+            # Some SGLang images ship without /usr/bin/protoc; install it unconditionally.
+            "apt-get update -qq && apt-get install -y -qq libclang-dev curl protobuf-compiler > /dev/null 2>&1 && "
             "if ! command -v cargo &>/dev/null; then curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable -q && source $HOME/.cargo/env; fi && "
-            "if ! command -v maturin &>/dev/null; then pip install --break-system-packages maturin; fi && "
+            # Force-reinstall maturin: some images ship the python module in dist-packages
+            # without the console-script entry point, so `command -v maturin` fails AND a
+            # plain `pip install maturin` reports "already satisfied" and skips the fix.
+            "pip install --break-system-packages --force-reinstall --quiet maturin && "
             "cd /sgl-workspace/ && "
             "git clone https://github.com/ai-dynamo/dynamo.git && "
             "cd dynamo && "

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -107,7 +107,15 @@ echo ""
 # Output goes to SLURM's --output (sweep_%j.log)
 set +e  # Temporarily disable exit-on-error to capture exit code
 cd "${SRTCTL_SOURCE}"
-uv run --python 3.12 --no-dev -m srtctl.cli.do_sweep "${OUTPUT_DIR}/{{ runtime_config_filename }}"
+# Lock-protected venv sync to avoid concurrent .venv-compute teardown/recreate
+# races across simultaneous SLURM jobs sharing this directory. uv may decide
+# the existing venv is invalid (broken python interpreter symlink) and tear
+# it down + rebuild; if N jobs do that at once they stomp each other with
+# "Directory not empty" / "Failed to spawn 'python -m'" / missing CACHEDIR.TAG
+# errors. The flock serializes only the venv init; the lock is released
+# before the actual sweep so jobs still run in parallel.
+flock -x "${SRTCTL_SOURCE}/.venv-compute.lock" uv sync --python 3.12 --no-dev
+uv run --python 3.12 --no-dev --no-sync -m srtctl.cli.do_sweep "${OUTPUT_DIR}/{{ runtime_config_filename }}"
 EXIT_CODE=$?
 set -e  # Re-enable exit-on-error
 


### PR DESCRIPTION
## Summary

Three independent bootstrap-time issues hit when running on a fresh SGLang container family (`lmsysorg/sglang:deepseek-v4-grace-blackwell-0426`) that does not have dynamo pre-installed. Each one alone took down the orchestrator; together they made the user-template DeepSeek-V4-Pro recipes unrunnable on a 16-node GB200 cluster.

### 1. `maturin: command not found` despite "Requirement already satisfied"

The container ships the `maturin` Python module under `/usr/local/lib/python3.12/dist-packages` but **does not create the `/usr/local/bin/maturin` console-script entry point**. So:

- `command -v maturin` → empty (existing guard fails closed → triggers `pip install`)
- `pip install --break-system-packages maturin` → "Requirement already satisfied" → no-op
- `maturin build -o /tmp` → `command not found` → cargo build aborts → exit 127

Fix: drop the `command -v` guard and `--force-reinstall` unconditionally. Pip recreates the `/usr/local/bin/maturin` entry point and the build proceeds.

### 2. `Could not find protoc` on cargo build

`modelexpress-common`'s `build.rs` invokes `prost-build`, which shells out to `protoc`. The portable-container path already `apt-get install`s `protobuf-compiler`; the SGLang-container path was missing it.

Fix: add `protobuf-compiler` to the SGLang `apt-get install` list.

### 3. `.venv-compute` concurrent-recreate race kills concurrent jobs

When 2+ SLURM jobs dispatch in the same second, all of them run `uv run` against the shared `${SRTCTL_SOURCE}/.venv-compute`. uv sees a stale `bin/python3 -> python` symlink (pointing at a no-longer-existing uv-managed interpreter), decides to tear down + rebuild the venv, and the parallel `rm -rf` / `pip install` calls stomp each other:

```
warning: Ignoring existing virtual environment linked to non-existent Python interpreter:
         .venv-compute/bin/python3 -> python
error: failed to remove directory '.venv-compute/lib': Directory not empty (os error 39)
error: Failed to spawn 'python -m': No such file or directory (os error 2)
error: failed to open file '.venv-compute/CACHEDIR.TAG': No such file or directory (os error 2)
```

Reproducibly kills **3 of 4 simultaneously-launched jobs** (observed at SLURM jobs 4772-4775, 4795-4799, 4812-4815).

Fix: serialize venv init with `flock`, then `uv run --no-sync` for the actual sweep so jobs still execute in parallel after the first one initializes the venv. Lock is released **before** the sweep; only the few-seconds venv-init phase is serialized.

```bash
flock -x "${SRTCTL_SOURCE}/.venv-compute.lock" uv sync --python 3.12 --no-dev
uv run --python 3.12 --no-dev --no-sync -m srtctl.cli.do_sweep ...
```

## Why one PR

All three are scoped to "make container bootstrap robust on images that don't have dynamo pre-baked." They were discovered serially while debugging the same workload; each fix exposes the next.

## Test plan

- [ ] Apply patch to a srt-slurm checkout
- [ ] Submit ≥4 simultaneous SLURM jobs against an SGLang container that lacks dynamo (e.g. `lmsysorg/sglang:deepseek-v4-grace-blackwell-0426`)
- [ ] Verify all 4 jobs successfully clear venv init (no `Failed to spawn` / `Directory not empty` errors)
- [ ] Verify all 4 jobs successfully build dynamo from source (no `maturin: command not found`, no `Could not find protoc`)
- [ ] Verify "✓ Dynamo installed from source" appears in each job's worker logs
- [ ] Verify sweeps run in parallel (lock is released before workload starts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)