### PR TITLE
Add TRT-LLM nsys profiling support

### DIFF
--- a/configs/setup-nsys-path.sh
+++ b/configs/setup-nsys-path.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+if [[ -x /opt/nsys/bin/nsys ]]; then
+  ln -sf /opt/nsys/bin/nsys /usr/local/bin/nsys
+  nsys --version
+else
+  echo "ERROR: /opt/nsys/bin/nsys is not executable; check the host nsys mount" >&2
+  exit 1
+fi

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -176,16 +176,19 @@ class TRTLLMProtocol:
         container_config_path = Path("/logs") / config_filename
         container_model_path = Path("/model")
 
-        cmd = [
-            "trtllm-llmapi-launch",
-            "python3",
-            "-m",
-            "dynamo.trtllm",
-            "--model-path",
-            str(container_model_path),
-            "--served-model-name",
-            runtime.model_path.name,
-        ]
+        cmd: list[str] = list(nsys_prefix) if nsys_prefix else []
+        cmd.extend(
+            [
+                "trtllm-llmapi-launch",
+                "python3",
+                "-m",
+                "dynamo.trtllm",
+                "--model-path",
+                str(container_model_path),
+                "--served-model-name",
+                runtime.model_path.name,
+            ]
+        )
 
         # Only add disaggregation mode for prefill/decode, not for agg
         if mode != "agg":


### PR DESCRIPTION
## Summary
  - Allow TRT-LLM worker launches to be wrapped with an `nsys profile` prefix.
  - Add a setup helper for containers where Nsight Systems is installed outside the default `PATH`.

## Testing
  - Not run separately for this split branch.