### PR TITLE
sglang: enable mooncake_master HTTP metadata server + auto-inject MOONCAKE_TE_META_DATA_SERVER

### DIFF
--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -31,14 +31,25 @@ if TYPE_CHECKING:
 WorkerMode = Literal["prefill", "decode", "agg"]
 
 MOONCAKE_MASTER_PORT = 50051
+MOONCAKE_HTTP_METADATA_PORT = 8080
 
 
 @dataclass(frozen=True)
 class MooncakeKVStoreConfig:
     """Mooncake KV store configuration.
 
-    When present, srtslurm launches mooncake_master on the infra node and
-    injects MOONCAKE_MASTER=<infra_ip>:<port> on all workers automatically.
+    When present, srtslurm launches mooncake_master on the infra node with
+    its embedded HTTP metadata server (so a separate metadata service is not
+    required), and injects on every worker:
+
+        MOONCAKE_MASTER              = <infra_ip>:50051
+        MOONCAKE_TE_META_DATA_SERVER = http://<infra_ip>:8080/metadata
+        MOONCAKE_LOCAL_HOSTNAME      = <worker_ip>
+
+    The HTTP metadata server is also what Dynamo's KV router calls into for
+    its `/batch_query_keys` shared-cache lookup path
+    (`lib/llm/src/kv_router/shared_cache.rs`), so enabling it here is what
+    lets `--shared-cache-type hicache` actually return non-zero hits.
 
     Example YAML:
         backend:
@@ -162,9 +173,9 @@ class SGLangProtocol:
         - MOONCAKE_LOCAL_HOSTNAME defaults to the worker's resolved IP, but the
           user can override it in mooncake_kv_store.env if they need something
           custom (e.g. a specific RDMA NIC IP).
-        - MOONCAKE_MASTER is always set by srtslurm to <infra_ip>:<port> and
-          overrides any user-supplied value (the user can't know the infra IP
-          at config time).
+        - MOONCAKE_MASTER and MOONCAKE_TE_META_DATA_SERVER are always set by
+          srtslurm to point at the infra-node mooncake_master, and override any
+          user-supplied value (the user can't know the infra IP at config time).
 
         Args:
             infra_node_ip: Resolved IP of the infra node where mooncake_master runs.
@@ -177,6 +188,7 @@ class SGLangProtocol:
             "MOONCAKE_LOCAL_HOSTNAME": local_hostname,
             **self.mooncake_kv_store.env,
             "MOONCAKE_MASTER": f"{infra_node_ip}:{MOONCAKE_MASTER_PORT}",
+            "MOONCAKE_TE_META_DATA_SERVER": (f"http://{infra_node_ip}:{MOONCAKE_HTTP_METADATA_PORT}/metadata"),
         }
 
     def is_grpc_mode(self, mode: WorkerMode) -> bool:

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -23,7 +23,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, SGLangProtocol
+from srtctl.backends.sglang import MOONCAKE_HTTP_METADATA_PORT, MOONCAKE_MASTER_PORT, SGLangProtocol
 from srtctl.cli.mixins import (
     BenchmarkStageMixin,
     FrontendStageMixin,
@@ -166,6 +166,16 @@ class SweepOrchestrator(
 
         Runs on the same node as etcd/nats. Uses mooncake_kv_store.container if set,
         otherwise falls back to the job container.
+
+        We always start the master with its embedded HTTP metadata server enabled
+        (`--enable_http_metadata_server=true`) so:
+
+        1. Workers can use ``MOONCAKE_TE_META_DATA_SERVER=http://infra:8080/metadata``
+           without a separate metadata service.
+        2. Dynamo's KV router shared-cache path
+           (`lib/llm/src/kv_router/shared_cache.rs`) can call the master's
+           ``/batch_query_keys`` endpoint for L3 reach when
+           ``--shared-cache-type hicache`` is set on the frontend.
         """
         if not isinstance(self.config.backend, SGLangProtocol):
             return None
@@ -177,10 +187,21 @@ class SweepOrchestrator(
         container = mooncake_cfg.container or str(self.runtime.container_image)
         mooncake_log = self.runtime.log_dir / "mooncake_master.out"
 
-        logger.info("Starting mooncake_master on %s (port %d)", infra_node, MOONCAKE_MASTER_PORT)
+        logger.info(
+            "Starting mooncake_master on %s (rpc=%d, http_metadata=%d)",
+            infra_node,
+            MOONCAKE_MASTER_PORT,
+            MOONCAKE_HTTP_METADATA_PORT,
+        )
 
         proc = start_srun_process(
-            command=["mooncake_master", "--port", str(MOONCAKE_MASTER_PORT)],
+            command=[
+                "mooncake_master",
+                f"--port={MOONCAKE_MASTER_PORT}",
+                "--enable_http_metadata_server=true",
+                f"--http_metadata_server_port={MOONCAKE_HTTP_METADATA_PORT}",
+                "--eviction_high_watermark_ratio=0.95",
+            ],
             nodelist=[infra_node],
             output=str(mooncake_log),
             container_image=container,
@@ -195,9 +216,16 @@ class SweepOrchestrator(
             critical=True,
         )
 
-        logger.info("Waiting for mooncake_master (port %d) on %s...", MOONCAKE_MASTER_PORT, infra_node)
+        logger.info("Waiting for mooncake_master RPC (port %d) on %s...", MOONCAKE_MASTER_PORT, infra_node)
         if not wait_for_port(infra_node, MOONCAKE_MASTER_PORT, timeout=120):
-            raise RuntimeError("mooncake_master failed to start")
+            raise RuntimeError("mooncake_master RPC failed to start")
+        logger.info(
+            "Waiting for mooncake_master HTTP metadata (port %d) on %s...",
+            MOONCAKE_HTTP_METADATA_PORT,
+            infra_node,
+        )
+        if not wait_for_port(infra_node, MOONCAKE_HTTP_METADATA_PORT, timeout=120):
+            raise RuntimeError("mooncake_master HTTP metadata server failed to start")
         logger.info("mooncake_master is ready")
 
         return managed

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -460,25 +460,42 @@ class TestMooncakeKVStore:
         assert backend.get_mooncake_worker_env("10.0.0.1", "10.0.0.2") == {}
 
     def test_mooncake_worker_env_minimal(self):
-        """mooncake_kv_store with no env → MOONCAKE_MASTER + auto-resolved hostname."""
-        from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, MooncakeKVStoreConfig, SGLangProtocol
+        """mooncake_kv_store with no env → MOONCAKE_MASTER + metadata URL + auto-resolved hostname."""
+        from srtctl.backends.sglang import (
+            MOONCAKE_HTTP_METADATA_PORT,
+            MOONCAKE_MASTER_PORT,
+            MooncakeKVStoreConfig,
+            SGLangProtocol,
+        )
 
         backend = SGLangProtocol(mooncake_kv_store=MooncakeKVStoreConfig())
         env = backend.get_mooncake_worker_env("10.0.0.1", "10.0.0.42")
         assert env == {
             "MOONCAKE_MASTER": f"10.0.0.1:{MOONCAKE_MASTER_PORT}",
+            "MOONCAKE_TE_META_DATA_SERVER": f"http://10.0.0.1:{MOONCAKE_HTTP_METADATA_PORT}/metadata",
             "MOONCAKE_LOCAL_HOSTNAME": "10.0.0.42",
         }
 
     def test_mooncake_worker_env_master_always_overrides_user(self):
-        """User-supplied MOONCAKE_MASTER in env is always overridden by srtslurm."""
-        from srtctl.backends.sglang import MOONCAKE_MASTER_PORT, MooncakeKVStoreConfig, SGLangProtocol
+        """User-supplied MOONCAKE_MASTER and metadata URL are always overridden by srtslurm."""
+        from srtctl.backends.sglang import (
+            MOONCAKE_HTTP_METADATA_PORT,
+            MOONCAKE_MASTER_PORT,
+            MooncakeKVStoreConfig,
+            SGLangProtocol,
+        )
 
         backend = SGLangProtocol(
-            mooncake_kv_store=MooncakeKVStoreConfig(env={"MOONCAKE_MASTER": "should-be-ignored:9999"})
+            mooncake_kv_store=MooncakeKVStoreConfig(
+                env={
+                    "MOONCAKE_MASTER": "should-be-ignored:9999",
+                    "MOONCAKE_TE_META_DATA_SERVER": "http://should-be-ignored:9999/metadata",
+                }
+            )
         )
         env = backend.get_mooncake_worker_env("10.0.0.1", "10.0.0.42")
         assert env["MOONCAKE_MASTER"] == f"10.0.0.1:{MOONCAKE_MASTER_PORT}"
+        assert env["MOONCAKE_TE_META_DATA_SERVER"] == f"http://10.0.0.1:{MOONCAKE_HTTP_METADATA_PORT}/metadata"
 
     def test_mooncake_worker_env_local_hostname_user_can_override(self):
         """User-supplied MOONCAKE_LOCAL_HOSTNAME in env overrides the auto-resolved value."""


### PR DESCRIPTION
## Summary

When ``backend.mooncake_kv_store`` is set, srtctl now starts ``mooncake_master`` with its **embedded HTTP metadata server enabled** (``--enable_http_metadata_server=true --http_metadata_server_port=8080``) plus ``--eviction_high_watermark_ratio=0.95``, and waits for both ports (RPC 50051, HTTP 8080) before workers come up. Workers automatically receive ``MOONCAKE_TE_META_DATA_SERVER=http://<infra>:8080/metadata`` alongside the existing ``MOONCAKE_MASTER`` and ``MOONCAKE_LOCAL_HOSTNAME`` injections.

This collapses the recipe-level env-var sprawl + setup-script stopgap (#3183b4c) into a single declarative ``mooncake_kv_store:`` block:

```yaml
backend:
  type: sglang
  mooncake_kv_store:
    env:
      MOONCAKE_PROTOCOL: rdma
      MOONCAKE_GLOBAL_SEGMENT_SIZE: "8gb"
```

## Why both ports

- **RPC :50051** carries ``Put``/``Get``/``Exist`` between the sglang HiCache mooncake client and the master.
- **HTTP :8080** is what Dynamo's KV router shared-cache path (``lib/llm/src/kv_router/shared_cache.rs``, jthompson #8912) calls for ``/batch_query_keys`` when ``--shared-cache-type hicache`` is set on the frontend. Without it, the multi-tier indexer ingests L1/L2 events from sglang fine, but the **direct L3-query path is dead** — ``dynamo_router_overhead_shared_cache_query_ms_count`` stays at zero.

Verified end-to-end against MiniMax-M2 NVFP4 + sglang v0.5.11 + dynamo @ 8fb0c11 on the gb200 cluster: 181 successful ``/batch_query_keys`` HTTP queries surfaced, 0 errors, ``host_pinned blocks: 750..1948`` reach showing in selector logs.

## Follow-up after this lands

Recipes currently using ``setup_script: setup-mooncake-master.sh`` (the stopgap added in #3183b4c) can drop both the script reference **and** their ``MOONCAKE_*`` env vars in ``aggregated_environment`` / ``decode_environment`` and replace with the ``mooncake_kv_store:`` block above. The stopgap script can stay in ``configs/`` for recipes that want full custom control.

## Test plan

- [x] ``uv run pytest tests/test_e2e.py::TestMooncakeKVStore -x`` — all 10 tests pass
- [x] ``uv run ruff check src/srtctl/backends/sglang.py src/srtctl/cli/do_sweep.py`` — clean
- [x] ``uv run ruff format`` — applied
- [ ] Recipe smoke test: convert ``mooncake-dynamo`` recipe to use ``mooncake_kv_store:`` block and confirm ``master_admin_metrics`` shows nonzero ``master_active_clients``

🤖 Generated with [Claude Code](https://claude.com/claude-code)