### PR TITLE
Add GPT-OSS TRT-LLM aggregated recipe

### DIFF
--- a/recipes/trtllm/gpt-oss-120b/b200-fp4/1k1k/agg-tp1.yaml
+++ b/recipes/trtllm/gpt-oss-120b/b200-fp4/1k1k/agg-tp1.yaml
@@ -1,0 +1,51 @@
+name: "gpt-oss-120b-trtllm-agg-b200-tp1-1k1k"
+
+model:
+  path: "hf:openai/gpt-oss-120b"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.3"
+  precision: "fp4"
+
+dynamo:
+  install: false
+
+resources:
+  gpu_type: "b200"
+  gpus_per_node: 1
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: trtllm
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    DYN_HEALTH_CHECK_ENABLED: "false"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    TLLM_LOG_LEVEL: "INFO"
+
+  trtllm_config:
+    aggregated:
+      backend: "pytorch"
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      max_batch_size: 512
+      max_num_tokens: 20000
+      max_seq_len: 2248
+      trust_remote_code: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "256"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2

--- a/recipes/trtllm/gpt-oss-120b/b200-fp4/1k8k/agg-tp1.yaml
+++ b/recipes/trtllm/gpt-oss-120b/b200-fp4/1k8k/agg-tp1.yaml
@@ -1,15 +1,12 @@
 name: "gpt-oss-120b-trtllm-agg-b200-tp1-1k8k"
 
 model:
-  path: "/lustre/fsw/coreai_prod_infbench/common/cache/hub/models--openai--gpt-oss-120b/snapshots/b5c939de8f754692c1647ca79fbf85e8c1e70f8a"
-  container: "/lustre/fsw/coreai_prod_infbench/common/docker/dynamo-trtllm-1.1.0.sqsh"
+  path: "hf:openai/gpt-oss-120b"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.3"
   precision: "fp4"
 
 dynamo:
   install: false
-
-extra_mount:
-  - "/lustre/fsw/coreai_prod_infbench/common/cache/hub/models--openai--gpt-oss-120b/blobs:/blobs"
 
 resources:
   gpu_type: "b200"
@@ -26,9 +23,6 @@ backend:
   type: trtllm
 
   aggregated_environment:
-    HF_HOME: "/lustre/fsw/coreai_prod_infbench/common/cache"
-    HF_HUB_OFFLINE: "1"
-    TRANSFORMERS_OFFLINE: "1"
     PYTHONUNBUFFERED: "1"
     DYN_HEALTH_CHECK_ENABLED: "false"
     TRTLLM_ENABLE_PDL: "1"

--- a/recipes/trtllm/gpt-oss-120b/b200-fp4/1k8k/agg-tp1.yaml
+++ b/recipes/trtllm/gpt-oss-120b/b200-fp4/1k8k/agg-tp1.yaml
@@ -1,0 +1,57 @@
+name: "gpt-oss-120b-trtllm-agg-b200-tp1-1k8k"
+
+model:
+  path: "/lustre/fsw/coreai_prod_infbench/common/cache/hub/models--openai--gpt-oss-120b/snapshots/b5c939de8f754692c1647ca79fbf85e8c1e70f8a"
+  container: "/lustre/fsw/coreai_prod_infbench/common/docker/dynamo-trtllm-1.1.0.sqsh"
+  precision: "fp4"
+
+dynamo:
+  install: false
+
+extra_mount:
+  - "/lustre/fsw/coreai_prod_infbench/common/cache/hub/models--openai--gpt-oss-120b/blobs:/blobs"
+
+resources:
+  gpu_type: "b200"
+  gpus_per_node: 1
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: trtllm
+
+  aggregated_environment:
+    HF_HOME: "/lustre/fsw/coreai_prod_infbench/common/cache"
+    HF_HUB_OFFLINE: "1"
+    TRANSFORMERS_OFFLINE: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_HEALTH_CHECK_ENABLED: "false"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    TLLM_LOG_LEVEL: "INFO"
+
+  trtllm_config:
+    aggregated:
+      backend: "pytorch"
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      max_batch_size: 512
+      max_num_tokens: 20000
+      max_seq_len: 9416
+      trust_remote_code: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 8192
+  concurrencies: "256"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2

--- a/recipes/trtllm/gpt-oss-120b/b200-fp4/8k1k/agg-tp1.yaml
+++ b/recipes/trtllm/gpt-oss-120b/b200-fp4/8k1k/agg-tp1.yaml
@@ -1,0 +1,51 @@
+name: "gpt-oss-120b-trtllm-agg-b200-tp1-8k1k"
+
+model:
+  path: "hf:openai/gpt-oss-120b"
+  container: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0-dev.3"
+  precision: "fp4"
+
+dynamo:
+  install: false
+
+resources:
+  gpu_type: "b200"
+  gpus_per_node: 1
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: trtllm
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    DYN_HEALTH_CHECK_ENABLED: "false"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+    TLLM_LOG_LEVEL: "INFO"
+
+  trtllm_config:
+    aggregated:
+      backend: "pytorch"
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      max_batch_size: 512
+      max_num_tokens: 20000
+      max_seq_len: 9416
+      trust_remote_code: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "256"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2


### PR DESCRIPTION
Adding GPTOSS 120B Recipes for the NV Inference dashboard: https://developer.nvidia.com/deep-learning-performance-training-inference/ai-inference

Tested on B200 cluster with 8 GPUS


```
+ python3 -u /srtctl-benchmarks/sa-bench/benchmark_serving.py --model b5c939de8f754692c1647ca79fbf85e8c1e70f8a --tokenizer /model --host localhost --port 8000 --backend dynamo --endpoint /v1/completions --disable-tqdm --dataset-name random --num-prompts 2560 --random-input-len 1024 --random-output-len 8192 --random-range-ratio 0.8 --ignore-eos --request-rate inf --percentile-metrics ttft,tpot,itl,e2el --max-concurrency 256 --trust-remote-code --use-chat-template --save-result --result-dir /logs/sa-bench_isl_1024_osl_8192 --result-filename results_concurrency_256_gpus_1.json
Namespace(backend='dynamo', base_url=None, host='localhost', port=8000, endpoint='/v1/completions', dataset=None, dataset_name='random', dataset_path=None, max_concurrency=256, model='b5c939de8f754692c1647ca79fbf85e8c1e70f8a', tokenizer='/model', best_of=1, use_beam_search=False, num_prompts=2560, logprobs=None, request_rate=inf, burstiness=1.0, seed=0, trust_remote_code=True, disable_tqdm=True, profile=False, save_result=True, metadata=None, result_dir='/logs/sa-bench_isl_1024_osl_8192', result_filename='results_concurrency_256_gpus_1.json', ignore_eos=True, percentile_metrics='ttft,tpot,itl,e2el', metric_percentiles='99', goodput=None, sonnet_input_len=550, sonnet_output_len=150, sonnet_prefix_len=200, sharegpt_output_len=None, random_input_len=1024, random_output_len=8192, random_range_ratio=0.8, random_prefix_len=0, use_chat_template=True, hf_subset=None, hf_split=None, hf_output_len=None, tokenizer_mode='auto', custom_tokenizer=None, served_model_name=None, lora_modules=None)
Starting initial single prompt test run...
Initial test run completed. Starting main benchmark run...
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 256
============ Serving Benchmark Result ============
Successful requests:                     2560      
Benchmark duration (s):                  3098.87   
Total input tokens:                      2373787   
Total generated tokens:                  18896008  
Request throughput (req/s):              0.83      
Output token throughput (tok/s):         6097.72   
Total Token throughput (tok/s):          6863.74   
---------------Time to First Token----------------
Mean TTFT (ms):                          94489.30  
Median TTFT (ms):                        71466.24  
P99 TTFT (ms):                           195382.90 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.76     
Median TPOT (ms):                        27.88     
P99 TPOT (ms):                           28.20     
---------------Inter-token Latency----------------
Mean ITL (ms):                           27.76     
Median ITL (ms):                         27.58     
P99 ITL (ms):                            33.72     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          299343.78 
Median E2EL (ms):                        282898.33 
P99 E2EL (ms):                           401097.91 
==================================================
+ set +x
2026-05-05 17:25:35
Completed benchmark with concurrency: 256
-----------------------------------------
```