### PR TITLE
Capture git state for extra mounts

### DIFF
--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 
 from srtctl.benchmarks.base import SCRIPTS_DIR
 from srtctl.core.config import get_srtslurm_setting, load_cluster_config
+from srtctl.core.git_state import GIT_STATE_FILENAME
 from srtctl.core.lockfile import collect_worker_fingerprints, generate_reproduction_report, write_lockfile
 from srtctl.core.schema import AIAnalysisConfig, S3Config
 from srtctl.core.slurm import start_srun_process
@@ -130,7 +131,7 @@ class PostProcessStageMixin:
         into logs/ so they get uploaded alongside benchmark results and worker logs.
         """
         output_dir = self.runtime.log_dir.parent
-        files_to_copy = ["config.yaml", "sbatch_script.sh", f"{self.runtime.job_id}.json"]
+        files_to_copy = ["config.yaml", "sbatch_script.sh", f"{self.runtime.job_id}.json", GIT_STATE_FILENAME]
         for name in files_to_copy:
             src = output_dir / name
             if not src.exists():

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -50,6 +50,11 @@ from srtctl.core.fingerprint import (
     format_check_results,
     format_diff,
 )
+from srtctl.core.git_state import (
+    GIT_STATE_FILENAME,
+    git_snapshot_sources_from_extra_mounts,
+    write_git_state_snapshot,
+)
 from srtctl.core.lockfile import load_lockfile_fingerprints
 from srtctl.core.schema import SrtConfig
 from srtctl.core.status import create_job_record
@@ -600,6 +605,9 @@ def submit_with_orchestrator(
             runtime_config_path = job_output_dir / runtime_config_filename
             runtime_config_path.write_text(resolved_runtime_config_text)
         shutil.copy(script_path, job_output_dir / "sbatch_script.sh")
+        git_sources = git_snapshot_sources_from_extra_mounts(config)
+        if git_sources:
+            write_git_state_snapshot(job_output_dir / GIT_STATE_FILENAME, git_sources)
 
         job_name = get_job_name(config)
 

--- a/src/srtctl/core/git_state.py
+++ b/src/srtctl/core/git_state.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capture git state for source trees mounted into a run."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from srtctl.core.schema import SrtConfig
+
+logger = logging.getLogger(__name__)
+
+GIT_STATE_FILENAME = "git_state.txt"
+_GIT_TIMEOUT_S = 10
+_MAX_UNTRACKED_BYTES = 200_000
+_URL_USERINFO_RE = re.compile(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)(?P<userinfo>[^/@\s]+)@")
+
+
+@dataclass(frozen=True)
+class GitSnapshotSource:
+    """A host path whose enclosing git repository should be captured."""
+
+    label: str
+    path: Path
+
+
+def _expand_path(path: str | Path) -> Path:
+    return Path(os.path.expandvars(str(path))).expanduser()
+
+
+def _run_git(repo: Path, args: list[str], *, check: bool = False) -> subprocess.CompletedProcess[str] | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+            check=False,
+        )
+    except Exception as e:
+        logger.debug("git command failed in %s: %s", repo, e)
+        return None
+    if check and result.returncode != 0:
+        return None
+    return result
+
+
+def _find_git_root(path: Path) -> Path | None:
+    candidate = path if path.is_dir() else path.parent
+    result = _run_git(candidate, ["rev-parse", "--show-toplevel"], check=True)
+    if result is None:
+        return None
+    root = result.stdout.strip()
+    return Path(root).resolve() if root else None
+
+
+def _split_mount(mount_spec: str) -> tuple[str, str] | None:
+    if ":" not in mount_spec:
+        return None
+    return mount_spec.split(":", 1)
+
+
+def git_snapshot_sources_from_extra_mounts(config: SrtConfig) -> list[GitSnapshotSource]:
+    """Collect git snapshot source paths from explicit extra_mount entries."""
+    sources: list[GitSnapshotSource] = []
+    if config.extra_mount:
+        for mount_spec in config.extra_mount:
+            split = _split_mount(mount_spec)
+            if split is None:
+                sources.append(GitSnapshotSource("extra_mount", _expand_path(mount_spec)))
+                continue
+            host_path, container_path = split
+            sources.append(GitSnapshotSource(f"extra_mount:{container_path}", _expand_path(host_path)))
+
+    return sources
+
+
+def _git_stdout(repo: Path, args: list[str]) -> str:
+    result = _run_git(repo, args)
+    if result is None:
+        return "<git command failed>\n"
+    if result.returncode != 0:
+        stderr = _redact_url_credentials(result.stderr.strip())
+        return f"<git command failed: {stderr or result.returncode}>\n"
+    return _redact_url_credentials(result.stdout) if result.stdout else "<none>\n"
+
+
+def _redact_url_credentials(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        scheme = match.group("scheme")
+        userinfo = match.group("userinfo")
+        if ":" in userinfo:
+            username, _password = userinfo.split(":", 1)
+            return f"{scheme}{username}:<redacted>@"
+        if userinfo.lower().startswith(("ghp_", "github_pat_", "glpat-", "x-access-token")):
+            return f"{scheme}<redacted>@"
+        return match.group(0)
+
+    return _URL_USERINFO_RE.sub(replace, text)
+
+
+def _untracked_files(repo: Path) -> list[str]:
+    result = _run_git(repo, ["ls-files", "--others", "--exclude-standard", "-z"])
+    if result is None or result.returncode != 0 or not result.stdout:
+        return []
+    return [p for p in result.stdout.split("\0") if p]
+
+
+def _format_untracked_file(repo: Path, rel_path: str) -> list[str]:
+    path = repo / rel_path
+    try:
+        data = path.read_bytes()
+    except Exception as e:
+        return [f"# unable to read untracked file {rel_path}: {e}\n"]
+
+    header = [
+        f"diff --git a/{rel_path} b/{rel_path}\n",
+        "new file mode 100644\n",
+        "--- /dev/null\n",
+        f"+++ b/{rel_path}\n",
+    ]
+    if len(data) > _MAX_UNTRACKED_BYTES:
+        return [*header, f"# omitted: untracked file is {len(data)} bytes\n"]
+    if b"\0" in data:
+        return [*header, f"# omitted: untracked file appears binary ({len(data)} bytes)\n"]
+
+    text = data.decode("utf-8", errors="replace")
+    return [*header, "@@\n", *[f"+{line}\n" for line in text.splitlines()]]
+
+
+def _format_repo_snapshot(repo: Path, labels: list[str], source_paths: list[Path]) -> list[str]:
+    lines = [
+        "\n",
+        "=" * 80 + "\n",
+        f"Repository: {repo}\n",
+        f"Labels: {', '.join(sorted(set(labels)))}\n",
+        "Source paths:\n",
+    ]
+    lines.extend(f"  - {p}\n" for p in source_paths)
+
+    for title, args in [
+        ("Remote URLs", ["remote", "-v"]),
+        ("Branch", ["branch", "--show-current"]),
+        ("HEAD", ["rev-parse", "HEAD"]),
+        ("Status", ["status", "--short", "--branch"]),
+        ("Last 10 commits", ["log", "--decorate", "--oneline", "-n", "10"]),
+        ("Staged diff", ["diff", "--cached", "--no-ext-diff"]),
+        ("Unstaged diff", ["diff", "--no-ext-diff"]),
+    ]:
+        lines.extend(["\n", f"## {title}\n", _git_stdout(repo, args)])
+
+    untracked = _untracked_files(repo)
+    lines.extend(["\n", "## Untracked files\n"])
+    if not untracked:
+        lines.append("<none>\n")
+    else:
+        lines.extend(f"  - {path}\n" for path in untracked)
+        lines.append("\n## Untracked file contents\n")
+        for rel_path in untracked:
+            lines.extend(_format_untracked_file(repo, rel_path))
+            lines.append("\n")
+
+    return lines
+
+
+def write_git_state_snapshot(output_path: Path, sources: Iterable[GitSnapshotSource]) -> bool:
+    """Write a best-effort git state snapshot.
+
+    The output includes the last 10 commits, staged diff, unstaged diff,
+    and untracked file contents for every unique git repository found
+    under the supplied source paths.
+    """
+    try:
+        grouped: dict[Path, tuple[list[str], list[Path]]] = {}
+        considered: list[GitSnapshotSource] = []
+        for source in sources:
+            expanded = GitSnapshotSource(source.label, _expand_path(source.path))
+            considered.append(expanded)
+            root = _find_git_root(expanded.path)
+            if root is None:
+                continue
+            labels, paths = grouped.setdefault(root, ([], []))
+            labels.append(expanded.label)
+            paths.append(expanded.path)
+
+        lines = [
+            "# srtctl git state snapshot\n",
+            f"Generated at: {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}\n",
+            "\n",
+            "Sources considered:\n",
+        ]
+        if considered:
+            lines.extend(f"  - {source.label}: {source.path}\n" for source in considered)
+        else:
+            lines.append("  <none>\n")
+
+        if not grouped:
+            lines.extend(["\n", "No git repositories found under the considered sources.\n"])
+        else:
+            for repo, (labels, paths) in sorted(grouped.items(), key=lambda item: str(item[0])):
+                lines.extend(_format_repo_snapshot(repo, labels, paths))
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("".join(lines))
+        logger.info("Wrote git state snapshot: %s", output_path)
+        return True
+    except Exception as e:
+        logger.warning("Failed to write git state snapshot %s: %s", output_path, e)
+        return False

--- a/tests/test_git_state.py
+++ b/tests/test_git_state.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for git state snapshots."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from srtctl.cli.submit import submit_single
+from srtctl.core.git_state import GIT_STATE_FILENAME, GitSnapshotSource, write_git_state_snapshot
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, check=True)
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir()
+    _git(path, "init")
+    _git(path, "config", "user.email", "srtctl@example.com")
+    _git(path, "config", "user.name", "srtctl")
+    (path / "tracked.txt").write_text("base\n")
+    _git(path, "add", "tracked.txt")
+    _git(path, "commit", "-m", "base commit")
+    return path
+
+
+def _dirty_repo(path: Path) -> None:
+    (path / "tracked.txt").write_text("base\nunstaged\n")
+    (path / "staged.txt").write_text("staged\n")
+    _git(path, "add", "staged.txt")
+    (path / "untracked.txt").write_text("untracked\n")
+
+
+def test_write_git_state_snapshot_includes_commits_and_dirty_changes(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    _dirty_repo(repo)
+
+    output = tmp_path / "git_state.txt"
+    assert write_git_state_snapshot(output, [GitSnapshotSource("extra_mount:/workspace/repo", repo)])
+
+    text = output.read_text()
+    assert "Repository:" in text
+    assert "extra_mount:/workspace/repo" in text
+    assert "base commit" in text
+    assert "## Staged diff" in text
+    assert "staged.txt" in text
+    assert "## Unstaged diff" in text
+    assert "+unstaged" in text
+    assert "## Untracked file contents" in text
+    assert "untracked.txt" in text
+    assert "+untracked" in text
+
+
+def test_write_git_state_snapshot_redacts_remote_credentials(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    _git(repo, "remote", "add", "origin", "https://YAMY1234:ghp_secret_token@github.com/YAMY1234/repo.git")
+
+    output = tmp_path / "git_state.txt"
+    assert write_git_state_snapshot(output, [GitSnapshotSource("repo", repo)])
+
+    text = output.read_text()
+    assert "ghp_secret_token" not in text
+    assert "https://YAMY1234:<redacted>@github.com/YAMY1234/repo.git" in text
+
+
+def test_submit_writes_git_state_for_extra_mount(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "extra-repo")
+    _dirty_repo(repo)
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    container = tmp_path / "container.sqsh"
+    container.write_text("fake")
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "git-state-test",
+                "model": {"path": str(model_dir), "container": str(container), "precision": "fp8"},
+                "resources": {
+                    "gpu_type": "h100",
+                    "gpus_per_node": 8,
+                    "prefill_nodes": 1,
+                    "prefill_workers": 1,
+                    "decode_nodes": 1,
+                    "decode_workers": 1,
+                },
+                "benchmark": {"type": "manual"},
+                "extra_mount": [f"{repo}:/workspace/extra-repo"],
+            },
+            sort_keys=False,
+        )
+    )
+
+    mock_result = MagicMock()
+    mock_result.stdout = "Submitted batch job 99999"
+    original_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list | tuple) and cmd and cmd[0] == "sbatch":
+            return mock_result
+        return original_run(cmd, *args, **kwargs)
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+        patch("srtctl.cli.submit.create_job_record"),
+        patch("srtctl.cli.submit._assert_preflight_passed"),
+        patch("srtctl.cli.submit.validate_setup"),
+    ):
+        submit_single(config_path=cfg, output_dir=tmp_path)
+
+    text = (tmp_path / "99999" / "git_state.txt").read_text()
+    assert "extra_mount:/workspace/extra-repo" in text
+    assert "base commit" in text
+    assert "staged.txt" in text
+    assert "untracked.txt" in text
+
+
+def test_submit_skips_git_state_without_extra_mount(tmp_path: Path) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    container = tmp_path / "container.sqsh"
+    container.write_text("fake")
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "no-extra-mount-test",
+                "model": {"path": str(model_dir), "container": str(container), "precision": "fp8"},
+                "resources": {
+                    "gpu_type": "h100",
+                    "gpus_per_node": 8,
+                    "prefill_nodes": 1,
+                    "prefill_workers": 1,
+                    "decode_nodes": 1,
+                    "decode_workers": 1,
+                },
+                "benchmark": {"type": "manual"},
+            },
+            sort_keys=False,
+        )
+    )
+
+    mock_result = MagicMock()
+    mock_result.stdout = "Submitted batch job 99999"
+    original_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list | tuple) and cmd and cmd[0] == "sbatch":
+            return mock_result
+        return original_run(cmd, *args, **kwargs)
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("srtctl.cli.submit.get_srtslurm_setting", return_value=None),
+        patch("srtctl.cli.submit.create_job_record"),
+        patch("srtctl.cli.submit._assert_preflight_passed"),
+        patch("srtctl.cli.submit.validate_setup"),
+    ):
+        submit_single(config_path=cfg, output_dir=tmp_path)
+
+    assert not (tmp_path / "99999" / GIT_STATE_FILENAME).exists()

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -780,6 +780,20 @@ class TestCopyConfigToLogs:
         assert (log_dir / "12345.json").exists()
         assert (log_dir / "12345.json").read_text() == '{"job_id": "12345"}\n'
 
+    def test_copies_git_state_txt(self, tmp_path):
+        """Test git_state.txt is copied from output dir to log dir."""
+        from srtctl.core.git_state import GIT_STATE_FILENAME
+
+        mixin, log_dir = self._create_mixin_with_runtime(tmp_path)
+
+        git_state_src = tmp_path / GIT_STATE_FILENAME
+        git_state_src.write_text("# srtctl git state snapshot\n")
+
+        mixin._copy_config_to_logs()
+
+        assert (log_dir / GIT_STATE_FILENAME).exists()
+        assert (log_dir / GIT_STATE_FILENAME).read_text() == "# srtctl git state snapshot\n"
+
     def test_copy_failure_does_not_raise(self, tmp_path):
         """Test graceful handling when copy fails."""
         mixin, log_dir = self._create_mixin_with_runtime(tmp_path)


### PR DESCRIPTION
## Summary

Capture git state for repositories explicitly provided through `extra_mount` and save it as `git_state.txt` in the job output directory. Postprocess copies the file into `logs/` so it is included with uploaded run artifacts.

The snapshot records, per unique git repo found under `extra_mount` host paths:
- remote URLs with credentials redacted
- current branch and HEAD
- `git status --short --branch`
- last 10 commits
- staged and unstaged diffs
- untracked file names and small text contents

This intentionally does not scan all runtime/container mounts and does not snapshot the srt-slurm source repo unless it is explicitly listed in `extra_mount`.

## Example

For a recipe with an extra source mount:

```yaml
extra_mount:
  - "/path/to/sglang:/sgl-workspace/sglang"
```

`srtctl` writes the snapshot at submit time and postprocess copies it into the uploaded log artifacts:

```text
outputs/<job_id>/
├── git_state.txt
└── logs/
    └── git_state.txt
```

Example `logs/git_state.txt`:

```text
# srtctl git state snapshot
Generated at: 2026-05-11T07:05:06Z

Sources considered:
  - extra_mount:/sgl-workspace/sglang: /path/to/sglang

================================================================================
Repository: /path/to/sglang
Labels: extra_mount:/sgl-workspace/sglang
Source paths:
  - /path/to/sglang

## Remote URLs
origin  https://github.com/example/sglang.git (fetch)
origin  https://github.com/example/sglang.git (push)

## Branch
my-sglang-branch

## HEAD
0123456789abcdef0123456789abcdef01234567

## Status
## my-sglang-branch
 M README.md
A  local_patch.py
?? scratch_notes.txt

## Last 10 commits
0123456 (HEAD -> my-sglang-branch) change scheduler behavior
89abcde previous commit

## Staged diff
diff --git a/local_patch.py b/local_patch.py
new file mode 100644
--- /dev/null
+++ b/local_patch.py
@@
+print("local patch")

## Unstaged diff
diff --git a/README.md b/README.md
--- a/README.md
+++ b/README.md
@@
+local README note

## Untracked files
  - scratch_notes.txt

## Untracked file contents
diff --git a/scratch_notes.txt b/scratch_notes.txt
new file mode 100644
--- /dev/null
+++ b/scratch_notes.txt
@@
+notes from this run
```
