### PR TITLE
feat: first-class mooncake KV store support for SGLang backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,8 @@ backend:
 
 `MOONCAKE_MASTER` is always computed from the runtime infra node IP — do not set it manually in `env`.
 
+**Validation:** In disaggregated mode, srtslurm rejects configs that set `mooncake_kv_store` without `disaggregation-transfer-backend: mooncake` on `sglang_config.prefill` or `sglang_config.decode`. This catches the common misconfiguration where the master process gets launched but workers fall back to default transport.
+
 ### ResourceConfig
 
 Supports explicit GPUs per worker (overrides computed values):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,33 @@ infra:
   etcd_nats_dedicated_node: true  # Reserve first node for infra services
 ```
 
+### Mooncake KV Store (SGLang only)
+
+When `mooncake_kv_store` is set under an SGLang backend, srtslurm:
+1. Launches `mooncake_master` on the infra node (same node as etcd/nats)
+2. Injects `MOONCAKE_MASTER=<infra_ip>:50051` on all workers automatically
+3. Passes through any env vars in `mooncake_kv_store.env` to all workers
+
+```yaml
+backend:
+  type: sglang
+  mooncake_kv_store:
+    container: nvcr.io/nvidia/mooncake:latest  # optional, defaults to job container
+    env:                                        # direct MOONCAKE_* / SGLANG_* env vars
+      MOONCAKE_PROTOCOL: rdma
+      MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
+      MOONCAKE_DEVICE: mlx5_0
+  sglang_config:
+    prefill:
+      disaggregation-transfer-backend: mooncake  # user still sets this
+      disaggregation-ib-device: "mlx5_0,mlx5_1"
+    decode:
+      disaggregation-transfer-backend: mooncake
+      disaggregation-ib-device: "mlx5_0,mlx5_1"
+```
+
+`MOONCAKE_MASTER` is always computed from the runtime infra node IP — do not set it manually in `env`.
+
 ### ResourceConfig
 
 Supports explicit GPUs per worker (overrides computed values):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,8 @@ backend:
 
 `MOONCAKE_MASTER` is always computed from the runtime infra node IP — do not set it manually in `env`.
 
+`MOONCAKE_LOCAL_HOSTNAME` is auto-resolved per-worker to that worker's own IP (using `runtime.network_interface`), so multi-node peer transfers don't fall back to `localhost`. If you need a specific NIC IP, set `MOONCAKE_LOCAL_HOSTNAME` in `env` to override the default.
+
 **Validation:** In disaggregated mode, srtslurm rejects configs that set `mooncake_kv_store` without `disaggregation-transfer-backend: mooncake` on `sglang_config.prefill` or `sglang_config.decode`. This catches the common misconfiguration where the master process gets launched but workers fall back to default transport.
 
 ### ResourceConfig

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,7 @@
 
 - [Architecture](architecture.md)
 - [SGLang Router](sglang-router.md)
+- [Mooncake KV Store](mooncake-kv-store.md)
 
 ## Benchmarking
 

--- a/docs/mooncake-kv-store.md
+++ b/docs/mooncake-kv-store.md
@@ -1,0 +1,200 @@
+# Mooncake KV Store
+
+First-class support for [Mooncake](https://github.com/kvcache-ai/Mooncake) as the KV transfer backend for SGLang prefill-decode disaggregation. When `mooncake_kv_store` is set under an SGLang backend, srtslurm launches and configures the mooncake master automatically and wires up worker env vars so peer-to-peer transfers work across multiple nodes.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [What srtslurm Owns vs What You Set](#what-srtslurm-owns-vs-what-you-set)
+- [Configuration Reference](#configuration-reference)
+- [Validation](#validation)
+- [Common Configurations](#common-configurations)
+  - [RDMA / InfiniBand](#rdma--infiniband)
+  - [TCP](#tcp)
+  - [Custom Master Container](#custom-master-container)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+SGLang supports several KV transfer backends for prefill-decode disaggregation: `mooncake`, `nixl`, `ascend`, `mori`, and `fake`. Mooncake is the default and uses RDMA/TCP for high-throughput transfers backed by a central master process.
+
+Without first-class support, running mooncake with srtslurm meant:
+
+1. Launching `mooncake_master` somewhere yourself (no integration with the SLURM job)
+2. Setting `MOONCAKE_MASTER`, `MOONCAKE_PROTOCOL`, `MOONCAKE_DEVICE`, etc. as env vars on every prefill and decode worker manually
+3. Resolving each worker's own IP for `MOONCAKE_LOCAL_HOSTNAME` so multi-node transfers don't fall back to `localhost`
+4. Adding `disaggregation-transfer-backend: mooncake` to `sglang_config`
+
+The `mooncake_kv_store` block automates 1–3. You still set the SGLang flags in step 4 because they're SGLang's CLI surface, not srtslurm's — but srtslurm validates that you did.
+
+## Quick Start
+
+Minimum config to run mooncake:
+
+```yaml
+backend:
+  type: sglang
+  mooncake_kv_store:
+    env:
+      MOONCAKE_PROTOCOL: rdma
+      MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
+  sglang_config:
+    prefill:
+      disaggregation-transfer-backend: mooncake
+      disaggregation-ib-device: "mlx5_0,mlx5_1"
+    decode:
+      disaggregation-transfer-backend: mooncake
+      disaggregation-ib-device: "mlx5_0,mlx5_1"
+```
+
+Even more minimal — just enable mooncake and let everything else default:
+
+```yaml
+backend:
+  type: sglang
+  mooncake_kv_store: {}
+  sglang_config:
+    prefill:
+      disaggregation-transfer-backend: mooncake
+    decode:
+      disaggregation-transfer-backend: mooncake
+```
+
+## What srtslurm Owns vs What You Set
+
+| Concern                                         | Owner     | Notes                                                                                                |
+| ----------------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
+| Launching `mooncake_master`                     | srtslurm  | Runs on the infra node (same node as etcd/nats; respects `infra.etcd_nats_dedicated_node`). Port 50051. |
+| `MOONCAKE_MASTER` env var on workers            | srtslurm  | Always computed as `<infra_node_ip>:50051`. User values in `env` are overridden.                      |
+| `MOONCAKE_LOCAL_HOSTNAME` env var               | srtslurm  | Auto-resolved per-worker via `runtime.network_interface`. User can override in `env` for custom NICs. |
+| `MOONCAKE_PROTOCOL`, `MOONCAKE_DEVICE`, etc.    | User      | Passed through `mooncake_kv_store.env` to all workers.                                               |
+| `disaggregation-transfer-backend: mooncake`     | User      | Set on `sglang_config.prefill` and `sglang_config.decode`. srtslurm validates this is present.       |
+| `disaggregation-ib-device`                      | User      | Set on `sglang_config.prefill` and `sglang_config.decode`. Format: `"mlx5_0,mlx5_1"` or JSON map.    |
+
+## Configuration Reference
+
+```yaml
+backend:
+  type: sglang
+  mooncake_kv_store:
+    container: nvcr.io/nvidia/mooncake:latest  # optional, default: job container
+    env:                                        # optional, default: {}
+      MOONCAKE_PROTOCOL: rdma
+      MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
+      MOONCAKE_DEVICE: mlx5_0
+      MOONCAKE_TE_META_DATA_SERVER: P2PHANDSHAKE
+      MOONCAKE_MASTER_METRICS_PORT: "9003"
+      # SGLang-specific staging buffer knobs:
+      SGLANG_DISAGG_STAGING_BUFFER: "true"
+      SGLANG_DISAGG_STAGING_BUFFER_SIZE_MB: "64"
+      SGLANG_DISAGG_STAGING_POOL_SIZE_MB: "4096"
+```
+
+### Fields
+
+- **`container`** (`str`, optional): Container image used for the `mooncake_master` srun. Defaults to the job container if unset. Useful when mooncake needs a different runtime than your SGLang container.
+- **`env`** (`dict[str, str]`, optional): Pass-through env vars injected on every prefill and decode worker. Keys map directly to mooncake's environment variable names — see the [SGLang server_args.py](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/environ.py) and [mooncake_store.py](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py) for the full list. Setting `MOONCAKE_MASTER` here is a no-op (srtslurm always wins).
+
+## Validation
+
+srtslurm rejects configs that set `mooncake_kv_store` in disaggregated mode without a matching `disaggregation-transfer-backend: mooncake` on `sglang_config.prefill` or `sglang_config.decode`. This catches the common mistake where the master process launches but workers fall back to default transport.
+
+```text
+ValidationError: mooncake_kv_store is set but neither sglang_config.prefill
+nor sglang_config.decode has 'disaggregation-transfer-backend: mooncake'.
+Add it to both modes (and 'disaggregation-ib-device') so workers actually
+use the mooncake master srtslurm launches for you.
+```
+
+Both dash and underscore forms (`disaggregation-transfer-backend`, `disaggregation_transfer_backend`) are accepted.
+
+## Common Configurations
+
+### RDMA / InfiniBand
+
+The most common production setup:
+
+```yaml
+backend:
+  type: sglang
+  mooncake_kv_store:
+    env:
+      MOONCAKE_PROTOCOL: rdma
+      MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
+      MOONCAKE_DEVICE: "mlx5_0,mlx5_1"
+  sglang_config:
+    prefill:
+      disaggregation-transfer-backend: mooncake
+      disaggregation-ib-device: "mlx5_0,mlx5_1"
+    decode:
+      disaggregation-transfer-backend: mooncake
+      disaggregation-ib-device: "mlx5_0,mlx5_1"
+```
+
+For a per-GPU IB device map, pass JSON to `disaggregation-ib-device`:
+
+```yaml
+sglang_config:
+  prefill:
+    disaggregation-ib-device: '{"0": "mlx5_0", "1": "mlx5_1", "2": "mlx5_2", "3": "mlx5_3"}'
+```
+
+### TCP
+
+For development / clusters without RDMA:
+
+```yaml
+backend:
+  type: sglang
+  mooncake_kv_store:
+    env:
+      MOONCAKE_PROTOCOL: tcp
+      MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
+  sglang_config:
+    prefill:
+      disaggregation-transfer-backend: mooncake
+    decode:
+      disaggregation-transfer-backend: mooncake
+```
+
+### Custom Master Container
+
+Pin a specific mooncake build for the master process:
+
+```yaml
+backend:
+  type: sglang
+  mooncake_kv_store:
+    container: nvcr.io/nvidia/mooncake:24.10
+    env:
+      MOONCAKE_PROTOCOL: rdma
+```
+
+The workers continue to use the job's main container — only the master process uses the override.
+
+## Troubleshooting
+
+### Master fails to start within 120s
+
+srtslurm waits up to 120 seconds for `mooncake_master` to bind on port 50051. If it times out, check:
+
+- `mooncake_master.out` in the run's log directory — usually shows a binary-not-found or RDMA setup error
+- Whether `mooncake_master` is on `$PATH` inside the master container. If you're using a custom container, verify it has the mooncake binaries installed.
+- Whether port 50051 is already in use on the infra node from a previous failed run (rare, but can happen if cleanup was interrupted)
+
+### Workers connect but transfers stall
+
+Almost always a `MOONCAKE_LOCAL_HOSTNAME` resolution issue. srtslurm auto-resolves it via `runtime.network_interface`. Verify in the worker log's `Env:` line that each worker has its own node's IP, not `localhost` or another worker's IP.
+
+If your cluster uses a separate RDMA NIC from the primary interface, override per-worker with the right IP — but note that `mooncake_kv_store.env` applies the same value everywhere, so for true per-worker overrides you'd need to set `runtime.network_interface` cluster-wide via `srtslurm.yaml`.
+
+### "Either MOONCAKE_MASTER or MOONCAKE_CLIENT is not set"
+
+This error from SGLang means the worker started before `MOONCAKE_MASTER` was injected. Check that `mooncake_kv_store` is present in the recipe — the env var is only auto-set when this block exists. Run `srtctl dry-run -f recipe.yaml` and look for `mooncake` in the env table.
+
+### "ValidationError: mooncake_kv_store is set but neither..."
+
+You added `mooncake_kv_store` but forgot `disaggregation-transfer-backend: mooncake` in `sglang_config.prefill` and `sglang_config.decode`. Add it to both modes — see [Validation](#validation) above.

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -155,17 +155,26 @@ class SGLangProtocol:
         """
         return {}
 
-    def get_mooncake_worker_env(self, infra_node_ip: str) -> dict[str, str]:
-        """Get mooncake env vars to inject on all workers.
+    def get_mooncake_worker_env(self, infra_node_ip: str, local_hostname: str) -> dict[str, str]:
+        """Get mooncake env vars to inject on a specific worker.
 
-        Returns empty dict if mooncake_kv_store is not configured.
-        Otherwise injects MOONCAKE_MASTER (computed from infra node IP) plus
-        any passthrough env vars from mooncake_kv_store.env. MOONCAKE_MASTER
-        is always set by srtslurm and overrides any user-supplied value.
+        Returns empty dict if mooncake_kv_store is not configured. Otherwise:
+        - MOONCAKE_LOCAL_HOSTNAME defaults to the worker's resolved IP, but the
+          user can override it in mooncake_kv_store.env if they need something
+          custom (e.g. a specific RDMA NIC IP).
+        - MOONCAKE_MASTER is always set by srtslurm to <infra_ip>:<port> and
+          overrides any user-supplied value (the user can't know the infra IP
+          at config time).
+
+        Args:
+            infra_node_ip: Resolved IP of the infra node where mooncake_master runs.
+            local_hostname: Resolved IP of the worker's own node, for peer-to-peer
+                transfers. Defaults to the worker's primary network interface IP.
         """
         if self.mooncake_kv_store is None:
             return {}
         return {
+            "MOONCAKE_LOCAL_HOSTNAME": local_hostname,
             **self.mooncake_kv_store.env,
             "MOONCAKE_MASTER": f"{infra_node_ip}:{MOONCAKE_MASTER_PORT}",
         }

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -160,13 +160,14 @@ class SGLangProtocol:
 
         Returns empty dict if mooncake_kv_store is not configured.
         Otherwise injects MOONCAKE_MASTER (computed from infra node IP) plus
-        any passthrough env vars from mooncake_kv_store.env.
+        any passthrough env vars from mooncake_kv_store.env. MOONCAKE_MASTER
+        is always set by srtslurm and overrides any user-supplied value.
         """
         if self.mooncake_kv_store is None:
             return {}
         return {
-            "MOONCAKE_MASTER": f"{infra_node_ip}:{MOONCAKE_MASTER_PORT}",
             **self.mooncake_kv_store.env,
+            "MOONCAKE_MASTER": f"{infra_node_ip}:{MOONCAKE_MASTER_PORT}",
         }
 
     def is_grpc_mode(self, mode: WorkerMode) -> bool:

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -30,6 +30,32 @@ if TYPE_CHECKING:
 # Type alias for worker modes
 WorkerMode = Literal["prefill", "decode", "agg"]
 
+MOONCAKE_MASTER_PORT = 50051
+
+
+@dataclass(frozen=True)
+class MooncakeKVStoreConfig:
+    """Mooncake KV store configuration.
+
+    When present, srtslurm launches mooncake_master on the infra node and
+    injects MOONCAKE_MASTER=<infra_ip>:<port> on all workers automatically.
+
+    Example YAML:
+        backend:
+          type: sglang
+          mooncake_kv_store:
+            container: nvcr.io/nvidia/mooncake:latest  # optional
+            env:
+              MOONCAKE_PROTOCOL: rdma
+              MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
+              MOONCAKE_DEVICE: mlx5_0
+    """
+
+    container: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+
+    Schema: ClassVar[type[Schema]] = Schema
+
 
 @dataclass(frozen=True)
 class SGLangServerConfig:
@@ -82,6 +108,10 @@ class SGLangProtocol:
     # Or global: true (enables for prefill+decode with defaults)
     kv_events_config: bool | dict[str, Any] | None = None
 
+    # Mooncake KV store - launches mooncake_master on infra node and injects
+    # MOONCAKE_MASTER env var on all workers automatically
+    mooncake_kv_store: MooncakeKVStoreConfig | None = None
+
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
     # =========================================================================
@@ -124,6 +154,20 @@ class SGLangProtocol:
         additional process-specific env vars are needed here.
         """
         return {}
+
+    def get_mooncake_worker_env(self, infra_node_ip: str) -> dict[str, str]:
+        """Get mooncake env vars to inject on all workers.
+
+        Returns empty dict if mooncake_kv_store is not configured.
+        Otherwise injects MOONCAKE_MASTER (computed from infra node IP) plus
+        any passthrough env vars from mooncake_kv_store.env.
+        """
+        if self.mooncake_kv_store is None:
+            return {}
+        return {
+            "MOONCAKE_MASTER": f"{infra_node_ip}:{MOONCAKE_MASTER_PORT}",
+            **self.mooncake_kv_store.env,
+        }
 
     def is_grpc_mode(self, mode: WorkerMode) -> bool:
         """Check if gRPC mode is enabled for a worker mode."""

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -23,6 +23,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, SGLangProtocol
 from srtctl.cli.mixins import (
     BenchmarkStageMixin,
     FrontendStageMixin,
@@ -157,6 +158,47 @@ class SweepOrchestrator(
         if not wait_for_port(infra_node, 2379, timeout=300):
             raise RuntimeError("etcd failed to start")
         logger.info("etcd is ready")
+
+        return managed
+
+    def start_mooncake_master(self, registry: ProcessRegistry) -> ManagedProcess | None:
+        """Launch mooncake_master on the infra node if mooncake_kv_store is configured.
+
+        Runs on the same node as etcd/nats. Uses mooncake_kv_store.container if set,
+        otherwise falls back to the job container.
+        """
+        if not isinstance(self.config.backend, SGLangProtocol):
+            return None
+        mooncake_cfg = self.config.backend.mooncake_kv_store
+        if mooncake_cfg is None:
+            return None
+
+        infra_node = self.runtime.nodes.infra
+        container = mooncake_cfg.container or str(self.runtime.container_image)
+        mooncake_log = self.runtime.log_dir / "mooncake_master.out"
+
+        logger.info("Starting mooncake_master on %s (port %d)", infra_node, MOONCAKE_MASTER_PORT)
+
+        proc = start_srun_process(
+            command=["mooncake_master", "--port", str(MOONCAKE_MASTER_PORT)],
+            nodelist=[infra_node],
+            output=str(mooncake_log),
+            container_image=container,
+            container_mounts=self.runtime.container_mounts,
+        )
+
+        managed = ManagedProcess(
+            name="mooncake_master",
+            popen=proc,
+            log_file=mooncake_log,
+            node=infra_node,
+            critical=True,
+        )
+
+        logger.info("Waiting for mooncake_master (port %d) on %s...", MOONCAKE_MASTER_PORT, infra_node)
+        if not wait_for_port(infra_node, MOONCAKE_MASTER_PORT, timeout=120):
+            raise RuntimeError("mooncake_master failed to start")
+        logger.info("mooncake_master is ready")
 
         return managed
 
@@ -506,6 +548,11 @@ class SweepOrchestrator(
             reporter.report(JobStatus.STARTING, JobStage.HEAD_INFRASTRUCTURE, "Starting head infrastructure")
             head_proc = self.start_head_infrastructure(registry)
             registry.add_process(head_proc)
+
+            # Stage 1b: Mooncake master (optional, co-located with infra node)
+            mooncake_proc = self.start_mooncake_master(registry)
+            if mooncake_proc is not None:
+                registry.add_process(mooncake_proc)
 
             # Pre-worker: Ensure HF model is cached before starting workers.
             # 1. Clean stale lock files from previous crashed downloads

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -198,9 +198,12 @@ class WorkerStageMixin:
         # Add backend-specific process environment variables (e.g., unique ports)
         env_to_set.update(self.backend.get_process_environment(process))
 
-        # Add mooncake worker env vars if configured (SGLang only)
+        # Add mooncake worker env vars if configured (SGLang only). Resolve the
+        # worker's own IP so MOONCAKE_LOCAL_HOSTNAME is correct for multi-node
+        # peer-to-peer transfers (defaulting to "localhost" silently breaks them).
         if hasattr(self.backend, "get_mooncake_worker_env"):
-            env_to_set.update(self.backend.get_mooncake_worker_env(self.runtime.infra_node_ip))
+            local_hostname = get_hostname_ip(process.node, self.runtime.network_interface)
+            env_to_set.update(self.backend.get_mooncake_worker_env(self.runtime.infra_node_ip, local_hostname))
 
         self._apply_kvbm_endpoint_env(env_to_set, endpoint_processes)
 
@@ -318,9 +321,13 @@ class WorkerStageMixin:
         if len(leader.gpu_indices) < self.runtime.gpus_per_node:
             env_to_set["CUDA_VISIBLE_DEVICES"] = leader.cuda_visible_devices
 
-        # Add mooncake worker env vars if configured (SGLang only)
+        # Add mooncake worker env vars if configured (SGLang only). For MPI-style
+        # endpoint launching we use the leader node's IP — mooncake's per-worker
+        # hostname is fundamentally per-process, but TRTLLM-style launching uses
+        # one srun for the whole endpoint, so leader IP is the best we can do.
         if hasattr(self.backend, "get_mooncake_worker_env"):
-            env_to_set.update(self.backend.get_mooncake_worker_env(self.runtime.infra_node_ip))
+            local_hostname = get_hostname_ip(leader.node, self.runtime.network_interface)
+            env_to_set.update(self.backend.get_mooncake_worker_env(self.runtime.infra_node_ip, local_hostname))
 
         self._apply_kvbm_endpoint_env(env_to_set, endpoint_processes)
 

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -198,6 +198,10 @@ class WorkerStageMixin:
         # Add backend-specific process environment variables (e.g., unique ports)
         env_to_set.update(self.backend.get_process_environment(process))
 
+        # Add mooncake worker env vars if configured (SGLang only)
+        if hasattr(self.backend, "get_mooncake_worker_env"):
+            env_to_set.update(self.backend.get_mooncake_worker_env(self.runtime.infra_node_ip))
+
         self._apply_kvbm_endpoint_env(env_to_set, endpoint_processes)
 
         # Log env vars in the format: VAR=value VAR2=value2
@@ -313,6 +317,10 @@ class WorkerStageMixin:
         # Set CUDA_VISIBLE_DEVICES if not using all GPUs on the node
         if len(leader.gpu_indices) < self.runtime.gpus_per_node:
             env_to_set["CUDA_VISIBLE_DEVICES"] = leader.cuda_visible_devices
+
+        # Add mooncake worker env vars if configured (SGLang only)
+        if hasattr(self.backend, "get_mooncake_worker_env"):
+            env_to_set.update(self.backend.get_mooncake_worker_env(self.runtime.infra_node_ip))
 
         self._apply_kvbm_endpoint_env(env_to_set, endpoint_processes)
 

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -243,6 +243,11 @@ def show_config_details(config: SrtConfig) -> None:
         has_env = True
         mode_envs.append(("benchmark", dict(config.benchmark.env)))
 
+    mooncake_cfg = getattr(backend, "mooncake_kv_store", None)
+    if mooncake_cfg is not None and mooncake_cfg.env:
+        has_env = True
+        mode_envs.append(("mooncake", dict(mooncake_cfg.env)))
+
     if has_env:
         env_table = Table(title="Environment Variables", show_lines=False, pad_edge=False)
         env_table.add_column("Scope", style="dim", width=14)
@@ -268,7 +273,13 @@ def show_config_details(config: SrtConfig) -> None:
         opts = " ".join(f"--{k} {v}" if v else f"--{k}" for k, v in config.srun_options.items())
         console.print(f"[dim]srun options:[/] {opts}")
 
-    if config.benchmark.type == "custom" or config.benchmark.container_image or config.telemetry.enabled:
+    show_extensions = (
+        config.benchmark.type == "custom"
+        or config.benchmark.container_image
+        or config.telemetry.enabled
+        or mooncake_cfg is not None
+    )
+    if show_extensions:
         details = Table(title="Execution Extensions", show_lines=False, pad_edge=False)
         details.add_column("Area", style="dim", width=14)
         details.add_column("Setting", style="yellow")
@@ -291,6 +302,10 @@ def show_config_details(config: SrtConfig) -> None:
             details.add_row("telemetry", "container_image", config.telemetry.container_image or "<unset>")
             details.add_row("telemetry", "storage_subdir", config.telemetry.storage_subdir)
             details.add_row("telemetry", "frequency", str(config.telemetry.default_frequency))
+
+        if mooncake_cfg is not None:
+            details.add_row("mooncake", "container", mooncake_cfg.container or "<job container>")
+            details.add_row("mooncake", "master_port", "50051 (auto)")
 
         console.print(Panel(details, border_style="blue"))
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1309,6 +1309,42 @@ class SrtConfig:
         """Validate configuration after initialization."""
         self._validate_profiling()
         self._validate_telemetry()
+        self._validate_mooncake_kv_store()
+
+    def _validate_mooncake_kv_store(self):
+        """Catch the common misconfiguration: mooncake_kv_store set without a
+        matching disaggregation-transfer-backend in sglang_config.
+
+        Without --disaggregation-transfer-backend mooncake on the worker CLI,
+        the master we launch is unused and the workers fall back to default
+        transport — almost never what the user intends.
+        """
+        mooncake_cfg = getattr(self.backend, "mooncake_kv_store", None)
+        if mooncake_cfg is None:
+            return
+
+        sglang_cfg = getattr(self.backend, "sglang_config", None)
+
+        def _has_mooncake_transfer(mode_cfg: dict | None) -> bool:
+            if not mode_cfg:
+                return False
+            # SGLang accepts both "disaggregation-transfer-backend" and the
+            # underscore form; _config_to_cli_args normalizes them.
+            for key in ("disaggregation-transfer-backend", "disaggregation_transfer_backend"):
+                if mode_cfg.get(key) == "mooncake":
+                    return True
+            return False
+
+        prefill_ok = sglang_cfg is not None and _has_mooncake_transfer(sglang_cfg.prefill)
+        decode_ok = sglang_cfg is not None and _has_mooncake_transfer(sglang_cfg.decode)
+
+        if self.resources.is_disaggregated and not (prefill_ok or decode_ok):
+            raise ValidationError(
+                "mooncake_kv_store is set but neither sglang_config.prefill nor "
+                "sglang_config.decode has 'disaggregation-transfer-backend: mooncake'. "
+                "Add it to both modes (and 'disaggregation-ib-device') so workers "
+                "actually use the mooncake master srtslurm launches for you."
+            )
 
     def _validate_profiling(self):
         """Validate profiling configuration matches serving mode."""

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -266,6 +266,10 @@ class TestDryRunExecutionExtensions:
                             "MOONCAKE_GLOBAL_SEGMENT_SIZE": "4gb",
                         },
                     },
+                    "sglang_config": {
+                        "prefill": {"disaggregation-transfer-backend": "mooncake"},
+                        "decode": {"disaggregation-transfer-backend": "mooncake"},
+                    },
                 }
             }
         )
@@ -287,6 +291,10 @@ class TestDryRunExecutionExtensions:
                 "backend": {
                     "type": "sglang",
                     "mooncake_kv_store": {"env": {"MOONCAKE_PROTOCOL": "tcp"}},
+                    "sglang_config": {
+                        "prefill": {"disaggregation-transfer-backend": "mooncake"},
+                        "decode": {"disaggregation-transfer-backend": "mooncake"},
+                    },
                 }
             }
         )

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -252,3 +252,45 @@ class TestDryRunExecutionExtensions:
         assert "telemetry" in output
         assert "scraper" in output
         assert "storage_subdir" in output
+
+    def test_mooncake_kv_store_details_shown(self, capsys):
+        """mooncake_kv_store should appear in env vars and execution extensions."""
+        config = _make_config(
+            {
+                "backend": {
+                    "type": "sglang",
+                    "mooncake_kv_store": {
+                        "container": "nvcr.io/nvidia/mooncake:latest",
+                        "env": {
+                            "MOONCAKE_PROTOCOL": "rdma",
+                            "MOONCAKE_GLOBAL_SEGMENT_SIZE": "4gb",
+                        },
+                    },
+                }
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        # Env table shows mooncake-scoped env vars
+        assert "mooncake" in output
+        assert "MOONCAKE_PROTOCOL" in output
+        assert "rdma" in output
+        assert "MOONCAKE_GLOBAL_SEGMENT_SIZE" in output
+        # Execution extensions shows master + container
+        assert "nvcr.io/nvidia/mooncake:latest" in output
+        assert "master_port" in output
+
+    def test_mooncake_kv_store_no_container_shows_default(self, capsys):
+        """mooncake_kv_store without explicit container falls back to job container label."""
+        config = _make_config(
+            {
+                "backend": {
+                    "type": "sglang",
+                    "mooncake_kv_store": {"env": {"MOONCAKE_PROTOCOL": "tcp"}},
+                }
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "<job container>" in output
+        assert "MOONCAKE_PROTOCOL" in output

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -457,15 +457,18 @@ class TestMooncakeKVStore:
         from srtctl.backends.sglang import SGLangProtocol
 
         backend = SGLangProtocol()
-        assert backend.get_mooncake_worker_env("10.0.0.1") == {}
+        assert backend.get_mooncake_worker_env("10.0.0.1", "10.0.0.2") == {}
 
     def test_mooncake_worker_env_minimal(self):
-        """mooncake_kv_store with no env → only MOONCAKE_MASTER is injected."""
+        """mooncake_kv_store with no env → MOONCAKE_MASTER + auto-resolved hostname."""
         from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, MooncakeKVStoreConfig, SGLangProtocol
 
         backend = SGLangProtocol(mooncake_kv_store=MooncakeKVStoreConfig())
-        env = backend.get_mooncake_worker_env("10.0.0.1")
-        assert env == {"MOONCAKE_MASTER": f"10.0.0.1:{MOONCAKE_MASTER_PORT}"}
+        env = backend.get_mooncake_worker_env("10.0.0.1", "10.0.0.42")
+        assert env == {
+            "MOONCAKE_MASTER": f"10.0.0.1:{MOONCAKE_MASTER_PORT}",
+            "MOONCAKE_LOCAL_HOSTNAME": "10.0.0.42",
+        }
 
     def test_mooncake_worker_env_master_always_overrides_user(self):
         """User-supplied MOONCAKE_MASTER in env is always overridden by srtslurm."""
@@ -474,8 +477,18 @@ class TestMooncakeKVStore:
         backend = SGLangProtocol(
             mooncake_kv_store=MooncakeKVStoreConfig(env={"MOONCAKE_MASTER": "should-be-ignored:9999"})
         )
-        env = backend.get_mooncake_worker_env("10.0.0.1")
+        env = backend.get_mooncake_worker_env("10.0.0.1", "10.0.0.42")
         assert env["MOONCAKE_MASTER"] == f"10.0.0.1:{MOONCAKE_MASTER_PORT}"
+
+    def test_mooncake_worker_env_local_hostname_user_can_override(self):
+        """User-supplied MOONCAKE_LOCAL_HOSTNAME in env overrides the auto-resolved value."""
+        from srtctl.backends.sglang import MooncakeKVStoreConfig, SGLangProtocol
+
+        backend = SGLangProtocol(
+            mooncake_kv_store=MooncakeKVStoreConfig(env={"MOONCAKE_LOCAL_HOSTNAME": "custom-rdma-nic"})
+        )
+        env = backend.get_mooncake_worker_env("10.0.0.1", "10.0.0.42")
+        assert env["MOONCAKE_LOCAL_HOSTNAME"] == "custom-rdma-nic"
 
     def test_mooncake_worker_env_passthrough(self):
         """mooncake_kv_store.env values are merged with MOONCAKE_MASTER."""
@@ -490,8 +503,9 @@ class TestMooncakeKVStore:
                 }
             )
         )
-        env = backend.get_mooncake_worker_env("192.168.1.5")
+        env = backend.get_mooncake_worker_env("192.168.1.5", "192.168.1.42")
         assert env["MOONCAKE_MASTER"] == f"192.168.1.5:{MOONCAKE_MASTER_PORT}"
+        assert env["MOONCAKE_LOCAL_HOSTNAME"] == "192.168.1.42"
         assert env["MOONCAKE_PROTOCOL"] == "rdma"
         assert env["MOONCAKE_GLOBAL_SEGMENT_SIZE"] == "4gb"
         assert env["MOONCAKE_DEVICE"] == "mlx5_0"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -526,6 +526,101 @@ backend:
         assert config.backend.mooncake_kv_store.env["MOONCAKE_PROTOCOL"] == "rdma"
         assert config.backend.mooncake_kv_store.env["MOONCAKE_GLOBAL_SEGMENT_SIZE"] == "4gb"
 
+    def test_mooncake_kv_store_disagg_without_transfer_backend_raises(self):
+        """Disagg mode + mooncake_kv_store but no transfer-backend flag → ValidationError."""
+        import yaml
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import SrtConfig
+
+        raw = yaml.safe_load("""
+name: test
+model:
+  path: /model
+  container: nvcr.io/test:latest
+  precision: bf16
+resources:
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpu_type: h100
+backend:
+  type: sglang
+  mooncake_kv_store:
+    env:
+      MOONCAKE_PROTOCOL: rdma
+""")
+        try:
+            SrtConfig.Schema().load(raw)
+        except ValidationError as e:
+            assert "mooncake_kv_store" in str(e)
+            assert "disaggregation-transfer-backend" in str(e)
+        else:
+            raise AssertionError("expected ValidationError")
+
+    def test_mooncake_kv_store_disagg_with_transfer_backend_passes(self):
+        """Disagg mode + mooncake_kv_store + transfer-backend on prefill+decode → OK."""
+        import yaml
+
+        from srtctl.core.schema import SrtConfig
+
+        raw = yaml.safe_load("""
+name: test
+model:
+  path: /model
+  container: nvcr.io/test:latest
+  precision: bf16
+resources:
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpu_type: h100
+backend:
+  type: sglang
+  mooncake_kv_store:
+    env:
+      MOONCAKE_PROTOCOL: rdma
+  sglang_config:
+    prefill:
+      disaggregation-transfer-backend: mooncake
+    decode:
+      disaggregation-transfer-backend: mooncake
+""")
+        config = SrtConfig.Schema().load(raw)
+        assert config.backend.mooncake_kv_store is not None
+
+    def test_mooncake_kv_store_underscore_form_accepted(self):
+        """Underscore form 'disaggregation_transfer_backend' is also accepted."""
+        import yaml
+
+        from srtctl.core.schema import SrtConfig
+
+        raw = yaml.safe_load("""
+name: test
+model:
+  path: /model
+  container: nvcr.io/test:latest
+  precision: bf16
+resources:
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpu_type: h100
+backend:
+  type: sglang
+  mooncake_kv_store: {}
+  sglang_config:
+    prefill:
+      disaggregation_transfer_backend: mooncake
+    decode:
+      disaggregation_transfer_backend: mooncake
+""")
+        # Should not raise.
+        SrtConfig.Schema().load(raw)
+
     def test_mooncake_kv_store_no_container(self):
         """mooncake_kv_store without container field defaults to None."""
         import yaml

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -447,3 +447,99 @@ class TestQwen32BCluster:
                     f"Need {total_gpus_needed} GPUs but only have {total_gpus_available} "
                     f"({r.total_nodes} nodes × {r.gpus_per_node} GPUs)"
                 )
+
+
+class TestMooncakeKVStore:
+    """Tests for mooncake_kv_store configuration on SGLangProtocol."""
+
+    def test_mooncake_worker_env_not_set(self):
+        """No mooncake_kv_store → get_mooncake_worker_env returns empty dict."""
+        from srtctl.backends.sglang import SGLangProtocol
+
+        backend = SGLangProtocol()
+        assert backend.get_mooncake_worker_env("10.0.0.1") == {}
+
+    def test_mooncake_worker_env_minimal(self):
+        """mooncake_kv_store with no env → only MOONCAKE_MASTER is injected."""
+        from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, MooncakeKVStoreConfig, SGLangProtocol
+
+        backend = SGLangProtocol(mooncake_kv_store=MooncakeKVStoreConfig())
+        env = backend.get_mooncake_worker_env("10.0.0.1")
+        assert env == {"MOONCAKE_MASTER": f"10.0.0.1:{MOONCAKE_MASTER_PORT}"}
+
+    def test_mooncake_worker_env_passthrough(self):
+        """mooncake_kv_store.env values are merged with MOONCAKE_MASTER."""
+        from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, MooncakeKVStoreConfig, SGLangProtocol
+
+        backend = SGLangProtocol(
+            mooncake_kv_store=MooncakeKVStoreConfig(
+                env={
+                    "MOONCAKE_PROTOCOL": "rdma",
+                    "MOONCAKE_GLOBAL_SEGMENT_SIZE": "4gb",
+                    "MOONCAKE_DEVICE": "mlx5_0",
+                }
+            )
+        )
+        env = backend.get_mooncake_worker_env("192.168.1.5")
+        assert env["MOONCAKE_MASTER"] == f"192.168.1.5:{MOONCAKE_MASTER_PORT}"
+        assert env["MOONCAKE_PROTOCOL"] == "rdma"
+        assert env["MOONCAKE_GLOBAL_SEGMENT_SIZE"] == "4gb"
+        assert env["MOONCAKE_DEVICE"] == "mlx5_0"
+
+    def test_mooncake_kv_store_loads_from_yaml(self):
+        """mooncake_kv_store round-trips through YAML deserialization."""
+        import yaml
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import SrtConfig
+
+        raw = yaml.safe_load("""
+name: test
+model:
+  path: /model
+  container: nvcr.io/test:latest
+  precision: bf16
+resources:
+  agg_nodes: 1
+  agg_workers: 1
+  gpu_type: h100
+backend:
+  type: sglang
+  mooncake_kv_store:
+    container: nvcr.io/nvidia/mooncake:latest
+    env:
+      MOONCAKE_PROTOCOL: rdma
+      MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
+""")
+        config = SrtConfig.Schema().load(raw)
+        assert config.backend.mooncake_kv_store is not None
+        assert config.backend.mooncake_kv_store.container == "nvcr.io/nvidia/mooncake:latest"
+        assert config.backend.mooncake_kv_store.env["MOONCAKE_PROTOCOL"] == "rdma"
+        assert config.backend.mooncake_kv_store.env["MOONCAKE_GLOBAL_SEGMENT_SIZE"] == "4gb"
+
+    def test_mooncake_kv_store_no_container(self):
+        """mooncake_kv_store without container field defaults to None."""
+        import yaml
+
+        from srtctl.core.schema import SrtConfig
+
+        raw = yaml.safe_load("""
+name: test
+model:
+  path: /model
+  container: nvcr.io/test:latest
+  precision: bf16
+resources:
+  agg_nodes: 1
+  agg_workers: 1
+  gpu_type: h100
+backend:
+  type: sglang
+  mooncake_kv_store:
+    env:
+      MOONCAKE_PROTOCOL: rdma
+""")
+        config = SrtConfig.Schema().load(raw)
+        assert config.backend.mooncake_kv_store is not None
+        assert config.backend.mooncake_kv_store.container is None
+        assert config.backend.mooncake_kv_store.env["MOONCAKE_PROTOCOL"] == "rdma"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -467,6 +467,16 @@ class TestMooncakeKVStore:
         env = backend.get_mooncake_worker_env("10.0.0.1")
         assert env == {"MOONCAKE_MASTER": f"10.0.0.1:{MOONCAKE_MASTER_PORT}"}
 
+    def test_mooncake_worker_env_master_always_overrides_user(self):
+        """User-supplied MOONCAKE_MASTER in env is always overridden by srtslurm."""
+        from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, MooncakeKVStoreConfig, SGLangProtocol
+
+        backend = SGLangProtocol(
+            mooncake_kv_store=MooncakeKVStoreConfig(env={"MOONCAKE_MASTER": "should-be-ignored:9999"})
+        )
+        env = backend.get_mooncake_worker_env("10.0.0.1")
+        assert env["MOONCAKE_MASTER"] == f"10.0.0.1:{MOONCAKE_MASTER_PORT}"
+
     def test_mooncake_worker_env_passthrough(self):
         """mooncake_kv_store.env values are merged with MOONCAKE_MASTER."""
         from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, MooncakeKVStoreConfig, SGLangProtocol
@@ -489,7 +499,6 @@ class TestMooncakeKVStore:
     def test_mooncake_kv_store_loads_from_yaml(self):
         """mooncake_kv_store round-trips through YAML deserialization."""
         import yaml
-        from marshmallow import ValidationError
 
         from srtctl.core.schema import SrtConfig
 

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -123,6 +123,7 @@ def test_worker_stage_wraps_nonfatal_fingerprint_hook(tmp_path: Path) -> None:
     mixin.runtime = SimpleNamespace(
         log_dir=tmp_path,
         head_node_ip="10.0.0.1",
+        infra_node_ip="10.0.0.1",
         nodes=SimpleNamespace(infra="infra-node", worker=["node-a"]),
         gpus_per_node=8,
         environment={},

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -124,6 +124,7 @@ def test_worker_stage_wraps_nonfatal_fingerprint_hook(tmp_path: Path) -> None:
         log_dir=tmp_path,
         head_node_ip="10.0.0.1",
         infra_node_ip="10.0.0.1",
+        network_interface=None,
         nodes=SimpleNamespace(infra="infra-node", worker=["node-a"]),
         gpus_per_node=8,
         environment={},


### PR DESCRIPTION
## Summary

- Adds `mooncake_kv_store` config block to `SGLangProtocol` with two fields: `container` (optional image for the master process) and `env` (passthrough `MOONCAKE_*`/`SGLANG_*` env vars)
- `SweepOrchestrator` launches `mooncake_master` on the infra node (co-located with etcd/nats, respects `etcd_nats_dedicated_node`) and waits for it on port 50051
- All workers automatically receive `MOONCAKE_MASTER=<infra_ip>:50051` plus any vars from `mooncake_kv_store.env`
- Users still manually set `disaggregation-transfer-backend` and `disaggregation-ib-device` via `sglang_config`

**Example YAML:**
```yaml
backend:
  type: sglang
  mooncake_kv_store:
    container: nvcr.io/nvidia/mooncake:latest  # optional
    env:
      MOONCAKE_PROTOCOL: rdma
      MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
      MOONCAKE_DEVICE: mlx5_0
  sglang_config:
    prefill:
      disaggregation-transfer-backend: mooncake
      disaggregation-ib-device: "mlx5_0,mlx5_1"
    decode:
      disaggregation-transfer-backend: mooncake
      disaggregation-ib-device: "mlx5_0,mlx5_1"
```

## Test plan

- [ ] `TestMooncakeKVStore` — 5 new unit tests covering: empty config, minimal config (only `MOONCAKE_MASTER` injected), passthrough env vars, full YAML round-trip, no-container default
- [ ] Existing `test_worker_stage_wraps_nonfatal_fingerprint_hook` — fixed mock to include `infra_node_ip`
- [ ] `make check` passes (671 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)