### PR TITLE
Handle null telemetry in live metrics startup

### DIFF
--- a/src/srtctl/analysis/live_metrics.py
+++ b/src/srtctl/analysis/live_metrics.py
@@ -310,8 +310,12 @@ def try_start_snapshotter(
         logger.debug("Live metrics: failed to load cluster config: %s", e)
         return None
 
-    cfg = (cluster_config or {}).get("telemetry", {}).get("live_metrics") if cluster_config else None
-    if not cfg or not cfg.get("enabled"):
+    telemetry = cluster_config.get("telemetry") if isinstance(cluster_config, dict) else None
+    if not isinstance(telemetry, dict):
+        return None
+
+    cfg = telemetry.get("live_metrics")
+    if not isinstance(cfg, dict) or not cfg.get("enabled"):
         return None
 
     # matplotlib is a required srtctl dependency (see pyproject.toml), so we

--- a/tests/test_live_metrics.py
+++ b/tests/test_live_metrics.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for best-effort live metrics startup."""
+
+import threading
+
+from srtctl.analysis.live_metrics import try_start_snapshotter
+
+
+def test_try_start_snapshotter_ignores_null_telemetry(monkeypatch, tmp_path):
+    """Cluster configs may dump omitted telemetry as null."""
+    monkeypatch.setattr("srtctl.core.config.load_cluster_config", lambda: {"telemetry": None})
+
+    assert try_start_snapshotter(tmp_path, threading.Event()) is None
+
+
+def test_try_start_snapshotter_ignores_null_live_metrics(monkeypatch, tmp_path):
+    monkeypatch.setattr("srtctl.core.config.load_cluster_config", lambda: {"telemetry": {"live_metrics": None}})
+
+    assert try_start_snapshotter(tmp_path, threading.Event()) is None


### PR DESCRIPTION
when telemetry not added in srtslurm.yaml, it failed with `attributeError: 'NoneType' object has no attribute 'get'`