### PR TITLE
fix: align glm5 gb300 sa-bench rounds with submission baselines

### DIFF
--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen1dep32_batch8_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen1dep32_batch8_eplb0_mtp3.yaml
@@ -117,8 +117,9 @@ benchmark:
   osl: 1024
   concurrencies: "333"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen4tep8_batch16_allconc_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen4tep8_batch16_allconc_eplb0_mtp3.yaml
@@ -119,8 +119,9 @@ benchmark:
   osl: 1024
   concurrencies: "24x44x92"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen4tep8_batch32_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen4tep8_batch32_eplb0_mtp2.yaml
@@ -121,8 +121,9 @@ benchmark:
   osl: 1024
   concurrencies: "180"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen5tep4_batch1_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx1dep2_gen5tep4_batch1_eplb0_mtp3.yaml
@@ -116,8 +116,9 @@ benchmark:
   osl: 1024
   concurrencies: "10"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx2dep2_gen1dep16_batch64_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx2dep2_gen1dep16_batch64_eplb0_mtp2.yaml
@@ -124,8 +124,9 @@ benchmark:
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx2dep2_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx2dep2_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -118,8 +118,9 @@ benchmark:
   osl: 1024
   concurrencies: "666"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx3dep2_gen1dep32_batch32_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx3dep2_gen1dep32_batch32_eplb0_mtp2.yaml
@@ -120,8 +120,9 @@ benchmark:
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx4dep2_gen1dep16_batch256_eplb256_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx4dep2_gen1dep16_batch256_eplb256_mtp1.yaml
@@ -151,8 +151,9 @@ benchmark:
   osl: 1024
   concurrencies: "4301"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx5dep2_gen2dep8_batch512_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx5dep2_gen2dep8_batch512_eplb0_mtp1.yaml
@@ -180,8 +180,9 @@ benchmark:
   osl: 1024
   concurrencies: "8602"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx6dep2_gen1dep32_batch128_eplb288_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/MTP/ctx6dep2_gen1dep32_batch128_eplb288_mtp1.yaml
@@ -135,8 +135,9 @@ benchmark:
   osl: 1024
   concurrencies: "4301"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen1dep32_batch16_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen1dep32_batch16_eplb0_mtp0.yaml
@@ -112,8 +112,9 @@ benchmark:
   osl: 1024
   concurrencies: "615"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen4tep8_batch64_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen4tep8_batch64_allconc_eplb0_mtp0.yaml
@@ -119,8 +119,9 @@ benchmark:
   osl: 1024
   concurrencies: "84x180x336"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0.yaml
@@ -110,8 +110,9 @@ benchmark:
   osl: 1024
   concurrencies: "5x10x25"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx2dep2_gen1dep32_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx2dep2_gen1dep32_batch32_eplb0_mtp0.yaml
@@ -114,8 +114,9 @@ benchmark:
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx3dep2_gen1dep32_batch64_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx3dep2_gen1dep32_batch64_eplb0_mtp0.yaml
@@ -118,8 +118,9 @@ benchmark:
   osl: 1024
   concurrencies: "2253"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx4dep2_gen1dep16_batch512_eplb256_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx4dep2_gen1dep16_batch512_eplb256_mtp0.yaml
@@ -176,8 +176,9 @@ benchmark:
   osl: 1024
   concurrencies: "8192"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx4dep2_gen1dep32_batch128_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx4dep2_gen1dep32_batch128_eplb0_mtp0.yaml
@@ -126,8 +126,9 @@ benchmark:
   osl: 1024
   concurrencies: "4301"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx6dep2_gen1dep32_batch256_eplb288_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx6dep2_gen1dep32_batch256_eplb288_mtp0.yaml
@@ -145,8 +145,9 @@ benchmark:
   osl: 1024
   concurrencies: "8192"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx12dep2_gen1dep16_batch32_eplb0_mtp2.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx12dep2_gen1dep16_batch32_eplb0_mtp2.yaml
@@ -120,8 +120,9 @@ benchmark:
   osl: 1024
   concurrencies: "666"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx13dep2_gen1dep8_batch128_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx13dep2_gen1dep8_batch128_eplb0_mtp1.yaml
@@ -132,8 +132,9 @@ benchmark:
   osl: 1024
   concurrencies: "1076"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx15dep2_gen1dep32_batch16_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx15dep2_gen1dep32_batch16_eplb0_mtp3.yaml
@@ -118,8 +118,9 @@ benchmark:
   osl: 1024
   concurrencies: "666"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx18dep2_gen1dep16_batch64_eplb0_mtp1.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx18dep2_gen1dep16_batch64_eplb0_mtp1.yaml
@@ -124,8 +124,9 @@ benchmark:
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen1tep8_batch16_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen1tep8_batch16_eplb0_mtp3.yaml
@@ -119,8 +119,9 @@ benchmark:
   osl: 1024
   concurrencies: "24"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen2tep8_batch8_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen2tep8_batch8_eplb0_mtp3.yaml
@@ -118,8 +118,9 @@ benchmark:
   osl: 1024
   concurrencies: "22"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen4tep8_batch4_allconc_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen4tep8_batch4_allconc_eplb0_mtp3.yaml
@@ -117,8 +117,9 @@ benchmark:
   osl: 1024
   concurrencies: "4x24"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen5tep4_batch1_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx1dep2_gen5tep4_batch1_eplb0_mtp3.yaml
@@ -116,8 +116,9 @@ benchmark:
   osl: 1024
   concurrencies: "5"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx5dep2_gen1dep32_batch4_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx5dep2_gen1dep32_batch4_eplb0_mtp3.yaml
@@ -116,8 +116,9 @@ benchmark:
   osl: 1024
   concurrencies: "180"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx9dep2_gen1dep32_batch8_eplb0_mtp3.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/MTP/ctx9dep2_gen1dep32_batch8_eplb0_mtp3.yaml
@@ -117,8 +117,9 @@ benchmark:
   osl: 1024
   concurrencies: "333"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx12dep2_gen1dep16_batch64_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx12dep2_gen1dep16_batch64_eplb0_mtp0.yaml
@@ -118,8 +118,9 @@ benchmark:
   osl: 1024
   concurrencies: "1127"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx15dep2_gen1dep32_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx15dep2_gen1dep32_batch32_eplb0_mtp0.yaml
@@ -114,8 +114,9 @@ benchmark:
   osl: 1024
   concurrencies: "1229"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen2tep8_batch16_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen2tep8_batch16_eplb0_mtp0.yaml
@@ -112,8 +112,9 @@ benchmark:
   osl: 1024
   concurrencies: "42"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen4tep8_batch1_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen4tep8_batch1_eplb0_mtp0.yaml
@@ -111,8 +111,9 @@ benchmark:
   osl: 1024
   concurrencies: "4"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx1dep2_gen5tep4_batch4_allconc_eplb0_mtp0.yaml
@@ -110,8 +110,9 @@ benchmark:
   osl: 1024
   concurrencies: "5x10x25"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx20dep2_gen1dep16_batch128_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx20dep2_gen1dep16_batch128_eplb0_mtp0.yaml
@@ -126,8 +126,9 @@ benchmark:
   osl: 1024
   concurrencies: "2151"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx2dep2_gen3tep8_batch32_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx2dep2_gen3tep8_batch32_eplb0_mtp0.yaml
@@ -115,8 +115,9 @@ benchmark:
   osl: 1024
   concurrencies: "117"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx4dep2_gen3tep8_batch64_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx4dep2_gen3tep8_batch64_eplb0_mtp0.yaml
@@ -119,8 +119,9 @@ benchmark:
   osl: 1024
   concurrencies: "231"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx9dep2_gen1dep32_batch16_eplb0_mtp0.yaml
+++ b/recipes/GLM5/disagg/trtllm_dynamo/gb300_nvfp4/ISL8K_OSL1K/STP/ctx9dep2_gen1dep32_batch16_eplb0_mtp0.yaml
@@ -112,8 +112,9 @@ benchmark:
   osl: 1024
   concurrencies: "615"
   req_rate: "inf"
+  num_prompts_mult: 16
   custom_tokenizer: "glm_moe_dsa"
-  use_chat_template: false
+  use_chat_template: true
 
 frontend:
   type: "dynamo"

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -83,7 +83,7 @@ PORT=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f2 | cut -d/ -f1)
 
 WORK_DIR="$(dirname "$0")"
 
-echo "SA-Bench Config: endpoint=${ENDPOINT}; isl=${ISL}; osl=${OSL}; concurrencies=${CONCURRENCIES}; req_rate=${REQ_RATE}; model=${MODEL_NAME}"
+echo "SA-Bench Config: endpoint=${ENDPOINT}; isl=${ISL}; osl=${OSL}; concurrencies=${CONCURRENCIES}; req_rate=${REQ_RATE}; model=${MODEL_NAME}; num_prompts_mult=${NUM_PROMPTS_MULT}; num_warmup_mult=${NUM_WARMUP_MULT}"
 
 # Profiling shared helpers
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -138,7 +138,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --trust-remote-code \
         "${CUSTOM_TOKENIZER_ARGS[@]}"
 
-    num_prompts=$((concurrency * 10))
+    num_prompts=$((concurrency * NUM_PROMPTS_MULT))
     
     # Generate result filename based on mode
     if [ "$IS_DISAGGREGATED" = "true" ]; then


### PR DESCRIPTION
Set GLM5 GB300 trtllm_dynamo recipes to use chat template and num_prompts_mult=16 so throughput runs match TRTLLM multi-round methodology, while keeping warmup fixed at 2x.