### PR TITLE
fix: using a setup script to install pip in trtllm venv

### DIFF
--- a/configs/install-trtllm-pip.sh
+++ b/configs/install-trtllm-pip.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# WRN to install pip in the dynamo trtllm runtime image's venv
+
+uv pip install pip


### PR DESCRIPTION
gsm8k eval run needs a pip install lm-eval[api] at runtime, which needs a pip in the venv