### PR TITLE
nginx: rework to make ulimit optional

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,7 +241,7 @@ All configs are **frozen dataclasses** with marshmallow validation:
 | `ModelConfig`     | Model settings      | path, container, precision                            |
 | `ResourceConfig`  | GPU/node allocation | gpu_type, gpus_per_node, prefill/decode nodes/workers |
 | `BackendConfig`   | Polymorphic backend | type, sglang_config, environment per mode             |
-| `FrontendConfig`  | Router settings     | type, enable_multiple_frontends, args, env            |
+| `FrontendConfig`  | Router settings     | type, enable_multiple_frontends, nginx_raise_ulimit, args, env |
 | `BenchmarkConfig` | Benchmark params    | type, isl, osl, concurrencies, sweep                  |
 | `ProfilingConfig` | Profiling settings  | type (nsys/torch), phase configs                      |
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -117,10 +117,13 @@ The `srtslurm.yaml` file can contain the following fields:
 | `containers`                    | dict   | Container image aliases                               |
 | `default_mounts`                | dict   | Cluster-wide container mounts                         |
 | `default_bash_preamble`         | string | Shell snippet prepended to every container srun       |
+| `nginx_raise_ulimit`          | bool   | Optional default for `frontend.nginx_raise_ulimit`  |
 
 **output_dir**: When set, job logs are written to `output_dir/{job_id}/logs` instead of `srtctl_root/outputs/{job_id}/logs`. Useful for CI/CD and ephemeral environments.
 
 **default_bash_preamble**: A shell snippet (e.g. `"ulimit -n 1048576 -s unlimited -u 1048576"`) prepended to every container srun launched by srtctl — workers, frontends, telemetry, benchmark, postprocess. Runs before per-call `bash_preamble` and the main command, so cluster-wide ulimits apply to everything downstream. Silently dropped for distroless containers (e.g. `prom/node-exporter`) that bypass the bash wrapper; a WARNING log is emitted in that case.
+
+**nginx_raise_ulimit**: When set to `true` or `false`, this value is applied to jobs that omit `frontend.nginx_raise_ulimit` in the recipe. Use `true` on clusters where raising the nginx container’s open-file limit is allowed; leave unset if each job should rely on the frontend default (`false`). A recipe that sets `frontend.nginx_raise_ulimit` always wins.
 
 ### Running without `srtslurm.yaml`
 
@@ -262,6 +265,10 @@ frontend:
   enable_multiple_frontends: true     # Enable nginx + multiple routers
   num_additional_frontends: 9         # Additional routers (total = 1 + this)
 
+  # Optional: raise nofile for nginx (shell ulimit + worker_rlimit_nofile in nginx.conf).
+  # Default false. Set true on clusters that allow it; can also set nginx_raise_ulimit in srtslurm.yaml.
+  # nginx_raise_ulimit: true
+
   # CLI args passed to the frontend/router
   args:
     router-mode: "kv"                 # dynamo: router-mode
@@ -279,6 +286,7 @@ frontend:
 | `enable_multiple_frontends` | bool | true          | Scale with nginx + multiple routers |
 | `num_additional_frontends`  | int  | 9             | Additional routers beyond master    |
 | `nginx_container`           | str  | nginx:1.27.4  | Custom nginx container image        |
+| `nginx_raise_ulimit`      | bool | false         | When true with nginx in use, run `ulimit -n 1048576` before nginx and emit `worker_rlimit_nofile 1048576` in generated `nginx.conf`. Off by default so restrictive clusters do not fail. Cluster `srtslurm.yaml` may set `nginx_raise_ulimit` for jobs that omit this field. |
 | `args`                      | dict | null          | CLI args for the frontend           |
 | `env`                       | dict | null          | Env vars for frontend processes     |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -130,6 +130,9 @@ model_paths:
 containers:
   latest: "/containers/sglang-latest.sqsh"
   stable: "/containers/sglang-stable.sqsh"
+
+# Optional: default for recipes that omit frontend.nginx_raise_ulimit (nginx high-nofile tuning)
+# nginx_raise_ulimit: true
 ```
 
 ## Create a Job Config

--- a/docs/sglang-router.md
+++ b/docs/sglang-router.md
@@ -138,6 +138,8 @@ frontend:
 - nginx round-robins requests to routers
 - Routers distributed across nodes using same logic as Dynamo frontends
 
+If the cluster rejects raising open-file limits inside the nginx container, keep the default (`frontend.nginx_raise_ulimit: false` or unset). If you need the previous high-nofile behavior, set `frontend.nginx_raise_ulimit: true` or a cluster default in `srtslurm.yaml` — see [Configuration Reference](config-reference.md#frontend).
+
 ## How Router Distribution Works
 
 The `num_additional_frontends` setting controls how many additional routers spawn beyond the first:

--- a/recipes/dsv4-pro/sglang/gb300-fp4/1k1k/disagg/stp/max-tpt.yaml
+++ b/recipes/dsv4-pro/sglang/gb300-fp4/1k1k/disagg/stp/max-tpt.yaml
@@ -16,6 +16,7 @@ frontend:
   enable_multiple_frontends: true
   num_additional_frontends: 8
   nginx_container: /mnt/home/yangminl/containers/nginx-1.27.4.sqsh
+  nginx_raise_ulimit: true
 
 model:
   path: dsv4-pro

--- a/src/srtctl/cli/mixins/frontend_stage.py
+++ b/src/srtctl/cli/mixins/frontend_stage.py
@@ -133,13 +133,15 @@ class FrontendStageMixin:
         # Install nginx and run it (daemon off keeps nginx in foreground so srun can manage it)
         # Use container path (/logs) since log_dir is mounted there
         container_config_path = "/logs/nginx.conf"
-        # ulimit inlined here because use_bash_wrapper=False bypasses the cluster
-        # default_bash_preamble; tracked for cleanup in a separate issue.
-        cmd = [
-            "bash",
-            "-c",
-            f"ulimit -n 1048576 && nginx -c {container_config_path} -g 'daemon off;'",
-        ]
+        # Optional ulimit: use_bash_wrapper=False bypasses default_bash_preamble;
+        # some clusters reject raising nofile inside the nginx container.
+        fe = self.config.frontend
+        inner = (
+            f"ulimit -n 1048576 && nginx -c {container_config_path} -g 'daemon off;'"
+            if fe.nginx_raise_ulimit
+            else f"nginx -c {container_config_path} -g 'daemon off;'"
+        )
+        cmd = ["bash", "-c", inner]
 
         proc = start_srun_process(
             command=cmd,
@@ -176,6 +178,7 @@ class FrontendStageMixin:
             frontend_hosts=frontend_hosts,
             backend_port=topology.frontend_port,
             listen_port=topology.public_port,
+            nginx_raise_ulimit=self.config.frontend.nginx_raise_ulimit,
         )
 
     def start_frontend(self, registry: "ProcessRegistry") -> list[ManagedProcess]:

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -148,6 +148,12 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         config["frontend"] = frontend
         logger.debug(f"Resolved nginx_container alias '{nginx_container}' -> '{resolved_nginx}'")
 
+    # Cluster-level default for nginx nofile ulimit (job yaml wins if present).
+    if "nginx_raise_ulimit" not in frontend and cluster_config.get("nginx_raise_ulimit") is not None:
+        frontend["nginx_raise_ulimit"] = cluster_config["nginx_raise_ulimit"]
+        config["frontend"] = frontend
+        logger.debug(f"Applied cluster nginx_raise_ulimit: {frontend['nginx_raise_ulimit']}")
+
     # Resolve benchmark.container_image alias for benches that ship their own
     # eval container (e.g. NeMo Skills for accuracy benchmarks). Mirrors how
     # model.container and frontend.nginx_container resolve against the same

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -203,6 +203,9 @@ class ClusterConfig:
     # sruns that bypass the bash wrapper (distroless containers).
     default_bash_preamble: str | None = None
     reporting: ReportingConfig | None = None
+    # When set, applied to job configs that omit ``frontend.nginx_raise_ulimit``.
+    # Clusters that disallow raising nofile for nginx containers should use false.
+    nginx_raise_ulimit: bool | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
 
@@ -1154,6 +1157,9 @@ class FrontendConfig:
             placeholder substitution, so write the URL out literally.
         num_additional_frontends: Additional routers beyond master (default: 9)
         nginx_container: Custom nginx container image (default: nginx:1.27.4)
+        nginx_raise_ulimit: Raise nofile before nginx and set ``worker_rlimit_nofile``
+            in generated nginx.conf. Off by default; enable on clusters that allow it.
+            Override per job or set ``nginx_raise_ulimit`` in srtslurm.yaml for the cluster.
         args: CLI arguments passed to the frontend/router process
         env: Environment variables for frontend processes
     """
@@ -1162,6 +1168,7 @@ class FrontendConfig:
     enable_multiple_frontends: bool = True
     num_additional_frontends: int = 9
     nginx_container: str = "nginx:1.27.4"
+    nginx_raise_ulimit: bool = False
     args: dict[str, Any] | None = None
     env: dict[str, str] | None = None
 

--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -3,7 +3,9 @@
 # Defines the group of servers to which NGINX will proxy requests.
 # NGINX will cycle through these servers in a round-robin fashion by default.
 worker_processes auto;
+{% if nginx_raise_ulimit %}
 worker_rlimit_nofile 1048576;
+{% endif %}
 
 http {
     access_log off;

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -524,6 +524,27 @@ class TestFrontendConfig:
 
         assert resolved["frontend"]["nginx_container"] == "nginx"
 
+    def test_nginx_raise_ulimit_cluster_default(self):
+        """srtslurm.yaml can set nginx_raise_ulimit when job omits frontend key."""
+        from srtctl.core.config import resolve_config_with_defaults
+
+        user_config = {
+            "name": "test",
+            "model": {"path": "/model", "container": "/c.sqsh", "precision": "fp8"},
+            "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
+            "frontend": {},
+        }
+
+        resolved = resolve_config_with_defaults(user_config, {"nginx_raise_ulimit": True})
+        assert resolved["frontend"]["nginx_raise_ulimit"] is True
+
+        user_explicit = {
+            **user_config,
+            "frontend": {"nginx_raise_ulimit": False},
+        }
+        resolved2 = resolve_config_with_defaults(user_explicit, {"nginx_raise_ulimit": True})
+        assert resolved2["frontend"]["nginx_raise_ulimit"] is False
+
     def test_telemetry_container_aliases_resolve(self):
         from srtctl.core.config import resolve_config_with_defaults
 

--- a/tests/test_frontend_topology.py
+++ b/tests/test_frontend_topology.py
@@ -17,6 +17,7 @@ def make_config(
     enable_multiple_frontends: bool = True,
     num_additional_frontends: int = 9,
     frontend_type: str = "dynamo",
+    nginx_raise_ulimit: bool = False,
 ) -> SrtConfig:
     """Create a minimal SrtConfig for testing."""
     return SrtConfig(
@@ -32,6 +33,7 @@ def make_config(
             type=frontend_type,
             enable_multiple_frontends=enable_multiple_frontends,
             num_additional_frontends=num_additional_frontends,
+            nginx_raise_ulimit=nginx_raise_ulimit,
         ),
     )
 
@@ -195,6 +197,26 @@ class TestNginxConfigGeneration:
 
         assert "server 10.0.0.1:8180" in nginx_config
         assert "listen 8000" in nginx_config
+        assert "worker_rlimit_nofile" not in nginx_config
+
+    def test_nginx_config_raises_nofile_when_enabled(self):
+        """worker_rlimit_nofile appears only when nginx_raise_ulimit is set."""
+        config = make_config(enable_multiple_frontends=True, nginx_raise_ulimit=True)
+        runtime = make_runtime(["node0", "node1"])
+
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+        topology = FrontendTopology(
+            nginx_node="node0",
+            frontend_nodes=["node1"],
+            frontend_port=8180,
+            public_port=8000,
+        )
+
+        with patch.object(orchestrator, "runtime", runtime):
+            with patch("srtctl.cli.mixins.frontend_stage.get_hostname_ip", side_effect=lambda x: f"10.0.0.{x[-1]}"):
+                nginx_config = orchestrator._generate_nginx_config(topology)
+
+        assert "worker_rlimit_nofile 1048576" in nginx_config
 
     def test_nginx_config_multiple_frontends(self):
         """Nginx config with multiple frontend backends."""
@@ -305,6 +327,44 @@ class TestStartFrontendIntegration:
 
         # Verify nginx config was written
         assert (tmp_path / "nginx.conf").exists()
+
+        # Default: no shell ulimit before nginx (restricted clusters)
+        nginx_cmd = mock_mixin_srun.call_args_list[0].kwargs["command"]
+        assert nginx_cmd[0] == "bash" and nginx_cmd[1] == "-c"
+        assert "ulimit" not in nginx_cmd[2]
+
+    @patch("srtctl.frontends.dynamo.start_srun_process")
+    @patch("srtctl.cli.mixins.frontend_stage.start_srun_process")
+    def test_multi_node_nginx_ulimit_when_opt_in(self, mock_mixin_srun, mock_dynamo_srun, tmp_path):
+        mock_mixin_srun.return_value = MagicMock()
+        mock_dynamo_srun.return_value = MagicMock()
+
+        config = make_config(
+            enable_multiple_frontends=True,
+            frontend_type="dynamo",
+            nginx_raise_ulimit=True,
+        )
+        runtime = make_runtime(["node0", "node1", "node2"])
+        runtime = RuntimeContext(
+            job_id=runtime.job_id,
+            run_name=runtime.run_name,
+            nodes=runtime.nodes,
+            head_node_ip=runtime.head_node_ip,
+            infra_node_ip=runtime.infra_node_ip,
+            log_dir=tmp_path,
+            model_path=runtime.model_path,
+            container_image=runtime.container_image,
+            gpus_per_node=runtime.gpus_per_node,
+            network_interface=runtime.network_interface,
+            container_mounts=runtime.container_mounts,
+            environment=runtime.environment,
+        )
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        orchestrator.start_frontend(MagicMock())
+
+        nginx_cmd = mock_mixin_srun.call_args_list[0].kwargs["command"]
+        assert "ulimit -n 1048576" in nginx_cmd[2]
 
     @patch("srtctl.frontends.sglang.start_srun_process")
     @patch("srtctl.cli.mixins.frontend_stage.start_srun_process")


### PR DESCRIPTION
## Make nginx nofile ulimit opt-in (`nginx_raise_ulimit`)

### Problem
`srun` for nginx always ran `ulimit -n 1048576` and generated `nginx.conf` with `worker_rlimit_nofile 1048576`. Some clusters allow raising nofile inside the nginx container; others reject it and jobs fail. That behavior should not be unconditional.

### Solution
- **Default:** no shell `ulimit` before nginx and no `worker_rlimit_nofile` line in the generated config.
- **Opt-in:** set `frontend.nginx_raise_ulimit: true` in the job YAML to restore the previous high-nofile behavior (shell + `worker_rlimit_nofile 1048576`).
- **Cluster default:** optional `nginx_raise_ulimit` in `srtslurm.yaml` applies when the job omits `frontend.nginx_raise_ulimit`; an explicit job value always wins.

### Files touched (conceptually)
- Schema: `FrontendConfig.nginx_raise_ulimit`, `ClusterConfig.nginx_raise_ulimit`
- Config merge: `resolve_config_with_defaults` propagates cluster → job when the frontend key is absent
- Runtime: `frontend_stage._start_nginx` builds the bash command conditionally; `nginx.conf.j2` wraps `worker_rlimit_nofile` in a template conditional
- Tests: nginx config / srun command assertions + cluster merge test

### Migration
Clusters that relied on the old always-on ulimit should set `nginx_raise_ulimit: true` in `srtslurm.yaml` or add `frontend.nginx_raise_ulimit: true` to recipes that need it. No change is required on clusters where the default (no raise) is correct.