### PR TITLE
log: demote per-srun command line to DEBUG

### DIFF
--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -289,7 +289,11 @@ def start_srun_process(
             )
         srun_cmd.extend(command)
 
-    logger.info("srun command: %s", shlex.join(srun_cmd))
+    # Demoted to debug — every worker srun line is multi-KB once the
+    # fingerprint heredoc is inlined (see core/fingerprint.generate_capture_script),
+    # which dominates the orchestrator log. Re-enable with `--verbose` / by setting
+    # the srtctl logger to DEBUG when troubleshooting srun arg construction.
+    logger.debug("srun command: %s", shlex.join(srun_cmd))
 
     # Start the process
     proc = subprocess.Popen(


### PR DESCRIPTION
## Summary

Per-worker srun commands now embed the fingerprint capture heredoc from `core/fingerprint.generate_capture_script` — multi-KB of inlined Python that dominates the orchestrator log. The srun command line itself remains useful for debugging argv construction; demoting to `DEBUG` keeps it accessible (`--verbose` / log-level tuning) without burying every other INFO line.

## Why

Today every worker startup logs ~5KB of fingerprint heredoc at INFO. With multinode jobs that's 3+ workers × N concurrencies × per-restart, and the log gets unreadable at the orchestrator level. Demoting puts the noise behind an explicit debug toggle without removing the diagnostic surface.

## Alternatives considered

- Truncate / elide the heredoc before logging — preserves INFO-level visibility but adds string-massaging logic.
- Move the fingerprint capture script to a runtime file (e.g. mounted at `/srtctl-runtime/fingerprint.py`) and replace the inlined heredoc with `python3 /srtctl-runtime/fingerprint.py /logs/...` — addresses the root cause (5KB inlined Python in argv) but is a larger structural change.

This patch is the minimal-surface fix; either alternative could land later.

## Test plan

- [ ] Manual: run a multinode job and confirm orchestrator log no longer dumps the fingerprint heredoc.
- [ ] Confirm `srtctl --verbose ...` (or whatever log-level knob is canonical) still surfaces the srun command.
- [ ] No tests assert on this log line — `grep -rn "srun command" tests/` returns empty.