### PR TITLE
feat(config): cluster-wide default_bash_preamble for ulimits and the like

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -116,8 +116,11 @@ The `srtslurm.yaml` file can contain the following fields:
 | `model_paths`                   | dict   | Model path aliases                                    |
 | `containers`                    | dict   | Container image aliases                               |
 | `default_mounts`                | dict   | Cluster-wide container mounts                         |
+| `default_bash_preamble`         | string | Shell snippet prepended to every container srun       |
 
 **output_dir**: When set, job logs are written to `output_dir/{job_id}/logs` instead of `srtctl_root/outputs/{job_id}/logs`. Useful for CI/CD and ephemeral environments.
+
+**default_bash_preamble**: A shell snippet (e.g. `"ulimit -n 1048576 -s unlimited -u 1048576"`) prepended to every container srun launched by srtctl — workers, frontends, telemetry, benchmark, postprocess. Runs before per-call `bash_preamble` and the main command, so cluster-wide ulimits apply to everything downstream. Silently dropped for distroless containers (e.g. `prom/node-exporter`) that bypass the bash wrapper; a WARNING log is emitted in that case.
 
 ### Running without `srtslurm.yaml`
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -197,6 +197,11 @@ class ClusterConfig:
     # Cluster-level container mounts (host_path -> container_path)
     # Applied to all jobs on this cluster, useful for cluster-specific paths
     default_mounts: dict[str, str] | None = None
+    # Shell snippet prepended to every container srun (after env exports, before
+    # the main command). Useful for cluster-wide ulimits, e.g.
+    # ``"ulimit -n 1048576 -s unlimited -u 1048576"``. Silently dropped for
+    # sruns that bypass the bash wrapper (distroless containers).
+    default_bash_preamble: str | None = None
     reporting: ReportingConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -24,6 +24,18 @@ from .ip_utils import get_node_ip
 logger = logging.getLogger(__name__)
 
 
+def _get_cluster_bash_preamble() -> str | None:
+    """Look up the cluster-wide default_bash_preamble.
+
+    Imported lazily to avoid a circular dependency (config.py imports schema,
+    which transitively imports from this module's siblings).
+    """
+    from .config import get_srtslurm_setting
+
+    value = get_srtslurm_setting("default_bash_preamble")
+    return value if isinstance(value, str) and value else None
+
+
 # ============================================================================
 # SLURM Environment
 # ============================================================================
@@ -250,8 +262,14 @@ def start_srun_process(
             for name, value in env_to_set.items():
                 bash_parts.append(f"export {name}={shlex.quote(value)}")
 
-        # Add preamble if provided. It runs after exports so setup/fingerprint
-        # hooks observe the same environment as the main command.
+        # Cluster-wide preamble (e.g. ulimits) runs first so it applies to
+        # exports, the local preamble, and the main command alike.
+        cluster_preamble = _get_cluster_bash_preamble()
+        if cluster_preamble:
+            bash_parts.insert(0, cluster_preamble)
+
+        # Add per-call preamble if provided. It runs after exports so setup
+        # / fingerprint hooks observe the same environment as the main command.
         if bash_preamble:
             bash_parts.append(bash_preamble)
 
@@ -262,6 +280,13 @@ def start_srun_process(
         bash_command = " && ".join(bash_parts)
         srun_cmd.extend(["bash", "-c", bash_command])
     else:
+        cluster_preamble = _get_cluster_bash_preamble()
+        if cluster_preamble:
+            logger.warning(
+                "Cluster default_bash_preamble is set but this srun bypasses the bash wrapper "
+                "(use_bash_wrapper=False); preamble will not be applied. command=%s",
+                shlex.join(command),
+            )
         srun_cmd.extend(command)
 
     logger.info("srun command: %s", shlex.join(srun_cmd))

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -22,6 +22,7 @@ def _built_bash_command(mock_popen: MagicMock) -> str:
 def test_start_srun_exports_env_before_preamble() -> None:
     with (
         patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
         patch("subprocess.Popen") as mock_popen,
     ):
         mock_popen.return_value = MagicMock()
@@ -34,6 +35,65 @@ def test_start_srun_exports_env_before_preamble() -> None:
     bash_cmd = _built_bash_command(mock_popen)
     assert bash_cmd.index("export NCCL_DEBUG=INFO") < bash_cmd.index("echo preamble")
     assert bash_cmd.index("echo preamble") < bash_cmd.index("python3 -m server")
+
+
+def test_cluster_bash_preamble_runs_before_exports_and_local_preamble() -> None:
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch(
+            "srtctl.core.slurm._get_cluster_bash_preamble",
+            return_value="ulimit -n 1048576",
+        ),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(
+            ["python3", "-m", "server"],
+            env_to_set={"NCCL_DEBUG": "INFO"},
+            bash_preamble="echo local",
+        )
+
+    bash_cmd = _built_bash_command(mock_popen)
+    # ulimit must come first so it applies to everything downstream.
+    assert bash_cmd.index("ulimit -n 1048576") < bash_cmd.index("export NCCL_DEBUG=INFO")
+    assert bash_cmd.index("export NCCL_DEBUG=INFO") < bash_cmd.index("echo local")
+    assert bash_cmd.index("echo local") < bash_cmd.index("python3 -m server")
+
+
+def test_cluster_bash_preamble_applied_when_only_cluster_set() -> None:
+    """Cluster preamble alone should land in the bash wrapper even with no local preamble or env."""
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch(
+            "srtctl.core.slurm._get_cluster_bash_preamble",
+            return_value="ulimit -n 1048576",
+        ),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(["python3", "-m", "server"])
+
+    bash_cmd = _built_bash_command(mock_popen)
+    assert bash_cmd.startswith("ulimit -n 1048576 && python3 -m server")
+
+
+def test_cluster_bash_preamble_warns_when_bash_wrapper_disabled(caplog) -> None:
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch(
+            "srtctl.core.slurm._get_cluster_bash_preamble",
+            return_value="ulimit -n 1048576",
+        ),
+        patch("subprocess.Popen") as mock_popen,
+        caplog.at_level("WARNING", logger="srtctl.core.slurm"),
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(["/bin/node_exporter"], use_bash_wrapper=False)
+
+    srun_cmd = mock_popen.call_args.args[0]
+    # Distroless path runs the binary directly; preamble cannot apply.
+    assert "bash" not in srun_cmd
+    assert any("default_bash_preamble" in record.message for record in caplog.records)
 
 
 def test_wrapped_nonfatal_hook_does_not_mask_prior_preamble_failure() -> None:


### PR DESCRIPTION
## Summary
- Add `default_bash_preamble: str | None` to `ClusterConfig` (`srtslurm.yaml`)
- `start_srun_process` prepends it inside the bash wrapper, before env exports and any per-call `bash_preamble`, so cluster-wide ulimits apply to workers, frontends, telemetry exporters/scraper, benchmark, and postprocess uniformly
- Distroless containers (`use_bash_wrapper=False`, e.g. `prom/node-exporter`) emit a WARNING and proceed without it — the preamble cannot run where there's no shell

## Why
Setting ulimits per-recipe means every recipe carries the same `srun_options: { propagate: ... }` line, and SLURM `--propagate` only inherits whatever the sbatch shell had (often 1024 file descriptors on a login node). One cluster-level shell snippet makes "raise NOFILE to 1M for every container on this cluster" a one-line change in `srtslurm.yaml`.

## Example
```yaml
# srtslurm.yaml
default_bash_preamble: "ulimit -n 1048576 -s unlimited -u 1048576 -l unlimited"
```

## Test plan
- [x] `pytest tests/test_slurm.py` — 6/6 pass (3 new tests covering: cluster-only preamble, cluster + local merge ordering, distroless WARNING path)
- [x] `pytest tests/` full suite — all green
- [x] Lazy-imported `get_srtslurm_setting` inside the helper to avoid a circular dep between `core/slurm.py` and `core/config.py`

## Notes
- Independent of #101 (telemetry alias work), but they touch overlapping files. Whichever lands first, the other rebases cleanly — only `docs/config-reference.md` and `schema.py`'s `ClusterConfig` block are shared territory and the additions don't overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)