### PR TITLE
Fix using image url for container

### DIFF
--- a/src/srtctl/cli/monitor.py
+++ b/src/srtctl/cli/monitor.py
@@ -623,7 +623,7 @@ def _detail_view(job_id: str, jobs: list[dict], state: _State, term_height: int 
     stage_color = job_info["stage_color"] if job_info else "dim"
 
     job_title = (
-        f"[bold cyan]{job_id}[/bold cyan] [dim cyan]{name}[/dim cyan]" f" [{stage_color}]{stage_label}[/{stage_color}]"
+        f"[bold cyan]{job_id}[/bold cyan] [dim cyan]{name}[/dim cyan] [{stage_color}]{stage_label}[/{stage_color}]"
     )
 
     content_h = term_height - 1

--- a/src/srtctl/core/validation.py
+++ b/src/srtctl/core/validation.py
@@ -190,13 +190,29 @@ def _preflight_container(
             [issue],
         )
 
-    ok, detail = _check_path(_expand_path(resolved), expect="file")
+    expanded = _expand_path(resolved)
+    # Mirror runtime.py: values without a /, ./ prefix are registry refs that
+    # pyxis will pull at srun time. Defer instead of failing preflight.
+    if not expanded.startswith(("/", "./")):
+        return (
+            PreflightResolution(
+                field="model.container",
+                raw=raw,
+                resolved=resolved,
+                source=source,
+                ok=True,
+                message=f"registry image (deferred to pyxis): {resolved}",
+            ),
+            [],
+        )
+
+    ok, detail = _check_path(expanded, expect="file")
     if ok:
         return (
             PreflightResolution(
                 field="model.container",
                 raw=raw,
-                resolved=str(Path(_expand_path(resolved)).resolve()),
+                resolved=str(Path(expanded).resolve()),
                 source=source,
                 ok=True,
                 message=detail,

--- a/tests/test_mcp_spec.py
+++ b/tests/test_mcp_spec.py
@@ -80,7 +80,7 @@ def test_preflight_config_reports_missing_container(tmp_path) -> None:
             "name": "mcp-test",
             "model": {
                 "path": str(model_dir),
-                "container": "missing-container",
+                "container": "/nonexistent/missing.sqsh",
                 "precision": "bf16",
             },
             "resources": {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -344,7 +344,7 @@ class TestPreflightConfigVariants:
                 "name": "bad-container",
                 "model": {
                     "path": str(model_dir),
-                    "container": "nvcr.io/fake:latest",
+                    "container": "/nonexistent/fake.sqsh",
                     "precision": "bf16",
                 },
                 "resources": {


### PR DESCRIPTION
Got:
```
Error: Preflight failed for minimax-nvfp4-b300-decode-sweep-dep2-1k1k.yaml:
- model.container: Container 'vllm/vllm-openai:v0.19.1-cu130' is not a local container path and is not defined in srtslurm.yaml containers. Provide or register the 
container yourself before submitting.
```

when setting:
```
model:
  path: "minimax-m2.5-nvfp4"
  container: "vllm/vllm-openai:v0.19.1-cu130"
  precision: "fp4"
```

This PR loosens the check.