### PR TITLE
[codex] Add SA-Bench DeepSeek V4 tokenizer mode

### DIFF
--- a/src/srtctl/benchmarks/sa_bench.py
+++ b/src/srtctl/benchmarks/sa_bench.py
@@ -111,5 +111,6 @@ class SABenchRunner(BenchmarkRunner):
             str(b.use_chat_template).lower(),
             dataset_name,
             b.dataset_path or "",
+            b.tokenizer_mode or "auto",
         ]
         return cmd

--- a/src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py
@@ -636,9 +636,29 @@ def get_tokenizer(
                 "to use mistral tokenizer mode."
             ) from e
         return MistralTokenizer.from_pretrained(str(pretrained_model_name_or_path))
+    if tokenizer_mode == "deepseek_v4":
+        try:
+            from vllm.tokenizers.deepseek_v4 import DeepseekV4Tokenizer
+        except ImportError as e:
+            raise ImportError(
+                "DeepseekV4Tokenizer requires vllm package.\n"
+                "Please install it with `pip install vllm` "
+                "to use deepseek_v4 tokenizer mode."
+            ) from e
+        return DeepseekV4Tokenizer.from_pretrained(str(pretrained_model_name_or_path))
     if custom_tokenizer:
         if custom_tokenizer == "glm_moe_dsa":
             return _load_glm_moe_dsa_tokenizer(pretrained_model_name_or_path)
+        if custom_tokenizer == "deepseek_v4":
+            try:
+                from vllm.tokenizers.deepseek_v4 import DeepseekV4Tokenizer
+            except ImportError as e:
+                raise ImportError(
+                    "DeepseekV4Tokenizer requires vllm package.\n"
+                    "Please install it with `pip install vllm` "
+                    "to use deepseek_v4 custom tokenizer."
+                ) from e
+            return DeepseekV4Tokenizer.from_pretrained(str(pretrained_model_name_or_path))
         from importlib import import_module
         try:
             module_path, class_name = custom_tokenizer.rsplit('.', 1)
@@ -652,7 +672,8 @@ def get_tokenizer(
         except (ValueError, ImportError, AttributeError) as e:
             raise ValueError(
                 f"Failed to load custom_tokenizer '{custom_tokenizer}'. "
-                "Expected 'glm_moe_dsa' or 'module.path.ClassName'.") from e
+                "Expected 'glm_moe_dsa', 'deepseek_v4', or 'module.path.ClassName'."
+            ) from e
 
     tokenizer = AutoTokenizer.from_pretrained(
         pretrained_model_name_or_path,

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -66,6 +66,10 @@ CUSTOM_TOKENIZER=${15:-}
 USE_CHAT_TEMPLATE=${16:-true}
 DATASET_NAME=${17:-random}
 DATASET_PATH=${18:-}
+TOKENIZER_MODE=${19:-auto}
+
+# Build optional tokenizer mode args
+TOKENIZER_MODE_ARGS=(--tokenizer-mode "$TOKENIZER_MODE")
 
 # Build optional custom tokenizer args
 CUSTOM_TOKENIZER_ARGS=()
@@ -110,7 +114,7 @@ PORT=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f2 | cut -d/ -f1)
 
 WORK_DIR="$(dirname "$0")"
 
-echo "SA-Bench Config: endpoint=${ENDPOINT}; isl=${ISL}; osl=${OSL}; concurrencies=${CONCURRENCIES}; req_rate=${REQ_RATE}; model=${MODEL_NAME}; dataset=${DATASET_NAME}; dataset_path=${DATASET_PATH}"
+echo "SA-Bench Config: endpoint=${ENDPOINT}; isl=${ISL}; osl=${OSL}; concurrencies=${CONCURRENCIES}; req_rate=${REQ_RATE}; model=${MODEL_NAME}; dataset=${DATASET_NAME}; dataset_path=${DATASET_PATH}; tokenizer_mode=${TOKENIZER_MODE}"
 
 # Profiling shared helpers
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -166,6 +170,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --percentile-metrics ttft,tpot,itl,e2el \
         --max-concurrency "$concurrency" \
         --trust-remote-code \
+        "${TOKENIZER_MODE_ARGS[@]}" \
         "${CHAT_TEMPLATE_ARGS[@]}" \
         "${CUSTOM_TOKENIZER_ARGS[@]}"
 
@@ -195,6 +200,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --percentile-metrics ttft,tpot,itl,e2el \
         --max-concurrency "$concurrency" \
         --trust-remote-code \
+        "${TOKENIZER_MODE_ARGS[@]}" \
         "${CHAT_TEMPLATE_ARGS[@]}" \
         "${CUSTOM_TOKENIZER_ARGS[@]}" \
         --save-result --result-dir "$result_dir" --result-filename "$result_filename"
@@ -208,4 +214,3 @@ done
 stop_all_profiling
 
 echo "SA-Bench complete. Results in $result_dir"
-

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -1317,11 +1317,12 @@ if __name__ == "__main__":
         "--tokenizer-mode",
         type=str,
         default="auto",
-        choices=["auto", "slow", "mistral", "custom"],
+        choices=["auto", "slow", "mistral", "deepseek_v4", "custom"],
         help='The tokenizer mode.\n\n* "auto" will use the '
         'fast tokenizer if available.\n* "slow" will '
         "always use the slow tokenizer. \n* "
-        '"mistral" will always use the `mistral_common` tokenizer. \n*'
+        '"mistral" will always use the `mistral_common` tokenizer. \n* '
+        '"deepseek_v4" will use vLLM\'s DeepSeek V4 tokenizer. \n* '
         '"custom" will use --tokenizer to select the preregistered tokenizer.',
     )
 
@@ -1329,7 +1330,7 @@ if __name__ == "__main__":
         "--custom-tokenizer",
         type=str,
         default=None,
-        help="Custom tokenizer to use (e.g., 'glm_moe_dsa' or 'module.path.ClassName'). "
+        help="Custom tokenizer to use (e.g., 'glm_moe_dsa', 'deepseek_v4', or 'module.path.ClassName'). "
         "When set, overrides the default tokenizer loading.",
     )
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -604,6 +604,7 @@ class BenchmarkConfig:
     dataset_path: str | None = None  # Container path to dataset file (mount via extra_mount)
     # Trace replay benchmark fields (uses aiperf with mooncake_trace dataset type)
     trace_file: str | None = None  # Path to trace JSONL file (container path, e.g., /traces/dataset.jsonl)
+    tokenizer_mode: str | None = None  # Tokenizer mode passed to SA-Bench (e.g., "auto", "deepseek_v4")
     custom_tokenizer: str | None = None  # Custom tokenizer class (e.g., "module.path.ClassName")
     use_chat_template: bool = True  # Pass --use-chat-template to benchmark (default: true)
     # Custom benchmark hook.

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -139,6 +139,7 @@ class TestSABenchRunner:
         cmd = runner.build_command(config, runtime)
         assert "custom" in cmd
         assert "/glm5_datasets/bench.jsonl" in cmd
+        assert cmd[-1] == "auto"
 
     def test_build_command_default_dataset_random(self):
         """Default dataset_name is 'random' when not specified."""
@@ -161,7 +162,37 @@ class TestSABenchRunner:
         )
         cmd = runner.build_command(config, runtime)
         assert "random" in cmd
-        assert cmd[-1] == ""  # empty dataset path
+        assert cmd[-2] == ""  # empty dataset path
+        assert cmd[-1] == "auto"
+
+    def test_build_command_passes_tokenizer_mode(self):
+        """build_command passes tokenizer_mode through to SA-Bench."""
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.sa_bench import SABenchRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = SABenchRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        runtime.model_path = "/model"
+        runtime.is_hf_model = False
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(
+                type="sa-bench",
+                isl=1024,
+                osl=128,
+                concurrencies="4x8",
+                tokenizer_mode="deepseek_v4",
+            ),
+        )
+
+        cmd = runner.build_command(config, runtime)
+        assert cmd[-1] == "deepseek_v4"
 
 
 class TestCustomBenchmarkRunner:


### PR DESCRIPTION
## Summary

Adds a narrow SA-Bench tokenizer-mode pass-through for DeepSeek V4 without bringing in any recipe payload.

Current `main` already has the DSV4 custom tokenizer package and the fast chat-template failure with guidance from PR #76. This PR fills the remaining gap from `aflowers/gb200-dsv4-recipes`: recipes can now set `benchmark.tokenizer_mode: deepseek_v4`, and SA-Bench will pass that through to `benchmark_serving.py`.

## What changed

- Adds `BenchmarkConfig.tokenizer_mode`.
- Passes tokenizer mode from `SABenchRunner` into `bench.sh` as a new trailing positional argument, preserving the existing dataset arguments.
- Adds `--tokenizer-mode deepseek_v4` support in `benchmark_serving.py` and `backend_request_func.py`.
- Adds `custom_tokenizer: deepseek_v4` as a short alias for the same vLLM DeepSeek V4 tokenizer.
- Adds focused tests for command construction.

## Validation

- `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q` -> 612 passed, 2 skipped, 6 deselected
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_benchmarks.py tests/test_configs.py -q` -> 104 passed
- `UV_PROJECT_ENVIRONMENT=.venv uv run --frozen --no-sync ruff check src/srtctl tests/test_benchmarks.py --ignore SIM117` -> passed
- `UV_PROJECT_ENVIRONMENT=.venv uv run --frozen --no-sync ruff format --check src/srtctl tests/test_benchmarks.py` -> passed
- `bash -n src/srtctl/benchmarks/scripts/sa-bench/bench.sh` -> passed
- `PYTHONPATH=src .venv/bin/python -m py_compile src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py` -> passed

Note: this intentionally does not port the side-branch auto-fallback behavior for missing chat templates; current `main` already fails fast with actionable DSV4 guidance instead.
