### PR TITLE
Fix DeepSeek V4 vLLM GB200 concurrencies

### DIFF
--- a/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-1p1d-dep8-dep8-16-c256-c512-c1024-offload.yaml
+++ b/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-1p1d-dep8-dep8-16-c256-c512-c1024-offload.yaml
@@ -112,7 +112,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "256x512x1024"
+  concurrencies: "64x128x256x512x1024"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-1p4d-dep8-tp8-c256-c512-offload.yaml
+++ b/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-1p4d-dep8-tp8-c256-c512-offload.yaml
@@ -112,7 +112,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "256x512x1024"
+  concurrencies: "256x512"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-1p8d-dep8-tp8-c1-c2-c4-c8-c16-c32-c64-c128-c256-offload.yaml
+++ b/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-1p8d-dep8-tp8-c1-c2-c4-c8-c16-c32-c64-c128-c256-offload.yaml
@@ -112,7 +112,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "256x512x1024"
+  concurrencies: "1x2x4x8x16x32x64x128x256x512"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-2p1d-dep8-dep8-c4096-offload.yaml
+++ b/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-2p1d-dep8-dep8-c4096-offload.yaml
@@ -108,7 +108,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "256x512x1024"
+  concurrencies: "4096"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-3p1d-dep8-dep16-c4096-offload.yaml
+++ b/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-3p1d-dep8-dep16-c4096-offload.yaml
@@ -108,7 +108,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "256x512x1024"
+  concurrencies: "4096"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-3p1d-dep8-dep8-c4096-offload.yaml
+++ b/recipes/vllm/deepseek-v4-pro/GB200/8k1k/disagg-gb200-3p1d-dep8-dep8-c4096-offload.yaml
@@ -108,7 +108,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "256x512x1024"
+  concurrencies: "4096"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"


### PR DESCRIPTION
## Summary
- align GB200 8k1k DeepSeek V4 Pro recipe concurrencies with the `deepseek-v4-pro-sa` source tree
- rename the 1p8d recipe to include the restored c1/c2/c4 concurrency points

## Validation
- compared current recipe concurrencies against `origin/aflowers/gb200-dsv4-recipes:recipes/vllm/deepseek-v4-pro-sa/8k1k`; all six matched
- ran `git diff --check origin/aflowers/vllm-gb200-v0.20.0..HEAD`