### PR TITLE
[codex] add AIME benchmark

### DIFF
--- a/docs/accuracy.md
+++ b/docs/accuracy.md
@@ -1,9 +1,11 @@
 # Accuracy Benchmarks
 
-In srt-slurm, users can run different accuracy benchmarks by setting the benchmark section in the config yaml file. Supported benchmarks include `mmlu`, `gpqa` and `longbenchv2`.
+In srt-slurm, users can run different accuracy benchmarks by setting the benchmark section in the config yaml file. Supported benchmarks include `aime`, `mmlu`, `gpqa` and `longbenchv2`.
 
 ## Table of Contents
 
+- [How Scoring Works](#how-scoring-works)
+- [AIME](#aime)
 - [MMLU](#mmlu)
 - [GPQA](#gpqa)
 - [LongBench-V2](#longbench-v2)
@@ -18,6 +20,40 @@ In srt-slurm, users can run different accuracy benchmarks by setting the benchma
 ---
 
 **Note**: The `context-length` argument in the config yaml needs to be larger than the `max_tokens` argument of accuracy benchmark.
+
+
+## How Scoring Works
+
+Accuracy benchmarks send a fixed dataset through the running OpenAI-compatible endpoint and compare each model
+response against the benchmark's expected answer. For AIME, NeMo Skills prompts the model to put the final answer in
+`\boxed{...}`, extracts that final boxed answer, and grades it with its math evaluator. There is no LLM judge in the
+default AIME path; the score is computed from exact/symbolic correctness.
+
+When `repeat` is greater than 1, the benchmark runs multiple sampled generations per problem. NeMo Skills summarizes
+metrics across those generations, which is useful for comparing pass@1-style deterministic accuracy and sampled
+accuracy on the same serving setup.
+
+
+## AIME
+
+For AIME, the benchmark section in yaml file can be modified in the following way:
+```bash
+benchmark:
+  type: "aime"
+  aime_dataset: "aime25" # One of: aime24, aime25, aime26
+  num_examples: null # Number of examples to run; null means all
+  max_tokens: 24576 # Max number of output tokens
+  repeat: 1 # Number of sampled repetitions
+  num_threads: 30 # Number of parallel requests
+```
+
+Then launch the script as usual:
+```bash
+srtctl apply -f config.yaml
+```
+
+After finishing benchmarking, AIME outputs are written under `/logs/accuracy/<aime_dataset>/` and summarized metrics
+are written to `/logs/accuracy/<aime_dataset>_metrics.json`.
 
 
 ## MMLU
@@ -189,5 +225,4 @@ The output includes per-category scores and aggregate metrics:
 2. **Memory**: Long-context evaluation requires significant GPU memory. Use appropriate `mem-fraction-static` settings
 3. **Throughput**: Increase `num_threads` for faster evaluation, but monitor for OOM errors
 4. **Categories**: Running specific categories is useful for targeted validation (e.g., just testing summarization capabilities)
-
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1087,6 +1087,7 @@ src/srtctl/
 |   |-- __init__.py          # Registry and exports
 |   |-- base.py              # BenchmarkRunner ABC, register_benchmark
 |   |-- sa_bench.py          # SA-Bench throughput benchmark
+|   |-- aime.py              # AIME math accuracy benchmark
 |   |-- mmlu.py              # MMLU accuracy benchmark
 |   |-- gpqa.py              # GPQA benchmark
 |   |-- longbenchv2.py       # LongBench v2 benchmark

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -419,6 +419,7 @@ Benchmark configuration. The `type` field determines which benchmark runner is u
 | `manual`          | No benchmark (default), manual testing mode    |
 | `sa-bench`        | Throughput/latency serving benchmark           |
 | `sglang-bench`    | SGLang bench_serving benchmark                 |
+| `aime`            | AIME math accuracy evaluation                  |
 | `mmlu`            | MMLU accuracy evaluation                       |
 | `gpqa`            | GPQA (Graduate-level science QA) evaluation    |
 | `longbenchv2`     | Long-context evaluation benchmark              |
@@ -517,6 +518,37 @@ benchmark:
 | `max_tokens`   | int  | No       | 32768   | Max tokens per response      |
 | `repeat`       | int  | No       | 8       | Number of repeats            |
 | `num_threads`  | int  | No       | 128     | Concurrent threads           |
+
+### aime
+
+AIME math accuracy evaluation using NVIDIA NeMo Skills.
+
+```yaml
+benchmark:
+  type: "aime"
+  aime_dataset: "aime25"             # Optional: aime24, aime25, or aime26
+  num_examples: null                 # Optional: Number of examples (all if null)
+  max_tokens: 24576                  # Optional: Max tokens per response
+  repeat: 1                          # Optional: Number of sampled repeats
+  num_threads: 30                    # Optional: Concurrent requests
+  temperature: null                  # Optional: 0.0 for repeat=1, 0.7 for repeat>1
+  top_p: null                        # Optional: NeMo Skills/default sampler value
+  top_k: null                        # Optional: NeMo Skills/default sampler value
+```
+
+| Field          | Type  | Required | Default | Description                         |
+| -------------- | ----- | -------- | ------- | ----------------------------------- |
+| `aime_dataset` | str   | No       | aime25  | NeMo Skills dataset to run          |
+| `num_examples` | int   | No       | all     | Number of examples to run           |
+| `max_tokens`   | int   | No       | 24576   | Max tokens per response             |
+| `repeat`       | int   | No       | 1       | Number of sampled repeats           |
+| `num_threads`  | int   | No       | 30      | Concurrent requests                 |
+| `temperature`  | float | No       | auto    | Sampling temperature                 |
+| `top_p`        | float | No       | default | Nucleus sampling threshold          |
+| `top_k`        | int   | No       | default | Top-k sampling                      |
+
+Results are written to `/logs/accuracy/<aime_dataset>/`; summarized metrics are also copied to
+`/logs/accuracy/<aime_dataset>_metrics.json`.
 
 ### longbenchv2
 

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -63,7 +63,7 @@ backend:
 
 # Benchmark configuration
 benchmark:
-  type: "sa-bench"           # sa-bench, mmlu, gpqa, or "manual" (no auto-benchmark)
+  type: "sa-bench"           # sa-bench, aime, mmlu, gpqa, or "manual" (no auto-benchmark)
   isl: 1024                  # Input sequence length
   osl: 1024                  # Output sequence length
   concurrencies: [256, 512]  # Concurrency levels to test

--- a/src/srtctl/benchmarks/__init__.py
+++ b/src/srtctl/benchmarks/__init__.py
@@ -5,6 +5,7 @@
 
 # Import runners to trigger registration
 from srtctl.benchmarks import (
+    aime,
     custom,
     gpqa,
     gsm8k,
@@ -29,6 +30,7 @@ __all__ = [
     "list_benchmarks",
     "register_benchmark",
     # Runners
+    "aime",
     "custom",
     "sa_bench",
     "sglang_bench",

--- a/src/srtctl/benchmarks/aime.py
+++ b/src/srtctl/benchmarks/aime.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AIME accuracy benchmark runner backed by NVIDIA NeMo Skills."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import SrtConfig
+
+
+SUPPORTED_AIME_DATASETS = ("aime24", "aime25", "aime26")
+
+
+@register_benchmark("aime")
+class AIMERunner(BenchmarkRunner):
+    """AIME math evaluation using NVIDIA NeMo Skills.
+
+    Optional config fields:
+        - benchmark.aime_dataset: NeMo Skills dataset name (default: aime25)
+        - benchmark.num_examples: Number of examples (default: all)
+        - benchmark.max_tokens: Max tokens per response (default: 24576)
+        - benchmark.repeat: Number of sampled repeats (default: 1)
+        - benchmark.num_threads: Concurrent requests (default: 30)
+        - benchmark.temperature: Sampling temperature (default: 0.0 for repeat=1, 0.7 for repeat>1)
+        - benchmark.top_p: Nucleus sampling threshold (default: NeMo Skills default)
+        - benchmark.top_k: Top-k sampling (default: NeMo Skills default)
+    """
+
+    @property
+    def name(self) -> str:
+        return "AIME"
+
+    @property
+    def script_path(self) -> str:
+        return "/srtctl-benchmarks/aime/bench.sh"
+
+    @property
+    def local_script_dir(self) -> str:
+        return str(SCRIPTS_DIR / "aime")
+
+    def validate_config(self, config: SrtConfig) -> list[str]:
+        b = config.benchmark
+        errors: list[str] = []
+
+        dataset = b.aime_dataset or "aime25"
+        if dataset not in SUPPORTED_AIME_DATASETS:
+            supported = ", ".join(SUPPORTED_AIME_DATASETS)
+            errors.append(f"benchmark.aime_dataset must be one of: {supported}")
+
+        for field in ("num_examples", "max_tokens", "num_threads", "repeat"):
+            value = getattr(b, field, None)
+            if value is not None and value <= 0:
+                errors.append(f"benchmark.{field} must be > 0")
+
+        if b.top_p is not None and not 0 <= b.top_p <= 1:
+            errors.append("benchmark.top_p must be between 0 and 1")
+        if b.top_k is not None and b.top_k < -1:
+            errors.append("benchmark.top_k must be >= -1")
+        if b.temperature is not None and b.temperature < 0:
+            errors.append("benchmark.temperature must be >= 0")
+
+        return errors
+
+    def build_command(
+        self,
+        config: SrtConfig,
+        runtime: RuntimeContext,
+    ) -> list[str]:
+        b = config.benchmark
+        endpoint = f"http://localhost:{runtime.frontend_port}"
+
+        return [
+            "bash",
+            self.script_path,
+            endpoint,
+            config.served_model_name,
+            b.aime_dataset or "aime25",
+            str(b.num_examples) if b.num_examples is not None else "",
+            str(b.max_tokens or 24576),
+            str(b.num_threads or 30),
+            str(b.repeat or 1),
+            str(b.temperature) if b.temperature is not None else "",
+            str(b.top_p) if b.top_p is not None else "",
+            str(b.top_k) if b.top_k is not None else "",
+        ]

--- a/src/srtctl/benchmarks/scripts/aime/bench.sh
+++ b/src/srtctl/benchmarks/scripts/aime/bench.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# AIME accuracy evaluation using NVIDIA NeMo Skills.
+# Expects: endpoint model_name [aime_dataset] [num_examples] [max_tokens] [num_threads] [repeat] [temperature] [top_p] [top_k]
+
+set -euo pipefail
+
+ENDPOINT=${1:?endpoint is required}
+MODEL_NAME=${2:-model}
+AIME_DATASET=${3:-aime25}
+NUM_EXAMPLES=${4:-}
+MAX_TOKENS=${5:-24576}
+NUM_THREADS=${6:-30}
+REPEAT=${7:-1}
+TEMPERATURE=${8:-}
+TOP_P=${9:-}
+TOP_K=${10:-}
+
+case "$AIME_DATASET" in
+    aime24|aime25|aime26) ;;
+    *)
+        echo "Unsupported AIME dataset: $AIME_DATASET. Expected one of: aime24, aime25, aime26" >&2
+        exit 2
+        ;;
+esac
+
+if ! [[ "$REPEAT" =~ ^[0-9]+$ ]] || [ "$REPEAT" -le 0 ]; then
+    echo "repeat must be a positive integer, got: $REPEAT" >&2
+    exit 2
+fi
+
+RESULT_ROOT="/logs/accuracy"
+RESULT_DIR="${RESULT_ROOT}/${AIME_DATASET}"
+METRICS_FILE="${RESULT_ROOT}/${AIME_DATASET}_metrics.json"
+mkdir -p "$RESULT_DIR"
+rm -f "$RESULT_DIR"/output.jsonl "$RESULT_DIR"/output-rs*.jsonl "$RESULT_DIR"/output*.done "$METRICS_FILE"
+
+BASE_URL="${ENDPOINT%/}"
+if [[ "$BASE_URL" != */v1 ]]; then
+    BASE_URL="${BASE_URL}/v1"
+fi
+
+export OPENAI_API_KEY="${OPENAI_API_KEY:-EMPTY}"
+
+echo "AIME Config: endpoint=${ENDPOINT}; base_url=${BASE_URL}; model=${MODEL_NAME}; dataset=${AIME_DATASET}; num_examples=${NUM_EXAMPLES:-all}; max_tokens=${MAX_TOKENS}; num_threads=${NUM_THREADS}; repeat=${REPEAT}; temperature=${TEMPERATURE:-auto}; top_p=${TOP_P:-default}; top_k=${TOP_K:-default}"
+
+NEMO_SKILLS_VENV="${NEMO_SKILLS_VENV:-/tmp/nemo-skills-venv}"
+NEMO_SKILLS_PACKAGE="${NEMO_SKILLS_PACKAGE:-git+https://github.com/NVIDIA-NeMo/Skills.git}"
+PYTHON_BIN="python3"
+
+has_nemo_skills() {
+    "$1" - "$AIME_DATASET" <<'PY' >/dev/null 2>&1
+import sys
+from pathlib import Path
+
+import hydra  # noqa: F401
+import litellm  # noqa: F401
+from nemo_skills.dataset.utils import get_dataset_path
+from nemo_skills.evaluation.metrics import ComputeMetrics  # noqa: F401
+
+dataset = sys.argv[1]
+dataset_path = get_dataset_path(dataset)
+assert (Path(dataset_path) / "prepare.py").exists()
+PY
+}
+
+if [ "${NEMO_SKILLS_FORCE_INSTALL:-0}" = "1" ] || ! has_nemo_skills "$PYTHON_BIN"; then
+    echo "Installing NeMo Skills into ${NEMO_SKILLS_VENV} ..."
+    if [ ! -d "$NEMO_SKILLS_VENV" ]; then
+        python3 -m venv --system-site-packages "$NEMO_SKILLS_VENV"
+    fi
+    PYTHON_BIN="${NEMO_SKILLS_VENV}/bin/python"
+    "$PYTHON_BIN" -m pip install --upgrade pip
+    "$PYTHON_BIN" -m pip install "$NEMO_SKILLS_PACKAGE"
+fi
+
+if ! has_nemo_skills "$PYTHON_BIN"; then
+    echo "NeMo Skills is not available after installation" >&2
+    exit 1
+fi
+
+echo "Preparing NeMo Skills dataset: ${AIME_DATASET}"
+"$PYTHON_BIN" -m nemo_skills.dataset.prepare "$AIME_DATASET" --parallelism 1 --retries 0
+
+DATASET_FILE=$("$PYTHON_BIN" - "$AIME_DATASET" <<'PY'
+import sys
+from pathlib import Path
+from nemo_skills.dataset.utils import get_dataset_path
+
+dataset = sys.argv[1]
+print(Path(get_dataset_path(dataset)) / "test.jsonl")
+PY
+)
+
+COMMON_ARGS=(
+    "++input_file=${DATASET_FILE}"
+    "++server.server_type=openai"
+    "++server.base_url=${BASE_URL}"
+    "++server.model=${MODEL_NAME}"
+    "++prompt_config=generic/math"
+    "++eval_type=math"
+    "++eval_config.split=test"
+    "++max_concurrent_requests=${NUM_THREADS}"
+    "++inference.tokens_to_generate=${MAX_TOKENS}"
+)
+
+if [ -n "$NUM_EXAMPLES" ]; then
+    COMMON_ARGS+=("++max_samples=${NUM_EXAMPLES}")
+fi
+if [ -n "$TOP_P" ]; then
+    COMMON_ARGS+=("++inference.top_p=${TOP_P}")
+fi
+if [ -n "$TOP_K" ]; then
+    COMMON_ARGS+=("++inference.top_k=${TOP_K}")
+fi
+
+run_generation() {
+    local output_file=$1
+    local seed=$2
+    local temperature=$3
+
+    local args=("${COMMON_ARGS[@]}" "++output_file=${output_file}" "++inference.temperature=${temperature}")
+    if [ -n "$seed" ]; then
+        args+=("++inference.random_seed=${seed}")
+    fi
+
+    "$PYTHON_BIN" -m nemo_skills.inference.generate "${args[@]}"
+}
+
+if [ "$REPEAT" -eq 1 ]; then
+    run_generation "${RESULT_DIR}/output.jsonl" "" "${TEMPERATURE:-0.0}"
+else
+    sample_temperature="${TEMPERATURE:-0.7}"
+    for ((seed = 0; seed < REPEAT; seed++)); do
+        run_generation "${RESULT_DIR}/output-rs${seed}.jsonl" "$seed" "$sample_temperature"
+    done
+fi
+
+echo "Computing NeMo Skills metrics..."
+"$PYTHON_BIN" - "$AIME_DATASET" "$RESULT_DIR" "$METRICS_FILE" <<'PY'
+import glob
+import json
+import sys
+from pathlib import Path
+
+from nemo_skills.evaluation.metrics import ComputeMetrics
+
+benchmark = sys.argv[1]
+result_dir = Path(sys.argv[2])
+metrics_file = Path(sys.argv[3])
+
+input_files = sorted(glob.glob(str(result_dir / "output-rs*.jsonl")))
+if not input_files:
+    input_files = [str(result_dir / "output.jsonl")]
+
+metrics = ComputeMetrics(benchmark=benchmark).compute_metrics(input_files=input_files)
+summary = {benchmark: metrics.get("_all_", metrics)}
+metrics_file.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+(result_dir / "metrics.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+print(json.dumps(summary, indent=2))
+PY
+
+echo "AIME evaluation complete. Results in ${RESULT_DIR}; metrics in ${METRICS_FILE}"

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -226,6 +226,7 @@ class BenchmarkType(str, Enum):
     ROUTER = "router"
     MOONCAKE_ROUTER = "mooncake-router"
     TRACE_REPLAY = "trace-replay"
+    AIME = "aime"
     MMLU = "mmlu"
     GPQA = "gpqa"
     LONGBENCHV2 = "longbenchv2"
@@ -584,6 +585,7 @@ class BenchmarkConfig:
     max_context_length: int | None = None
     categories: list[str] | None = None
     num_shots: int | None = None  # GSM8K few-shot examples
+    aime_dataset: str | None = None  # NeMo Skills AIME dataset: aime24, aime25, or aime26
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None

--- a/src/srtctl/core/yaml_utils.py
+++ b/src/srtctl/core/yaml_utils.py
@@ -67,7 +67,7 @@ def comment_aware_merge(base: CommentedMap, override: CommentedMap | dict[str, A
             val = override[key]
             if val is None:
                 continue  # None → delete key
-            if isinstance(base[key], CommentedMap) and isinstance(val, (dict, CommentedMap)):
+            if isinstance(base[key], CommentedMap) and isinstance(val, dict | CommentedMap):
                 result[key] = comment_aware_merge(base[key], val)
             else:
                 result[key] = copy.deepcopy(val)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -18,6 +18,7 @@ class TestBenchmarkRegistry:
         assert "custom" in benchmarks
         assert "sa-bench" in benchmarks
         assert "sglang-bench" in benchmarks
+        assert "aime" in benchmarks
         assert "mmlu" in benchmarks
         assert "gpqa" in benchmarks
         assert "longbenchv2" in benchmarks
@@ -476,6 +477,86 @@ class TestTraceReplayRunner:
         assert config.benchmark.itl_threshold_ms == 7
 
 
+class TestAIMERunner:
+    """Test AIME runner."""
+
+    def test_get_runner(self):
+        """Can get runner for AIME."""
+        runner = get_runner("aime")
+        assert runner.name == "AIME"
+        assert "aime" in runner.script_path
+
+    def test_validate_valid(self):
+        from srtctl.benchmarks.aime import AIMERunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = AIMERunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(type="aime", aime_dataset="aime25", repeat=8),
+        )
+        errors = runner.validate_config(config)
+        assert errors == []
+
+    def test_validate_invalid_dataset(self):
+        from srtctl.benchmarks.aime import AIMERunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = AIMERunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(type="aime", aime_dataset="math-500"),
+        )
+        errors = runner.validate_config(config)
+        assert any("aime_dataset" in e for e in errors)
+
+    def test_build_command(self):
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.aime import AIMERunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = AIMERunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/models/qwen", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(
+                type="aime",
+                aime_dataset="aime24",
+                num_examples=10,
+                max_tokens=4096,
+                repeat=4,
+                num_threads=8,
+                temperature=0.6,
+                top_p=0.95,
+            ),
+        )
+
+        cmd = runner.build_command(config, runtime)
+        assert cmd == [
+            "bash",
+            "/srtctl-benchmarks/aime/bench.sh",
+            "http://localhost:8000",
+            "qwen",
+            "aime24",
+            "10",
+            "4096",
+            "8",
+            "4",
+            "0.6",
+            "0.95",
+            "",
+        ]
+
+
 class TestScriptsExist:
     """Test that benchmark scripts exist."""
 
@@ -491,4 +572,9 @@ class TestScriptsExist:
     def test_mmlu_script_exists(self):
         """MMLU script exists."""
         script = SCRIPTS_DIR / "mmlu" / "bench.sh"
+        assert script.exists()
+
+    def test_aime_script_exists(self):
+        """AIME script exists."""
+        script = SCRIPTS_DIR / "aime" / "bench.sh"
         assert script.exists()


### PR DESCRIPTION
## Summary

Adds AIME as a first-class benchmark runner backed by NVIDIA NeMo Skills.

- Registers `benchmark.type: "aime"` with config validation and command construction.
- Adds a bundled AIME benchmark script that prepares NeMo Skills AIME datasets, runs generation through the OpenAI-compatible endpoint, and writes NeMo Skills metrics under `/logs/accuracy`.
- Supports `aime24`, `aime25`, and `aime26`, plus optional `num_examples`, `max_tokens`, `repeat`, `num_threads`, `temperature`, `top_p`, and `top_k`.
- Updates docs, config reference, example config, and benchmark tests.
- Includes a one-line Ruff modernization in `yaml_utils.py` required for the repo lint target.

## Validation

- `bash -n src/srtctl/benchmarks/scripts/aime/bench.sh`
- `uv run ruff format --check src/srtctl/benchmarks/aime.py src/srtctl/benchmarks/__init__.py src/srtctl/core/schema.py tests/test_benchmarks.py`
- `uv run ruff check src/srtctl/benchmarks/aime.py src/srtctl/benchmarks/__init__.py src/srtctl/core/schema.py tests/test_benchmarks.py`
- `uv run --with pytest pytest tests/test_benchmarks.py -q`
- `make check`