### PR TITLE
Assign Dynamo system ports by launch role

### DIFF
--- a/src/srtctl/backends/base.py
+++ b/src/srtctl/backends/base.py
@@ -90,6 +90,7 @@ class BackendProtocol(Protocol):
         self,
         endpoints: list["Endpoint"],
         base_sys_port: int = 8081,
+        sys_port_stride: int = 1,
     ) -> list["Process"]:
         """Convert logical endpoints to physical processes."""
         ...

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -198,11 +198,12 @@ class SGLangProtocol:
         self,
         endpoints: list["Endpoint"],
         base_sys_port: int = 8081,
+        sys_port_stride: int = 1,
     ) -> list["Process"]:
         """Convert endpoints to processes."""
         from srtctl.core.topology import endpoints_to_processes
 
-        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port)
+        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port, sys_port_stride=sys_port_stride)
 
     def build_worker_command(
         self,

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -146,11 +146,12 @@ class TRTLLMProtocol:
         self,
         endpoints: list["Endpoint"],
         base_sys_port: int = 8081,
+        sys_port_stride: int = 1,
     ) -> list["Process"]:
         """Convert endpoints to processes."""
         from srtctl.core.topology import endpoints_to_processes
 
-        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port)
+        return endpoints_to_processes(endpoints, base_sys_port=base_sys_port, sys_port_stride=sys_port_stride)
 
     def build_worker_command(
         self,

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -197,6 +197,7 @@ class VLLMProtocol:
         self,
         endpoints: list[Endpoint],
         base_sys_port: int = 8081,
+        sys_port_stride: int = 1,
     ) -> list[Process]:
         """Convert endpoints to processes.
 
@@ -210,7 +211,7 @@ class VLLMProtocol:
 
         if not has_dp_mode:
             # Standard TP mode: one process per node
-            return endpoints_to_processes(endpoints, base_sys_port=base_sys_port)
+            return endpoints_to_processes(endpoints, base_sys_port=base_sys_port, sys_port_stride=sys_port_stride)
 
         # DP+EP mode: one process per GPU
         processes: list[Process] = []
@@ -244,7 +245,7 @@ class VLLMProtocol:
                             nixl_port=nixl_port,
                         )
                     )
-                    current_sys_port += 1
+                    current_sys_port += sys_port_stride
             else:
                 # DP+EP mode: one process per GPU
                 # Each process gets a single GPU and a unique dp_rank
@@ -275,7 +276,7 @@ class VLLMProtocol:
                                 nixl_port=nixl_port,
                             )
                         )
-                        current_sys_port += 1
+                        current_sys_port += sys_port_stride
                         dp_rank += 1
 
         return processes

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -40,6 +40,15 @@ from srtctl.logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
 
+DYNAMO_SYSTEM_PORT_BASE = 8081
+
+
+def _backend_system_port_base(frontend_type: str, frontend_count: int, sys_port_stride: int) -> int:
+    """Return the first backend system port for the configured frontend."""
+    if frontend_type == "dynamo":
+        return DYNAMO_SYSTEM_PORT_BASE + (frontend_count * sys_port_stride)
+    return 8081
+
 
 @dataclass
 class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixin, PostProcessStageMixin):
@@ -81,7 +90,15 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
     @functools.cached_property
     def backend_processes(self) -> list[Process]:
         """Compute physical process topology from endpoints (cached)."""
-        return self.backend.endpoints_to_processes(self.endpoints)
+        sys_port_stride = max(self.runtime.gpus_per_node, 1)
+        frontend_count = 0
+        if self.config.frontend.type == "dynamo":
+            frontend_count = len(self._compute_frontend_topology().frontend_nodes)
+        return self.backend.endpoints_to_processes(
+            self.endpoints,
+            base_sys_port=_backend_system_port_base(self.config.frontend.type, frontend_count, sys_port_stride),
+            sys_port_stride=sys_port_stride if self.config.frontend.type == "dynamo" else 1,
+        )
 
     def start_head_infrastructure(self, registry: ProcessRegistry) -> ManagedProcess:
         """Start NATS and etcd on the infra node.

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _wrap_command_with_rank_system_port(cmd: list[str], base_port: int) -> list[str]:
+    """Set one Dynamo system port per Slurm local rank for MPI endpoint launches."""
+    inner = f"export DYN_SYSTEM_PORT=$(({base_port} + ${{SLURM_LOCALID:-0}})); exec {shlex.join(cmd)}"
+    return ["bash", "-lc", inner]
+
+
 class WorkerStageMixin:
     """Mixin for worker process startup stage.
 
@@ -227,13 +233,20 @@ class WorkerStageMixin:
             dump_config_path=config_dump,
         )
 
+        use_rank_system_port = self.config.frontend.type == "dynamo"
+        if use_rank_system_port:
+            cmd = _wrap_command_with_rank_system_port(cmd, leader.sys_port)
+
         # Environment variables
         env_to_set = {
             "HEAD_NODE_IP": self.runtime.head_node_ip,
             "ETCD_ENDPOINTS": f"http://{self.runtime.nodes.infra}:2379",
             "NATS_SERVER": f"nats://{self.runtime.nodes.infra}:4222",
-            "DYN_SYSTEM_PORT": str(leader.sys_port),
         }
+        if use_rank_system_port:
+            env_to_set["DYN_SYSTEM_PORT_BASE"] = str(leader.sys_port)
+        else:
+            env_to_set["DYN_SYSTEM_PORT"] = str(leader.sys_port)
 
         # Add mode-specific environment variables from backend
         env_to_set.update(self.backend.get_environment_for_mode(mode))

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -366,6 +366,7 @@ def allocate_endpoints(
 def endpoints_to_processes(
     endpoints: list[Endpoint],
     base_sys_port: int = 8081,
+    sys_port_stride: int = 1,
     port_allocator: NodePortAllocator | None = None,
 ) -> list[Process]:
     """Convert endpoints to physical processes.
@@ -379,6 +380,7 @@ def endpoints_to_processes(
     Args:
         endpoints: List of Endpoint objects
         base_sys_port: Starting port for DYN_SYSTEM_PORT assignment
+        sys_port_stride: Distance between assigned DYN_SYSTEM_PORT base values
         port_allocator: NodePortAllocator for HTTP/bootstrap ports (created if None)
 
     Returns:
@@ -424,6 +426,6 @@ def endpoints_to_processes(
                     nixl_port=node_nixl_port,
                 )
             )
-            current_sys_port += 1
+            current_sys_port += sys_port_stride
 
     return processes

--- a/src/srtctl/frontends/dynamo.py
+++ b/src/srtctl/frontends/dynamo.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DYNAMO_SYSTEM_PORT_BASE = 8081
+
 
 class DynamoFrontend:
     """Dynamo frontend implementation.
@@ -81,6 +83,7 @@ class DynamoFrontend:
                 "ETCD_ENDPOINTS": f"http://{runtime.nodes.infra}:2379",
                 "NATS_SERVER": f"nats://{runtime.nodes.infra}:4222",
                 "DYN_REQUEST_PLANE": "nats",
+                "DYN_SYSTEM_PORT": str(DYNAMO_SYSTEM_PORT_BASE + idx),
             }
 
             # Add frontend env from config


### PR DESCRIPTION
## Summary
  - Assign explicit Dynamo system ports to frontend processes.
  - Reserve backend system-port ranges based on `gpus_per_node`.
  - Derive MPI worker `DYN_SYSTEM_PORT` from the assigned base plus `SLURM_LOCALID`.

## Testing
  - `uv run pytest tests/test_frontend_topology.py tests/test_endpoint_allocation.py`