### PR TITLE
Prefer container infra binaries and prewarm Pyxis images

### DIFF
--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -144,6 +144,39 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
 
         return managed
 
+    def prewarm_container_image(self) -> None:
+        """Serially import/materialize the runtime container on allocated nodes.
+
+        Pyxis can race when many concurrent srun steps import the same registry
+        image into a shared cache. A cheap per-node warmup avoids that before
+        the real infra and worker steps launch in parallel.
+        """
+        if os.environ.get("SRTCTL_PREWARM_CONTAINER", "1").lower() in {"0", "false", "no"}:
+            logger.info("Skipping container prewarm (SRTCTL_PREWARM_CONTAINER disabled)")
+            return
+
+        nodes = list(dict.fromkeys((self.runtime.nodes.infra, *self.runtime.nodes.worker)))
+        logger.info("Prewarming container image on %d node(s)", len(nodes))
+        logger.info("Container image: %s", self.runtime.container_image)
+
+        for node in nodes:
+            log_file = self.runtime.log_dir / f"container_prewarm_{node}.out"
+            logger.info("Prewarming container on %s", node)
+            proc = start_srun_process(
+                command=["true"],
+                nodelist=[node],
+                output=str(log_file),
+                container_image=str(self.runtime.container_image),
+                container_mounts=self.runtime.container_mounts,
+                srun_options=self.runtime.srun_options,
+                use_bash_wrapper=False,
+            )
+            exit_code = proc.wait()
+            if exit_code != 0:
+                raise RuntimeError(f"Container prewarm failed on {node} with exit code {exit_code}; see {log_file}")
+
+        logger.info("Container prewarm complete")
+
     def _print_connection_info(self) -> None:
         """Print srun commands for connecting to nodes."""
         container_args = f"--container-image={self.runtime.container_image}"
@@ -327,6 +360,7 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
         try:
             # Stage 1: Head infrastructure (NATS, etcd)
             reporter.report(JobStatus.STARTING, JobStage.HEAD_INFRASTRUCTURE, "Starting head infrastructure")
+            self.prewarm_container_image()
             head_proc = self.start_head_infrastructure(registry)
             registry.add_process(head_proc)
 

--- a/src/srtctl/cli/setup_head.py
+++ b/src/srtctl/cli/setup_head.py
@@ -119,7 +119,40 @@ def setup_logging():
     )
 
 
-def start_nats(binary_path: str = "/configs/nats-server") -> subprocess.Popen:
+def resolve_binary(requested_path: str, executable_name: str, fallback_path: str) -> str:
+    """Resolve an infra binary from PATH first, then the mounted configs dir.
+
+    Dynamo runtime images often package NATS/etcd already. Keep /configs as a
+    fallback for older images or cluster packaging that stages binaries there.
+    """
+    if "/" not in requested_path:
+        if path := shutil.which(requested_path):
+            logger.info("Using %s from PATH: %s", executable_name, path)
+            return path
+        if os.path.exists(fallback_path):
+            logger.info("Using %s from fallback path: %s", executable_name, fallback_path)
+            return fallback_path
+    elif os.path.exists(requested_path):
+        logger.info("Using %s from configured path: %s", executable_name, requested_path)
+        return requested_path
+
+    if path := shutil.which(executable_name):
+        logger.info("Using %s from PATH: %s", executable_name, path)
+        return path
+    if os.path.exists(fallback_path):
+        logger.info("Using %s from fallback path: %s", executable_name, fallback_path)
+        return fallback_path
+
+    raise FileNotFoundError(
+        f"{executable_name} not found. Tried requested path/name {requested_path!r}, "
+        f"PATH lookup for {executable_name!r}, and fallback {fallback_path!r}."
+    )
+
+
+def start_nats(
+    binary_path: str = "nats-server",
+    max_payload_mb: int | None = None,
+) -> subprocess.Popen:
     """Start NATS server.
 
     Args:
@@ -128,8 +161,7 @@ def start_nats(binary_path: str = "/configs/nats-server") -> subprocess.Popen:
     Returns:
         Popen object for the NATS process
     """
-    if not os.path.exists(binary_path):
-        raise FileNotFoundError(f"NATS binary not found: {binary_path}")
+    binary_path = resolve_binary(binary_path, "nats-server", "/configs/nats-server")
 
     # Use /tmp for JetStream storage - avoids "Temporary storage directory" warning
     # and ensures we're using fast local storage'
@@ -151,7 +183,7 @@ def start_nats(binary_path: str = "/configs/nats-server") -> subprocess.Popen:
 
 def start_etcd(
     host_ip: str,
-    binary_path: str = "/configs/etcd",
+    binary_path: str = "etcd",
     log_dir: Path | None = None,
 ) -> subprocess.Popen:
     """Start etcd server.
@@ -164,8 +196,7 @@ def start_etcd(
     Returns:
         Popen object for the etcd process
     """
-    if not os.path.exists(binary_path):
-        raise FileNotFoundError(f"etcd binary not found: {binary_path}")
+    binary_path = resolve_binary(binary_path, "etcd", "/configs/etcd")
 
     logger.info("Starting etcd server...")
 
@@ -237,14 +268,14 @@ def main():
     parser.add_argument(
         "--nats-binary",
         type=str,
-        default="/configs/nats-server",
-        help="Path to NATS binary",
+        default="nats-server",
+        help="NATS binary name or path. Defaults to PATH lookup, then /configs/nats-server.",
     )
     parser.add_argument(
         "--etcd-binary",
         type=str,
-        default="/configs/etcd",
-        help="Path to etcd binary",
+        default="etcd",
+        help="etcd binary name or path. Defaults to PATH lookup, then /configs/etcd.",
     )
 
     args = parser.parse_args()

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -526,17 +526,20 @@ class TestSweepRunEvalIntegration:
 
         orch = self._make_orchestrator()
 
-        with patch.dict(os.environ, {"EVAL_ONLY": "true"}, clear=False):
-            with patch.object(orch, "start_head_infrastructure") as mock_head:
-                mock_head.return_value = MagicMock()
-                with patch.object(orch, "start_all_workers", return_value={}):
-                    with patch.object(orch, "start_frontend", return_value=[]):
-                        with patch.object(orch, "_run_post_eval", return_value=0) as mock_eval:
-                            with patch.object(orch, "run_benchmark") as mock_bench:
-                                with patch.object(orch, "run_postprocess"):
-                                    with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
-                                        mock_reporter_cls.from_config.return_value = MagicMock()
-                                        exit_code = orch.run()
+        with (
+            patch.dict(os.environ, {"EVAL_ONLY": "true"}, clear=False),
+            patch.object(orch, "prewarm_container_image"),
+            patch.object(orch, "start_head_infrastructure") as mock_head,
+            patch.object(orch, "start_all_workers", return_value={}),
+            patch.object(orch, "start_frontend", return_value=[]),
+            patch.object(orch, "_run_post_eval", return_value=0) as mock_eval,
+            patch.object(orch, "run_benchmark") as mock_bench,
+            patch.object(orch, "run_postprocess"),
+            patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls,
+        ):
+            mock_head.return_value = MagicMock()
+            mock_reporter_cls.from_config.return_value = MagicMock()
+            exit_code = orch.run()
 
         mock_eval.assert_called_once()
         mock_bench.assert_not_called()
@@ -549,17 +552,20 @@ class TestSweepRunEvalIntegration:
 
         orch = self._make_orchestrator()
 
-        with patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False):
-            with patch.object(orch, "start_head_infrastructure") as mock_head:
-                mock_head.return_value = MagicMock()
-                with patch.object(orch, "start_all_workers", return_value={}):
-                    with patch.object(orch, "start_frontend", return_value=[]):
-                        with patch.object(orch, "run_benchmark", return_value=0) as mock_bench:
-                            with patch.object(orch, "_run_post_eval", return_value=0) as mock_eval:
-                                with patch.object(orch, "run_postprocess"):
-                                    with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
-                                        mock_reporter_cls.from_config.return_value = MagicMock()
-                                        exit_code = orch.run()
+        with (
+            patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False),
+            patch.object(orch, "prewarm_container_image"),
+            patch.object(orch, "start_head_infrastructure") as mock_head,
+            patch.object(orch, "start_all_workers", return_value={}),
+            patch.object(orch, "start_frontend", return_value=[]),
+            patch.object(orch, "run_benchmark", return_value=0) as mock_bench,
+            patch.object(orch, "_run_post_eval", return_value=0) as mock_eval,
+            patch.object(orch, "run_postprocess"),
+            patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls,
+        ):
+            mock_head.return_value = MagicMock()
+            mock_reporter_cls.from_config.return_value = MagicMock()
+            exit_code = orch.run()
 
         mock_bench.assert_called_once()
         mock_eval.assert_called_once()
@@ -572,16 +578,19 @@ class TestSweepRunEvalIntegration:
 
         orch = self._make_orchestrator()
 
-        with patch.dict(os.environ, {"EVAL_ONLY": "true"}, clear=False):
-            with patch.object(orch, "start_head_infrastructure") as mock_head:
-                mock_head.return_value = MagicMock()
-                with patch.object(orch, "start_all_workers", return_value={}):
-                    with patch.object(orch, "start_frontend", return_value=[]):
-                        with patch.object(orch, "_run_post_eval", return_value=1):
-                            with patch.object(orch, "run_postprocess"):
-                                with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
-                                    mock_reporter_cls.from_config.return_value = MagicMock()
-                                    exit_code = orch.run()
+        with (
+            patch.dict(os.environ, {"EVAL_ONLY": "true"}, clear=False),
+            patch.object(orch, "prewarm_container_image"),
+            patch.object(orch, "start_head_infrastructure") as mock_head,
+            patch.object(orch, "start_all_workers", return_value={}),
+            patch.object(orch, "start_frontend", return_value=[]),
+            patch.object(orch, "_run_post_eval", return_value=1),
+            patch.object(orch, "run_postprocess"),
+            patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls,
+        ):
+            mock_head.return_value = MagicMock()
+            mock_reporter_cls.from_config.return_value = MagicMock()
+            exit_code = orch.run()
 
         assert exit_code == 1
 
@@ -592,17 +601,20 @@ class TestSweepRunEvalIntegration:
 
         orch = self._make_orchestrator()
 
-        with patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False):
-            with patch.object(orch, "start_head_infrastructure") as mock_head:
-                mock_head.return_value = MagicMock()
-                with patch.object(orch, "start_all_workers", return_value={}):
-                    with patch.object(orch, "start_frontend", return_value=[]):
-                        with patch.object(orch, "run_benchmark", return_value=0):
-                            with patch.object(orch, "_run_post_eval", return_value=1):
-                                with patch.object(orch, "run_postprocess"):
-                                    with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
-                                        mock_reporter_cls.from_config.return_value = MagicMock()
-                                        exit_code = orch.run()
+        with (
+            patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False),
+            patch.object(orch, "prewarm_container_image"),
+            patch.object(orch, "start_head_infrastructure") as mock_head,
+            patch.object(orch, "start_all_workers", return_value={}),
+            patch.object(orch, "start_frontend", return_value=[]),
+            patch.object(orch, "run_benchmark", return_value=0),
+            patch.object(orch, "_run_post_eval", return_value=1),
+            patch.object(orch, "run_postprocess"),
+            patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls,
+        ):
+            mock_head.return_value = MagicMock()
+            mock_reporter_cls.from_config.return_value = MagicMock()
+            exit_code = orch.run()
 
         assert exit_code == 0
 
@@ -613,17 +625,20 @@ class TestSweepRunEvalIntegration:
 
         orch = self._make_orchestrator()
 
-        with patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False):
-            with patch.object(orch, "start_head_infrastructure") as mock_head:
-                mock_head.return_value = MagicMock()
-                with patch.object(orch, "start_all_workers", return_value={}):
-                    with patch.object(orch, "start_frontend", return_value=[]):
-                        with patch.object(orch, "run_benchmark", return_value=1):
-                            with patch.object(orch, "_run_post_eval") as mock_eval:
-                                with patch.object(orch, "run_postprocess"):
-                                    with patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls:
-                                        mock_reporter_cls.from_config.return_value = MagicMock()
-                                        exit_code = orch.run()
+        with (
+            patch.dict(os.environ, {"EVAL_ONLY": "false", "RUN_EVAL": "true"}, clear=False),
+            patch.object(orch, "prewarm_container_image"),
+            patch.object(orch, "start_head_infrastructure") as mock_head,
+            patch.object(orch, "start_all_workers", return_value={}),
+            patch.object(orch, "start_frontend", return_value=[]),
+            patch.object(orch, "run_benchmark", return_value=1),
+            patch.object(orch, "_run_post_eval") as mock_eval,
+            patch.object(orch, "run_postprocess"),
+            patch("srtctl.cli.do_sweep.StatusReporter") as mock_reporter_cls,
+        ):
+            mock_head.return_value = MagicMock()
+            mock_reporter_cls.from_config.return_value = MagicMock()
+            exit_code = orch.run()
 
         mock_eval.assert_not_called()
         assert exit_code == 1


### PR DESCRIPTION
## Summary
  - Prefer NATS and etcd binaries available inside the container.
  - Preserve support for explicitly mounted infra binaries.
  - Prewarm Pyxis images before launching distributed services and workers.

## Testing
  - `uv run pytest tests/test_benchmarks.py`