### PR TITLE
Default SA-Bench random workers to auto

### DIFF
--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -104,10 +104,11 @@ if [ "$DATASET_NAME" = "random" ]; then
         --random-input-len "$ISL"
         --random-output-len "$OSL"
         --random-range-ratio "${RANDOM_RANGE_RATIO}"
-        # Parallel random prompt generation. Default 48 saturates a 144-core
-        # GB300 host. Override via env: RANDOM_NUM_WORKERS=8 etc. 0 = auto =
+        # Parallel random prompt generation. Default 0 delegates to auto:
         # min(cpu_count, 8). 1 = serial (no multiprocessing).
-        --random-num-workers "${RANDOM_NUM_WORKERS:-48}"
+        # Override via env for host-specific tuning, e.g. RANDOM_NUM_WORKERS=48
+        # on a 144-core GB300 host.
+        --random-num-workers "${RANDOM_NUM_WORKERS:-0}"
     )
 fi
 

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -104,10 +104,7 @@ if [ "$DATASET_NAME" = "random" ]; then
         --random-input-len "$ISL"
         --random-output-len "$OSL"
         --random-range-ratio "${RANDOM_RANGE_RATIO}"
-        # Parallel random prompt generation. Default 0 delegates to auto:
-        # min(cpu_count, 8). 1 = serial (no multiprocessing).
-        # Override via env for host-specific tuning, e.g. RANDOM_NUM_WORKERS=48
-        # on a 144-core GB300 host.
+        # 0 delegates worker selection to benchmark_serving.py; override via RANDOM_NUM_WORKERS.
         --random-num-workers "${RANDOM_NUM_WORKERS:-0}"
     )
 fi


### PR DESCRIPTION
Use SA-Bench's existing auto worker default for random prompt generation instead of a GB300-tuned 48-worker default.

Validation:
- bash -n src/srtctl/benchmarks/scripts/sa-bench/bench.sh