### PR TITLE
feat(vllm): update DP+EP to use `--local-data-parallel-rank`

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -91,6 +91,17 @@ class VLLMProtocol:
     # dynamo 1.0.0+: translated to --kv-transfer-config (--connector was removed).
     connector: str | None = "nixl"
 
+    # DP+EP launch convention. Controls two coupled behaviors that changed
+    # together in newer vLLM versions:
+    #   False (default, vLLM 0.12.0 and earlier): each DP rank's process sees
+    #     only its own GPU via CUDA_VISIBLE_DEVICES, and vLLM infers the local
+    #     rank from that.
+    #   True (vLLM 0.12.1+): each DP rank's process sees the full local DP
+    #     group's GPUs via CUDA_VISIBLE_DEVICES, and the local rank is passed
+    #     explicitly via --local-data-parallel-rank.
+    # Set to True when running a vLLM version that requires the new convention.
+    dp_explicit_local_rank: bool = False
+
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
     # =========================================================================
@@ -243,10 +254,14 @@ class VLLMProtocol:
                     current_sys_port += 1
             else:
                 # DP+EP mode: one process per GPU. Each process *owns* one GPU
-                # (gpu_indices, used for telemetry tagging) but is given
-                # visibility to the endpoint's full GPU set on the node via
-                # visible_gpu_indices, so CUDA_VISIBLE_DEVICES isn't constrained
-                # to the rank's single device.
+                # (gpu_indices, used for telemetry tagging). When
+                # dp_explicit_local_rank is True (newer vLLM convention), the
+                # process is also given visibility to the endpoint's full GPU
+                # set on the node via visible_gpu_indices, so
+                # CUDA_VISIBLE_DEVICES isn't constrained to the rank's single
+                # device — and build_worker_command will pass
+                # --local-data-parallel-rank.
+                visible = endpoint.gpu_indices if self.dp_explicit_local_rank else None
                 dp_rank = 0
                 for _node_rank, node in enumerate(endpoint.nodes):
                     for gpu_idx in sorted(endpoint.gpu_indices):
@@ -264,7 +279,7 @@ class VLLMProtocol:
                             Process(
                                 node=node,
                                 gpu_indices=frozenset([gpu_idx]),
-                                visible_gpu_indices=endpoint.gpu_indices,
+                                visible_gpu_indices=visible,
                                 sys_port=current_sys_port,
                                 http_port=http_port,
                                 endpoint_mode=endpoint.mode,

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -242,8 +242,11 @@ class VLLMProtocol:
                     )
                     current_sys_port += 1
             else:
-                # DP+EP mode: one process per GPU
-                # Each process gets a single GPU and a unique dp_rank
+                # DP+EP mode: one process per GPU. Each process *owns* one GPU
+                # (gpu_indices, used for telemetry tagging) but is given
+                # visibility to the endpoint's full GPU set on the node via
+                # visible_gpu_indices, so CUDA_VISIBLE_DEVICES isn't constrained
+                # to the rank's single device.
                 dp_rank = 0
                 for _node_rank, node in enumerate(endpoint.nodes):
                     for gpu_idx in sorted(endpoint.gpu_indices):
@@ -260,7 +263,8 @@ class VLLMProtocol:
                         processes.append(
                             Process(
                                 node=node,
-                                gpu_indices=frozenset([gpu_idx]),  # Single GPU per process
+                                gpu_indices=frozenset([gpu_idx]),
+                                visible_gpu_indices=endpoint.gpu_indices,
                                 sys_port=current_sys_port,
                                 http_port=http_port,
                                 endpoint_mode=endpoint.mode,
@@ -365,6 +369,18 @@ class VLLMProtocol:
                 ]
             )
             # Note: --data-parallel-size is added via _config_to_cli_args from vllm_config
+
+            # When the process can see more GPUs than it owns (i.e. CUDA_VISIBLE_DEVICES
+            # exposes the whole local DP group rather than a single device), vLLM can't
+            # infer the local DP rank from CUDA_VISIBLE_DEVICES alone — there may be
+            # multiple GPUs per DP rank, so the local rank doesn't necessarily match
+            # any GPU index. Compute it as the position among DP processes on the same
+            # node, ordered by global dp_rank.
+            if process.visible_gpu_indices is not None and len(process.visible_gpu_indices) > len(process.gpu_indices):
+                local_dp_rank = sum(
+                    1 for p in endpoint_processes if p.node == process.node and p.node_rank < process.node_rank
+                )
+                cmd.extend(["--local-data-parallel-rank", str(local_dp_rank)])
         elif is_multi_node:
             # Standard TP+PP multi-node coordination flags
             node_rank = endpoint_nodes.index(process.node)

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -185,8 +185,8 @@ class WorkerStageMixin:
             profile_dir = str(self.runtime.log_dir / "profiles")
             env_to_set.update(profiling.get_env_vars(mode, profile_dir))
 
-        # Set CUDA_VISIBLE_DEVICES if not using all GPUs
-        if len(process.gpu_indices) < self.runtime.gpus_per_node:
+        # Set CUDA_VISIBLE_DEVICES if not all GPUs on the node are visible
+        if process.num_visible_gpus < self.runtime.gpus_per_node:
             env_to_set["CUDA_VISIBLE_DEVICES"] = process.cuda_visible_devices
 
         # Add backend-specific process environment variables (e.g., unique ports)
@@ -302,8 +302,8 @@ class WorkerStageMixin:
             profile_dir = str(self.runtime.log_dir / "profiles")
             env_to_set.update(profiling.get_env_vars(mode, profile_dir))
 
-        # Set CUDA_VISIBLE_DEVICES if not using all GPUs on the node
-        if len(leader.gpu_indices) < self.runtime.gpus_per_node:
+        # Set CUDA_VISIBLE_DEVICES if not all GPUs on the node are visible
+        if leader.num_visible_gpus < self.runtime.gpus_per_node:
             env_to_set["CUDA_VISIBLE_DEVICES"] = leader.cuda_visible_devices
 
         self._apply_kvbm_endpoint_env(env_to_set, endpoint_processes)

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -146,7 +146,7 @@ class Process:
 
     Attributes:
         node: The node hostname this process runs on
-        gpu_indices: GPU indices visible to this process
+        gpu_indices: GPU indices owned/used by this process (drives telemetry tagging)
         sys_port: DYN_SYSTEM_PORT for this process
         http_port: HTTP serving port for this process (avoids conflicts on same node)
         bootstrap_port: P/D coordination port (only for prefill leaders)
@@ -155,6 +155,10 @@ class Process:
         endpoint_mode: The mode of the parent endpoint
         endpoint_index: The index of the parent endpoint
         node_rank: Rank within the endpoint (0 for leader)
+        visible_gpu_indices: Override for CUDA_VISIBLE_DEVICES when the set of
+            GPUs the process should *see* differs from the GPUs it owns (e.g.
+            vLLM DP+EP, where each rank owns one GPU but needs visibility to
+            the whole local group). Defaults to ``gpu_indices``.
     """
 
     node: str
@@ -167,6 +171,7 @@ class Process:
     bootstrap_port: int | None = None
     kv_events_port: int | None = None
     nixl_port: int | None = None
+    visible_gpu_indices: frozenset[int] | None = None
 
     @property
     def is_leader(self) -> bool:
@@ -174,9 +179,18 @@ class Process:
         return self.node_rank == 0
 
     @property
+    def _visible_indices(self) -> frozenset[int]:
+        return self.visible_gpu_indices if self.visible_gpu_indices is not None else self.gpu_indices
+
+    @property
+    def num_visible_gpus(self) -> int:
+        """Number of GPUs visible to this process (for CUDA_VISIBLE_DEVICES decisions)."""
+        return len(self._visible_indices)
+
+    @property
     def cuda_visible_devices(self) -> str:
         """CUDA_VISIBLE_DEVICES string for this process."""
-        return ",".join(str(i) for i in sorted(self.gpu_indices))
+        return ",".join(str(i) for i in sorted(self._visible_indices))
 
 
 def allocate_endpoints(

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1161,9 +1161,12 @@ class TestVLLMDataParallelMode:
         # Should create 16 processes (1 per GPU), not 2 (1 per node)
         assert len(processes) == 16
 
-        # Each process should have exactly 1 GPU
+        # Each process owns exactly 1 GPU (for telemetry tagging) but is given
+        # visibility to the endpoint's full GPU set on the node so
+        # CUDA_VISIBLE_DEVICES isn't constrained to that single device.
         for proc in processes:
             assert len(proc.gpu_indices) == 1
+            assert proc.visible_gpu_indices == frozenset(range(8))
 
         # First 8 processes on node0, next 8 on node1
         node0_processes = [p for p in processes if p.node == "node0"]
@@ -1262,6 +1265,85 @@ class TestVLLMDataParallelMode:
         assert "--nnodes" not in cmd
         assert "--node-rank" not in cmd
         assert "--headless" not in cmd
+
+        # Single-GPU visibility (visible_gpu_indices unset): vLLM can infer
+        # the local DP rank from CUDA_VISIBLE_DEVICES, so we don't pass it.
+        assert "--local-data-parallel-rank" not in cmd
+
+    def test_dp_mode_command_includes_local_dp_rank_with_full_visibility(self):
+        """When the process sees the whole local DP group, the command should pass
+        --local-data-parallel-rank (computed as position among same-node DP processes,
+        not as a GPU index)."""
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Process
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                prefill={
+                    "data-parallel-size": 16,
+                    "enable-expert-parallel": True,
+                },
+            )
+        )
+
+        # 2 nodes × 8 ranks; pick a process on node1 with global dp_rank=10.
+        # Local DP rank on node1 should be 10 - 8 = 2, regardless of which GPU
+        # this rank happens to own.
+        all_node_gpus = frozenset(range(8))
+        process = Process(
+            node="node1",
+            gpu_indices=frozenset([2]),
+            visible_gpu_indices=all_node_gpus,
+            sys_port=8091,
+            http_port=0,
+            endpoint_mode="prefill",
+            endpoint_index=0,
+            node_rank=10,
+        )
+
+        endpoint_processes = [
+            Process(
+                node="node0",
+                gpu_indices=frozenset([i]),
+                visible_gpu_indices=all_node_gpus,
+                sys_port=8081 + i,
+                http_port=0,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=i,
+            )
+            for i in range(8)
+        ] + [
+            Process(
+                node="node1",
+                gpu_indices=frozenset([i]),
+                visible_gpu_indices=all_node_gpus,
+                sys_port=8089 + i,
+                http_port=0,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=8 + i,
+            )
+            for i in range(8)
+        ]
+
+        mock_runtime = MagicMock()
+        mock_runtime.model_path = Path("/model")
+        mock_runtime.is_hf_model = False
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            cmd = backend.build_worker_command(
+                process=process,
+                endpoint_processes=endpoint_processes,
+                runtime=mock_runtime,
+            )
+
+        assert "--local-data-parallel-rank" in cmd
+        idx = cmd.index("--local-data-parallel-rank")
+        assert cmd[idx + 1] == "2"
 
     def test_standard_tp_mode_still_works(self):
         """Test that standard TP mode (no DP) still creates per-node processes."""

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1137,7 +1137,12 @@ class TestVLLMDataParallelMode:
         assert backend_dp._get_dp_size("prefill") == 16
 
     def test_dp_mode_creates_per_gpu_processes(self):
-        """Test that DP mode creates one process per GPU instead of per node."""
+        """Test that DP mode creates one process per GPU instead of per node.
+
+        Default behavior (dp_explicit_local_rank=False): each process owns one
+        GPU and visible_gpu_indices is unset, so CUDA_VISIBLE_DEVICES is
+        constrained to that GPU.
+        """
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
         from srtctl.core.topology import Endpoint
 
@@ -1161,12 +1166,11 @@ class TestVLLMDataParallelMode:
         # Should create 16 processes (1 per GPU), not 2 (1 per node)
         assert len(processes) == 16
 
-        # Each process owns exactly 1 GPU (for telemetry tagging) but is given
-        # visibility to the endpoint's full GPU set on the node so
-        # CUDA_VISIBLE_DEVICES isn't constrained to that single device.
+        # Default flag: each process owns 1 GPU, visible_gpu_indices unset
+        # (CUDA_VISIBLE_DEVICES constrained to that GPU — prior behavior).
         for proc in processes:
             assert len(proc.gpu_indices) == 1
-            assert proc.visible_gpu_indices == frozenset(range(8))
+            assert proc.visible_gpu_indices is None
 
         # First 8 processes on node0, next 8 on node1
         node0_processes = [p for p in processes if p.node == "node0"]
@@ -1183,6 +1187,32 @@ class TestVLLMDataParallelMode:
         # dp_rank (stored in node_rank) should go from 0 to 15
         dp_ranks = [p.node_rank for p in processes]
         assert dp_ranks == list(range(16))
+
+    def test_dp_mode_explicit_local_rank_widens_visibility(self):
+        """With dp_explicit_local_rank=True (newer vLLM convention), processes
+        still own one GPU each but are given visibility to the endpoint's full
+        local GPU set so CUDA_VISIBLE_DEVICES isn't constrained per-rank."""
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                prefill={"data-parallel-size": 16, "enable-expert-parallel": True},
+            ),
+            dp_explicit_local_rank=True,
+        )
+        endpoint = Endpoint(
+            mode="prefill",
+            index=0,
+            nodes=("node0", "node1"),
+            gpu_indices=frozenset(range(8)),
+            gpus_per_node=8,
+        )
+        processes = backend.endpoints_to_processes([endpoint])
+        assert len(processes) == 16
+        for proc in processes:
+            assert len(proc.gpu_indices) == 1
+            assert proc.visible_gpu_indices == frozenset(range(8))
 
     def test_dp_mode_command_includes_dp_flags(self):
         """Test that DP mode command includes correct DP flags instead of TP flags."""

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -137,6 +137,7 @@ def test_worker_stage_wraps_nonfatal_fingerprint_hook(tmp_path: Path) -> None:
         sys_port=5000,
         gpu_indices=list(range(8)),
         cuda_visible_devices="0,1,2,3,4,5,6,7",
+        num_visible_gpus=8,
     )
 
     with (


### PR DESCRIPTION
This solves the same problem as https://github.com/NVIDIA/srt-slurm/pull/90 but keeps "external lb" mode (top-level vllm process per rank) rather than switching to "hybrid lb" mode which funnels all dp ranks' requests through a single frontend process and is undesirable.

Specifically this allows for the gpus assigned to each process to be a proper subset of its `CUDA_VISIBLE_DEVICES` values.

And for vLLM it also sets the `--local-data-parallel-rank` arg, which is needed to identify which local GPUs to use in this case.

Note that this requires a vLLM version which includes yet-to-be merged PR https://github.com/vllm-project/vllm/pull/41164. 

As such I'm assuming that the changes in this PR may need to be adjusted so that the new vllm DP launching behavior can be toggled based on the vLLM version being used?