### PR TITLE
feat(schema): make gsm8k a first-class BenchmarkType

### DIFF
--- a/src/srtctl/benchmarks/gsm8k.py
+++ b/src/srtctl/benchmarks/gsm8k.py
@@ -59,16 +59,18 @@ class GSM8KRunner(BenchmarkRunner):
         runtime: RuntimeContext,
     ) -> list[str]:
         b = config.benchmark
+        # TODO: support overriding endpoint via config to target external servers;
+        # mmlu/gpqa/longbenchv2 share the same limitation today.
         endpoint = f"http://localhost:{runtime.frontend_port}"
 
         return [
             "bash",
             self.script_path,
             endpoint,
-            str(1319 if b.num_examples is None else b.num_examples),
-            str(16384 if b.max_tokens is None else b.max_tokens),
-            str(512 if b.num_threads is None else b.num_threads),
-            str(5 if b.num_shots is None else b.num_shots),
+            str(b.num_examples or 1319),
+            str(b.max_tokens or 16384),
+            str(b.num_threads or 512),
+            str(b.num_shots if b.num_shots is not None else 5),
             str(b.temperature) if b.temperature is not None else "",
             str(b.top_p) if b.top_p is not None else "",
             str(b.top_k) if b.top_k is not None else "",

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -228,6 +228,7 @@ class BenchmarkType(str, Enum):
     TRACE_REPLAY = "trace-replay"
     MMLU = "mmlu"
     GPQA = "gpqa"
+    GSM8K = "gsm8k"
     LONGBENCHV2 = "longbenchv2"
 
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -20,6 +20,7 @@ class TestBenchmarkRegistry:
         assert "sglang-bench" in benchmarks
         assert "mmlu" in benchmarks
         assert "gpqa" in benchmarks
+        assert "gsm8k" in benchmarks
         assert "longbenchv2" in benchmarks
         assert "router" in benchmarks
 
@@ -575,6 +576,11 @@ class TestScriptsExist:
     def test_mmlu_script_exists(self):
         """MMLU script exists."""
         script = SCRIPTS_DIR / "mmlu" / "bench.sh"
+        assert script.exists()
+
+    def test_gsm8k_script_exists(self):
+        """GSM8K script exists."""
+        script = SCRIPTS_DIR / "gsm8k" / "bench.sh"
         assert script.exists()
 
 


### PR DESCRIPTION
## What was missing

The gsm8k accuracy-eval runner (`src/srtctl/benchmarks/gsm8k.py`) and bench script (`src/srtctl/benchmarks/scripts/gsm8k/bench.sh`) have existed and been registered via `@register_benchmark(\"gsm8k\")` for a while. But `BenchmarkType` in `src/srtctl/core/schema.py` only listed `MMLU`, `GPQA`, and `LONGBENCHV2` -- not `GSM8K`.

That meant any recipe yaml setting:

```yaml
benchmark:
  type: gsm8k
```

failed schema validation before the runner ever got dispatched. Users had to fork the schema or fall back to `type: manual` to invoke gsm8k.

## Why it matters

GSM8K is a standard accuracy gate for reasoning models. Without first-class enum support it's invisible to `srtctl validate`, MCP authoring tools, and anything else that walks `BenchmarkType`. The runner was already production-quality; only the enum entry was holding it back.

## How to use

```yaml
benchmark:
  type: gsm8k
  num_examples: 1319   # optional; defaults match sglang.test.run_eval
  num_shots: 5         # optional; 0 = zero-shot
```

## Diff summary

- `src/srtctl/core/schema.py`: add `GSM8K = \"gsm8k\"` to `BenchmarkType`, alphabetically grouped with the other accuracy evals.
- `src/srtctl/benchmarks/gsm8k.py`: switch parameter defaulting from the verbose `str(X if b.field is None else b.field)` to the `b.field or DEFAULT` style already used by mmlu/gpqa/longbenchv2. `num_shots` keeps the explicit `is not None` check since `0` (zero-shot) is a valid value. Adds a TODO noting that endpoint-URL override is missing across all accuracy evals -- that's a separate cross-cutting change and out of scope here.
- `tests/test_benchmarks.py`: add `\"gsm8k\" in benchmarks` to the registry assertion and a `test_gsm8k_script_exists` mirror of the mmlu coverage.

## Test plan

- [x] `ruff check` and `ruff format --check` clean on the touched files.
- [x] `pytest tests/test_benchmarks.py::TestScriptsExist` passes (4/4).
- [ ] CI on this PR.