### PR TITLE
add dsv4 8k1k config

### DIFF
--- a/recipes/dsv4-pro/sglang/gb300-fp4/8k1k.yaml
+++ b/recipes/dsv4-pro/sglang/gb300-fp4/8k1k.yaml
@@ -1,0 +1,283 @@
+base:
+  name: dsv4-pro-gb300-fp4_8k1k_disagg_dep16
+
+  slurm:
+    time_limit: 03:00:00
+
+  sbatch_directives:
+    cpus-per-task: '144'
+    mem: '0'
+
+  dynamo:
+    hash: "dd37acac04fa8b00a95de4f089d717080c98e2f4"
+    install: true
+
+  frontend:
+    type: dynamo
+    enable_multiple_frontends: true
+    num_additional_frontends: 8
+    env:
+      DYN_ROUTER_LOAD_BLOCK_SIZE: "1"
+    args:
+      router-mode: "kv"
+      router-kv-overlap-score-weight: 0
+      router-queue-threshold: 64
+      router-temperature: 0.5
+      no-kv-events: true
+
+  model:
+    path: dsv4-pro
+    container: "dsv4-grace-blackwell-baizhou-revert"
+    precision: fp4
+
+  resources:
+    gpu_type: gb300
+    gpus_per_node: 4
+
+  extra_mount:
+  - /mnt/home/yangminl/sglang-cw-dev:/sgl-workspace/sglang
+  - /mnt/home/yangminl/sglang-cw-dev:/workspace/sglang
+
+  backend:
+    type: sglang
+
+    prefill_environment:
+      SGLANG_DG_CACHE_DIR: /configs/deepgemm_cache     # NOTE hack for quick tests
+      PYTHONUNBUFFERED: '1'
+      SGLANG_JIT_DEEPGEMM_PRECOMPILE: '0'
+      SGLANG_ENABLE_THINKING: '1'
+      SGLANG_REASONING_EFFORT: max
+      SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: '1'
+      SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN: '1'
+      SGLANG_OPT_USE_JIT_NORM: '1'
+      SGLANG_OPT_USE_JIT_INDEXER_METADATA: '1'
+      SGLANG_OPT_USE_TOPK_V2: '1'
+      SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2: '1'
+      SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE: '1'
+      SGLANG_OPT_FIX_HASH_MEGA_MOE: '1'
+      SGLANG_OPT_USE_FAST_MASK_EP: '1'
+      SGLANG_OPT_FIX_MEGA_MOE_MEMORY: '1'
+      SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "8192"
+      SGLANG_OPT_FIX_NEXTN_MEGA_MOE: '1'
+      SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
+      SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: '0'
+      NCCL_MNNVL_ENABLE: '1'
+      NCCL_CUMEM_ENABLE: '1'
+      SGLANG_MOONCAKE_CUSTOM_MEM_POOL: 'True'
+      MC_FORCE_MNNVL: '1'
+      SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: '100000'
+      SGLANG_DISAGGREGATION_WAITING_TIMEOUT: '100000'
+      SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW: '1'
+      DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
+      SGLANG_LOG_FORWARD_ITERS: '1'
+      SGLANG_LOG_MS: '1'
+      SGLANG_REQUEST_STATE_WAIT_TIMEOUT: '60'
+      DYN_LOG: 'info,dynamo_runtime::pipeline::network::ingress::push_handler=warn'
+      # SGLANG_REQ_LIFECYCLE_LOG: "1"
+
+    decode_environment:
+      SGLANG_DG_CACHE_DIR: /configs/deepgemm_cache     # NOTE hack for quick tests
+      PYTHONUNBUFFERED: '1'
+      SGLANG_JIT_DEEPGEMM_PRECOMPILE: '0'
+      SGLANG_ENABLE_THINKING: '1'
+      SGLANG_REASONING_EFFORT: max
+      SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: '1'
+      SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN: '1'
+      SGLANG_OPT_USE_JIT_NORM: '1'
+      SGLANG_OPT_USE_JIT_INDEXER_METADATA: '1'
+      SGLANG_OPT_USE_TOPK_V2: '1'
+      SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE: '1'
+      SGLANG_OPT_FIX_HASH_MEGA_MOE: '1'
+      SGLANG_OPT_USE_FAST_MASK_EP: '1'
+      SGLANG_OPT_FIX_MEGA_MOE_MEMORY: '1'
+      SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: '1152'
+      SGLANG_OPT_FIX_NEXTN_MEGA_MOE: '1'
+      SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
+      SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: '0'
+      NCCL_MNNVL_ENABLE: '1'
+      NCCL_CUMEM_ENABLE: '1'
+      SGLANG_MOONCAKE_CUSTOM_MEM_POOL: 'True'
+      SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION: "8"
+      MC_FORCE_MNNVL: '1'
+      SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: '100000'
+      SGLANG_DISAGGREGATION_WAITING_TIMEOUT: '100000'
+      SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW: '1'
+      DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
+      SGLANG_LOG_FORWARD_ITERS: '1'
+      SGLANG_LOG_MS: '1'
+      SGLANG_REQUEST_STATE_WAIT_TIMEOUT: '60'
+      DYN_LOG: 'info,dynamo_runtime::pipeline::network::ingress::push_handler=warn'
+      # SGLANG_REQ_LIFECYCLE_LOG: "1"
+      # SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2 intentionally NOT set: CAR_V2
+      # is single-node only and corrupts results in 2-node decode setups.
+
+    sglang_config:
+      prefill:
+        served-model-name: deepseek-ai/DeepSeek-V4-Pro
+        trust-remote-code: true
+        watchdog-timeout: 86400
+        # disable-radix-cache: true # NOTE try to enable radix cache
+
+        # Tokenizer
+        skip-tokenizer-init: true
+        stream-interval: 60
+        # tokenizer-worker-num: 16  # need this if we run tokenizer
+
+        # Parallel
+        tensor-parallel-size: 4
+        data-parallel-size: 4
+        expert-parallel-size: 4
+        # dp
+        enable-dp-attention: true
+        moe-dense-tp-size: 1
+        enable-dp-lm-head: true
+        # ep
+        moe-a2a-backend: deepep
+        deepep-config: '{"normal_dispatch":{"num_sms":88,"num_max_nvl_chunked_send_tokens":28,"num_max_nvl_chunked_recv_tokens":512},"normal_combine": {"num_sms":88,"num_max_nvl_chunked_send_tokens":16,"num_max_nvl_chunked_recv_tokens":512}}'
+
+        # Disagg
+        disaggregation-mode: prefill
+        disaggregation-transfer-backend: mooncake
+
+        # Size
+        mem-fraction-static: 0.9
+        max-running-requests: 512
+        cuda-graph-max-bs: 512
+        chunked-prefill-size: 32768
+
+      decode:
+        served-model-name: deepseek-ai/DeepSeek-V4-Pro
+        trust-remote-code: true
+        watchdog-timeout: 86400
+        # disable-radix-cache: true # NOTE try to enable radix cache
+
+        # Tokenizer
+        skip-tokenizer-init: true
+        stream-interval: 60
+
+        # Parallel
+        tensor-parallel-size: 16
+        data-parallel-size: 16
+        expert-parallel-size: 16
+        # dp
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        moe-dense-tp-size: 1
+        # ep
+        moe-a2a-backend: deepep
+        deepep-config: '{"normal_dispatch":{"num_sms":88,"num_max_nvl_chunked_send_tokens":28,"num_max_nvl_chunked_recv_tokens":512},"normal_combine": {"num_sms":88,"num_max_nvl_chunked_send_tokens":16,"num_max_nvl_chunked_recv_tokens":512}}'
+
+        # Disagg
+        disaggregation-mode: decode
+        disaggregation-transfer-backend: mooncake
+
+        # Size
+        mem-fraction-static: 0.94
+        swa-full-tokens-ratio: 0.12
+        context-length: 16384
+        max-running-requests: 18432
+        cuda-graph-max-bs: 1152
+
+  benchmark:
+    type: custom
+
+zip_override_8k1k_hightpt:
+  resources:
+    prefill_nodes:   [1, 4, 8, 10, 14]
+    prefill_workers: [1, 4, 8, 10, 14]
+    decode_nodes:    4
+    decode_workers:  1
+  backend:
+    sglang_config:
+      decode:
+        max-running-requests: 18432  # to refine
+        cuda-graph-max-bs:    1152
+
+  benchmark:
+    type: custom
+    command: # only change --num-prompts --max-concurrency
+    - |
+      set -e
+      ulimit -n 1048576
+      REPO=/configs/upstream-sa-bench/InferenceX
+      [ -d "$REPO" ] || git clone https://github.com/fzyzcjy/InferenceX.git "$REPO"
+      cd "$REPO/utils/bench_serving"
+      python3 benchmark_serving.py \
+        --backend vllm --model deepseek-ai/DeepSeek-V4-Pro --tokenizer /model \
+        --host 127.0.0.1 --port 8000 --endpoint /v1/completions \
+        --dataset-name random \
+        --random-input-len 8192 --random-output-len 1024 --random-range-ratio 0.8 \
+        --random-num-workers 96 \
+        --num-prompts 2560 --max-concurrency 256 --request-rate inf \
+        --num-warmups 2048 \
+        --ignore-eos --trust-remote-code \
+        --percentile-metrics ttft,tpot,itl,e2el \
+        --save-result --result-dir /logs --result-filename results.json
+    - |
+      set -e
+      ulimit -n 1048576
+      REPO=/configs/upstream-sa-bench/InferenceX
+      [ -d "$REPO" ] || git clone https://github.com/fzyzcjy/InferenceX.git "$REPO"
+      cd "$REPO/utils/bench_serving"
+      python3 benchmark_serving.py \
+        --backend vllm --model deepseek-ai/DeepSeek-V4-Pro --tokenizer /model \
+        --host 127.0.0.1 --port 8000 --endpoint /v1/completions \
+        --dataset-name random \
+        --random-input-len 8192 --random-output-len 1024 --random-range-ratio 0.8 \
+        --random-num-workers 96 \
+        --num-prompts 10240 --max-concurrency 1024 --request-rate inf \
+        --num-warmups 2048 \
+        --ignore-eos --trust-remote-code \
+        --percentile-metrics ttft,tpot,itl,e2el \
+        --save-result --result-dir /logs --result-filename results.json
+    - |
+      set -e
+      ulimit -n 1048576
+      REPO=/configs/upstream-sa-bench/InferenceX
+      [ -d "$REPO" ] || git clone https://github.com/fzyzcjy/InferenceX.git "$REPO"
+      cd "$REPO/utils/bench_serving"
+      python3 benchmark_serving.py \
+        --backend vllm --model deepseek-ai/DeepSeek-V4-Pro --tokenizer /model \
+        --host 127.0.0.1 --port 8000 --endpoint /v1/completions \
+        --dataset-name random \
+        --random-input-len 8192 --random-output-len 1024 --random-range-ratio 0.8 \
+        --random-num-workers 96 \
+        --num-prompts 24000 --max-concurrency 2400 --request-rate inf \
+        --num-warmups 2048 \
+        --ignore-eos --trust-remote-code \
+        --percentile-metrics ttft,tpot,itl,e2el \
+        --save-result --result-dir /logs --result-filename results.json
+    - |
+      set -e
+      ulimit -n 1048576
+      REPO=/configs/upstream-sa-bench/InferenceX
+      [ -d "$REPO" ] || git clone https://github.com/fzyzcjy/InferenceX.git "$REPO"
+      cd "$REPO/utils/bench_serving"
+      python3 benchmark_serving.py \
+        --backend vllm --model deepseek-ai/DeepSeek-V4-Pro --tokenizer /model \
+        --host 127.0.0.1 --port 8000 --endpoint /v1/completions \
+        --dataset-name random \
+        --random-input-len 8192 --random-output-len 1024 --random-range-ratio 0.8 \
+        --random-num-workers 96 \
+        --num-prompts 40960 --max-concurrency 4096 --request-rate inf \
+        --num-warmups 2048 \
+        --ignore-eos --trust-remote-code \
+        --percentile-metrics ttft,tpot,itl,e2el \
+        --save-result --result-dir /logs --result-filename results.json
+    - |
+      set -e
+      ulimit -n 1048576
+      REPO=/configs/upstream-sa-bench/InferenceX
+      [ -d "$REPO" ] || git clone https://github.com/fzyzcjy/InferenceX.git "$REPO"
+      cd "$REPO/utils/bench_serving"
+      python3 benchmark_serving.py \
+        --backend vllm --model deepseek-ai/DeepSeek-V4-Pro --tokenizer /model \
+        --host 127.0.0.1 --port 8000 --endpoint /v1/completions \
+        --dataset-name random \
+        --random-input-len 8192 --random-output-len 1024 --random-range-ratio 0.8 \
+        --random-num-workers 96 \
+        --num-prompts 163840 --max-concurrency 16384 --request-rate inf \
+        --num-warmups 2048 \
+        --ignore-eos --trust-remote-code \
+        --percentile-metrics ttft,tpot,itl,e2el \
+        --save-result --result-dir /logs --result-filename results.json


### PR DESCRIPTION
## Summary
- Add a GB300 FP4 DeepSeek V4 Pro 8k1k disaggregated SGLang recipe as `recipes/dsv4-pro/sglang/gb300-fp4/8k1k.yaml`.
- Include zipped high-throughput variants for 1/4/8/10/14 prefill workers against a 4-node decode worker.
- Keep the benchmark commands aligned with each resource point, up to 163840 prompts at max concurrency 16384.

## Validation
- Parsed the YAML with `python3`/PyYAML.
- Checked the `zip_override_8k1k_hightpt` resource list and final benchmark command.
- Ran `git diff --check`.
