### PR TITLE
feat: live in-flight batch-metrics snapshotter (opt-in)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "rich>=13.0.0",
     "questionary>=2.0.0",
     "ruamel.yaml>=0.18.0",
+    "matplotlib>=3.7.0",
 ]
 
 [project.scripts]

--- a/src/srtctl/analysis/__init__.py
+++ b/src/srtctl/analysis/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable benchmark-log analysis utilities.
+
+Currently exposes the in-flight batch-metrics live snapshotter
+(:mod:`.live_metrics`) and its underlying log parser
+(:mod:`.batch_log_parser`).
+"""

--- a/src/srtctl/analysis/batch_log_parser.py
+++ b/src/srtctl/analysis/batch_log_parser.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Incremental parser for SGLang prefill/decode batch-log lines.
+
+This module is intentionally narrow: it walks worker log files in a
+``logs/`` directory and extracts numeric metrics from
+``Prefill batch, ...`` / ``Decode batch, ...`` lines. It does not
+aggregate, plot, or interpret the data.
+
+A :class:`LogState` is kept across snapshot ticks so re-parsing a
+multi-hour benchmark every minute stays cheap — only newly appended
+bytes are read on each ``refresh()``.
+
+A line we parse looks like (one of two timestamp variants observed in
+SGLang scheduler logs)::
+
+    p0\\x1b[2m2026-04-27T23:03:15.250907Z\\x1b[0m ... Prefill batch,
+        #new-seq: 1, #new-token: 256, #cached-token: 0,
+        full token usage: 0.00, #running-req: 0, #queue-req: 0,
+        #prealloc-req: 0, #inflight-req: 0,
+        input throughput (token/s): 0.00,
+
+    [2025-11-04 05:31:43 DP0 TP0 EP0] Decode batch, #running-req: 1,
+        #full token: 7424, full token usage: 0.00,
+        ..., gen throughput (token/s): 0.03, #queue-req: 0,
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Field definitions
+# ---------------------------------------------------------------------------
+
+PREFILL_METRICS: dict[str, str] = {
+    "#new-seq": r"#new-seq:\s*([\d.]+)",
+    "#new-token": r"#new-token:\s*([\d.]+)",
+    "#cached-token": r"#cached-token:\s*([\d.]+)",
+    "full token usage": r"full token usage:\s*([\d.]+)",
+    "#running-req": r"#running-req:\s*([\d.]+)",
+    "#queue-req": r"#queue-req:\s*([\d.]+)",
+    "#prealloc-req": r"#prealloc-req:\s*([\d.]+)",
+    "#inflight-req": r"#inflight-req:\s*([\d.]+)",
+    "input throughput (token/s)": r"input throughput \(token/s\):\s*([\d.]+)",
+}
+
+DECODE_METRICS: dict[str, str] = {
+    "#running-req": r"#running-req:\s*([\d.]+)",
+    "#full token": r"#full token:\s*([\d.]+)",
+    "full token usage": r"full token usage:\s*([\d.]+)",
+    "#prealloc-req": r"#prealloc-req:\s*([\d.]+)",
+    "#transfer-req": r"#transfer-req:\s*([\d.]+)",
+    "#retracted-req": r"#retracted-req:\s*([\d.]+)",
+    "gen throughput (token/s)": r"gen throughput \(token/s\):\s*([\d.]+)",
+    "#queue-req": r"#queue-req:\s*([\d.]+)",
+}
+
+PREFILL_KEYWORD = "Prefill batch"
+DECODE_KEYWORD = "Decode batch"
+
+# Compiled lazily.
+_PATTERN_CACHE: dict[str, re.Pattern[str]] = {}
+
+# Two timestamp variants seen across SGLang versions.
+_TS_ANSI = re.compile(r"\[2m(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}\.\d+)")
+_TS_BRACKET = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
+
+
+def _pattern(raw: str) -> re.Pattern[str]:
+    cached = _PATTERN_CACHE.get(raw)
+    if cached is None:
+        cached = re.compile(raw)
+        _PATTERN_CACHE[raw] = cached
+    return cached
+
+
+def _parse_timestamp(line: str) -> datetime | None:
+    m = _TS_ANSI.search(line)
+    if m:
+        try:
+            return datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M:%S.%f")
+        except ValueError:
+            return None
+    m = _TS_BRACKET.search(line)
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-file series
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FileSeries:
+    """Time-series accumulated from one worker log file.
+
+    Mutated in place by :func:`parse_file_incremental` so successive
+    snapshot ticks only read newly appended bytes (using ``byte_offset``
+    as the resume point).
+    """
+
+    path: Path
+    timestamps: list[datetime] = field(default_factory=list)
+    metrics: dict[str, list[float | None]] = field(default_factory=dict)
+    byte_offset: int = 0
+
+    @property
+    def empty(self) -> bool:
+        return not self.timestamps
+
+    @property
+    def label(self) -> str:
+        """Short legend label for plotting (filename minus extension)."""
+        stem = self.path.name
+        for ext in (".out", ".err"):
+            if stem.endswith(ext):
+                stem = stem[: -len(ext)]
+                break
+        return stem
+
+
+def parse_file_incremental(series: FileSeries, keyword: str, metrics_def: dict[str, str]) -> int:
+    """Append rows parsed from new bytes in ``series.path`` onto ``series``.
+
+    Returns the number of new rows appended this call.
+    """
+    for name in metrics_def:
+        series.metrics.setdefault(name, [])
+
+    try:
+        size = series.path.stat().st_size
+    except FileNotFoundError:
+        return 0
+    if size <= series.byte_offset:
+        return 0
+
+    new_rows = 0
+    try:
+        with open(series.path, errors="replace") as f:
+            f.seek(series.byte_offset)
+            for line in f:
+                if keyword not in line:
+                    continue
+                ts = _parse_timestamp(line)
+                if ts is None:
+                    continue
+
+                values: dict[str, float | None] = {}
+                any_value = False
+                for name, raw in metrics_def.items():
+                    m = _pattern(raw).search(line)
+                    if m is None:
+                        values[name] = None
+                        continue
+                    try:
+                        values[name] = float(m.group(1))
+                        any_value = True
+                    except ValueError:
+                        values[name] = None
+
+                if not any_value:
+                    continue
+
+                series.timestamps.append(ts)
+                for name in metrics_def:
+                    series.metrics[name].append(values[name])
+                new_rows += 1
+
+            series.byte_offset = f.tell()
+    except OSError as e:
+        logger.warning("failed to read %s: %s", series.path, e)
+        return 0
+
+    return new_rows
+
+
+# ---------------------------------------------------------------------------
+# Log directory discovery + state
+# ---------------------------------------------------------------------------
+
+
+def _classify_log_files(log_dir: Path) -> tuple[list[Path], list[Path]]:
+    """Find prefill/decode worker logs in ``log_dir``.
+
+    Filenames containing ``prefill`` go to the prefill list, ``decode``
+    to the decode list. ``_agg_`` files (aggregated mode) are added to
+    both since they carry both prefill and decode batch lines.
+    """
+    if not log_dir.is_dir():
+        return [], []
+
+    prefill: list[Path] = []
+    decode: list[Path] = []
+    agg: list[Path] = []
+    for entry in sorted(os.listdir(log_dir)):
+        if not (entry.endswith(".out") or entry.endswith(".err")):
+            continue
+        path = log_dir / entry
+        if "prefill" in entry:
+            prefill.append(path)
+        elif "decode" in entry:
+            decode.append(path)
+        elif "_agg_" in entry:
+            agg.append(path)
+
+    return prefill + agg, decode + agg
+
+
+@dataclass
+class LogState:
+    """Per-log-dir incremental parse state.
+
+    A single instance is created when the snapshotter starts and reused
+    across all ticks: file discovery is re-run on every refresh (workers
+    can come up late), but each file's bytes are only read once.
+    """
+
+    log_dir: Path
+    prefill_files: dict[Path, FileSeries] = field(default_factory=dict)
+    decode_files: dict[Path, FileSeries] = field(default_factory=dict)
+
+    def refresh(self) -> tuple[int, int]:
+        """Re-discover files and parse newly appended bytes.
+
+        Returns ``(new_prefill_rows, new_decode_rows)`` parsed this call.
+        """
+        pf_paths, dc_paths = _classify_log_files(self.log_dir)
+
+        new_pf = 0
+        for p in pf_paths:
+            s = self.prefill_files.setdefault(p, FileSeries(path=p))
+            new_pf += parse_file_incremental(s, PREFILL_KEYWORD, PREFILL_METRICS)
+
+        new_dc = 0
+        for p in dc_paths:
+            s = self.decode_files.setdefault(p, FileSeries(path=p))
+            new_dc += parse_file_incremental(s, DECODE_KEYWORD, DECODE_METRICS)
+
+        return new_pf, new_dc
+
+    @property
+    def has_data(self) -> bool:
+        return any(not s.empty for s in self.prefill_files.values()) or any(
+            not s.empty for s in self.decode_files.values()
+        )

--- a/src/srtctl/analysis/batch_log_parser.py
+++ b/src/srtctl/analysis/batch_log_parser.py
@@ -124,12 +124,22 @@ class FileSeries:
 
     @property
     def label(self) -> str:
-        """Short legend label for plotting (filename minus extension)."""
+        """Short legend label for plotting.
+
+        Tries to extract just the worker index from typical SLURM-named
+        files such as ``slurm-gb300-133-181_prefill_w0.out`` -> ``"p0"``
+        or ``..._decode_w3.out`` -> ``"d3"``. Falls back to the full
+        filename stem when it can't infer a short form.
+        """
         stem = self.path.name
         for ext in (".out", ".err"):
             if stem.endswith(ext):
                 stem = stem[: -len(ext)]
                 break
+        # Match ``<anything>_(prefill|decode|agg)_w<n>``.
+        m = re.search(r"_(prefill|decode|agg)_w(\d+)$", stem)
+        if m:
+            return f"{m.group(1)[0]}{m.group(2)}"
         return stem
 
 

--- a/src/srtctl/analysis/live_metrics.py
+++ b/src/srtctl/analysis/live_metrics.py
@@ -69,35 +69,54 @@ def _global_origin(prefill: Iterable[FileSeries], decode: Iterable[FileSeries]) 
     return first_seen
 
 
+# ---------------------------------------------------------------------------
+# Plot layout: (prefill_metric, decode_metric) row pairs.
+# Use None to leave a cell empty. Only metrics listed here are plotted;
+# all parsed metrics remain available in LogState for other consumers.
+# To add/remove/reorder rows, edit this list — no other code needs to
+# change.
+# ---------------------------------------------------------------------------
+_PLOT_ROWS: list[tuple[str | None, str | None]] = [
+    ("input throughput (token/s)", "gen throughput (token/s)"),
+    ("#new-seq",                   "#running-req"),
+    ("#new-token",                 "#full token"),
+    ("#cached-token",              "full token usage"),
+    ("#prealloc-req",              "#prealloc-req"),
+    ("#queue-req",                 "#queue-req"),
+    ("#inflight-req",              "#transfer-req"),
+]
+
+
 def _render_png(
     state: LogState,
     output_path: Path,
     title: str,
     downsample: int,
 ) -> None:
-    """Render per-worker time-series for every metric to a PNG.
+    """Render per-worker time-series to a PNG.
 
-    Layout: prefill metrics in column 0, decode metrics in column 1, one
-    metric per row. Each axis carries one line per worker file.
+    Layout is driven by ``_PLOT_ROWS``: each entry is a
+    ``(prefill_metric, decode_metric)`` pair drawn on the same row so
+    semantically related metrics sit side-by-side. Either cell can be
+    ``None`` to leave it blank.
     """
-    # Lazy import keeps the analysis subpackage usable for parser-only
-    # consumers (and lets the orchestrator survive matplotlib being
-    # missing — see try_start_snapshotter).
     import matplotlib
 
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
+    import numpy as np
 
     pf_files = [s for s in state.prefill_files.values() if not s.empty]
     dc_files = [s for s in state.decode_files.values() if not s.empty]
 
     origin = _global_origin(pf_files, dc_files)
     if origin is None:
-        return  # nothing to draw — caller already gated on has_data
+        return
 
-    pf_metrics = list(PREFILL_METRICS.keys())
-    dc_metrics = list(DECODE_METRICS.keys())
-    n_rows = max(len(pf_metrics), len(dc_metrics))
+    n_rows = len(_PLOT_ROWS)
+    # Use tab20 so up to 20 workers each get a distinct colour.
+    cmap = plt.cm.get_cmap("tab20", max(len(pf_files), len(dc_files), 1))
+    colors = [cmap(i) for i in range(cmap.N)]
 
     fig, axes = plt.subplots(n_rows, 2, figsize=(20, 3.0 * n_rows), squeeze=False)
     fig.suptitle(
@@ -107,48 +126,41 @@ def _render_png(
         y=1.0,
     )
 
-    colors = plt.cm.tab10.colors
+    def _draw_ax(ax: "plt.Axes", metric: str | None, files: list[FileSeries], side: str) -> None:
+        if metric is None:
+            ax.set_visible(False)
+            return
 
-    def _plot_column(col: int, metrics: list[str], files: list[FileSeries]) -> None:
-        for row, metric in enumerate(metrics):
-            ax = axes[row][col]
-            drawn = False
-            for idx, s in enumerate(files):
-                vs = s.metrics.get(metric)
-                if not vs:
-                    continue
-                pairs = [(t, v) for t, v in zip(s.timestamps, vs, strict=False) if v is not None]
-                if downsample > 1:
-                    pairs = pairs[::downsample]
-                if not pairs:
-                    continue
-                stamps = [p[0] for p in pairs]
-                values = [p[1] for p in pairs]
-                ax.plot(
-                    _elapsed_seconds(stamps, origin),
-                    values,
-                    color=colors[idx % len(colors)],
-                    linewidth=0.8,
-                    alpha=0.85,
-                    label=s.label,
-                )
-                drawn = True
+        drawn = False
+        for idx, s in enumerate(files):
+            vs = s.metrics.get(metric)
+            if not vs:
+                continue
+            pairs = [(t, v) for t, v in zip(s.timestamps, vs, strict=False) if v is not None]
+            if downsample > 1:
+                pairs = pairs[::downsample]
+            if not pairs:
+                continue
+            elapsed = _elapsed_seconds([p[0] for p in pairs], origin)
+            values = [p[1] for p in pairs]
+            ax.plot(elapsed, values, color=colors[idx % len(colors)],
+                    linewidth=0.9, alpha=0.8, label=s.label)
+            drawn = True
 
-            ax.set_title(("Prefill" if col == 0 else "Decode") + f": {metric}", fontsize=10, fontweight="bold")
-            ax.set_xlabel("Elapsed (s)", fontsize=8)
-            ax.set_ylabel(metric, fontsize=8)
-            ax.tick_params(labelsize=7)
-            ax.grid(True, alpha=0.3)
-            if not drawn:
-                ax.text(0.5, 0.5, "no data", ha="center", va="center", transform=ax.transAxes, color="grey", fontsize=9)
-            elif len(files) > 1:
-                ax.legend(fontsize=6, loc="upper right", ncol=2)
+        ax.set_title(f"{side}: {metric}", fontsize=10, fontweight="bold")
+        ax.set_xlabel("Elapsed (s)", fontsize=8)
+        ax.set_ylabel(metric, fontsize=8)
+        ax.tick_params(labelsize=7)
+        ax.grid(True, alpha=0.3)
+        if not drawn:
+            ax.text(0.5, 0.5, "no data", ha="center", va="center",
+                    transform=ax.transAxes, color="grey", fontsize=9)
+        elif files:
+            ax.legend(fontsize=7, loc="upper right", ncol=max(1, len(files) // 8 + 1))
 
-        for hidden in range(len(metrics), n_rows):
-            axes[hidden][col].set_visible(False)
-
-    _plot_column(0, pf_metrics, pf_files)
-    _plot_column(1, dc_metrics, dc_files)
+    for row, (pf_metric, dc_metric) in enumerate(_PLOT_ROWS):
+        _draw_ax(axes[row][0], pf_metric, pf_files, "Prefill")
+        _draw_ax(axes[row][1], dc_metric, dc_files, "Decode")
 
     plt.tight_layout()
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/srtctl/analysis/live_metrics.py
+++ b/src/srtctl/analysis/live_metrics.py
@@ -76,12 +76,12 @@ def _global_origin(prefill: Iterable[FileSeries], decode: Iterable[FileSeries]) 
 # ---------------------------------------------------------------------------
 _PLOT_ROWS: list[tuple[str | None, str | None]] = [
     ("input throughput (token/s)", "gen throughput (token/s)"),
-    ("#new-seq",                   "#running-req"),
-    ("#new-token",                 "#full token"),
-    ("#cached-token",              "full token usage"),
-    ("#prealloc-req",              "#prealloc-req"),
-    ("#queue-req",                 "#queue-req"),
-    ("#inflight-req",              "#transfer-req"),
+    ("#new-seq", "#running-req"),
+    ("#new-token", "#full token"),
+    ("#cached-token", "full token usage"),
+    ("#prealloc-req", "#prealloc-req"),
+    ("#queue-req", "#queue-req"),
+    ("#inflight-req", "#transfer-req"),
 ]
 
 
@@ -140,8 +140,7 @@ def _render_png(
                 continue
             elapsed = _elapsed_seconds([p[0] for p in pairs], origin)
             values = [p[1] for p in pairs]
-            ax.plot(elapsed, values, color=colors[idx % len(colors)],
-                    linewidth=0.9, alpha=0.8, label=s.label)
+            ax.plot(elapsed, values, color=colors[idx % len(colors)], linewidth=0.9, alpha=0.8, label=s.label)
             drawn = True
 
         ax.set_title(f"{side}: {metric}", fontsize=10, fontweight="bold")
@@ -150,8 +149,7 @@ def _render_png(
         ax.tick_params(labelsize=7)
         ax.grid(True, alpha=0.3)
         if not drawn:
-            ax.text(0.5, 0.5, "no data", ha="center", va="center",
-                    transform=ax.transAxes, color="grey", fontsize=9)
+            ax.text(0.5, 0.5, "no data", ha="center", va="center", transform=ax.transAxes, color="grey", fontsize=9)
         elif files:
             ax.legend(fontsize=7, loc="upper right", ncol=max(1, len(files) // 8 + 1))
 

--- a/src/srtctl/analysis/live_metrics.py
+++ b/src/srtctl/analysis/live_metrics.py
@@ -315,7 +315,7 @@ def try_start_snapshotter(
         logger.debug("Live metrics: failed to load cluster config: %s", e)
         return None
 
-    cfg = (cluster_config or {}).get("reporting", {}).get("live_metrics") if cluster_config else None
+    cfg = (cluster_config or {}).get("telemetry", {}).get("live_metrics") if cluster_config else None
     if not cfg or not cfg.get("enabled"):
         return None
 

--- a/src/srtctl/analysis/live_metrics.py
+++ b/src/srtctl/analysis/live_metrics.py
@@ -36,8 +36,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from srtctl.analysis.batch_log_parser import (
-    DECODE_METRICS,
-    PREFILL_METRICS,
     FileSeries,
     LogState,
 )
@@ -104,7 +102,6 @@ def _render_png(
 
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
-    import numpy as np
 
     pf_files = [s for s in state.prefill_files.values() if not s.empty]
     dc_files = [s for s in state.decode_files.values() if not s.empty]
@@ -126,7 +123,7 @@ def _render_png(
         y=1.0,
     )
 
-    def _draw_ax(ax: "plt.Axes", metric: str | None, files: list[FileSeries], side: str) -> None:
+    def _draw_ax(ax: plt.Axes, metric: str | None, files: list[FileSeries], side: str) -> None:
         if metric is None:
             ax.set_visible(False)
             return

--- a/src/srtctl/analysis/live_metrics.py
+++ b/src/srtctl/analysis/live_metrics.py
@@ -316,15 +316,8 @@ def try_start_snapshotter(
     if not cfg or not cfg.get("enabled"):
         return None
 
-    try:
-        import matplotlib  # noqa: F401  -- imported here so we fail fast & loud
-    except ImportError as e:
-        logger.warning(
-            "Live metrics enabled in cluster config but matplotlib is not installed (%s); "
-            "skipping snapshotter",
-            e,
-        )
-        return None
+    # matplotlib is a required srtctl dependency (see pyproject.toml), so we
+    # do not need a runtime presence check here.
 
     try:
         snap = LiveMetricsSnapshotter(

--- a/src/srtctl/analysis/live_metrics.py
+++ b/src/srtctl/analysis/live_metrics.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-flight batch-metrics snapshotter.
+
+The orchestrator runs on the head node and shares a filesystem with the
+worker logs (``outputs/<jobid>/logs/*prefill_w*.out`` etc.), so we can
+poll those logs from a background daemon thread without ssh / scp /
+container hops. Every ``interval_seconds`` we incrementally re-parse the
+freshly appended bytes (see :class:`.batch_log_parser.LogState`) and
+overwrite ``batch_metrics.png`` in place.
+
+Usage from the orchestrator:
+
+>>> snap = try_start_snapshotter(log_dir=runtime.log_dir, stop_event=ev)
+>>> try:
+...     ...  # run benchmark
+... finally:
+...     if snap is not None:
+...         snap.stop()
+
+The plot view is intentionally simple: one line per worker file per
+metric, no cluster-wide aggregation, no DP-rank scaling. Aggregated
+views can be added in a follow-up without touching the snapshotter or
+the parser.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from srtctl.analysis.batch_log_parser import (
+    DECODE_METRICS,
+    PREFILL_METRICS,
+    FileSeries,
+    LogState,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Plotting (lazy matplotlib import)
+# ---------------------------------------------------------------------------
+
+
+def _elapsed_seconds(stamps: list[datetime], origin: datetime) -> list[float]:
+    return [(t - origin).total_seconds() for t in stamps]
+
+
+def _global_origin(prefill: Iterable[FileSeries], decode: Iterable[FileSeries]) -> datetime | None:
+    """Earliest timestamp seen across all worker files, or ``None`` if empty."""
+    first_seen: datetime | None = None
+    for s in (*prefill, *decode):
+        if s.empty:
+            continue
+        candidate = s.timestamps[0]
+        if first_seen is None or candidate < first_seen:
+            first_seen = candidate
+    return first_seen
+
+
+def _render_png(
+    state: LogState,
+    output_path: Path,
+    title: str,
+    downsample: int,
+) -> None:
+    """Render per-worker time-series for every metric to a PNG.
+
+    Layout: prefill metrics in column 0, decode metrics in column 1, one
+    metric per row. Each axis carries one line per worker file.
+    """
+    # Lazy import keeps the analysis subpackage usable for parser-only
+    # consumers (and lets the orchestrator survive matplotlib being
+    # missing — see try_start_snapshotter).
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    pf_files = [s for s in state.prefill_files.values() if not s.empty]
+    dc_files = [s for s in state.decode_files.values() if not s.empty]
+
+    origin = _global_origin(pf_files, dc_files)
+    if origin is None:
+        return  # nothing to draw — caller already gated on has_data
+
+    pf_metrics = list(PREFILL_METRICS.keys())
+    dc_metrics = list(DECODE_METRICS.keys())
+    n_rows = max(len(pf_metrics), len(dc_metrics))
+
+    fig, axes = plt.subplots(n_rows, 2, figsize=(20, 3.0 * n_rows), squeeze=False)
+    fig.suptitle(
+        f"{title}\nprefill: {len(pf_files)} workers · decode: {len(dc_files)} workers",
+        fontsize=13,
+        fontweight="bold",
+        y=1.0,
+    )
+
+    colors = plt.cm.tab10.colors
+
+    def _plot_column(col: int, metrics: list[str], files: list[FileSeries]) -> None:
+        for row, metric in enumerate(metrics):
+            ax = axes[row][col]
+            drawn = False
+            for idx, s in enumerate(files):
+                vs = s.metrics.get(metric)
+                if not vs:
+                    continue
+                pairs = [(t, v) for t, v in zip(s.timestamps, vs, strict=False) if v is not None]
+                if downsample > 1:
+                    pairs = pairs[::downsample]
+                if not pairs:
+                    continue
+                stamps = [p[0] for p in pairs]
+                values = [p[1] for p in pairs]
+                ax.plot(
+                    _elapsed_seconds(stamps, origin),
+                    values,
+                    color=colors[idx % len(colors)],
+                    linewidth=0.8,
+                    alpha=0.85,
+                    label=s.label,
+                )
+                drawn = True
+
+            ax.set_title(("Prefill" if col == 0 else "Decode") + f": {metric}", fontsize=10, fontweight="bold")
+            ax.set_xlabel("Elapsed (s)", fontsize=8)
+            ax.set_ylabel(metric, fontsize=8)
+            ax.tick_params(labelsize=7)
+            ax.grid(True, alpha=0.3)
+            if not drawn:
+                ax.text(0.5, 0.5, "no data", ha="center", va="center", transform=ax.transAxes, color="grey", fontsize=9)
+            elif len(files) > 1:
+                ax.legend(fontsize=6, loc="upper right", ncol=2)
+
+        for hidden in range(len(metrics), n_rows):
+            axes[hidden][col].set_visible(False)
+
+    _plot_column(0, pf_metrics, pf_files)
+    _plot_column(1, dc_metrics, dc_files)
+
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic-ish write: render to a sibling tmp file then rename, so
+    # readers (e.g. an image viewer with auto-reload) never see a
+    # half-written PNG. Append ``.tmp`` to the full filename rather than
+    # replacing the suffix (which would confuse matplotlib's format
+    # inference).
+    tmp = output_path.parent / (output_path.name + ".tmp")
+    fig.savefig(tmp, dpi=110, bbox_inches="tight", format="png")
+    plt.close(fig)
+    os.replace(tmp, output_path)
+
+
+# ---------------------------------------------------------------------------
+# Snapshotter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SnapshotterParams:
+    log_dir: Path
+    output_path: Path
+    interval_seconds: int
+    downsample: int
+
+
+class LiveMetricsSnapshotter:
+    """Daemon thread that periodically refreshes ``batch_metrics.png``.
+
+    Best-effort: any exception from a tick is logged and swallowed so
+    the snapshotter can never fail a benchmark run. Parsing is
+    incremental (file byte offsets cached in :class:`LogState`), so
+    long-running benchmarks stay cheap.
+    """
+
+    def __init__(
+        self,
+        log_dir: Path,
+        interval_seconds: int = 60,
+        downsample: int = 1,
+        output_filename: str = "batch_metrics.png",
+        title: str | None = None,
+    ) -> None:
+        self._params = _SnapshotterParams(
+            log_dir=Path(log_dir),
+            output_path=Path(log_dir) / output_filename,
+            interval_seconds=max(5, int(interval_seconds)),
+            downsample=max(1, int(downsample)),
+        )
+        self._title = title or f"{Path(log_dir).resolve().parent.name} batch metrics"
+        self._state = LogState(log_dir=self._params.log_dir)
+        self._stop_event: threading.Event | None = None
+        self._thread: threading.Thread | None = None
+        self._tick_count = 0
+
+    # ---- lifecycle ----------------------------------------------------
+
+    def start(self, stop_event: threading.Event | None = None) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event = stop_event or threading.Event()
+        self._thread = threading.Thread(target=self._loop, name="LiveMetricsSnapshotter", daemon=True)
+        self._thread.start()
+        logger.info(
+            "Live batch-metrics snapshotter started: log_dir=%s interval=%ds output=%s",
+            self._params.log_dir,
+            self._params.interval_seconds,
+            self._params.output_path,
+        )
+
+    def stop(self, timeout: float = 10.0) -> None:
+        if self._stop_event is not None:
+            self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            if self._thread.is_alive():
+                logger.warning("Live metrics snapshotter did not exit within %.1fs", timeout)
+        self._thread = None
+
+    # ---- tick loop ----------------------------------------------------
+
+    def _tick(self) -> None:
+        try:
+            self._state.refresh()
+            if not self._state.has_data:
+                return
+            _render_png(
+                state=self._state,
+                output_path=self._params.output_path,
+                title=self._title,
+                downsample=self._params.downsample,
+            )
+            self._tick_count += 1
+            logger.debug(
+                "Live metrics tick #%d wrote %s (prefill_files=%d, decode_files=%d)",
+                self._tick_count,
+                self._params.output_path,
+                len(self._state.prefill_files),
+                len(self._state.decode_files),
+            )
+        except Exception as e:  # never let snapshot failures affect the benchmark
+            logger.warning("Live metrics snapshot failed: %s", e, exc_info=False)
+
+    def _loop(self) -> None:
+        assert self._stop_event is not None
+        # Give workers a few seconds to print their first batch lines so
+        # the very first scheduled PNG isn't empty. Don't return early
+        # on stop: still try one final tick below so a benchmark that
+        # crashed before the first interval still produces a snapshot.
+        warmup = min(self._params.interval_seconds, 15)
+        warmed_stopped = self._stop_event.wait(timeout=warmup)
+
+        if not warmed_stopped:
+            while not self._stop_event.is_set():
+                self._tick()
+                if self._stop_event.wait(timeout=self._params.interval_seconds):
+                    break
+
+        # Final tick: reflects the very end of the run (post-benchmark
+        # / post-cleanup), or — if we were stopped during warmup — the
+        # only snapshot we'll write at all.
+        self._tick()
+        logger.info("Live metrics snapshotter exited after %d ticks", self._tick_count)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator-facing helper
+# ---------------------------------------------------------------------------
+
+
+def try_start_snapshotter(
+    log_dir: Path,
+    stop_event: threading.Event,
+) -> LiveMetricsSnapshotter | None:
+    """Start a snapshotter if cluster config opts in, otherwise return ``None``.
+
+    All failures (matplotlib missing, malformed config, thread refused
+    to start) are logged and swallowed: live metrics is best-effort
+    visualisation, never a hard dependency on the benchmark path. This
+    is the single entry point :class:`BenchmarkStageMixin` uses, which
+    keeps the mixin free of any analysis-package internals.
+    """
+    try:
+        from srtctl.core.config import load_cluster_config
+    except ImportError:  # pragma: no cover - defensive
+        return None
+
+    try:
+        cluster_config = load_cluster_config()
+    except Exception as e:
+        logger.debug("Live metrics: failed to load cluster config: %s", e)
+        return None
+
+    cfg = (cluster_config or {}).get("reporting", {}).get("live_metrics") if cluster_config else None
+    if not cfg or not cfg.get("enabled"):
+        return None
+
+    try:
+        import matplotlib  # noqa: F401  -- imported here so we fail fast & loud
+    except ImportError as e:
+        logger.warning(
+            "Live metrics enabled in cluster config but matplotlib is not installed (%s); "
+            "skipping snapshotter",
+            e,
+        )
+        return None
+
+    try:
+        snap = LiveMetricsSnapshotter(
+            log_dir=log_dir,
+            interval_seconds=int(cfg.get("interval_seconds", 60)),
+            downsample=int(cfg.get("downsample", 1)),
+        )
+        snap.start(stop_event)
+        return snap
+    except Exception as e:
+        logger.warning("Failed to start live metrics snapshotter: %s", e)
+        return None

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -176,6 +176,7 @@ class BenchmarkStageMixin:
         stop_event: threading.Event,
     ) -> int:
         """Run the actual benchmark script."""
+        from srtctl.analysis.live_metrics import try_start_snapshotter
 
         cmd = runner.build_command(self.config, self.runtime)
         env_to_set = self._get_benchmark_env(runner)
@@ -187,6 +188,10 @@ class BenchmarkStageMixin:
         logger.info("Command: %s", shlex.join(cmd))
         logger.info("Log: %s", log_file)
 
+        # Optional in-flight batch-metrics snapshotter — no-op unless
+        # opted in via reporting.live_metrics in the cluster config.
+        snapshotter = try_start_snapshotter(self.runtime.log_dir, stop_event)
+
         proc = start_srun_process(
             command=cmd,
             nodelist=[self.runtime.nodes.head],
@@ -196,15 +201,17 @@ class BenchmarkStageMixin:
             env_to_set=env_to_set,
         )
 
-        # Wait for benchmark to complete
-        while proc.poll() is None:
-            if stop_event.is_set():
-                logger.info("Stop requested, terminating benchmark")
-                proc.terminate()
-                return 1
-            time.sleep(1)
-
-        return proc.returncode or 0
+        try:
+            while proc.poll() is None:
+                if stop_event.is_set():
+                    logger.info("Stop requested, terminating benchmark")
+                    proc.terminate()
+                    return 1
+                time.sleep(1)
+            return proc.returncode or 0
+        finally:
+            if snapshotter is not None:
+                snapshotter.stop()
 
     def _get_benchmark_profiling_env(self, runner: "BenchmarkRunner") -> dict[str, str]:
         """Get environment variables for the benchmark script."""

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -65,12 +65,34 @@ class ReportingStatusConfig:
 
 
 @dataclass(frozen=True)
+class LiveMetricsConfig:
+    """Configuration for the in-flight batch-metrics snapshotter.
+
+    When enabled, the orchestrator spawns a daemon thread during the
+    benchmark stage that re-parses prefill/decode worker logs every
+    ``interval_seconds`` and overwrites ``<log_dir>/batch_metrics.png``
+    in place, giving a near-real-time view of the run without any
+    external monitoring stack.
+
+    Lives entirely in :mod:`srtctl.analysis.live_metrics`; this dataclass
+    only defines the user-visible knobs.
+    """
+
+    enabled: bool = False
+    interval_seconds: int = 60
+    downsample: int = 1
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
 class ReportingConfig:
     """Reporting configuration for status updates, AI analysis, and log exports."""
 
     status: ReportingStatusConfig | None = None
     ai_analysis: "AIAnalysisConfig | None" = None
     s3: "S3Config | None" = None
+    live_metrics: LiveMetricsConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -65,34 +65,12 @@ class ReportingStatusConfig:
 
 
 @dataclass(frozen=True)
-class LiveMetricsConfig:
-    """Configuration for the in-flight batch-metrics snapshotter.
-
-    When enabled, the orchestrator spawns a daemon thread during the
-    benchmark stage that re-parses prefill/decode worker logs every
-    ``interval_seconds`` and overwrites ``<log_dir>/batch_metrics.png``
-    in place, giving a near-real-time view of the run without any
-    external monitoring stack.
-
-    Lives entirely in :mod:`srtctl.analysis.live_metrics`; this dataclass
-    only defines the user-visible knobs.
-    """
-
-    enabled: bool = False
-    interval_seconds: int = 60
-    downsample: int = 1
-
-    Schema: ClassVar[type[Schema]] = Schema
-
-
-@dataclass(frozen=True)
 class ReportingConfig:
     """Reporting configuration for status updates, AI analysis, and log exports."""
 
     status: ReportingStatusConfig | None = None
     ai_analysis: "AIAnalysisConfig | None" = None
     s3: "S3Config | None" = None
-    live_metrics: LiveMetricsConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
 
@@ -892,11 +870,35 @@ class TelemetryExporterConfig:
 
 
 @dataclass(frozen=True)
+class LiveMetricsConfig:
+    """In-flight batch-metrics snapshotter (a form of lightweight telemetry).
+
+    When enabled, the orchestrator spawns a daemon thread during the benchmark
+    stage that re-parses prefill/decode worker logs every ``interval_seconds``
+    and atomically overwrites ``<log_dir>/batch_metrics.png``, giving a
+    near-real-time view of the run without any external monitoring stack.
+
+    Lives entirely in :mod:`srtctl.analysis.live_metrics`; this dataclass
+    only defines the user-visible knobs.
+    """
+
+    enabled: bool = False
+    interval_seconds: int = 60
+    downsample: int = 1
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
 class TelemetryConfig:
     """Telemetry configuration for benchmark jobs.
 
     The default provider bundles a scraper with dcgm_exporter and node_exporter.
     Other providers can reuse the same top-level contract later.
+
+    ``live_metrics`` is a lightweight complementary signal: it tails worker
+    logs in-process (no external stack required) and writes a per-run
+    ``batch_metrics.png`` during the benchmark.
     """
 
     enabled: bool = False
@@ -910,6 +912,7 @@ class TelemetryConfig:
     extra_metadata: dict[str, str] = field(default_factory=dict)
     dcgm_exporter: TelemetryExporterConfig | None = None
     node_exporter: TelemetryExporterConfig | None = None
+    live_metrics: LiveMetricsConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -203,6 +203,7 @@ class ClusterConfig:
     # sruns that bypass the bash wrapper (distroless containers).
     default_bash_preamble: str | None = None
     reporting: ReportingConfig | None = None
+    telemetry: dict | None = None  # opaque dict, parsed by try_start_snapshotter
     # When set, applied to job configs that omit ``frontend.nginx_raise_ulimit``.
     # Clusters that disallow raising nofile for nginx containers should use false.
     nginx_raise_ulimit: bool | None = None
@@ -1356,7 +1357,7 @@ class SrtConfig:
     def _validate_telemetry(self):
         """Validate telemetry configuration."""
         telemetry = self.telemetry
-        if not telemetry.enabled:
+        if telemetry is None or not telemetry.enabled:
             return
 
         if telemetry.provider != TelemetryProvider.SCRAPER:


### PR DESCRIPTION
## Summary

Adds an **opt-in, zero-dependency-on-production-path** feature that spawns a daemon thread during the benchmark stage.  
Every N seconds it re-parses prefill/decode worker logs and atomically overwrites `<log_dir>/batch_metrics.png`, giving a near-real-time view of the run without any external monitoring stack.

`live_metrics` lives under the `telemetry` block in `srtslurm.yaml` — it is a lightweight complementary signal (log polling, no scraper container required) that fits naturally alongside the existing DCGM/node_exporter telemetry.

### Files changed

| File | Purpose |
|---|---|
| `src/srtctl/analysis/__init__.py` | New `analysis` subpackage |
| `src/srtctl/analysis/batch_log_parser.py` | Incremental, stateful SGLang log parser — no plotting, no aggregation |
| `src/srtctl/analysis/live_metrics.py` | Background snapshotter thread + matplotlib renderer |
| `src/srtctl/core/schema.py` | New `LiveMetricsConfig` dataclass nested under `TelemetryConfig` |
| `src/srtctl/cli/mixins/benchmark_stage.py` | 3-line hook to start/stop the snapshotter around the benchmark proc |

### How to enable

In `srtslurm.yaml`:

```yaml
telemetry:
  live_metrics:
    enabled: true
    interval_seconds: 60   # default
    downsample: 1          # keep every sample
```

When disabled (default), **zero code paths are touched** — `try_start_snapshotter` returns `None` immediately.

### Plot layout

7 rows × 2 columns, semantically paired (prefill left, decode right):

| Row | Prefill | Decode |
|---|---|---|
| 0 | input throughput (token/s) | gen throughput (token/s) |
| 1 | #new-seq | #running-req |
| 2 | #new-token | #full token |
| 3 | #cached-token | full token usage |
| 4 | #prealloc-req | #prealloc-req |
| 5 | #queue-req | #queue-req |
| 6 | #inflight-req | #transfer-req |

Worker labels are shortened to `p0`…`pN` / `d0`…`dN`. Colour map is `tab20` (supports up to 20 workers).

### Design notes

- Parser uses a `byte_offset` per file — safe to call repeatedly on growing logs.
- Snapshotter swallows its own exceptions so a plotting failure never kills the benchmark.
- Atomic write: `fig.savefig(tmp) → os.replace(tmp, dst)` — readers never see a torn file.
- `matplotlib` is an **optional** soft dependency; the snapshotter degrades gracefully if missing.
- A "final tick" always runs on shutdown so the last state is captured even if the benchmark crashes early.

## Test plan

- [x] Smoke-tested locally against CoreWeave `491-tom-radixcache` logs — plot generated correctly
- [ ] End-to-end live smoke test on CoreWeave cluster pending
- [ ] `enabled: false` (default) — confirm no behaviour change in existing benchmarks