### PR TITLE
Add DeepSeek-V4-Pro 1k/1k MTP-off SA recipes for GB200 (TEP8 + DEP16)

### DIFF
--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/DEP16/1k1k_c1024.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/DEP16/1k1k_c1024.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — DEP16 c=1024
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_dep16_c1024_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 4
+  decode_workers: 1
+  gpus_per_decode: 16
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '1024'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 16
+      disable_overlap_scheduler: false
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 16
+      max_num_tokens: 16
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 16
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1024'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/DEP16/1k1k_c1536.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/DEP16/1k1k_c1536.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — DEP16 c=1536
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_dep16_c1536_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 4
+  decode_workers: 1
+  gpus_per_decode: 16
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '1536'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: false
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 16
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1536'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/DEP16/1k1k_c2048.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/DEP16/1k1k_c2048.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — DEP16 c=2048
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_dep16_c2048_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 4
+  decode_workers: 1
+  gpus_per_decode: 16
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '2048'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 128
+      disable_overlap_scheduler: false
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 128
+      max_num_tokens: 128
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 16
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '2048'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/DEP16/1k1k_c512.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/DEP16/1k1k_c512.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — DEP16 c=512
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_dep16_c512_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 4
+  decode_workers: 1
+  gpus_per_decode: 16
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '512'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 8
+      disable_overlap_scheduler: false
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 16
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '512'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c1.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c1.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — TEP8 c=1
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_tep8_c1_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '1'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 1
+      disable_overlap_scheduler: false
+      enable_attention_dp: false
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 1
+      max_num_tokens: 1
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 8
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c12.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c12.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — TEP8 c=12
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_tep8_c12_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '12'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 4
+      disable_overlap_scheduler: false
+      enable_attention_dp: false
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 4
+      max_num_tokens: 4
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 8
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '12'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c128.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c128.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — TEP8 c=128
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_tep8_c128_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '128'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 16
+      disable_overlap_scheduler: false
+      enable_attention_dp: false
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 16
+      max_num_tokens: 16
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 8
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '128'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c2.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c2.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — TEP8 c=2
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_tep8_c2_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '2'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 1
+      disable_overlap_scheduler: false
+      enable_attention_dp: false
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 1
+      max_num_tokens: 1
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 8
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '2'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c24.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c24.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — TEP8 c=24
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_tep8_c24_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '24'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 8
+      disable_overlap_scheduler: false
+      enable_attention_dp: false
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 8
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '24'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c256.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c256.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — TEP8 c=256
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_tep8_c256_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '256'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 32
+      disable_overlap_scheduler: false
+      enable_attention_dp: false
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 32
+      max_num_tokens: 32
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 8
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '256'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c4.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c4.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — TEP8 c=4
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_tep8_c4_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '4'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 1
+      disable_overlap_scheduler: false
+      enable_attention_dp: false
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 1
+      max_num_tokens: 1
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 8
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '4'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false

--- a/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c6.yaml
+++ b/recipes/DeepSeekV4-Pro/disagg/trtllm_dynamo/gb200_nvfp4/ISL1K_OSL1K/TEP8/1k1k_c6.yaml
@@ -1,0 +1,109 @@
+# DSv4-Pro 1k/1k MTP-off SA recipe — TEP8 c=6
+# Engine fields byte-translated from the executed-sweep ctx_config.yaml + gen_config.yaml.
+# Additions on top of the verbatim engine config:
+#   - trust_remote_code: true (DSV4-Pro safety)
+#   - host_cache_size: 0 in tep8 prefill kv_cache_config
+#   - 3 allowed env-var deviations on workers (UCX_*, TLLM_BENCHMARK_REQ_QUEUES_SIZE)
+#   - 4 srt-slurm default overrides (dynamo.install, multi_frontend, prompts_mult, chat_template)
+name: dsv4_pro_nvfp4_ISL1K_OSL1K_tep8_c6_eplb0_mtp0
+model:
+  path: /lustre/share/coreai_comparch_aarwlt/hf_repos/deepseek-ai/DeepSeek-V4-Pro
+  container: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime@sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895
+  precision: fp4
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  prefill_nodes: 2
+  prefill_workers: 1
+  gpus_per_prefill: 8
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+  decode_environment:
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE: '0'
+    TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP: '1'
+    UCX_CUDA_IPC_ENABLE_MNNVL: n
+    UCX_RNDV_SCHEME: put_zcopy
+    PYTHONUNBUFFERED: '1'
+    TLLM_BENCHMARK_REQ_QUEUES_SIZE: '6'
+  trtllm_config:
+    prefill:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: false
+      disable_overlap_scheduler: true
+      enable_attention_dp: true
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.5
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 8
+      max_num_tokens: 8512
+      max_seq_len: 1128
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    decode:
+      allreduce_strategy: AUTO
+      cache_transceiver_config:
+        backend: NIXL
+        max_tokens_in_buffer: 1152
+        transceiver_runtime: PYTHON
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 2
+      disable_overlap_scheduler: false
+      enable_attention_dp: false
+      kv_cache_config:
+        dtype: fp8
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.55
+        host_cache_size: 0
+        tokens_per_block: 128
+      max_batch_size: 2
+      max_num_tokens: 2
+      max_seq_len: 2176
+      moe_config:
+        backend: TRTLLM
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      print_iter_log: true
+      stream_interval: 20
+      tensor_parallel_size: 8
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '6'
+  req_rate: inf
+  num_prompts_mult: 1
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+dynamo:
+  install: false


### PR DESCRIPTION
## Summary

12 srt-slurm recipes for the DeepSeek-V4-Pro 1k/1k gen-only MTP-off SA reproduction sweep on GB200. Engine configs are byte-translated from the executed-sweep `ctx_config.yaml` + `gen_config.yaml` — the same runs that produced the published pareto curve. Two parallelism families:

- **TEP8** (ctx TP=8 attn_dp=true + decode TP=8 EP=8 attn_dp=false): c=1, 2, 4, 6, 12, 24, 128, 256
- **DEP16** (ctx TP=8 attn_dp=true + decode TP=16 EP=16 attn_dp=true): c=512, 1024, 1536, 2048

Beyond verbatim per-c engine values, four srt-slurm default-override fields are set explicitly to prevent silent runtime drift:

- `dynamo.install: false` — default `true` would pip-install Dynamo 0.8.0 over the recipe's container
- `frontend.enable_multiple_frontends: false` — default `true` would start nginx multi-frontend
- `benchmark.num_prompts_mult: 1` — default 10 would inflate prompt count by 10×
- `benchmark.use_chat_template: false` — default `true` would crash for DSV4-Pro (no registered `custom_tokenizer` adapter)

Plus three approved env-var deviations on workers (matching the executed sweep's per-c launch values):

- `UCX_CUDA_IPC_ENABLE_MNNVL=n`
- `UCX_RNDV_SCHEME=put_zcopy`
- `TLLM_BENCHMARK_REQ_QUEUES_SIZE=<concurrency>` (decode worker only)

## Test plan

- [x] Sweep executed end-to-end and pareto curve published
- [x] `srtctl dry-run` validates representative recipes (tep8 c=1 4-node, dep16 c=2048 6-node)
- [ ] Rerun a subset from these committed recipes to confirm reproducibility
