### PR TITLE
recipes(qwen3.5): refresh fp8 mtp-off wideep configs

### DIFF
--- a/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-1p1d-dep16-dpep-ccsweep.yaml
+++ b/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-1p1d-dep16-dpep-ccsweep.yaml
@@ -130,7 +130,7 @@ backend:
       # cc2048 smoke: per-DP = 2048/16 = 128
       chunked-prefill-size: 4096
       context-length: 4096
-      mem-fraction-static: 0.80  # lowered from 0.85; cuda-graph capture OOM at 0.85 (DeepEP ~25GB non-PyTorch)
+      mem-fraction-static: 0.75  # DEP16+ DeepEP buffers scale with ep_size; 0.80 OOM at cuda-graph capture (~25GB non-PyTorch)
       max-mamba-cache-size: 2048  # sglang divides by dp_size=16 → 128 per-DP
       max-running-requests: 2048  # sglang divides by dp_size=16 → 128 per-DP
       cuda-graph-max-bs: 128

--- a/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-1p1d-dep16-dpep-ccsweep.yaml
+++ b/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-1p1d-dep16-dpep-ccsweep.yaml
@@ -1,9 +1,9 @@
 # Qwen3.5-397B-A17B-FP8 1P1D DEP4 (prefill) + DEP16 (decode) + deepep (low_latency)
 # Phase 4a: smoke cc2048; flip concurrencies to full sweep for Phase 4b.
 
-name: "qwen3.5-1p1d-dep16-dpep-router"
+name: "qwen3.5-wideep-1p1d-dep16-dpep-ccsweep"
 
-setup_script: rebuild-deepep.sh
+setup_script: setup-router-and-deepep.sh
 
 dynamo:
   hash: 4e4006138bb9dde377a2bb2cacbcc65aaa616ac1
@@ -12,6 +12,14 @@ model:
   path: "qwen3.5-fp8"
   container: "dev"
   precision: "fp8"
+
+identity:
+  model:
+    repo: "Qwen/Qwen3.5-397B-A17B-FP8"
+  container:
+    image: "lmsysorg/sglang:0.5.10.post1"
+  frameworks:
+    sglang: "0.5.10.post1"
 
 resources:
   gpu_type: "gb200"
@@ -110,7 +118,6 @@ backend:
       moe-dense-tp-size: 1
       enable-dp-attention: true
       enable-dp-lm-head: true
-      prefill-round-robin-balance: true
 
       mamba-scheduler-strategy: "no_buffer"
       mamba-track-interval: 128

--- a/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-1p1d-dep32-dpep-ccsweep.yaml
+++ b/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-1p1d-dep32-dpep-ccsweep.yaml
@@ -1,9 +1,9 @@
 # Qwen3.5-397B-A17B-FP8 1P1D DEP4 (prefill) + DEP32 (decode) + deepep
 # Phase 5a: smoke cc2048; flip for Phase 5b.
 
-name: "qwen3.5-1p1d-dep32-dpep-router"
+name: "qwen3.5-wideep-1p1d-dep32-dpep-ccsweep"
 
-setup_script: rebuild-deepep.sh
+setup_script: setup-router-and-deepep.sh
 
 dynamo:
   hash: 4e4006138bb9dde377a2bb2cacbcc65aaa616ac1
@@ -12,6 +12,14 @@ model:
   path: "qwen3.5-fp8"
   container: "dev"
   precision: "fp8"
+
+identity:
+  model:
+    repo: "Qwen/Qwen3.5-397B-A17B-FP8"
+  container:
+    image: "lmsysorg/sglang:0.5.10.post1"
+  frameworks:
+    sglang: "0.5.10.post1"
 
 resources:
   gpu_type: "gb200"
@@ -110,7 +118,6 @@ backend:
       moe-dense-tp-size: 1
       enable-dp-attention: true
       enable-dp-lm-head: true
-      prefill-round-robin-balance: true
 
       mamba-scheduler-strategy: "no_buffer"
       mamba-track-interval: 128

--- a/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-1p1d-dep8-dpep-ccsweep.yaml
+++ b/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-1p1d-dep8-dpep-ccsweep.yaml
@@ -1,9 +1,9 @@
 # Qwen3.5-397B-A17B-FP8 1P1D DEP4 (prefill) + DEP8 (decode) + no deepep
 # Phase 3a: smoke cc2048; flip concurrencies to full sweep for Phase 3b.
 
-name: "qwen3.5-1p1d-dep8-dpep-router"
+name: "qwen3.5-wideep-1p1d-dep8-dpep-ccsweep"
 
-setup_script: rebuild-deepep.sh
+setup_script: setup-router-and-deepep.sh
 
 dynamo:
   hash: 4e4006138bb9dde377a2bb2cacbcc65aaa616ac1
@@ -12,6 +12,14 @@ model:
   path: "qwen3.5-fp8"
   container: "dev"
   precision: "fp8"
+
+identity:
+  model:
+    repo: "Qwen/Qwen3.5-397B-A17B-FP8"
+  container:
+    image: "lmsysorg/sglang:0.5.10.post1"
+  frameworks:
+    sglang: "0.5.10.post1"
 
 resources:
   gpu_type: "gb200"
@@ -48,7 +56,7 @@ backend:
     NCCL_CUMEM_ENABLE: "1"
     MC_FORCE_MNNVL: "1"
     MC_TE_METRIC: "true"
-    SGLANG_DG_CACHE_DIR: "/configs/deepgemm-cache"
+    SGLANG_DG_CACHE_DIR: "/tmp/deepgemm-cache"  # node-local, seeded from /configs/deepgemm-cache by setup script
     FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
     SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
     SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
@@ -113,7 +121,6 @@ backend:
       moe-dense-tp-size: 1
       enable-dp-attention: true
       enable-dp-lm-head: true
-      prefill-round-robin-balance: true
 
       mamba-scheduler-strategy: "no_buffer"
       mamba-track-interval: 128

--- a/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-2p1d-dep16-dpep-cc2048x4096.yaml
+++ b/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-2p1d-dep16-dpep-cc2048x4096.yaml
@@ -1,9 +1,9 @@
 # Qwen3.5-397B-A17B-FP8 2P1D DEP4 (prefill×2) + DEP16 (decode) + deepep
 # Phase 4c: single cc4096 point
 
-name: "qwen3.5-2p1d-dep16-dpep-router-cc2048x4096"
+name: "qwen3.5-wideep-2p1d-dep16-dpep-cc2048x4096"
 
-setup_script: rebuild-deepep.sh
+setup_script: setup-router-and-deepep.sh
 
 dynamo:
   hash: 4e4006138bb9dde377a2bb2cacbcc65aaa616ac1
@@ -12,6 +12,14 @@ model:
   path: "qwen3.5-fp8"
   container: "dev"
   precision: "fp8"
+
+identity:
+  model:
+    repo: "Qwen/Qwen3.5-397B-A17B-FP8"
+  container:
+    image: "lmsysorg/sglang:0.5.10.post1"
+  frameworks:
+    sglang: "0.5.10.post1"
 
 resources:
   gpu_type: "gb200"
@@ -109,7 +117,6 @@ backend:
       moe-dense-tp-size: 1
       enable-dp-attention: true
       enable-dp-lm-head: true
-      prefill-round-robin-balance: true
 
       mamba-scheduler-strategy: "no_buffer"
       mamba-track-interval: 128

--- a/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-2p1d-dep32-dpep-cc1024x2048.yaml
+++ b/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-2p1d-dep32-dpep-cc1024x2048.yaml
@@ -1,9 +1,9 @@
 # Qwen3.5-397B-A17B-FP8 2P1D DEP4 (prefill×2) + DEP32 (decode) + deepep
 # Phase 5c: single cc4096 point
 
-name: "qwen3.5-2p1d-dep32-dpep-router-cc1024x2048"
+name: "qwen3.5-wideep-2p1d-dep32-dpep-cc1024x2048"
 
-setup_script: rebuild-deepep.sh
+setup_script: setup-router-and-deepep.sh
 
 dynamo:
   hash: 4e4006138bb9dde377a2bb2cacbcc65aaa616ac1
@@ -12,6 +12,14 @@ model:
   path: "qwen3.5-fp8"
   container: "dev"
   precision: "fp8"
+
+identity:
+  model:
+    repo: "Qwen/Qwen3.5-397B-A17B-FP8"
+  container:
+    image: "lmsysorg/sglang:0.5.10.post1"
+  frameworks:
+    sglang: "0.5.10.post1"
 
 resources:
   gpu_type: "gb200"
@@ -109,7 +117,6 @@ backend:
       moe-dense-tp-size: 1
       enable-dp-attention: true
       enable-dp-lm-head: true
-      prefill-round-robin-balance: true
 
       mamba-scheduler-strategy: "no_buffer"
       mamba-track-interval: 128

--- a/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-3p1d-dep16-dpep-cc4096.yaml
+++ b/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-3p1d-dep16-dpep-cc4096.yaml
@@ -1,7 +1,7 @@
-# Qwen3.5-397B-A17B-FP8 2P1D DEP4 (prefill×2) + DEP32 (decode) + deepep
-# Phase 5c: single cc4096 point
+# Qwen3.5-397B-A17B-FP8 3P1D DEP4 (prefill×3) + DEP16 (decode) + deepep
+# 3P unlocks decode at cc=4096 with per-DP=256 (2P still prefill-saturated)
 
-name: "qwen3.5-wideep-3p1d-dep32-dpep-cc4096"
+name: "qwen3.5-wideep-3p1d-dep16-dpep-cc4096"
 
 setup_script: setup-router-and-deepep.sh
 
@@ -25,7 +25,7 @@ resources:
   gpu_type: "gb200"
   gpus_per_node: 4
   prefill_nodes: 3
-  decode_nodes: 8
+  decode_nodes: 4
   prefill_workers: 3
   decode_workers: 1
 
@@ -111,9 +111,9 @@ backend:
       quantization: "fp8"
       kv-cache-dtype: "fp8_e4m3"
 
-      tensor-parallel-size: 32
-      data-parallel-size: 32
-      expert-parallel-size: 32
+      tensor-parallel-size: 16
+      data-parallel-size: 16
+      expert-parallel-size: 16
       moe-dense-tp-size: 1
       enable-dp-attention: true
       enable-dp-lm-head: true
@@ -126,13 +126,13 @@ backend:
       disable-radix-cache: true
       disaggregation-bootstrap-port: 31000
 
-      # cc4096: per-DP = 4096/32 = 128
+      # cc4096: per-DP = 4096/16 = 256
       chunked-prefill-size: 4096
       context-length: 8192
-      mem-fraction-static: 0.75  # DEP32 DeepEP buffers scale with ep_size; 0.80 OOM at graph capture (2377537)
-      max-mamba-cache-size: 4096  # sglang divides by dp_size=32 → 128 per-DP
-      max-running-requests: 4096  # sglang divides by dp_size=32 → 128 per-DP
-      cuda-graph-max-bs: 128
+      mem-fraction-static: 0.75  # DEP16+ DeepEP buffers scale with ep_size; 0.80 OOM at graph capture
+      max-mamba-cache-size: 4096  # sglang divides by dp_size=16 → 256 per-DP
+      max-running-requests: 4096  # sglang divides by dp_size=16 → 256 per-DP
+      cuda-graph-max-bs: 256
       watchdog-timeout: 1000000
 
       page-size: 64

--- a/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-6p1d-dep32-dpep-cc8192.yaml
+++ b/recipes/qwen3.5/fp8/disagg/mooncake/stp_prefix_off/wideep-6p1d-dep32-dpep-cc8192.yaml
@@ -1,9 +1,9 @@
 # Qwen3.5-397B-A17B-FP8 2P1D DEP4 (prefill×2) + DEP32 (decode) + deepep
 # Phase 5c: single cc4096 point
 
-name: "qwen3.5-6p1d-dep32-dpep-router-cc8192"
+name: "qwen3.5-wideep-6p1d-dep32-dpep-cc8192"
 
-setup_script: rebuild-deepep.sh
+setup_script: setup-router-and-deepep.sh
 
 dynamo:
   hash: 4e4006138bb9dde377a2bb2cacbcc65aaa616ac1
@@ -12,6 +12,14 @@ model:
   path: "qwen3.5-fp8"
   container: "dev"
   precision: "fp8"
+
+identity:
+  model:
+    repo: "Qwen/Qwen3.5-397B-A17B-FP8"
+  container:
+    image: "lmsysorg/sglang:0.5.10.post1"
+  frameworks:
+    sglang: "0.5.10.post1"
 
 resources:
   gpu_type: "gb200"
@@ -109,7 +117,6 @@ backend:
       moe-dense-tp-size: 1
       enable-dp-attention: true
       enable-dp-lm-head: true
-      prefill-round-robin-balance: true
 
       mamba-scheduler-strategy: "no_buffer"
       mamba-track-interval: 128


### PR DESCRIPTION
## Summary

Refresh of the Qwen3.5 FP8 mtp-off wideep recipes introduced by #128 driven by decode-side performance
sweeps on GB200.

## Changes per recipe

- **`setup_script`**: switched from `rebuild-deepep.sh` to `setup-router-and-deepep.sh`. Even though sglang-router is not actually used by these recipes, this setup script additionally seeds the decode `SGLANG_DG_CACHE_DIR` (`/tmp/deepgemm-cache`, node-local) from the shared `/configs` cache; the underlying deepep-rebuild step is the same.
- **`identity`**: declares the sglang repo, container image, and framework version actually exercised (`lmsysorg/sglang:0.5.10.post1`), so jobs that apply these recipes can verify they're running the intended version.
- **`name`**: prefixed with `wideep-` so the runtime job name matches the file name (e.g. `qwen3.5-wideep-1p1d-dep8-dpep-ccsweep`).
- Drop deprecated decode option `prefill-round-robin-balance: true`.
- **DEP16+**: lower decode `mem-fraction-static` from 0.80 to 0.75. DeepEP buffers scale linearly with `ep_size`; at 0.80 CUDA graph capture OOMs inside `cuda_graph_runner.capture_one_batch_size` for DEP16/DEP32.
- Add `SGLANG_HEALTH_STARTING_OK` / `SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION` to both prefill and decode env; align decode `SGLANG_DG_CACHE_DIR` and `SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK`.
- Extend 1P ccsweep ranges so both the prefill-unsaturated and prefill-saturated regimes are sampled (DEP16 → cc=4096, DEP32 → cc=8192).

## New recipe

- **`wideep-3p1d-dep16-dpep-cc4096.yaml`**: mirrors `wideep-3p1d-dep32-dpep-cc4096.yaml` but for DEP16. At cc=4096 (per-DP=256), 1P and 2P prefill remain saturated; only 3P unlocks the decode at full per-DP capacity, and this point produces the highest realized `out/gpu` of all tested configurations.

## Caveat

`6p1d-dep32-cc8192` (and any other multi-prefill recipe that fans out past ~5 workers) tends to hit `zmq.error.ZMQError: Address already in use` during sglang engine init when run on plain `main`. #134 (port jitter / odd-port allocation) resolves this; on plain `main`, multiple resubmissions may be required for the 6P+ configurations to start cleanly.

## Test plan

- [x] `srtctl dry-run -f <recipe>` for all 8 recipes (node counts + identity fields verified)
- [x] `srtctl apply -f wideep-1p1d-dep8-dpep-ccsweep.yaml`: completes the full cc sweep (8 → 2048); output throughput matches the prior locally-generated config within <1 %
- [x] `srtctl apply -f wideep-6p1d-dep32-dpep-cc8192.yaml` (on a branch carrying #134): initializes cleanly (no ZMQError) and completes the cc=8192 point
