### PR TITLE
Expand environment variables in extra_mount paths

### DIFF
--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -219,9 +219,11 @@ def show_config_details(config: SrtConfig) -> None:
         for mount_spec in config.extra_mount:
             parts = mount_spec.split(":", 1)
             if len(parts) == 2:
-                mounts_table.add_row("recipe", parts[0], parts[1])
+                expanded_host = os.path.expanduser(os.path.expandvars(parts[0]))
+                mounts_table.add_row("recipe", expanded_host, parts[1])
             else:
-                mounts_table.add_row("recipe", mount_spec, mount_spec)
+                expanded_host = os.path.expanduser(os.path.expandvars(mount_spec))
+                mounts_table.add_row("recipe", expanded_host, mount_spec)
 
     # Recipe container_mounts (FormattablePath mounts)
     if config.container_mounts:

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -237,7 +237,8 @@ class RuntimeContext:
         if config.extra_mount:
             for mount_spec in config.extra_mount:
                 host_path, container_path = mount_spec.split(":", 1)
-                container_mounts[Path(host_path).resolve()] = Path(container_path)
+                expanded_host = os.path.expandvars(host_path)
+                container_mounts[Path(expanded_host).expanduser().resolve()] = Path(container_path)
 
         # Mount InferenceX workspace if available (for lm-eval support).
         # Skip exists() check: the orchestrator runs on the SLURM head node

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1882,3 +1882,63 @@ class TestInfmaxWorkspaceMount:
                     runtime = RuntimeContext.from_config(config, job_id="12345")
 
                     assert Path("/infmax-workspace") not in runtime.container_mounts.values()
+
+
+class TestExtraMountExpansion:
+    """Test path expansion for recipe extra_mount entries."""
+
+    def test_extra_mount_host_path_expands_environment_variables(self, tmp_path):
+        import os
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.core.runtime import RuntimeContext
+        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        container_path = tmp_path / "container.sqsh"
+        container_path.touch()
+        extra_root = tmp_path / "extra"
+        extra_root.mkdir()
+
+        slurm_env = {
+            "SLURM_JOB_ID": "12345",
+            "SLURM_JOBID": "12345",
+            "SLURM_NODELIST": "gpu-[01-02]",
+            "SLURM_JOB_NUM_NODES": "2",
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+            "SRT_EXTRA_ROOT": str(extra_root),
+        }
+
+        def mock_scontrol(cmd, **kwargs):
+            if cmd[0] == "scontrol" and "hostnames" in cmd:
+                result = MagicMock()
+                result.stdout = "gpu-01\ngpu-02"
+                result.returncode = 0
+                return result
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with patch.dict(os.environ, slurm_env):
+            with patch("subprocess.run", mock_scontrol):
+                with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+                    config = SrtConfig(
+                        name="test",
+                        model=ModelConfig(
+                            path=str(model_path),
+                            container=str(container_path),
+                            precision="fp8",
+                        ),
+                        resources=ResourceConfig(
+                            gpu_type="h100",
+                            gpus_per_node=8,
+                            prefill_nodes=1,
+                            decode_nodes=1,
+                        ),
+                        extra_mount=("$SRT_EXTRA_ROOT:/extra",),
+                    )
+                    runtime = RuntimeContext.from_config(config, job_id="12345")
+
+                    assert extra_root.resolve() in runtime.container_mounts
+                    assert runtime.container_mounts[extra_root.resolve()] == Path("/extra")

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3,6 +3,7 @@
 
 """Tests for dry-run config details display (mounts, env vars)."""
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -66,6 +67,16 @@ class TestDryRunMounts:
         assert "/shared/cache" in output
         assert "/cache" in output
         assert "recipe" in output
+
+    def test_extra_mount_expands_env_and_user_in_dry_run(self, capsys):
+        with patch.dict(os.environ, {"SRT_EXTRA_ROOT": "/expanded/extra", "HOME": "/home/tester"}):
+            config = _make_config({"extra_mount": ["$SRT_EXTRA_ROOT:/extra", "~/cache:/cache"]})
+            show_config_details(config)
+        output = capsys.readouterr().out
+        assert "/expanded/extra" in output
+        assert "/home/tester/cache" in output
+        assert "$SRT_EXTRA_ROOT" not in output
+        assert "~/cache" not in output
 
     def test_cluster_mounts_from_srtslurm_yaml(self, capsys):
         cluster_mounts = {"/shared/datasets": "/datasets", "/shared/models": "/models"}


### PR DESCRIPTION
## Summary
- Expand environment variables and ~ in recipe extra_mount host paths before adding them to container mounts.
- Show the expanded extra_mount host path in the submit/dry-run mounts table.
- Add coverage for env-var expansion in extra_mount.

## Context
The config reference already documents this behavior: docs/config-reference.md says FormattablePath supports $VAR / ${VAR} environment variable expansion, and the extra_mount section notes that although extra_mount uses simple host:container strings rather than FormattablePath, environment variables are still expanded. Runtime handling was not applying that documented behavior for extra_mount host paths.

## Validation
- git diff --check
- Added tests/test_configs.py coverage for extra_mount env expansion

Note: targeted pytest was not run locally because this machine only has Python 3.9 and no pytest installed; the repo requires a newer Python test environment.