### PR TITLE
feat(config): resolve container aliases for telemetry + preflight

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -119,6 +119,20 @@ The `srtslurm.yaml` file can contain the following fields:
 
 **output_dir**: When set, job logs are written to `output_dir/{job_id}/logs` instead of `srtctl_root/outputs/{job_id}/logs`. Useful for CI/CD and ephemeral environments.
 
+### Running without `srtslurm.yaml`
+
+`srtslurm.yaml` is optional. A recipe can be fully self-sustaining as long as it supplies everything the cluster yaml would otherwise provide:
+
+- Set `slurm.account`, `slurm.partition`, and `slurm.time_limit` directly in the recipe (no `default_*` fallback).
+- Use absolute paths for `model.path`, `model.container`, and any other container fields — alias resolution is a no-op without the yaml's `containers:` / `model_paths:` maps.
+- List every cluster-side mount the job needs in `extra_mount` (e.g. the lustre share that holds your model weights and `.sqsh` files). `default_mounts` is the only `srtslurm.yaml` field with no recipe-level equivalent until you spell mounts out yourself.
+- Set `resources.gpus_per_node` explicitly.
+- Status reporting and S3 log upload are skipped (their config lives under `reporting:` in the cluster yaml).
+
+Workers' nats and etcd come from the dynamo/sglang container, not the yaml, so disagg/agg topologies still work end-to-end. `srtctl_root` falls back to the package install path automatically.
+
+This is useful for portable recipes that you want to share across clusters or hand to a teammate without dragging cluster config along.
+
 ---
 
 ## name

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -161,6 +161,29 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         config["benchmark"] = benchmark
         logger.debug(f"Resolved benchmark.container_image alias '{benchmark_container}' -> '{resolved_bench}'")
 
+    # Resolve telemetry container aliases (scraper + dcgm/node exporters). All
+    # three are nullable in the schema; only resolve fields that are set.
+    telemetry = config.get("telemetry")
+    if telemetry and containers:
+        scraper_image = telemetry.get("container_image")
+        if scraper_image and scraper_image in containers:
+            resolved_scraper = containers[scraper_image]
+            telemetry["container_image"] = resolved_scraper
+            logger.debug(f"Resolved telemetry.container_image alias '{scraper_image}' -> '{resolved_scraper}'")
+
+        for exporter_key in ("dcgm_exporter", "node_exporter"):
+            exporter = telemetry.get(exporter_key)
+            if not exporter:
+                continue
+            exporter_image = exporter.get("container_image")
+            if exporter_image and exporter_image in containers:
+                resolved_exporter = containers[exporter_image]
+                exporter["container_image"] = resolved_exporter
+                logger.debug(
+                    f"Resolved telemetry.{exporter_key}.container_image alias "
+                    f"'{exporter_image}' -> '{resolved_exporter}'"
+                )
+
     return config
 
 

--- a/src/srtctl/core/validation.py
+++ b/src/srtctl/core/validation.py
@@ -232,6 +232,54 @@ def _preflight_container(
     )
 
 
+_TELEMETRY_IMAGE_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("telemetry.container_image", ("container_image",)),
+    ("telemetry.dcgm_exporter.container_image", ("dcgm_exporter", "container_image")),
+    ("telemetry.node_exporter.container_image", ("node_exporter", "container_image")),
+)
+
+
+def _preflight_telemetry(
+    raw_config: dict[str, Any],
+    resolved_config: dict[str, Any],
+    cluster_config: dict[str, Any] | None,
+) -> list[PreflightIssue]:
+    telemetry = resolved_config.get("telemetry") or {}
+    if not telemetry.get("enabled"):
+        return []
+
+    aliases = (cluster_config or {}).get("containers") or {}
+    raw_telemetry = raw_config.get("telemetry") or {}
+    issues: list[PreflightIssue] = []
+
+    for field, path in _TELEMETRY_IMAGE_FIELDS:
+        resolved_value: Any = telemetry
+        raw_value: Any = raw_telemetry
+        for key in path:
+            resolved_value = (resolved_value or {}).get(key) if isinstance(resolved_value, dict) else None
+            raw_value = (raw_value or {}).get(key) if isinstance(raw_value, dict) else None
+        if not resolved_value:
+            continue  # schema-level validator handles required-when-enabled
+
+        ok, _ = _check_path(_expand_path(resolved_value), expect="file")
+        if ok:
+            continue
+
+        if raw_value in aliases:
+            message = (
+                f"Telemetry alias '{raw_value}' resolved to '{resolved_value}', but that file is unavailable. "
+                "Provide or register the container yourself before submitting."
+            )
+        else:
+            message = (
+                f"Telemetry container '{resolved_value}' is not a local container path and is not defined "
+                "in srtslurm.yaml containers. Provide or register the container yourself before submitting."
+            )
+        issues.append(PreflightIssue(code="telemetry-container-not-available", field=field, message=message))
+
+    return issues
+
+
 def validate_topology(resources: dict[str, Any] | None) -> list[PreflightIssue]:
     """Catch semantically wrong resources blocks that pass the marshmallow schema.
 
@@ -384,7 +432,8 @@ def preflight_config_variants(
         model, model_issues = _preflight_model(variant, resolved, active_cluster_config)
         container, container_issues = _preflight_container(variant, resolved, active_cluster_config)
         topology_issues = validate_topology(variant.get("resources"))
-        issues = [*model_issues, *container_issues, *topology_issues]
+        telemetry_issues = _preflight_telemetry(variant, resolved, active_cluster_config)
+        issues = [*model_issues, *container_issues, *topology_issues, *telemetry_issues]
         results.append(
             PreflightResult(
                 variant=suffix,

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -452,6 +452,57 @@ class TestFrontendConfig:
 
         assert resolved["frontend"]["nginx_container"] == "nginx"
 
+    def test_telemetry_container_aliases_resolve(self):
+        from srtctl.core.config import resolve_config_with_defaults
+
+        user_config = {
+            "name": "test",
+            "model": {"path": "/model", "container": "sglang", "precision": "fp8"},
+            "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
+            "telemetry": {
+                "enabled": True,
+                "container_image": "telemetry-scraper",
+                "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},
+                "node_exporter": {"container_image": "node-exporter", "port": 9101},
+            },
+        }
+        cluster_config = {
+            "containers": {
+                "sglang": "/path/to/sglang.sqsh",
+                "telemetry-scraper": "/path/to/scraper.sqsh",
+                "dcgm-exporter": "/path/to/dcgm.sqsh",
+                "node-exporter": "/path/to/node.sqsh",
+            }
+        }
+
+        resolved = resolve_config_with_defaults(user_config, cluster_config)
+
+        assert resolved["telemetry"]["container_image"] == "/path/to/scraper.sqsh"
+        assert resolved["telemetry"]["dcgm_exporter"]["container_image"] == "/path/to/dcgm.sqsh"
+        assert resolved["telemetry"]["node_exporter"]["container_image"] == "/path/to/node.sqsh"
+
+    def test_telemetry_literal_paths_pass_through(self):
+        from srtctl.core.config import resolve_config_with_defaults
+
+        user_config = {
+            "name": "test",
+            "model": {"path": "/model", "container": "/container.sqsh", "precision": "fp8"},
+            "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
+            "telemetry": {
+                "enabled": True,
+                "container_image": "/abs/scraper.sqsh",
+                "dcgm_exporter": {"container_image": "/abs/dcgm.sqsh", "port": 9401},
+                "node_exporter": {"container_image": "/abs/node.sqsh", "port": 9101},
+            },
+        }
+        cluster_config = {"containers": {"dcgm-exporter": "/aliased/dcgm.sqsh"}}
+
+        resolved = resolve_config_with_defaults(user_config, cluster_config)
+
+        assert resolved["telemetry"]["container_image"] == "/abs/scraper.sqsh"
+        assert resolved["telemetry"]["dcgm_exporter"]["container_image"] == "/abs/dcgm.sqsh"
+        assert resolved["telemetry"]["node_exporter"]["container_image"] == "/abs/node.sqsh"
+
 
 class TestSetupScript:
     """Tests for setup_script functionality."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -358,3 +358,115 @@ class TestPreflightConfigVariants:
 
         assert results[0].ok is False
         assert any(issue.code == "container-not-available" for issue in results[0].errors)
+
+    def test_telemetry_aliases_resolve_and_pass_when_files_exist(self, tmp_path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        container_file = tmp_path / "container.sqsh"
+        container_file.write_text("sqsh")
+        scraper_file = tmp_path / "scraper.sqsh"
+        scraper_file.write_text("sqsh")
+        dcgm_file = tmp_path / "dcgm.sqsh"
+        dcgm_file.write_text("sqsh")
+        node_file = tmp_path / "node.sqsh"
+        node_file.write_text("sqsh")
+
+        results = preflight_config_variants(
+            {
+                "name": "telemetry-ok",
+                "model": {"path": "qwen32b", "container": "sglang-latest", "precision": "bf16"},
+                "resources": {
+                    "gpu_type": "gb200",
+                    "gpus_per_node": 4,
+                    "prefill_nodes": 1,
+                    "decode_nodes": 1,
+                    "prefill_workers": 1,
+                    "decode_workers": 1,
+                },
+                "telemetry": {
+                    "enabled": True,
+                    "container_image": "telemetry-scraper",
+                    "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},
+                    "node_exporter": {"container_image": "node-exporter", "port": 9101},
+                },
+            },
+            cluster_config={
+                "model_paths": {"qwen32b": str(model_dir)},
+                "containers": {
+                    "sglang-latest": str(container_file),
+                    "telemetry-scraper": str(scraper_file),
+                    "dcgm-exporter": str(dcgm_file),
+                    "node-exporter": str(node_file),
+                },
+            },
+        )
+
+        assert results[0].ok is True
+        assert results[0].errors == []
+
+    def test_telemetry_missing_sqsh_fails_preflight(self, tmp_path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        container_file = tmp_path / "container.sqsh"
+        container_file.write_text("sqsh")
+        scraper_file = tmp_path / "scraper.sqsh"
+        scraper_file.write_text("sqsh")
+        dcgm_file = tmp_path / "dcgm.sqsh"
+        dcgm_file.write_text("sqsh")
+        # node.sqsh deliberately missing
+
+        results = preflight_config_variants(
+            {
+                "name": "telemetry-bad",
+                "model": {"path": str(model_dir), "container": str(container_file), "precision": "bf16"},
+                "resources": {
+                    "gpu_type": "gb200",
+                    "gpus_per_node": 4,
+                    "prefill_nodes": 1,
+                    "decode_nodes": 1,
+                    "prefill_workers": 1,
+                    "decode_workers": 1,
+                },
+                "telemetry": {
+                    "enabled": True,
+                    "container_image": str(scraper_file),
+                    "dcgm_exporter": {"container_image": str(dcgm_file), "port": 9401},
+                    "node_exporter": {"container_image": str(tmp_path / "node.sqsh"), "port": 9101},
+                },
+            },
+        )
+
+        assert results[0].ok is False
+        telemetry_errors = [issue for issue in results[0].errors if issue.code == "telemetry-container-not-available"]
+        assert len(telemetry_errors) == 1
+        assert telemetry_errors[0].field == "telemetry.node_exporter.container_image"
+
+    def test_telemetry_disabled_skips_preflight(self, tmp_path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        container_file = tmp_path / "container.sqsh"
+        container_file.write_text("sqsh")
+
+        results = preflight_config_variants(
+            {
+                "name": "telemetry-off",
+                "model": {"path": str(model_dir), "container": str(container_file), "precision": "bf16"},
+                "resources": {
+                    "gpu_type": "gb200",
+                    "gpus_per_node": 4,
+                    "prefill_nodes": 1,
+                    "decode_nodes": 1,
+                    "prefill_workers": 1,
+                    "decode_workers": 1,
+                },
+                "telemetry": {
+                    "enabled": False,
+                    "container_image": "/does/not/exist.sqsh",
+                    "dcgm_exporter": {"container_image": "/does/not/exist.sqsh", "port": 9401},
+                    "node_exporter": {"container_image": "/does/not/exist.sqsh", "port": 9101},
+                },
+            },
+        )
+
+        assert results[0].ok is True
+        assert not any(issue.code == "telemetry-container-not-available" for issue in results[0].errors)


### PR DESCRIPTION
## Summary
- Resolve `srtslurm.yaml` `containers:` aliases for `telemetry.container_image`, `telemetry.dcgm_exporter.container_image`, and `telemetry.node_exporter.container_image` (mirrors how `model.container`, `frontend.nginx_container`, and `benchmark.container_image` already work)
- Preflight checks the resolved sqsh paths exist when `telemetry.enabled: true`; skipped entirely when disabled
- Literal absolute paths still pass through unchanged in both layers

## Why
Recipes today have to write absolute sqsh paths for the three telemetry container fields, and we get no early error when the path is wrong — the failure surfaces only when srun tries to launch the exporter. Both gaps were already solved for model/frontend/benchmark; this just extends the same pattern.

## Test plan
- [x] `pytest tests/test_telemetry.py tests/test_configs.py::TestFrontendConfig tests/test_validation.py::TestPreflightConfigVariants` — 17/17 pass locally and on the cluster
- [x] `pytest tests/` full suite — 616 passed, 0 failed
- [x] Manual: alias `dcgm-exporter` / `node-exporter` registered in srtslurm.yaml on sgl-gb200, recipe references resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)