### PR TITLE
Preserve SRTSLURM_CONFIG in sbatch scripts

### DIFF
--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -197,6 +197,13 @@ def generate_minimal_sbatch_script(
     env = Environment(loader=FileSystemLoader(str(template_dir)))
     template = env.get_template("job_script_minimal.j2")
 
+    srtslurm_config = None
+    env_srtslurm_config = os.environ.get("SRTSLURM_CONFIG")
+    if env_srtslurm_config:
+        srtslurm_path = Path(os.path.expanduser(os.path.expandvars(env_srtslurm_config))).resolve()
+        if srtslurm_path.exists():
+            srtslurm_config = str(srtslurm_path)
+
     total_nodes = config.resources.total_nodes
     # Add extra node for dedicated etcd/nats infrastructure
     if config.infra.etcd_nats_dedicated_node:
@@ -227,6 +234,7 @@ def generate_minimal_sbatch_script(
         srtctl_source=str(srtctl_source.resolve()),
         output_base=output_base,
         setup_script=setup_script,
+        srtslurm_config=srtslurm_config,
     )
 
     return rendered

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -49,6 +49,9 @@ mkdir -p "${LOG_DIR}"
 
 # Export for Python orchestrator to use the same paths
 export SRTCTL_OUTPUT_DIR="${OUTPUT_DIR}"
+{% if srtslurm_config %}
+export SRTSLURM_CONFIG="{{ srtslurm_config }}"
+{% endif %}
 
 # Redirect stderr to stdout (SLURM captures both via --output)
 exec 2>&1

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -479,6 +479,39 @@ class TestSetupScript:
         )
         assert 'export SRTCTL_SETUP_SCRIPT="install-sglang-main.sh"' in script
 
+    def test_sbatch_template_canonicalizes_srtslurm_config_env_var(self, monkeypatch, tmp_path):
+        """Test that sbatch preserves SRTSLURM_CONFIG as an absolute path."""
+        from pathlib import Path
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+        from srtctl.core.schema import (
+            ModelConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        config_dir = tmp_path / "out" / "srt_slurm"
+        config_dir.mkdir(parents=True)
+        cluster_config = config_dir / "srtslurm_infarch.yaml"
+        cluster_config.write_text('cluster: "test"\n')
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("SRTSLURM_CONFIG", "out/srt_slurm/srtslurm_infarch.yaml")
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/container.sqsh", precision="fp8"),
+            resources=ResourceConfig(gpu_type="h100", gpus_per_node=8, agg_nodes=1),
+        )
+
+        script = generate_minimal_sbatch_script(
+            config=config,
+            config_path=Path("/tmp/test.yaml"),
+            setup_script=None,
+        )
+
+        assert f'export SRTSLURM_CONFIG="{cluster_config.resolve()}"' in script
+
     def test_setup_script_env_var_override(self, monkeypatch):
         """Test that SRTCTL_SETUP_SCRIPT env var overrides config."""
         import os


### PR DESCRIPTION
## Summary
  - Preserve `SRTSLURM_CONFIG` when generating sbatch scripts.
  - Resolve relative `SRTSLURM_CONFIG` values at submit time.
  - Export the resolved path in the generated job script.
  
## Testing
  - `uv run pytest tests/test_configs.py::TestSetupScript::test_sbatch_template_canonicalizes_srtslurm_config_env_var`