### PR TITLE
fix(nginx): raise file descriptor limit for nginx workers

### DIFF
--- a/src/srtctl/cli/mixins/frontend_stage.py
+++ b/src/srtctl/cli/mixins/frontend_stage.py
@@ -133,10 +133,12 @@ class FrontendStageMixin:
         # Install nginx and run it (daemon off keeps nginx in foreground so srun can manage it)
         # Use container path (/logs) since log_dir is mounted there
         container_config_path = "/logs/nginx.conf"
+        # ulimit inlined here because use_bash_wrapper=False bypasses the cluster
+        # default_bash_preamble; tracked for cleanup in a separate issue.
         cmd = [
             "bash",
             "-c",
-            f"nginx -c {container_config_path} -g 'daemon off;'",
+            f"ulimit -n 1048576 && nginx -c {container_config_path} -g 'daemon off;'",
         ]
 
         proc = start_srun_process(

--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -3,6 +3,7 @@
 # Defines the group of servers to which NGINX will proxy requests.
 # NGINX will cycle through these servers in a round-robin fashion by default.
 worker_processes auto;
+worker_rlimit_nofile 1048576;
 
 http {
     access_log off;


### PR DESCRIPTION
## Summary

- Set `worker_rlimit_nofile 1048576` in `nginx.conf.j2` so each nginx worker can open enough fds for its `worker_connections` (65535) regardless of the shell limit.
- Inline `ulimit -n 1048576 &&` in the nginx `bash -c` command in `_start_nginx`, since that call site uses `use_bash_wrapper=False` and therefore bypasses the cluster-wide `default_bash_preamble` (silently — only a warning is logged).
- Tracking issue for the underlying preamble bypass: #107. Once that lands, the inlined `ulimit` here can be removed.

## Test plan

- [ ] Submit a multi-node sweep that uses nginx (>=2 nodes, `multiple_frontends` enabled).
- [ ] Confirm nginx starts cleanly — no `worker_connections exceed open file resource limit` warning in `<head>_nginx.out`.
- [ ] Confirm the effective fd limit reported at nginx startup is the new value (or capped by the container hard limit, in which case file an infra ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)