### PR TITLE
Sglang port jitter

### DIFF
--- a/src/srtctl/backends/base.py
+++ b/src/srtctl/backends/base.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from srtctl.core.runtime import RuntimeContext
-    from srtctl.core.topology import Endpoint, Process
+    from srtctl.core.topology import Endpoint, NodePortAllocator, Process
 
 
 class BackendType(str, Enum):
@@ -92,9 +92,20 @@ class BackendProtocol(Protocol):
         self,
         endpoints: list["Endpoint"],
         base_sys_port: int = 8081,
+        port_allocator: Optional["NodePortAllocator"] = None,
     ) -> list["Process"]:
-        """Convert logical endpoints to physical processes."""
+        """Convert logical endpoints to physical processes.
+
+        ``port_allocator`` lets callers (the orchestrator) inject a jittered
+        allocator built from the SLURM job id; backends that don't pass it
+        through retain the default ``NodePortAllocator()`` behavior.
+        """
         ...
+
+    # Optional duck-typed extension: ``dp_attention_tcp_ports(process)``.
+    # Implemented by SGLang to surface the TCP ports its DP-attention path
+    # derives from --port (rpc/metrics/etc.). Other backends omit it; the
+    # preflight caller checks via getattr and skips backends that don't.
 
     def build_worker_command(
         self,

--- a/src/srtctl/backends/mocker.py
+++ b/src/srtctl/backends/mocker.py
@@ -30,7 +30,7 @@ from marshmallow_dataclass import dataclass
 if TYPE_CHECKING:
     from srtctl.backends.base import SrunConfig
     from srtctl.core.runtime import RuntimeContext
-    from srtctl.core.topology import Endpoint, Process
+    from srtctl.core.topology import Endpoint, NodePortAllocator, Process
 
 # Type alias for worker modes
 WorkerMode = Literal["prefill", "decode", "agg"]
@@ -184,11 +184,12 @@ class MockerProtocol:
         self,
         endpoints: list["Endpoint"],
         base_sys_port: int = 8081,
+        port_allocator: "NodePortAllocator | None" = None,
     ) -> list["Process"]:
         """Convert endpoints to processes."""
         from srtctl.core.topology import endpoints_to_processes
 
-        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port)
+        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port, port_allocator=port_allocator)
 
     def build_worker_command(
         self,

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -25,7 +25,7 @@ from marshmallow_dataclass import dataclass
 if TYPE_CHECKING:
     from srtctl.backends.base import SrunConfig
     from srtctl.core.runtime import RuntimeContext
-    from srtctl.core.topology import Endpoint, Process
+    from srtctl.core.topology import Endpoint, NodePortAllocator, Process
 
 # Type alias for worker modes
 WorkerMode = Literal["prefill", "decode", "agg"]
@@ -264,11 +264,33 @@ class SGLangProtocol:
         self,
         endpoints: list["Endpoint"],
         base_sys_port: int = 8081,
+        port_allocator: "NodePortAllocator | None" = None,
     ) -> list["Process"]:
         """Convert endpoints to processes."""
         from srtctl.core.topology import endpoints_to_processes
 
-        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port)
+        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port, port_allocator=port_allocator)
+
+    def dp_attention_tcp_ports(self, process: "Process") -> list[int] | None:
+        """Return TCP ports SGLang's DP-attention path would bind from --port.
+
+        SGLang's PortArgs.init_new (server_args.py) computes:
+            dist_init_port  = port + 233
+            port_base       = port + 234
+            detokenizer_port = port + 235
+            rpc_port        = port + 236
+            metrics_port    = port + 237
+        when ``enable-dp-attention=true``. We surface all six (incl. --port
+        itself, which SGLang's HTTP server binds) so preflight can flag any
+        collision.
+        """
+        if not process.is_leader:
+            return None
+        config = self.get_config_for_mode(process.endpoint_mode)
+        if not config.get("enable-dp-attention") and not config.get("enable_dp_attention"):
+            return None
+        base = process.http_port
+        return [base, base + 233, base + 234, base + 235, base + 236, base + 237]
 
     def build_worker_command(
         self,

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -14,7 +14,7 @@ from marshmallow_dataclass import dataclass
 if TYPE_CHECKING:
     from srtctl.backends.base import SrunConfig
     from srtctl.core.runtime import RuntimeContext
-    from srtctl.core.topology import Endpoint, Process
+    from srtctl.core.topology import Endpoint, NodePortAllocator, Process
 
 # Type alias for worker modes
 WorkerMode = Literal["prefill", "decode", "agg"]
@@ -146,11 +146,12 @@ class TRTLLMProtocol:
         self,
         endpoints: list["Endpoint"],
         base_sys_port: int = 8081,
+        port_allocator: "NodePortAllocator | None" = None,
     ) -> list["Process"]:
         """Convert endpoints to processes."""
         from srtctl.core.topology import endpoints_to_processes
 
-        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port)
+        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port, port_allocator=port_allocator)
 
     def build_worker_command(
         self,

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -27,7 +27,7 @@ from marshmallow_dataclass import dataclass
 if TYPE_CHECKING:
     from srtctl.backends.base import SrunConfig
     from srtctl.core.runtime import RuntimeContext
-    from srtctl.core.topology import Endpoint, Process
+    from srtctl.core.topology import Endpoint, NodePortAllocator, Process
 
 # Type alias for worker modes
 WorkerMode = Literal["prefill", "decode", "agg"]
@@ -193,6 +193,7 @@ class VLLMProtocol:
         self,
         endpoints: list[Endpoint],
         base_sys_port: int = 8081,
+        port_allocator: NodePortAllocator | None = None,
     ) -> list[Process]:
         """Convert endpoints to processes.
 
@@ -206,12 +207,13 @@ class VLLMProtocol:
 
         if not has_dp_mode:
             # Standard TP mode: one process per node
-            return endpoints_to_processes(endpoints, base_sys_port=base_sys_port)
+            return endpoints_to_processes(endpoints, base_sys_port=base_sys_port, port_allocator=port_allocator)
 
         # DP+EP mode: one process per GPU
         processes: list[Process] = []
         current_sys_port = base_sys_port
-        port_allocator = NodePortAllocator()
+        if port_allocator is None:
+            port_allocator = NodePortAllocator()
 
         for endpoint in endpoints:
             if not self._is_dp_mode(endpoint.mode):

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -44,7 +44,7 @@ from srtctl.core.runtime import RuntimeContext
 from srtctl.core.schema import SrtConfig
 from srtctl.core.slurm import get_slurm_job_id, start_srun_process
 from srtctl.core.status import JobStage, JobStatus, StatusReporter
-from srtctl.core.topology import Endpoint, Process
+from srtctl.core.topology import Endpoint, NodePortAllocator, Process
 from srtctl.logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -95,8 +95,86 @@ class SweepOrchestrator(
 
     @functools.cached_property
     def backend_processes(self) -> list[Process]:
-        """Compute physical process topology from endpoints (cached)."""
-        return self.backend.endpoints_to_processes(self.endpoints)
+        """Compute physical process topology from endpoints (cached).
+
+        Builds a per-job-jittered ``NodePortAllocator`` so different SLURM
+        jobs land on different ``--port`` values. SGLang derives ZMQ TCP
+        ports (rpc/metrics/etc.) from --port in DP-attention mode, so a
+        leaked process from a previous job that holds the old port no
+        longer collides with the new job. See
+        ``compute_port_jitter`` in ``srtctl.core.topology``.
+        """
+        allocator = NodePortAllocator.from_job_id(self.runtime.job_id)
+        return self.backend.endpoints_to_processes(self.endpoints, port_allocator=allocator)
+
+    def preflight_check_ports(self) -> None:
+        """Verify SGLang DP-attention TCP ports are free on each prefill node.
+
+        SGLang's PortArgs.init_new() probes ports early (during engine init)
+        but doesn't bind them until ~15 min later in
+        engine.py:`self.send_to_rpc = get_zmq_socket(... bind=True)`. If a
+        leaked process from a previous job (or any concurrent listener)
+        grabs the port in that window, the engine crashes. We pre-flight
+        each prefill node here and fail-fast with diagnostic info instead
+        of letting the worker crash 15 minutes later.
+
+        Skips cleanly for backends that don't expose
+        ``dp_attention_tcp_ports`` (only SGLang implements it today —
+        TRTLLM/vLLM port-derivation behavior hasn't been verified).
+        """
+        from srtctl.runtime_scripts import check_ports as _check_ports_module
+
+        get_ports = getattr(self.backend, "dp_attention_tcp_ports", None)
+        if get_ports is None:
+            logger.debug("preflight: backend does not expose dp_attention_tcp_ports; skipping")
+            return
+
+        script_path = Path(_check_ports_module.__file__).resolve()
+        targets: list[tuple[Process, list[int]]] = []
+        for process in self.backend_processes:
+            ports = get_ports(process)
+            if ports:
+                targets.append((process, ports))
+        if not targets:
+            logger.debug("preflight: no DP-attention TCP ports to check (backend skipped)")
+            return
+
+        for process, ports in targets:
+            cmd = ["python3", str(script_path), "--ports", *(str(p) for p in ports)]
+            # Run on the bare host (no --container-image): pyxis startup adds
+            # tens of seconds and is unnecessary — pyxis containers use host
+            # networking, so a host-side scan sees container-bound ports too.
+            # --time 1:00 (1 minute) gives generous headroom; the helper itself
+            # finishes in well under a second.
+            proc = start_srun_process(
+                command=cmd,
+                nodelist=[process.node],
+                container_image=None,
+                container_mounts=None,
+                use_bash_wrapper=False,
+                srun_options={"time": "1:00"},
+            )
+            stdout, _ = proc.communicate(timeout=120)
+            output = (stdout or b"").decode(errors="replace").rstrip()
+            if proc.returncode == 0:
+                logger.info(
+                    "preflight: ports %s free on %s",
+                    ",".join(str(p) for p in ports),
+                    process.node,
+                )
+                if output:
+                    logger.debug("preflight stdout (%s):\n%s", process.node, output)
+                continue
+
+            # Busy or helper failure: surface every line for diagnosis. Each
+            # PORT_BUSY row carries pid/uid/user/name/cmdline/state of the
+            # offending listener, parsed by the helper from /proc.
+            for line in output.splitlines() or [f"<no output, rc={proc.returncode}>"]:
+                logger.warning("preflight %s: %s", process.node, line)
+            raise RuntimeError(
+                f"preflight: port collision on {process.node} (rc={proc.returncode}). "
+                f"Ports checked: {ports}. See preflight log lines above for the offending process."
+            )
 
     def start_head_infrastructure(self, registry: ProcessRegistry) -> ManagedProcess:
         """Start NATS and etcd on the infra node.
@@ -589,6 +667,16 @@ class SweepOrchestrator(
             if self.runtime.is_hf_model:
                 self._clean_stale_hf_locks()
                 self._ensure_model_cached()
+
+            # Stage 1.5: Preflight port collision check on prefill nodes
+            # before launching workers (catches leaked listeners from prior
+            # jobs that would otherwise crash the engine 15 min into init).
+            try:
+                self.preflight_check_ports()
+            except RuntimeError as e:
+                logger.error("Preflight failed: %s", e)
+                reporter.report(JobStatus.FAILED, JobStage.PREFLIGHT, str(e))
+                raise
 
             # Stage 2: Workers
             reporter.report(JobStatus.WORKERS, JobStage.WORKERS, "Starting workers")

--- a/src/srtctl/contract/enums.py
+++ b/src/srtctl/contract/enums.py
@@ -28,6 +28,7 @@ class JobStage(str, Enum):
 
     STARTING = "starting"
     HEAD_INFRASTRUCTURE = "head_infrastructure"
+    PREFLIGHT = "preflight"
     WORKERS = "workers"
     FRONTEND = "frontend"
     BENCHMARK = "benchmark"

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -26,6 +26,27 @@ from typing import Literal
 WorkerMode = Literal["prefill", "decode", "agg"]
 
 
+PORT_JITTER_MOD = 10000  # Spread per-job http port over a 10k range; collision prob ~1e-4.
+
+
+def compute_port_jitter(job_id: str | None, mod: int = PORT_JITTER_MOD) -> int:
+    """Deterministic per-job offset to avoid cross-job port collisions.
+
+    SGLang's DP-attention path derives ZMQ TCP ports from --port (rpc_port =
+    port + 236). When every job uses the same --port (30000) and a previous
+    run leaks a process on the recycled physical node, the new run can't
+    bind. Jittering the base by job id makes different runs land on
+    different ports.
+    """
+    if job_id is None:
+        return 0
+    try:
+        return int(job_id) % mod
+    except (TypeError, ValueError):
+        # Non-numeric job id (tests, manual invocations) — no jitter.
+        return 0
+
+
 @dataclass
 class NodePortAllocator:
     """Allocates unique ports per node to avoid conflicts.
@@ -49,6 +70,10 @@ class NodePortAllocator:
 
         # Different node starts fresh
         port3 = allocator.next_http_port("node1")  # 30000
+
+    Use ``NodePortAllocator.from_job_id(job_id)`` to construct an allocator
+    whose ``base_http_port`` and ``base_bootstrap_port`` are shifted by a
+    deterministic per-job offset — see ``compute_port_jitter``.
     """
 
     base_http_port: int = 30000
@@ -60,6 +85,20 @@ class NodePortAllocator:
     _bootstrap_ports: dict[str, int] = field(default_factory=dict, repr=False)
     _next_kv_events_port: int = field(default=0, repr=False)  # Global counter
     _next_nixl_port: int = field(default=0, repr=False)  # Global counter for NIXL
+
+    @classmethod
+    def from_job_id(cls, job_id: str | None) -> "NodePortAllocator":
+        """Build an allocator with per-job jitter applied to base_http/bootstrap ports.
+
+        Within one job, http_base and bootstrap_base move by the same offset,
+        preserving the 1000-port gap that keeps them from colliding (rpc_port
+        only reaches +237 from http_base).
+        """
+        jitter = compute_port_jitter(job_id)
+        return cls(
+            base_http_port=30000 + jitter,
+            base_bootstrap_port=31000 + jitter,
+        )
 
     def next_http_port(self, node: str) -> int:
         """Get next available HTTP port for a node."""

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -26,22 +26,46 @@ from typing import Literal
 WorkerMode = Literal["prefill", "decode", "agg"]
 
 
-PORT_JITTER_MOD = 10000  # Spread per-job http port over a 10k range; collision prob ~1e-4.
+PORT_JITTER_MOD = 5000  # Spread per-job http port over 5000 odd values (1, 3, …, 9999).
 
 
 def compute_port_jitter(job_id: str | None, mod: int = PORT_JITTER_MOD) -> int:
-    """Deterministic per-job offset to avoid cross-job port collisions.
+    """Deterministic per-job ODD offset to avoid cross-job port collisions.
 
     SGLang's DP-attention path derives ZMQ TCP ports from --port (rpc_port =
-    port + 236). When every job uses the same --port (30000) and a previous
-    run leaks a process on the recycled physical node, the new run can't
-    bind. Jittering the base by job id makes different runs land on
-    different ports.
+    port + 236). Two failure modes drive this jitter:
+
+    1. **Cross-job leak** — when every job uses --port 30000, a leaked
+       process from a previous run on the recycled physical node holds
+       the deterministic rpc_port and the new run can't bind.
+    2. **Kernel even-port preference** — Linux ``__inet_hash_connect``
+       allocates ports for outbound connect() in two passes: even ports
+       first, odd ports only after the entire even pool is exhausted (see
+       ``net/ipv4/inet_hashtables.c`` — ``offset &= ~1U`` then
+       ``port += 2``). NIXL/UCX/NCCL/torch.distributed open many outbound
+       sockets during prefill engine init; if our planned ``rpc_port`` is
+       both inside the kernel's ephemeral range
+       (``/proc/sys/net/ipv4/ip_local_port_range``, default 32768-60999)
+       AND even, the kernel happily hands it to one of those connect()
+       calls before SGLang's later ``bind('tcp://127.0.0.1:<port>')`` can
+       claim it (see ``engine.py:225``). Result: ``zmq.error.ZMQError:
+       Address already in use`` ~15 min into engine init, after model load.
+
+    Forcing the offset ODD (since 236 is even, parity is preserved
+    rpc_port == http_port mod 2) keeps rpc_port out of the kernel's
+    first-pass connect() pool. Empirically: the 5 jobs that hit failure
+    mode 2 in the 145859-145876 sweep all had even job IDs (and thus
+    even rpc_ports under the previous mod=10000 jitter); the matching
+    odd-id jobs all succeeded the prefill stage.
+
+    Mapping: ``((job_id % 5000) * 2) + 1`` → distinct odd values in
+    [1, 9999], period 5000 jobs. Two consecutive job IDs always land on
+    different odd offsets (delta = 2).
     """
     if job_id is None:
         return 0
     try:
-        return int(job_id) % mod
+        return ((int(job_id) % mod) * 2) + 1
     except (TypeError, ValueError):
         # Non-numeric job id (tests, manual invocations) — no jitter.
         return 0

--- a/src/srtctl/runtime_scripts/check_ports.py
+++ b/src/srtctl/runtime_scripts/check_ports.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pre-flight check: verify TCP ports are free on the host network namespace.
+
+Designed to run on the bare host (no container, no third-party deps) before
+SGLang prefill workers launch. Pyxis containers use host networking, so a
+host-side scan sees both bare-host listeners and any containerized listener
+bound to a host port.
+
+Output is parsed by ``do_sweep.py`` preflight; keep the format stable.
+
+Usage:
+    python3 check_ports.py --ports 30000 30236 30237
+
+Output (one line per port):
+    PORT_OK    127.0.0.1:30000
+    PORT_BUSY  127.0.0.1:30236  pid=12345 uid=1234 user=jullin name=python3 cmdline='python3 -m dynamo.sglang ...' state=R
+
+Exit 0 if all ports OK, 1 if any port is busy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pwd
+import re
+import shlex
+import sys
+from pathlib import Path
+
+# Linux TCP socket states (see net/tcp_states.h). 0A == LISTEN.
+TCP_LISTEN = "0A"
+
+
+def _decode_local_address(field: str) -> tuple[str, int] | None:
+    """Decode the ``local_address`` column from /proc/net/tcp{,6}.
+
+    IPv4 form: ``0100007F:7530`` (LE-encoded address, hex port).
+    IPv6 form: 32 hex chars + ``:`` + 4 hex port.
+    """
+    if ":" not in field:
+        return None
+    addr_hex, port_hex = field.rsplit(":", 1)
+    try:
+        port = int(port_hex, 16)
+    except ValueError:
+        return None
+    if len(addr_hex) == 8:
+        # IPv4: little-endian byte order
+        try:
+            packed = bytes.fromhex(addr_hex)
+        except ValueError:
+            return None
+        ip = ".".join(str(b) for b in reversed(packed))
+        return ip, port
+    if len(addr_hex) == 32:
+        # IPv6: 32 hex chars; for our purposes we just need to know whether
+        # it's loopback or any. Translate the in6_addr struct (which the
+        # kernel writes as four LE 32-bit words) to a colon-grouped form.
+        # Simplification: we only care about ::1 (loopback) and :: (any) for
+        # diagnostic clarity; otherwise fall through to "ipv6".
+        try:
+            words = [addr_hex[i : i + 8] for i in range(0, 32, 8)]
+            decoded = b"".join(bytes.fromhex(w)[::-1] for w in words)
+        except ValueError:
+            return None
+        if decoded == b"\x00" * 16:
+            return "::", port
+        if decoded == b"\x00" * 15 + b"\x01":
+            return "::1", port
+        return "ipv6", port
+    return None
+
+
+def _read_listening_inodes(proc_net_path: str, target_ports: set[int]) -> dict[int, list[tuple[str, int]]]:
+    """Return ``{inode: [(local_ip, port), ...]}`` for each LISTEN entry on a target port.
+
+    Multiple entries can map to the same inode if the kernel double-lists
+    (rare); we keep all addresses for diagnostic output.
+    """
+    result: dict[int, list[tuple[str, int]]] = {}
+    try:
+        with open(proc_net_path) as fh:
+            next(fh)  # skip header
+            for line in fh:
+                cols = line.split()
+                # Columns: sl local_address rem_address st tx_q rx_q tr tm->when retrnsmt uid timeout inode
+                if len(cols) < 12:
+                    continue
+                if cols[3] != TCP_LISTEN:
+                    continue
+                local = _decode_local_address(cols[1])
+                if local is None or local[1] not in target_ports:
+                    continue
+                try:
+                    inode = int(cols[9])
+                except ValueError:
+                    continue
+                result.setdefault(inode, []).append(local)
+    except FileNotFoundError:
+        pass
+    return result
+
+
+_SOCKET_FD_RE = re.compile(r"^socket:\[(\d+)\]$")
+
+
+def _find_owner_pid(target_inodes: set[int]) -> dict[int, int]:
+    """Walk /proc/*/fd/* to map socket inodes to owning pids.
+
+    Returns ``{inode: pid}``. Inodes not found are absent (caller falls back
+    to placeholder fields). Tolerates EACCES/ENOENT silently.
+    """
+    if not target_inodes:
+        return {}
+    found: dict[int, int] = {}
+    for entry in os.scandir("/proc"):
+        if not entry.is_dir() or not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        fd_dir = Path("/proc") / entry.name / "fd"
+        try:
+            fd_iter = os.scandir(fd_dir)
+        except (FileNotFoundError, PermissionError, ProcessLookupError):
+            continue
+        with fd_iter as it:
+            for fd_entry in it:
+                try:
+                    target = os.readlink(fd_entry.path)
+                except (FileNotFoundError, PermissionError, ProcessLookupError):
+                    continue
+                m = _SOCKET_FD_RE.match(target)
+                if not m:
+                    continue
+                inode = int(m.group(1))
+                if inode in target_inodes and inode not in found:
+                    found[inode] = pid
+                    if len(found) == len(target_inodes):
+                        return found
+    return found
+
+
+def _read_proc_field(pid: int, name: str) -> str | None:
+    try:
+        return (Path("/proc") / str(pid) / name).read_text()
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        return None
+
+
+def _process_info(pid: int) -> dict[str, str]:
+    """Best-effort ``{uid, user, name, cmdline, state}`` for a pid."""
+    info: dict[str, str] = {"pid": str(pid)}
+
+    comm = _read_proc_field(pid, "comm")
+    if comm is not None:
+        info["name"] = comm.strip() or "?"
+
+    cmdline = _read_proc_field(pid, "cmdline")
+    if cmdline is not None:
+        # NUL-separated argv; collapse to a shell-quoted string for log clarity.
+        argv = [a for a in cmdline.split("\0") if a]
+        info["cmdline"] = shlex.join(argv) if argv else "?"
+
+    status = _read_proc_field(pid, "status")
+    if status is not None:
+        for line in status.splitlines():
+            if line.startswith("Uid:"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    uid = parts[1]
+                    info["uid"] = uid
+                    try:
+                        info["user"] = pwd.getpwuid(int(uid)).pw_name
+                    except (KeyError, ValueError):
+                        info["user"] = "?"
+            elif line.startswith("State:"):
+                # "State:\tR (running)" -> "R"
+                parts = line.split()
+                if len(parts) >= 2:
+                    info["state"] = parts[1]
+    return info
+
+
+def _format_busy(addr: tuple[str, int], info: dict[str, str] | None) -> str:
+    ip, port = addr
+    fields = ["pid", "uid", "user", "name", "cmdline", "state"]
+    if info is None:
+        info = {}
+    parts = []
+    for f in fields:
+        v = info.get(f, "?")
+        if f == "cmdline":
+            # Quote so spaces don't confuse downstream parsers.
+            parts.append(f"cmdline={v!r}")
+        else:
+            parts.append(f"{f}={v}")
+    return f"PORT_BUSY  {ip}:{port}  " + " ".join(parts)
+
+
+def check_ports(ports: list[int]) -> int:
+    """Check each port; print one line per port; return non-zero if any busy."""
+    target_set = set(ports)
+
+    # Aggregate listening inodes across IPv4 and IPv6 (host network namespace).
+    inode_to_addrs: dict[int, list[tuple[str, int]]] = {}
+    for path in ("/proc/net/tcp", "/proc/net/tcp6"):
+        for inode, addrs in _read_listening_inodes(path, target_set).items():
+            inode_to_addrs.setdefault(inode, []).extend(addrs)
+
+    # Build port -> (inode, addrs) map. A port can have multiple inodes
+    # (IPv4+IPv6 dual-stack); we report each separately.
+    port_to_entries: dict[int, list[tuple[int, tuple[str, int]]]] = {}
+    for inode, addrs in inode_to_addrs.items():
+        for addr in addrs:
+            port_to_entries.setdefault(addr[1], []).append((inode, addr))
+
+    # Resolve owner pids for any busy ports.
+    busy_inodes = {inode for entries in port_to_entries.values() for inode, _ in entries}
+    inode_to_pid = _find_owner_pid(busy_inodes)
+
+    # Emit one line per requested port (in input order).
+    any_busy = False
+    for port in ports:
+        entries = port_to_entries.get(port, [])
+        if not entries:
+            print(f"PORT_OK    127.0.0.1:{port}", flush=True)
+            continue
+        any_busy = True
+        for inode, addr in entries:
+            pid = inode_to_pid.get(inode)
+            info = _process_info(pid) if pid is not None else None
+            print(_format_busy(addr, info), flush=True)
+    return 1 if any_busy else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ports", type=int, nargs="+", required=True, help="TCP ports to check")
+    args = parser.parse_args(argv)
+    return check_ports(args.ports)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/srtctl/runtime_scripts/check_ports.py
+++ b/src/srtctl/runtime_scripts/check_ports.py
@@ -74,19 +74,24 @@ def _decode_local_address(field: str) -> tuple[str, int] | None:
     return None
 
 
-def _read_listening_inodes(proc_net_path: str, target_ports: set[int]) -> dict[int, list[tuple[str, int]]]:
-    """Return ``{inode: [(local_ip, port), ...]}`` for each LISTEN entry on a target port.
+def _read_listening_inodes(proc_net_path: str, target_ports: set[int]) -> dict[int, list[tuple[str, int, int]]]:
+    """Return ``{inode: [(local_ip, port, uid), ...]}`` for each LISTEN entry on a target port.
+
+    The ``uid`` is the socket owner's uid as reported by the kernel in
+    /proc/net/tcp column 7. We capture it here so that even when we can't
+    walk ``/proc/<pid>/fd`` (cross-user collision), the diagnostic still
+    surfaces who owns the offending listener.
 
     Multiple entries can map to the same inode if the kernel double-lists
     (rare); we keep all addresses for diagnostic output.
     """
-    result: dict[int, list[tuple[str, int]]] = {}
+    result: dict[int, list[tuple[str, int, int]]] = {}
     try:
         with open(proc_net_path) as fh:
             next(fh)  # skip header
             for line in fh:
                 cols = line.split()
-                # Columns: sl local_address rem_address st tx_q rx_q tr tm->when retrnsmt uid timeout inode
+                # Columns: sl local_address rem_address st tx_q:rx_q tr:tm->when retrnsmt uid timeout inode
                 if len(cols) < 12:
                     continue
                 if cols[3] != TCP_LISTEN:
@@ -98,7 +103,11 @@ def _read_listening_inodes(proc_net_path: str, target_ports: set[int]) -> dict[i
                     inode = int(cols[9])
                 except ValueError:
                     continue
-                result.setdefault(inode, []).append(local)
+                try:
+                    uid = int(cols[7])
+                except ValueError:
+                    uid = -1
+                result.setdefault(inode, []).append((local[0], local[1], uid))
     except FileNotFoundError:
         pass
     return result
@@ -183,6 +192,23 @@ def _process_info(pid: int) -> dict[str, str]:
     return info
 
 
+def _info_from_uid(uid: int) -> dict[str, str]:
+    """Build a minimal ``{uid, user}`` info dict for the cross-user fallback.
+
+    Used when we know the socket's owner uid (from /proc/net/tcp) but can't
+    walk ``/proc/<pid>/fd`` to map the inode to a pid (typical when the
+    offending listener belongs to another user — e.g. a system daemon, or
+    a leftover process from a different SLURM user on a shared node).
+    """
+    info: dict[str, str] = {"uid": str(uid) if uid >= 0 else "?"}
+    if uid >= 0:
+        try:
+            info["user"] = pwd.getpwuid(uid).pw_name
+        except (KeyError, ValueError):
+            info["user"] = "?"
+    return info
+
+
 def _format_busy(addr: tuple[str, int], info: dict[str, str] | None) -> str:
     ip, port = addr
     fields = ["pid", "uid", "user", "name", "cmdline", "state"]
@@ -203,21 +229,24 @@ def check_ports(ports: list[int]) -> int:
     """Check each port; print one line per port; return non-zero if any busy."""
     target_set = set(ports)
 
-    # Aggregate listening inodes across IPv4 and IPv6 (host network namespace).
-    inode_to_addrs: dict[int, list[tuple[str, int]]] = {}
+    # Aggregate listening sockets across IPv4 and IPv6 (host network namespace).
+    # Each entry is (ip, port, uid) so the cross-user fallback path can still
+    # surface "user=root" / "user=nginx" even when /proc/<pid>/fd is unreadable.
+    inode_to_sockets: dict[int, list[tuple[str, int, int]]] = {}
     for path in ("/proc/net/tcp", "/proc/net/tcp6"):
-        for inode, addrs in _read_listening_inodes(path, target_set).items():
-            inode_to_addrs.setdefault(inode, []).extend(addrs)
+        for inode, sockets in _read_listening_inodes(path, target_set).items():
+            inode_to_sockets.setdefault(inode, []).extend(sockets)
 
-    # Build port -> (inode, addrs) map. A port can have multiple inodes
-    # (IPv4+IPv6 dual-stack); we report each separately.
-    port_to_entries: dict[int, list[tuple[int, tuple[str, int]]]] = {}
-    for inode, addrs in inode_to_addrs.items():
-        for addr in addrs:
-            port_to_entries.setdefault(addr[1], []).append((inode, addr))
+    # port -> [(inode, ip, uid), ...]. A port can have multiple inodes (IPv4 +
+    # IPv6 dual-stack); we report each separately.
+    port_to_entries: dict[int, list[tuple[int, str, int]]] = {}
+    for inode, sockets in inode_to_sockets.items():
+        for ip, port, uid in sockets:
+            port_to_entries.setdefault(port, []).append((inode, ip, uid))
 
-    # Resolve owner pids for any busy ports.
-    busy_inodes = {inode for entries in port_to_entries.values() for inode, _ in entries}
+    # Resolve owner pids for any busy ports. Fails silently for inodes whose
+    # owning pid belongs to another user (we can't read their /proc/<pid>/fd).
+    busy_inodes = {inode for entries in port_to_entries.values() for (inode, *_) in entries}
     inode_to_pid = _find_owner_pid(busy_inodes)
 
     # Emit one line per requested port (in input order).
@@ -228,10 +257,23 @@ def check_ports(ports: list[int]) -> int:
             print(f"PORT_OK    127.0.0.1:{port}", flush=True)
             continue
         any_busy = True
-        for inode, addr in entries:
+        for inode, ip, uid in entries:
             pid = inode_to_pid.get(inode)
-            info = _process_info(pid) if pid is not None else None
-            print(_format_busy(addr, info), flush=True)
+            if pid is not None:
+                info = _process_info(pid)
+                # Backfill uid/user from /proc/net/tcp if /proc/<pid>/status
+                # didn't yield them (rare, but be defensive).
+                info.setdefault("uid", str(uid) if uid >= 0 else "?")
+                if "user" not in info and uid >= 0:
+                    try:
+                        info["user"] = pwd.getpwuid(uid).pw_name
+                    except (KeyError, ValueError):
+                        info["user"] = "?"
+            else:
+                # Cross-user case: pid resolution failed. We still have uid
+                # from /proc/net/tcp, so at minimum emit user=<owner>.
+                info = _info_from_uid(uid)
+            print(_format_busy((ip, port), info), flush=True)
     return 1 if any_busy else 0
 
 

--- a/tests/test_check_ports.py
+++ b/tests/test_check_ports.py
@@ -117,12 +117,59 @@ class TestProcessInfo:
 
 class TestFormatBusy:
     def test_format_busy_unknown_owner(self):
-        # When pid resolution fails (e.g. another user's process), the script
-        # must still emit a PORT_BUSY row with placeholder fields rather than
-        # crashing. This is the diagnostic-fallback path.
+        # When pid AND uid resolution fail, the script must still emit a
+        # PORT_BUSY row with all-placeholder fields rather than crashing.
         line = check_ports._format_busy(("127.0.0.1", 30236), None)
         assert line.startswith("PORT_BUSY")
         assert "127.0.0.1:30236" in line
         assert "pid=?" in line
         assert "user=?" in line
         assert "cmdline=" in line
+
+
+class TestUidFallback:
+    """Verify the cross-user fallback path emits user= even without pid."""
+
+    def test_info_from_uid_resolves_username(self):
+        # uid 0 is root on every Linux system.
+        info = check_ports._info_from_uid(0)
+        assert info["uid"] == "0"
+        assert info["user"] == "root"
+
+    def test_info_from_uid_missing_user_falls_back(self):
+        # Pick a uid extremely unlikely to exist in /etc/passwd.
+        info = check_ports._info_from_uid(2**31 - 2)
+        # Either "?" if the lookup failed, or some unusual entry — accept both.
+        assert info["uid"] == str(2**31 - 2)
+        assert "user" in info
+
+    def test_info_from_uid_negative_means_unknown(self):
+        info = check_ports._info_from_uid(-1)
+        assert info["uid"] == "?"
+        assert "user" not in info  # No uid -> can't even attempt lookup.
+
+    def test_busy_with_uid_only(self, monkeypatch, capsys, listening_socket):
+        """Simulate the cross-user case: /proc/net/tcp shows the listener but
+        we can't walk /proc/<pid>/fd to get the pid.
+
+        We do this by monkeypatching ``_find_owner_pid`` to return {} (as if
+        every fd directory was permission-denied). The script must still emit
+        a PORT_BUSY line with user= populated from the uid recorded in
+        /proc/net/tcp (which we own — it's our test process).
+        """
+        port = listening_socket
+        free = _free_port()
+
+        monkeypatch.setattr(check_ports, "_find_owner_pid", lambda inodes: {})
+        rc = check_ports.check_ports([port, free])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert f"PORT_OK    127.0.0.1:{free}" in out
+        # Pid is "?" (we faked the lookup) but uid+user must be filled from
+        # /proc/net/tcp's column 7 — which is our own uid.
+        busy = next(line for line in out.splitlines() if line.startswith("PORT_BUSY"))
+        assert f":{port}" in busy
+        assert "pid=?" in busy
+        assert f"uid={os.getuid()}" in busy
+        # User name should resolve since the test runs under a real user.
+        assert "user=?" not in busy

--- a/tests/test_check_ports.py
+++ b/tests/test_check_ports.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for srtctl/runtime_scripts/check_ports.py."""
+
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from srtctl.runtime_scripts import check_ports
+
+SCRIPT_PATH = Path(check_ports.__file__).resolve()
+
+
+def _free_port() -> int:
+    """Pick a port that is currently free."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def listening_socket():
+    """Bind+listen on a loopback port; tear down after the test."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+    s.bind(("127.0.0.1", 0))
+    s.listen(8)
+    port = s.getsockname()[1]
+    try:
+        yield port
+    finally:
+        s.close()
+
+
+def _run_script(ports: list[int]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--ports", *(str(p) for p in ports)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestCheckPortsCLI:
+    def test_all_free_returns_zero(self):
+        # Pick two ports we're confident are free, then immediately query.
+        # Tiny TOCTOU window but harmless for the test (the script doesn't bind).
+        ports = [_free_port(), _free_port()]
+        result = _run_script(ports)
+        assert result.returncode == 0, result.stdout + result.stderr
+        for p in ports:
+            assert f"PORT_OK    127.0.0.1:{p}" in result.stdout
+
+    def test_busy_port_emits_diagnostic(self, listening_socket):
+        port = listening_socket
+        free = _free_port()
+        result = _run_script([port, free])
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert f"PORT_OK    127.0.0.1:{free}" in result.stdout
+        # The busy port line must include the test's own pid + diagnostic fields.
+        busy_line = next(
+            (line for line in result.stdout.splitlines() if line.startswith("PORT_BUSY")),
+            None,
+        )
+        assert busy_line is not None, result.stdout
+        assert f":{port}" in busy_line
+        assert f"pid={os.getpid()}" in busy_line
+        assert "user=" in busy_line
+        assert "cmdline=" in busy_line
+        assert "name=" in busy_line
+
+
+class TestDecodeLocalAddress:
+    def test_ipv4_loopback(self):
+        # /proc/net/tcp encodes 127.0.0.1 as 0100007F (LE bytes)
+        # and port 30236 as hex 7620.
+        assert check_ports._decode_local_address("0100007F:7620") == ("127.0.0.1", 0x7620)
+
+    def test_ipv4_any(self):
+        assert check_ports._decode_local_address("00000000:1F90") == ("0.0.0.0", 8080)
+
+    def test_ipv6_loopback(self):
+        # ::1 encoded by the kernel as four LE 32-bit words: 00000000 00000000 00000000 01000000
+        # (the trailing 01000000 is byte-reversed 00000001 -> ...01)
+        assert check_ports._decode_local_address("00000000000000000000000001000000:1F90") == ("::1", 8080)
+
+    def test_ipv6_any(self):
+        assert check_ports._decode_local_address("00000000000000000000000000000000:1F90") == ("::", 8080)
+
+    def test_invalid_returns_none(self):
+        assert check_ports._decode_local_address("not-an-address") is None
+        assert check_ports._decode_local_address("0100007F") is None  # missing port
+        assert check_ports._decode_local_address("0100007F:GGGG") is None  # bad hex
+
+
+class TestProcessInfo:
+    def test_process_info_self(self):
+        info = check_ports._process_info(os.getpid())
+        # On Linux, the test runner has a comm and at least argv[0].
+        assert info["pid"] == str(os.getpid())
+        assert "name" in info
+        assert info.get("uid") is not None
+        assert info.get("user") not in (None, "")
+
+    def test_process_info_missing_pid(self):
+        # PID 1 may or may not be readable depending on container; pick a
+        # guaranteed-not-running pid.
+        info = check_ports._process_info(2**31 - 1)
+        # Just the seed field; others are absent because /proc reads failed.
+        assert info == {"pid": str(2**31 - 1)}
+
+
+class TestFormatBusy:
+    def test_format_busy_unknown_owner(self):
+        # When pid resolution fails (e.g. another user's process), the script
+        # must still emit a PORT_BUSY row with placeholder fields rather than
+        # crashing. This is the diagnostic-fallback path.
+        line = check_ports._format_busy(("127.0.0.1", 30236), None)
+        assert line.startswith("PORT_BUSY")
+        assert "127.0.0.1:30236" in line
+        assert "pid=?" in line
+        assert "user=?" in line
+        assert "cmdline=" in line

--- a/tests/test_endpoint_allocation.py
+++ b/tests/test_endpoint_allocation.py
@@ -5,7 +5,12 @@
 
 import pytest
 
-from srtctl.core.topology import allocate_endpoints, endpoints_to_processes
+from srtctl.core.topology import (
+    NodePortAllocator,
+    allocate_endpoints,
+    compute_port_jitter,
+    endpoints_to_processes,
+)
 
 
 class TestAllocateEndpoints:
@@ -373,3 +378,73 @@ class TestEndpointsToProcesses:
         assert len(nixl_ports) == len(set(nixl_ports))  # All unique
         assert min(nixl_ports) == 6550  # Starts at base
         assert nixl_ports == [6550, 6551]  # Sequential
+
+
+class TestPortJitter:
+    """Tests for per-job port jitter that WARs the SGLang ZMQ rpc_port collision."""
+
+    def test_compute_port_jitter_deterministic(self):
+        # Same job id always returns the same offset.
+        assert compute_port_jitter("144826") == compute_port_jitter("144826")
+        assert compute_port_jitter("12345") == 12345 % 10000
+
+    def test_compute_port_jitter_non_numeric_falls_back(self):
+        assert compute_port_jitter("not-a-number") == 0
+        assert compute_port_jitter("") == 0
+        assert compute_port_jitter(None) == 0
+
+    def test_compute_port_jitter_range(self):
+        for jid in ("0", "9999", "10000", "10001", "144826"):
+            j = compute_port_jitter(jid)
+            assert 0 <= j < 10000
+
+    def test_from_job_id_shifts_bases(self):
+        a = NodePortAllocator.from_job_id("12345")
+        # 12345 % 10000 = 2345
+        assert a.base_http_port == 30000 + 2345
+        assert a.base_bootstrap_port == 31000 + 2345
+        # kv_events / nixl unaffected (they're already globally unique).
+        assert a.base_kv_events_port == 5550
+        assert a.base_nixl_port == 6550
+
+    def test_from_job_id_none_means_no_jitter(self):
+        a = NodePortAllocator.from_job_id(None)
+        assert a.base_http_port == 30000
+        assert a.base_bootstrap_port == 31000
+
+    def test_endpoints_to_processes_with_jittered_allocator(self):
+        """Jittered allocator shifts http_port + bootstrap_port; sys_port unchanged."""
+        endpoints = allocate_endpoints(
+            num_prefill=1,
+            num_decode=1,
+            num_agg=0,
+            gpus_per_prefill=2,
+            gpus_per_decode=2,
+            gpus_per_agg=8,
+            gpus_per_node=4,
+            available_nodes=("node0",),
+        )
+
+        # job_id 144826 -> jitter 4826 (the actual job id of the first failing run)
+        allocator = NodePortAllocator.from_job_id("144826")
+        processes = endpoints_to_processes(endpoints, base_sys_port=8081, port_allocator=allocator)
+
+        leaders = [p for p in processes if p.is_leader]
+        assert len(leaders) == 2
+        for leader in leaders:
+            assert leader.http_port >= 30000 + 4826
+        # SGLang's ZMQ rpc_port = http_port + 236; verify it's no longer 30236.
+        prefill = [p for p in processes if p.endpoint_mode == "prefill"][0]
+        assert prefill.http_port + 236 != 30236
+        assert prefill.bootstrap_port == 31000 + 4826
+
+    def test_different_job_ids_produce_different_ports(self):
+        """The 8 failing jobs should now land on different rpc_port values."""
+        failing_job_ids = ["144826", "144827", "144828", "144829", "144831", "144832", "144835", "144836"]
+        rpc_ports = set()
+        for jid in failing_job_ids:
+            allocator = NodePortAllocator.from_job_id(jid)
+            rpc_ports.add(allocator.base_http_port + 236)
+        # All 8 jobs would have used distinct rpc_ports — exactly the
+        # property the WAR is supposed to provide.
+        assert len(rpc_ports) == 8

--- a/tests/test_endpoint_allocation.py
+++ b/tests/test_endpoint_allocation.py
@@ -386,23 +386,40 @@ class TestPortJitter:
     def test_compute_port_jitter_deterministic(self):
         # Same job id always returns the same offset.
         assert compute_port_jitter("144826") == compute_port_jitter("144826")
-        assert compute_port_jitter("12345") == 12345 % 10000
+        # Mapping: ((id % 5000) * 2) + 1
+        assert compute_port_jitter("12345") == ((12345 % 5000) * 2) + 1
 
     def test_compute_port_jitter_non_numeric_falls_back(self):
         assert compute_port_jitter("not-a-number") == 0
         assert compute_port_jitter("") == 0
         assert compute_port_jitter(None) == 0
 
+    def test_compute_port_jitter_always_odd(self):
+        """Critical: jitter must be odd so rpc_port (port+236) stays odd.
+
+        Linux ``__inet_hash_connect`` allocates ports for outbound connect()
+        in two passes — even ports first, odd ports only after the entire
+        even pool is exhausted. NIXL/UCX outbound connections during prefill
+        engine init grab even ports preferentially. If our planned rpc_port
+        is even AND inside the kernel ephemeral range
+        (/proc/sys/net/ipv4/ip_local_port_range, default 32768-60999), the
+        kernel snatches it before SGLang can bind.
+        """
+        for jid in ("0", "1", "2", "144826", "144827", "145866", "145867", "9999", "10000", "99999"):
+            j = compute_port_jitter(jid)
+            assert j % 2 == 1, f"jitter for job {jid} must be odd, got {j}"
+
     def test_compute_port_jitter_range(self):
         for jid in ("0", "9999", "10000", "10001", "144826"):
             j = compute_port_jitter(jid)
-            assert 0 <= j < 10000
+            # Odd values in [1, 9999].
+            assert 1 <= j <= 9999
 
     def test_from_job_id_shifts_bases(self):
         a = NodePortAllocator.from_job_id("12345")
-        # 12345 % 10000 = 2345
-        assert a.base_http_port == 30000 + 2345
-        assert a.base_bootstrap_port == 31000 + 2345
+        # 12345 % 5000 = 2345 -> jitter = 2345*2 + 1 = 4691
+        assert a.base_http_port == 30000 + 4691
+        assert a.base_bootstrap_port == 31000 + 4691
         # kv_events / nixl unaffected (they're already globally unique).
         assert a.base_kv_events_port == 5550
         assert a.base_nixl_port == 6550
@@ -411,6 +428,14 @@ class TestPortJitter:
         a = NodePortAllocator.from_job_id(None)
         assert a.base_http_port == 30000
         assert a.base_bootstrap_port == 31000
+
+    def test_from_job_id_rpc_port_is_odd(self):
+        """rpc_port (= http_port + 236) must be odd to avoid the kernel
+        even-port-first connect() pool — see test_compute_port_jitter_always_odd."""
+        # Sample the originally-failing run + the second-wave failing runs.
+        for jid in ("144826", "144827", "145866", "145867", "145868", "145872", "145874", "145876"):
+            a = NodePortAllocator.from_job_id(jid)
+            assert (a.base_http_port + 236) % 2 == 1, f"rpc_port for {jid} must be odd"
 
     def test_endpoints_to_processes_with_jittered_allocator(self):
         """Jittered allocator shifts http_port + bootstrap_port; sys_port unchanged."""
@@ -425,26 +450,40 @@ class TestPortJitter:
             available_nodes=("node0",),
         )
 
-        # job_id 144826 -> jitter 4826 (the actual job id of the first failing run)
+        # job_id 144826 -> jitter = ((144826 % 5000) * 2) + 1 = 9653
         allocator = NodePortAllocator.from_job_id("144826")
+        expected_jitter = 9653
         processes = endpoints_to_processes(endpoints, base_sys_port=8081, port_allocator=allocator)
 
         leaders = [p for p in processes if p.is_leader]
         assert len(leaders) == 2
         for leader in leaders:
-            assert leader.http_port >= 30000 + 4826
-        # SGLang's ZMQ rpc_port = http_port + 236; verify it's no longer 30236.
+            assert leader.http_port >= 30000 + expected_jitter
+        # SGLang's ZMQ rpc_port = http_port + 236; verify it's no longer 30236
+        # AND that it's odd.
         prefill = [p for p in processes if p.endpoint_mode == "prefill"][0]
         assert prefill.http_port + 236 != 30236
-        assert prefill.bootstrap_port == 31000 + 4826
+        assert (prefill.http_port + 236) % 2 == 1
+        assert prefill.bootstrap_port == 31000 + expected_jitter
 
     def test_different_job_ids_produce_different_ports(self):
-        """The 8 failing jobs should now land on different rpc_port values."""
+        """The originally-failing 8 jobs land on 8 distinct rpc_ports."""
         failing_job_ids = ["144826", "144827", "144828", "144829", "144831", "144832", "144835", "144836"]
         rpc_ports = set()
         for jid in failing_job_ids:
             allocator = NodePortAllocator.from_job_id(jid)
             rpc_ports.add(allocator.base_http_port + 236)
-        # All 8 jobs would have used distinct rpc_ports — exactly the
-        # property the WAR is supposed to provide.
         assert len(rpc_ports) == 8
+
+    def test_second_wave_failures_now_get_odd_ports(self):
+        """The 145866-145876 wave failed because they had even rpc_ports.
+
+        Under the new odd-jitter formula they all map to odd rpc_ports — the
+        property that should keep them out of the kernel's even-first
+        connect() pool.
+        """
+        second_wave = ["145866", "145868", "145872", "145874", "145876"]
+        for jid in second_wave:
+            allocator = NodePortAllocator.from_job_id(jid)
+            rpc_port = allocator.base_http_port + 236
+            assert rpc_port % 2 == 1, f"job {jid} must now have odd rpc_port, got {rpc_port}"

--- a/tests/test_preflight_ports.py
+++ b/tests/test_preflight_ports.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for SweepOrchestrator.preflight_check_ports.
+
+We can't actually srun in unit tests; instead we patch start_srun_process to
+return a fake Popen whose communicate() yields known stdout/returncode, then
+verify the orchestrator's parsing/abort logic.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from srtctl.backends.sglang import SGLangProtocol, SGLangServerConfig
+from srtctl.cli.do_sweep import SweepOrchestrator
+from srtctl.core.runtime import Nodes, RuntimeContext
+from srtctl.core.schema import (
+    FrontendConfig,
+    ResourceConfig,
+    SrtConfig,
+)
+
+
+def _make_runtime(job_id: str = "144826") -> RuntimeContext:
+    return RuntimeContext(
+        job_id=job_id,
+        run_name="test-run",
+        nodes=Nodes(head="node0", bench="node0", infra="node0", worker=("node0", "node1")),
+        head_node_ip="10.0.0.1",
+        infra_node_ip="10.0.0.1",
+        log_dir=Path("/tmp/logs"),
+        model_path=Path("/models/test"),
+        container_image=Path("/path/to/container.sqsh"),
+        gpus_per_node=8,
+        network_interface=None,
+        container_mounts={},
+        environment={},
+    )
+
+
+def _make_config_with_dp_attention() -> SrtConfig:
+    """SGLang prefill recipe with enable-dp-attention=true (the failing case)."""
+    return SrtConfig(
+        name="test-dp",
+        model={"path": "test-model", "container": "test.sqsh", "precision": "fp16"},
+        resources=ResourceConfig(
+            gpu_type="a100",
+            gpus_per_node=8,
+            prefill_nodes=1,
+            decode_nodes=1,
+            prefill_workers=1,
+            decode_workers=1,
+        ),
+        frontend=FrontendConfig(type="dynamo"),
+        backend=SGLangProtocol(
+            sglang_config=SGLangServerConfig(
+                prefill={"enable-dp-attention": True, "data-parallel-size": 4},
+                decode={},
+            ),
+        ),
+    )
+
+
+def _make_config_no_dp_attention() -> SrtConfig:
+    """SGLang recipe without DP attention — preflight should be a no-op."""
+    return SrtConfig(
+        name="test-no-dp",
+        model={"path": "test-model", "container": "test.sqsh", "precision": "fp16"},
+        resources=ResourceConfig(
+            gpu_type="a100",
+            gpus_per_node=8,
+            prefill_nodes=1,
+            decode_nodes=1,
+            prefill_workers=1,
+            decode_workers=1,
+        ),
+        frontend=FrontendConfig(type="dynamo"),
+        backend=SGLangProtocol(
+            sglang_config=SGLangServerConfig(prefill={}, decode={}),
+        ),
+    )
+
+
+def _fake_popen(stdout: bytes, returncode: int) -> MagicMock:
+    proc = MagicMock()
+    proc.communicate.return_value = (stdout, b"")
+    proc.returncode = returncode
+    return proc
+
+
+class TestPreflightCheckPorts:
+    def test_skips_when_no_dp_attention_ports(self, caplog):
+        config = _make_config_no_dp_attention()
+        runtime = _make_runtime()
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        with (
+            patch("srtctl.cli.do_sweep.start_srun_process") as mock_srun,
+            caplog.at_level("DEBUG", logger="srtctl.cli.do_sweep"),
+        ):
+            orchestrator.preflight_check_ports()
+        # No srun should have been spawned because no process has DP-attn ports.
+        mock_srun.assert_not_called()
+
+    def test_skips_when_backend_does_not_implement_method(self):
+        """Backends without dp_attention_tcp_ports (TRTLLM/vLLM/Mocker) skip cleanly.
+
+        The orchestrator uses getattr(backend, "dp_attention_tcp_ports", None)
+        so unverified backends fall through without crashing.
+        """
+        config = _make_config_with_dp_attention()
+        runtime = _make_runtime()
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        # Replace the orchestrator's `backend` property with one that lacks
+        # the optional method, simulating TRTLLM/vLLM/Mocker.
+        class _BareBackend:
+            type = "test-bare"
+            # Intentionally no dp_attention_tcp_ports attribute.
+
+        with (
+            patch.object(SweepOrchestrator, "backend", new=_BareBackend()),
+            patch("srtctl.cli.do_sweep.start_srun_process") as mock_srun,
+        ):
+            orchestrator.preflight_check_ports()  # must return cleanly
+
+        mock_srun.assert_not_called()
+        # Verified live behavior of the on-disk non-SGLang backends: none of
+        # them expose this method either.
+        from srtctl.backends.mocker import MockerProtocol
+        from srtctl.backends.trtllm import TRTLLMProtocol
+        from srtctl.backends.vllm import VLLMProtocol
+
+        for cls in (TRTLLMProtocol, VLLMProtocol, MockerProtocol):
+            assert not hasattr(cls, "dp_attention_tcp_ports"), (
+                f"{cls.__name__} must not stub dp_attention_tcp_ports until SGLang's "
+                "DP-attention TCP-port behavior is verified for it"
+            )
+
+    def test_all_ports_free_logs_info_and_returns(self, caplog):
+        config = _make_config_with_dp_attention()
+        runtime = _make_runtime()
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        # Helper exits 0 with one PORT_OK line per checked port.
+        ports_per_call: list[list[int]] = []
+
+        def fake_srun(*, command, nodelist, **kw):
+            # The 3rd positional arg of `command` after "python3" + script path is "--ports"
+            assert command[2] == "--ports"
+            ports = [int(p) for p in command[3:]]
+            ports_per_call.append(ports)
+            stdout = "\n".join(f"PORT_OK    127.0.0.1:{p}" for p in ports).encode()
+            return _fake_popen(stdout, 0)
+
+        with (
+            patch("srtctl.cli.do_sweep.start_srun_process", side_effect=fake_srun),
+            caplog.at_level("INFO", logger="srtctl.cli.do_sweep"),
+        ):
+            orchestrator.preflight_check_ports()
+
+        # One srun per prefill leader.
+        prefill_leaders = [p for p in orchestrator.backend_processes if p.is_leader and p.endpoint_mode == "prefill"]
+        assert len(ports_per_call) == len(prefill_leaders)
+
+        # Each call must include all six SGLang DP-attention TCP ports.
+        for ports, leader in zip(ports_per_call, prefill_leaders, strict=False):
+            base = leader.http_port
+            assert ports == [base, base + 233, base + 234, base + 235, base + 236, base + 237]
+
+        # Per-job jitter is applied: --port should NOT be 30000 for job 144826.
+        for leader in prefill_leaders:
+            assert leader.http_port != 30000
+            # rpc_port (the failing one) should not be 30236 anymore.
+            assert leader.http_port + 236 != 30236
+
+        # Confirm the user-facing success log line is present.
+        assert any("preflight: ports" in r.message and "free on" in r.message for r in caplog.records)
+
+    def test_busy_port_aborts_with_diagnostic(self, caplog):
+        config = _make_config_with_dp_attention()
+        runtime = _make_runtime()
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        # Simulate the offending listener: a python3 process owned by `jullin`
+        # bound to the would-be rpc_port (matches the actual failing pattern).
+        leaders = [p for p in orchestrator.backend_processes if p.is_leader and p.endpoint_mode == "prefill"]
+        assert leaders, "test setup expects at least one prefill leader"
+        rpc_port = leaders[0].http_port + 236
+        busy_stdout = (
+            f"PORT_OK    127.0.0.1:{leaders[0].http_port}\n"
+            f"PORT_BUSY  127.0.0.1:{rpc_port}  pid=12345 uid=1234 user=jullin "
+            f"name=python3 cmdline='python3 -m dynamo.sglang' state=R\n"
+        ).encode()
+
+        def fake_srun(**_):
+            return _fake_popen(busy_stdout, 1)
+
+        with (
+            patch("srtctl.cli.do_sweep.start_srun_process", side_effect=fake_srun),
+            caplog.at_level("WARNING", logger="srtctl.cli.do_sweep"),
+            pytest.raises(RuntimeError, match="port collision"),
+        ):
+            orchestrator.preflight_check_ports()
+
+        # The PORT_BUSY diagnostic line must surface in the log so the user
+        # can see pid/user/cmdline of the offending process.
+        log_text = "\n".join(r.message for r in caplog.records)
+        assert "PORT_BUSY" in log_text
+        assert "pid=12345" in log_text
+        assert "user=jullin" in log_text
+        assert "dynamo.sglang" in log_text
+
+    def test_helper_failure_with_no_output_still_aborts(self):
+        """A helper crash (non-zero rc, empty stdout) must still fail-fast."""
+        config = _make_config_with_dp_attention()
+        runtime = _make_runtime()
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        def fake_srun(**_):
+            return _fake_popen(b"", 2)
+
+        with (
+            patch("srtctl.cli.do_sweep.start_srun_process", side_effect=fake_srun),
+            pytest.raises(RuntimeError, match="rc=2"),
+        ):
+            orchestrator.preflight_check_ports()
+
+    def test_runs_outside_pyxis(self):
+        """Preflight srun must not request a container image (pyxis is slow)."""
+        config = _make_config_with_dp_attention()
+        runtime = _make_runtime()
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        captured_kwargs: list[dict] = []
+
+        def fake_srun(*, command, nodelist, **kw):
+            captured_kwargs.append({"command": command, "nodelist": nodelist, **kw})
+            # Pretend everything is free.
+            ports = [int(p) for p in command[3:]]
+            stdout = "\n".join(f"PORT_OK    127.0.0.1:{p}" for p in ports).encode()
+            return _fake_popen(stdout, 0)
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", side_effect=fake_srun):
+            orchestrator.preflight_check_ports()
+
+        assert captured_kwargs, "preflight should have invoked srun at least once"
+        for kw in captured_kwargs:
+            assert kw["container_image"] is None, "preflight must not pyxis-mount"
+            assert kw["container_mounts"] is None
+            assert kw["use_bash_wrapper"] is False
+            # 1 minute time budget per the plan.
+            assert kw["srun_options"] == {"time": "1:00"}

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -557,6 +557,7 @@ class TestJobStageEnum:
         """Stage values match API spec."""
         assert JobStage.STARTING.value == "starting"
         assert JobStage.HEAD_INFRASTRUCTURE.value == "head_infrastructure"
+        assert JobStage.PREFLIGHT.value == "preflight"
         assert JobStage.WORKERS.value == "workers"
         assert JobStage.FRONTEND.value == "frontend"
         assert JobStage.BENCHMARK.value == "benchmark"


### PR DESCRIPTION
Add port jittering and port checking for sglang to avoid using ports already in use.
Reports port collision at startup instead of 15min into a run after sglang tries binding the port.
NIXL also uses the same port range, but only uses even ports.
The port jittering always uses odd ports to prevent collision.

<strike> Also fixes a bug in client when `telemetry: null`. </strike> Fixed on main.