### PR TITLE
fix(sa-bench): shard high-concurrency loadgen across frontends

### DIFF
--- a/src/srtctl/benchmarks/base.py
+++ b/src/srtctl/benchmarks/base.py
@@ -69,7 +69,8 @@ class BenchmarkRunner(ABC):
 
     def get_environment(self, config: SrtConfig, runtime: RuntimeContext) -> dict[str, str]:
         """Get benchmark-specific environment variables."""
-        return {}
+        del runtime
+        return dict(config.benchmark.env)
 
 
 class AIPerfBenchmarkRunner(BenchmarkRunner):

--- a/src/srtctl/benchmarks/custom.py
+++ b/src/srtctl/benchmarks/custom.py
@@ -58,7 +58,3 @@ class CustomBenchmarkRunner(BenchmarkRunner):
 
     def get_container_image(self, config: SrtConfig, runtime: RuntimeContext) -> str | Path:
         return config.benchmark.container_image or runtime.container_image
-
-    def get_environment(self, config: SrtConfig, runtime: RuntimeContext) -> dict[str, str]:
-        del runtime
-        return dict(config.benchmark.env)

--- a/src/srtctl/benchmarks/sa_bench.py
+++ b/src/srtctl/benchmarks/sa_bench.py
@@ -28,6 +28,9 @@ class SABenchRunner(BenchmarkRunner):
         - benchmark.req_rate: Request rate (default: "inf")
         - benchmark.dataset_name: "random" (default) or "custom"
         - benchmark.dataset_path: Container path to dataset file (required when dataset_name="custom")
+        - benchmark.env.SA_BENCH_API_URLS: Comma-separated API URLs or bases for multi-target traffic.
+        - benchmark.env.SA_BENCH_SHARD_FRONTENDS: When true, srt-slurm fills SA_BENCH_API_URLS
+          from its frontend topology unless SA_BENCH_API_URLS is explicitly set.
         - benchmark.slow_down_sleep_time / benchmark.slow_down_wait_time: When both are set and
           frontend is sglang, SA-Bench POSTs /slow_down on each decode worker leader (framework-derived
           URLs). Omit either field to disable slow_down.
@@ -92,6 +95,9 @@ class SABenchRunner(BenchmarkRunner):
         tokenizer_path = str(runtime.model_path) if runtime.is_hf_model else "/model"
 
         dataset_name = b.dataset_name or "random"
+        model_name = str(runtime.model_path) if runtime.is_hf_model else config.served_model_name
+        if config.backend_type == "mocker" and not runtime.is_hf_model:
+            model_name = "/model"
 
         cmd = [
             "bash",
@@ -102,7 +108,7 @@ class SABenchRunner(BenchmarkRunner):
             str(concurrencies) if concurrencies else "",
             str(b.req_rate) if b.req_rate else "inf",
             tokenizer_path,
-            config.served_model_name,
+            model_name,
             str(is_disaggregated).lower(),
             str(total_gpus),
             str(prefill_gpus),

--- a/src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py
@@ -7,6 +7,7 @@ import os
 import sys
 import time
 import traceback
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 
 import aiohttp
@@ -15,6 +16,15 @@ from tqdm.asyncio import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
+
+
+@asynccontextmanager
+async def _get_session(session: aiohttp.ClientSession | None = None):
+    if session is not None:
+        yield session
+    else:
+        async with aiohttp.ClientSession(trust_env=True, timeout=AIOHTTP_TIMEOUT) as local_session:
+            yield local_session
 
 
 @dataclass
@@ -45,17 +55,20 @@ class RequestFuncOutput:
     prompt_len: int = 0
     error: str = ""
     start_time: float = 0.0  # absolute perf_counter time when request was sent
-    text_chunks: list[str] = field(default_factory=list)  # text content of each SSE chunk (incl. first), same length as itl+1
+    text_chunks: list[str] = field(
+        default_factory=list
+    )  # text content of each SSE chunk (incl. first), same length as itl+1
 
 
 async def async_request_tgi(
     request_func_input: RequestFuncInput,
     pbar: tqdm | None = None,
+    session: aiohttp.ClientSession | None = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
 
-    async with aiohttp.ClientSession(trust_env=True, timeout=AIOHTTP_TIMEOUT) as session:
+    async with _get_session(session) as session:
         params = {
             "best_of": request_func_input.best_of,
             "max_new_tokens": request_func_input.output_len,
@@ -122,11 +135,12 @@ async def async_request_tgi(
 async def async_request_trt_llm(
     request_func_input: RequestFuncInput,
     pbar: tqdm | None = None,
+    session: aiohttp.ClientSession | None = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
 
-    async with aiohttp.ClientSession(trust_env=True, timeout=AIOHTTP_TIMEOUT) as session:
+    async with _get_session(session) as session:
         assert request_func_input.best_of == 1
         payload = {
             "accumulate_tokens": True,
@@ -190,8 +204,9 @@ async def async_request_trt_llm(
 async def async_request_deepspeed_mii(
     request_func_input: RequestFuncInput,
     pbar: tqdm | None = None,
+    session: aiohttp.ClientSession | None = None,
 ) -> RequestFuncOutput:
-    async with aiohttp.ClientSession(trust_env=True, timeout=AIOHTTP_TIMEOUT) as session:
+    async with _get_session(session) as session:
         assert request_func_input.best_of == 1
 
         payload = {
@@ -232,13 +247,14 @@ async def async_request_deepspeed_mii(
 async def async_request_openai_completions(
     request_func_input: RequestFuncInput,
     pbar: tqdm | None = None,
+    session: aiohttp.ClientSession | None = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
-    assert api_url.endswith(
-        ("completions", "profile")
-    ), "OpenAI Completions API URL must end with 'completions' or 'profile'."
+    assert api_url.endswith(("completions", "profile")), (
+        "OpenAI Completions API URL must end with 'completions' or 'profile'."
+    )
 
-    async with aiohttp.ClientSession(trust_env=True, timeout=AIOHTTP_TIMEOUT) as session:
+    async with _get_session(session) as session:
         payload = {
             "model": request_func_input.model_name if request_func_input.model_name else request_func_input.model,
             "prompt": request_func_input.prompt,
@@ -305,7 +321,7 @@ async def async_request_openai_completions(
                     else:
                         output.success = False
                         output.error = (
-                            "Never received a valid chunk to calculate TTFT." "This response will be marked as failed!"
+                            "Never received a valid chunk to calculate TTFT.This response will be marked as failed!"
                         )
                     output.generated_text = generated_text
                     output.latency = most_recent_timestamp - st
@@ -325,13 +341,14 @@ async def async_request_openai_completions(
 async def async_request_dynamo_completions(
     request_func_input: RequestFuncInput,
     pbar: tqdm | None = None,
+    session: aiohttp.ClientSession | None = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
-    assert api_url.endswith(
-        ("completions", "profile")
-    ), "OpenAI Completions API URL must end with 'completions' or 'profile'."
+    assert api_url.endswith(("completions", "profile")), (
+        "OpenAI Completions API URL must end with 'completions' or 'profile'."
+    )
 
-    async with aiohttp.ClientSession(trust_env=True, timeout=AIOHTTP_TIMEOUT) as session:
+    async with _get_session(session) as session:
         payload = {
             "model": request_func_input.model_name if request_func_input.model_name else request_func_input.model,
             "prompt": request_func_input.prompt,
@@ -404,7 +421,7 @@ async def async_request_dynamo_completions(
                     else:
                         output.success = False
                         output.error = (
-                            "Never received a valid chunk to calculate TTFT." "This response will be marked as failed!"
+                            "Never received a valid chunk to calculate TTFT.This response will be marked as failed!"
                         )
                     output.generated_text = generated_text
                     output.latency = most_recent_timestamp - st
@@ -424,11 +441,12 @@ async def async_request_dynamo_completions(
 async def async_request_openai_chat_completions(
     request_func_input: RequestFuncInput,
     pbar: tqdm | None = None,
+    session: aiohttp.ClientSession | None = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("chat/completions"), "OpenAI Chat Completions API URL must end with 'chat/completions'."
 
-    async with aiohttp.ClientSession(trust_env=True, timeout=AIOHTTP_TIMEOUT) as session:
+    async with _get_session(session) as session:
         content = [{"type": "text", "text": request_func_input.prompt}]
         if request_func_input.multi_modal_content:
             content.append(request_func_input.multi_modal_content)
@@ -589,17 +607,24 @@ def _load_glm_moe_dsa_tokenizer(pretrained_model_name_or_path: str) -> "PreTrain
     from transformers import PreTrainedTokenizerFast
 
     _SAFE_CONFIG_KEYS = (
-        "pad_token", "pad_token_id", "eos_token", "eos_token_id",
-        "bos_token", "bos_token_id", "unk_token", "unk_token_id",
-        "model_max_length", "padding_side", "truncation_side",
+        "pad_token",
+        "pad_token_id",
+        "eos_token",
+        "eos_token_id",
+        "bos_token",
+        "bos_token_id",
+        "unk_token",
+        "unk_token_id",
+        "model_max_length",
+        "padding_side",
+        "truncation_side",
     )
 
     path = Path(pretrained_model_name_or_path)
     tokenizer_json = path / "tokenizer.json"
     if not tokenizer_json.exists():
         raise FileNotFoundError(
-            f"Expected tokenizer.json at {tokenizer_json}. "
-            "GlmMoeDsaTokenizer loads from tokenizer.json only."
+            f"Expected tokenizer.json at {tokenizer_json}. GlmMoeDsaTokenizer loads from tokenizer.json only."
         )
 
     rust_tok = RustTokenizer.from_file(str(tokenizer_json))
@@ -651,8 +676,9 @@ def get_tokenizer(
         if custom_tokenizer == "glm_moe_dsa":
             return _load_glm_moe_dsa_tokenizer(pretrained_model_name_or_path)
         from importlib import import_module
+
         try:
-            module_path, class_name = custom_tokenizer.rsplit('.', 1)
+            module_path, class_name = custom_tokenizer.rsplit(".", 1)
             module = import_module(module_path)
             tokenizer_class = getattr(module, class_name)
             return tokenizer_class.from_pretrained(
@@ -663,7 +689,8 @@ def get_tokenizer(
         except (ValueError, ImportError, AttributeError) as e:
             raise ValueError(
                 f"Failed to load custom_tokenizer '{custom_tokenizer}'. "
-                "Expected 'glm_moe_dsa' or 'module.path.ClassName'.") from e
+                "Expected 'glm_moe_dsa' or 'module.path.ClassName'."
+            ) from e
 
     tokenizer = AutoTokenizer.from_pretrained(
         pretrained_model_name_or_path,

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -134,10 +134,52 @@ fi
 # Parse endpoint into host:port
 HOST=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f1)
 PORT=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f2 | cut -d/ -f1)
+API_ENDPOINT="/v1/completions"
+
+# Optional direct frontend sharding to avoid single-destination ephemeral port limits.
+#   SA_BENCH_API_URLS: comma-separated full API URLs or frontend base URLs
+#   SA_BENCH_SHARD_FRONTENDS=true: parse /logs/nginx.conf upstream servers
+API_URL_ARGS=()
+add_api_url_arg() {
+    local url="$1"
+    url="$(echo "$url" | xargs)"
+    if [ -z "$url" ]; then
+        return
+    fi
+    if [[ "$url" == *"/v1/"* ]]; then
+        API_URL_ARGS+=(--api-url "$url")
+    else
+        API_URL_ARGS+=(--api-url "${url%/}${API_ENDPOINT}")
+    fi
+}
+
+if [ -n "${SA_BENCH_API_URLS:-}" ]; then
+    IFS=',' read -r -a _api_urls <<< "${SA_BENCH_API_URLS}"
+    for u in "${_api_urls[@]}"; do
+        add_api_url_arg "$u"
+    done
+elif [ "${SA_BENCH_SHARD_FRONTENDS:-false}" = "true" ] && [ -f /logs/nginx.conf ]; then
+    while read -r fe_host fe_port; do
+        add_api_url_arg "http://${fe_host}:${fe_port}"
+    done < <(
+        python3 - <<'PY'
+import re
+from pathlib import Path
+
+for line in Path("/logs/nginx.conf").read_text(encoding="utf-8").splitlines():
+    match = re.match(r"\s*server\s+([^:;\s]+):(\d+)\s*;", line)
+    if match:
+        print(match.group(1), match.group(2))
+PY
+    )
+fi
 
 WORK_DIR="$(dirname "$0")"
 
 echo "SA-Bench Config: endpoint=${ENDPOINT}; isl=${ISL}; osl=${OSL}; concurrencies=${CONCURRENCIES}; req_rate=${REQ_RATE}; model=${MODEL_NAME}; dataset=${DATASET_NAME}; dataset_path=${DATASET_PATH}"
+if [ ${#API_URL_ARGS[@]} -gt 0 ]; then
+    echo "SA-Bench direct API sharding enabled: $(( ${#API_URL_ARGS[@]} / 2 )) target(s)"
+fi
 
 # Profiling shared helpers
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -184,7 +226,8 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         python3 -u "${WORK_DIR}/benchmark_serving.py" \
             --model "${MODEL_NAME}" --tokenizer "${MODEL_PATH}" \
             --host "$HOST" --port "$PORT" \
-            --backend "dynamo" --endpoint /v1/completions \
+            --backend "dynamo" --endpoint "$API_ENDPOINT" \
+            "${API_URL_ARGS[@]}" \
             --disable-tqdm \
             "${DATASET_ARGS[@]}" \
             --num-prompts "$num_warmup_prompts" \
@@ -214,7 +257,8 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
     python3 -u "${WORK_DIR}/benchmark_serving.py" \
         --model "${MODEL_NAME}" --tokenizer "${MODEL_PATH}" \
         --host "$HOST" --port "$PORT" \
-        --backend "dynamo" --endpoint /v1/completions \
+        --backend "dynamo" --endpoint "$API_ENDPOINT" \
+        "${API_URL_ARGS[@]}" \
         --disable-tqdm \
         "${DATASET_ARGS[@]}" \
         --num-prompts "$num_prompts" \

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -136,9 +136,10 @@ HOST=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f1)
 PORT=$(echo "$ENDPOINT" | sed 's|http://||' | cut -d: -f2 | cut -d/ -f1)
 API_ENDPOINT="/v1/completions"
 
-# Optional direct frontend sharding to avoid single-destination ephemeral port limits.
-#   SA_BENCH_API_URLS: comma-separated full API URLs or frontend base URLs
-#   SA_BENCH_SHARD_FRONTENDS=true: parse /logs/nginx.conf upstream servers
+# Optional API-target sharding to avoid single-destination ephemeral port limits.
+#   SA_BENCH_API_URLS: comma-separated full API URLs or API base URLs.
+# srt-slurm may populate SA_BENCH_API_URLS from its frontend topology when
+# SA_BENCH_SHARD_FRONTENDS=true. SA-Bench itself does not parse nginx config.
 API_URL_ARGS=()
 add_api_url_arg() {
     local url="$1"
@@ -158,27 +159,17 @@ if [ -n "${SA_BENCH_API_URLS:-}" ]; then
     for u in "${_api_urls[@]}"; do
         add_api_url_arg "$u"
     done
-elif [ "${SA_BENCH_SHARD_FRONTENDS:-false}" = "true" ] && [ -f /logs/nginx.conf ]; then
-    while read -r fe_host fe_port; do
-        add_api_url_arg "http://${fe_host}:${fe_port}"
-    done < <(
-        python3 - <<'PY'
-import re
-from pathlib import Path
-
-for line in Path("/logs/nginx.conf").read_text(encoding="utf-8").splitlines():
-    match = re.match(r"\s*server\s+([^:;\s]+):(\d+)\s*;", line)
-    if match:
-        print(match.group(1), match.group(2))
-PY
-    )
+elif [ "${SA_BENCH_SHARD_FRONTENDS:-false}" = "true" ]; then
+    echo "ERROR: SA_BENCH_SHARD_FRONTENDS=true but SA_BENCH_API_URLS is empty." >&2
+    echo "srt-slurm should populate SA_BENCH_API_URLS from frontend topology." >&2
+    exit 1
 fi
 
 WORK_DIR="$(dirname "$0")"
 
 echo "SA-Bench Config: endpoint=${ENDPOINT}; isl=${ISL}; osl=${OSL}; concurrencies=${CONCURRENCIES}; req_rate=${REQ_RATE}; model=${MODEL_NAME}; dataset=${DATASET_NAME}; dataset_path=${DATASET_PATH}"
 if [ ${#API_URL_ARGS[@]} -gt 0 ]; then
-    echo "SA-Bench direct API sharding enabled: $(( ${#API_URL_ARGS[@]} / 2 )) target(s)"
+    echo "SA-Bench API target sharding enabled: $(( ${#API_URL_ARGS[@]} / 2 )) target(s)"
 fi
 
 # Profiling shared helpers

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -38,7 +38,7 @@ import random
 import time
 import warnings
 from collections.abc import AsyncGenerator, Collection
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from multiprocessing import Pool, cpu_count
 from typing import Any
@@ -72,6 +72,47 @@ from benchmark_utils import convert_to_pytorch_benchmark_format
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
 
 
+@dataclass
+class ClientStats:
+    scheduled: int = 0
+    started: int = 0
+    completed: int = 0
+    success: int = 0
+    error: int = 0
+    error_types: dict[str, int] = field(default_factory=dict)
+    last_print: float = field(default_factory=time.perf_counter)
+
+    def record_output(self, output: RequestFuncOutput) -> None:
+        self.completed += 1
+        if output.success:
+            self.success += 1
+        else:
+            self.error += 1
+            lines = [line.strip() for line in (output.error or "").splitlines() if line.strip()]
+            summary = (lines[-1] if lines else "<empty error>")[:160]
+            self.error_types[summary] = self.error_types.get(summary, 0) + 1
+
+    def maybe_print(self, *, final: bool = False) -> None:
+        now = time.perf_counter()
+        if not final and now - self.last_print < 5:
+            return
+        inflight = self.started - self.completed
+        print(
+            "[client-stats] "
+            f"scheduled={self.scheduled} started={self.started} completed={self.completed} "
+            f"success={self.success} error={self.error} inflight={inflight}",
+            flush=True,
+        )
+        self.last_print = now
+
+    def print_error_summary(self) -> None:
+        if not self.error_types:
+            return
+        print("[client-stats] error summary:", flush=True)
+        for error, count in sorted(self.error_types.items(), key=lambda item: item[1], reverse=True)[:10]:
+            print(f"[client-stats]   {count}x {error}", flush=True)
+
+
 async def _post_slow_down_all_aiohttp(
     server_bases: list[str],
     forward_sleep_time: float | None,
@@ -98,9 +139,7 @@ async def _post_slow_down_all_aiohttp(
                     ) as resp:
                         if resp.status >= 400:
                             body = await resp.text()
-                            print(
-                                f"Warning: slow_down POST {url} -> HTTP {resp.status}: {body[:500]}"
-                            )
+                            print(f"Warning: slow_down POST {url} -> HTTP {resp.status}: {body[:500]}")
                 except aiohttp.ClientError as e:
                     print(f"Warning: slow_down POST {url} failed: {e}")
     except aiohttp.ClientError as e:
@@ -310,7 +349,7 @@ def sample_vision_arena_requests(
         output_len = fixed_output_len
 
         assert isinstance(data["images"][0], Image), (
-            "Input image format must be `PIL.Image.Image`, " f"given {type(data['image'])}."
+            f"Input image format must be `PIL.Image.Image`, given {type(data['image'])}."
         )
         image: Image = data["images"][0]
         image = image.convert("RGB")
@@ -410,9 +449,7 @@ def _process_random_no_chat(args):
     serial loop in ``sample_random_requests``."""
     i, offset, input_len, output_len, prefix_token_ids, prefix_len, vocab_size = args
     tokenizer = _worker_tokenizer
-    prompt = tokenizer.decode(
-        prefix_token_ids + [(offset + i + j) % vocab_size for j in range(input_len)]
-    )
+    prompt = tokenizer.decode(prefix_token_ids + [(offset + i + j) % vocab_size for j in range(input_len)])
     re_encoded_sequence = tokenizer.encode(prompt, add_special_tokens=False)[: (prefix_len + input_len)]
     prompt = tokenizer.decode(re_encoded_sequence)
     return (prompt, int(prefix_len + input_len), int(output_len), None)
@@ -423,10 +460,8 @@ def _process_random_chat(args):
     existing serial loop in ``sample_random_requests``."""
     i, offset, input_len, output_len, chat_template_len, vocab_size = args
     tokenizer = _worker_tokenizer
-    origin_text = tokenizer.decode(
-        [(offset + i + j) % vocab_size for j in range(int(input_len * 1.5))]
-    )
-    re_encoded_sequence = tokenizer.encode(origin_text, add_special_tokens=False)[: input_len]
+    origin_text = tokenizer.decode([(offset + i + j) % vocab_size for j in range(int(input_len * 1.5))])
+    re_encoded_sequence = tokenizer.encode(origin_text, add_special_tokens=False)[:input_len]
     prompt_text = tokenizer.decode(re_encoded_sequence)
     prompt = tokenizer.apply_chat_template(
         [{"role": "user", "content": prompt_text}],
@@ -451,13 +486,19 @@ def sample_random_requests(
     custom_tokenizer: str | None = None,
 ) -> list[tuple[str, int, int]]:
     if use_chat_template:
-        chat_template_len = len(tokenizer.encode(
-            tokenizer.apply_chat_template(
-                [{"role": "user", "content": "a"}],
-                add_generation_prompt=True,
-                tokenize=False,
-            ), add_special_tokens=False,
-        )) - 1
+        chat_template_len = (
+            len(
+                tokenizer.encode(
+                    tokenizer.apply_chat_template(
+                        [{"role": "user", "content": "a"}],
+                        add_generation_prompt=True,
+                        tokenize=False,
+                    ),
+                    add_special_tokens=False,
+                )
+            )
+            - 1
+        )
         input_len = input_len - chat_template_len
 
     input_lens = np.random.randint(
@@ -478,16 +519,14 @@ def sample_random_requests(
     # worker function so behavior is identical in both.
     if use_chat_template:
         args_list = [
-            (i, int(offsets[i]), int(input_lens[i]), int(output_lens[i]),
-             chat_template_len, vocab_size)
+            (i, int(offsets[i]), int(input_lens[i]), int(output_lens[i]), chat_template_len, vocab_size)
             for i in range(num_prompts)
         ]
         worker_fn = _process_random_chat
     else:
         prefix_token_ids = np.random.randint(0, vocab_size, size=prefix_len).tolist()
         args_list = [
-            (i, int(offsets[i]), int(input_lens[i]), int(output_lens[i]),
-             prefix_token_ids, prefix_len, vocab_size)
+            (i, int(offsets[i]), int(input_lens[i]), int(output_lens[i]), prefix_token_ids, prefix_len, vocab_size)
             for i in range(num_prompts)
         ]
         worker_fn = _process_random_no_chat
@@ -504,7 +543,8 @@ def sample_random_requests(
             initargs=(tokenizer_id, tokenizer_mode, trust_remote_code, custom_tokenizer),
         ) as pool:
             input_requests = pool.map(
-                worker_fn, args_list,
+                worker_fn,
+                args_list,
                 chunksize=max(1, num_prompts // (num_workers * 4)),
             )
     else:
@@ -627,7 +667,7 @@ def calculate_metrics(
 
     if completed == 0:
         warnings.warn(
-            "All requests failed. This is likely due to a misconfiguration " "on the benchmark arguments.",
+            "All requests failed. This is likely due to a misconfiguration on the benchmark arguments.",
             stacklevel=2,
         )
 
@@ -667,7 +707,9 @@ def calculate_metrics(
                     tokens_per_second[second_bucket] += num_tokens
 
         if tokens_per_second:
-            smoothed_tokens_per_second = np.convolve(tokens_per_second, np.ones(peak_output_smooth_factor) / peak_output_smooth_factor, mode='valid')
+            smoothed_tokens_per_second = np.convolve(
+                tokens_per_second, np.ones(peak_output_smooth_factor) / peak_output_smooth_factor, mode="valid"
+            )
             peak_output_tokens_per_s = float(max(smoothed_tokens_per_second))
 
     metrics = BenchmarkMetrics(
@@ -703,6 +745,7 @@ def calculate_metrics(
 async def benchmark(
     backend: str,
     api_url: str,
+    api_urls: list[str] | None,
     base_url: str,
     model_id: str,
     model_name: str,
@@ -729,32 +772,39 @@ async def benchmark(
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
+    request_api_urls = api_urls or [api_url]
+    if not request_api_urls:
+        raise ValueError("At least one API URL is required.")
+    if profile and len(request_api_urls) > 1:
+        raise ValueError("--profile is not supported with multiple --api-url targets.")
+
     print("Starting initial single prompt test run...")
     test_prompt, test_prompt_len, test_output_len, test_mm_content = input_requests[0]
     if backend != "openai-chat" and test_mm_content is not None:
         # multi-modal benchmark is only available on OpenAI Chat backend.
         raise ValueError("Multi-modal content is only supported on 'openai-chat' backend.")
-    test_input = RequestFuncInput(
-        model=model_id,
-        model_name=model_name,
-        prompt=test_prompt,
-        api_url=api_url,
-        prompt_len=test_prompt_len,
-        output_len=test_output_len,
-        logprobs=logprobs,
-        best_of=best_of,
-        multi_modal_content=test_mm_content,
-        ignore_eos=ignore_eos,
-    )
 
-    test_output = await request_func(request_func_input=test_input)
-    if not test_output.success:
-        raise ValueError(
-            "Initial test run failed - Please make sure benchmark arguments "
-            f"are correctly specified. Error: {test_output.error}"
+    for test_api_url in request_api_urls:
+        test_input = RequestFuncInput(
+            model=model_id,
+            model_name=model_name,
+            prompt=test_prompt,
+            api_url=test_api_url,
+            prompt_len=test_prompt_len,
+            output_len=test_output_len,
+            logprobs=logprobs,
+            best_of=best_of,
+            multi_modal_content=test_mm_content,
+            ignore_eos=ignore_eos,
         )
-    else:
-        print("Initial test run completed. Starting main benchmark run...")
+
+        test_output = await request_func(request_func_input=test_input)
+        if not test_output.success:
+            raise ValueError(
+                "Initial test run failed - Please make sure benchmark arguments "
+                f"are correctly specified. url={test_api_url} Error: {test_output.error}"
+            )
+    print("Initial test run completed. Starting main benchmark run...")
 
     if lora_modules:
         # For each input request, choose a LoRA module at random.
@@ -786,6 +836,10 @@ async def benchmark(
     print(f"Traffic request rate: {request_rate}")
     print(f"Burstiness factor: {burstiness} ({distribution})")
     print(f"Maximum request concurrency: {max_concurrency}")
+    if len(request_api_urls) > 1:
+        print(f"Sharding requests across {len(request_api_urls)} API URLs:")
+        for idx, target_url in enumerate(request_api_urls):
+            print(f"  [{idx}] {target_url}")
 
     slow_bases = [s.strip() for s in (slow_down_servers or []) if s.strip()]
     slow_down_task: asyncio.Task | None = None
@@ -806,10 +860,7 @@ async def benchmark(
 
             async def _slow_down_disable_after_wait():
                 await asyncio.sleep(slow_down_wait_time)
-                print(
-                    f"slow_down auto-disabled after {slow_down_wait_time}s "
-                    f"({len(bases_snapshot)} server(s))."
-                )
+                print(f"slow_down auto-disabled after {slow_down_wait_time}s ({len(bases_snapshot)} server(s)).")
                 await _post_slow_down_all_aiohttp(bases_snapshot, None)
 
             slow_down_task = asyncio.create_task(_slow_down_disable_after_wait())
@@ -821,37 +872,68 @@ async def benchmark(
     #    semaphore = (asyncio.Semaphore(max_concurrency)
     #                 if max_concurrency else contextlib.nullcontext())
     semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else None
+    stats = ClientStats()
 
     async def limited_request_func(request_func_input, pbar):
+        async def run_request():
+            stats.started += 1
+            stats.maybe_print()
+            output = await request_func(request_func_input=request_func_input, pbar=pbar, session=session)
+            stats.record_output(output)
+            stats.maybe_print()
+            return output
+
         if semaphore is None:
-            return await request_func(request_func_input=request_func_input, pbar=pbar)
+            return await run_request()
         async with semaphore:
-            return await request_func(request_func_input=request_func_input, pbar=pbar)
+            return await run_request()
 
     benchmark_start_time = time.perf_counter()
     tasks: list[asyncio.Task] = []
-    async for request in get_request(input_requests, request_rate, burstiness):
-        prompt, prompt_len, output_len, mm_content = request
-        req_model_id, req_model_name = model_id, model_name
-        if lora_modules:
-            req_lora_module = next(lora_modules)
-            req_model_id, req_model_name = req_lora_module, req_lora_module
 
-        request_func_input = RequestFuncInput(
-            model=req_model_id,
-            model_name=req_model_name,
-            prompt=prompt,
-            api_url=api_url,
-            prompt_len=prompt_len,
-            output_len=output_len,
-            logprobs=logprobs,
-            best_of=best_of,
-            multi_modal_content=mm_content,
-            ignore_eos=ignore_eos,
-        )
-        tasks.append(asyncio.create_task(limited_request_func(request_func_input=request_func_input, pbar=pbar)))
-    outputs: list[RequestFuncOutput] = await asyncio.gather(*tasks)
-    
+    conn_limit_env = os.environ.get("SA_BENCH_AIOHTTP_CONN_LIMIT")
+    connector_limit = int(conn_limit_env) if conn_limit_env else 0
+    print(
+        f"SA-Bench shared aiohttp session: connector_limit={connector_limit} limit_per_host=0 ttl_dns_cache=300",
+        flush=True,
+    )
+    connector = aiohttp.TCPConnector(
+        limit=connector_limit,
+        limit_per_host=0,
+        ttl_dns_cache=300,
+        enable_cleanup_closed=True,
+    )
+    timeout = aiohttp.ClientTimeout(total=6 * 60 * 60)
+    async with aiohttp.ClientSession(trust_env=True, timeout=timeout, connector=connector) as session:
+        request_idx = 0
+        async for request in get_request(input_requests, request_rate, burstiness):
+            prompt, prompt_len, output_len, mm_content = request
+            req_model_id, req_model_name = model_id, model_name
+            if lora_modules:
+                req_lora_module = next(lora_modules)
+                req_model_id, req_model_name = req_lora_module, req_lora_module
+            target_api_url = request_api_urls[request_idx % len(request_api_urls)]
+            request_idx += 1
+
+            request_func_input = RequestFuncInput(
+                model=req_model_id,
+                model_name=req_model_name,
+                prompt=prompt,
+                api_url=target_api_url,
+                prompt_len=prompt_len,
+                output_len=output_len,
+                logprobs=logprobs,
+                best_of=best_of,
+                multi_modal_content=mm_content,
+                ignore_eos=ignore_eos,
+            )
+            stats.scheduled += 1
+            stats.maybe_print()
+            tasks.append(asyncio.create_task(limited_request_func(request_func_input=request_func_input, pbar=pbar)))
+        outputs: list[RequestFuncOutput] = await asyncio.gather(*tasks)
+        stats.maybe_print(final=True)
+        stats.print_error_summary()
+
     if slow_down_task is not None and not slow_down_task.done():
         slow_down_task.cancel()
         try:
@@ -919,6 +1001,8 @@ async def benchmark(
         "generated_texts": [output.generated_text for output in outputs],
         "errors": [output.error for output in outputs],
     }
+    if len(request_api_urls) > 1:
+        result["api_urls"] = request_api_urls
 
     def process_one_metric(
         # E.g., "ttft"
@@ -1044,12 +1128,21 @@ def main(args: argparse.Namespace):
     tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
     tokenizer_mode = args.tokenizer_mode
 
-    if args.base_url is not None:
+    if args.api_urls:
+        api_urls = args.api_urls
+        api_url = api_urls[0]
+        if api_url.endswith(args.endpoint):
+            base_url = api_url[: -len(args.endpoint)]
+        else:
+            base_url = api_url.rsplit("/", 1)[0]
+    elif args.base_url is not None:
         api_url = f"{args.base_url}{args.endpoint}"
         base_url = f"{args.base_url}"
+        api_urls = None
     else:
         api_url = f"http://{args.host}:{args.port}{args.endpoint}"
         base_url = f"http://{args.host}:{args.port}"
+        api_urls = None
 
     tokenizer = load_tokenizer(
         tokenizer_id,
@@ -1064,11 +1157,9 @@ def main(args: argparse.Namespace):
         # HF DeepSeek-V4 tokenizer has no jinja chat_template and would otherwise
         # crash deep inside transformers with a generic ValueError.
         from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
         has_jinja = bool(getattr(tokenizer, "chat_template", None))
-        has_method_override = (
-            type(tokenizer).apply_chat_template
-            is not PreTrainedTokenizerBase.apply_chat_template
-        )
+        has_method_override = type(tokenizer).apply_chat_template is not PreTrainedTokenizerBase.apply_chat_template
         if not has_jinja and not has_method_override:
             raise ValueError(
                 "--use-chat-template was set, but the loaded tokenizer "
@@ -1099,7 +1190,6 @@ def main(args: argparse.Namespace):
             num_requests=args.num_prompts,
         )
     else:
-
         if args.dataset is not None:
             warnings.warn(
                 "The '--dataset' argument will be deprecated in the next "
@@ -1146,9 +1236,9 @@ def main(args: argparse.Namespace):
                     for prompt, prompt_formatted, prompt_len, output_len, _ in input_requests
                 ]
             else:
-                assert (
-                    tokenizer.chat_template or tokenizer.default_chat_template
-                ), "Tokenizer/model must have chat template for sonnet dataset."
+                assert tokenizer.chat_template or tokenizer.default_chat_template, (
+                    "Tokenizer/model must have chat template for sonnet dataset."
+                )
                 input_requests = sample_sonnet_requests(
                     dataset_path=args.dataset_path,
                     num_requests=args.num_prompts,
@@ -1202,6 +1292,7 @@ def main(args: argparse.Namespace):
         benchmark(
             backend=backend,
             api_url=api_url,
+            api_urls=api_urls,
             base_url=base_url,
             model_id=model_id,
             model_name=model_name,
@@ -1251,6 +1342,8 @@ def main(args: argparse.Namespace):
         result_json["request_rate"] = args.request_rate if args.request_rate < float("inf") else "inf"
         result_json["burstiness"] = args.burstiness
         result_json["max_concurrency"] = args.max_concurrency
+        if args.api_urls:
+            result_json["api_urls"] = args.api_urls
 
         # Merge with benchmark result
         result_json = {**result_json, **benchmark_result}
@@ -1282,6 +1375,17 @@ if __name__ == "__main__":
         default=None,
         help="Server or API base url if not using http host and port.",
     )
+    parser.add_argument(
+        "--api-url",
+        action="append",
+        dest="api_urls",
+        default=None,
+        help=(
+            "Full API URL to send requests to. Repeat to shard requests "
+            "round-robin across multiple frontend endpoints. Overrides "
+            "--base-url/--host/--port for request traffic."
+        ),
+    )
     # Use 127.0.0.1 here instead of localhost to force the use of ipv4
     parser.add_argument("--host", type=str, default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
@@ -1295,7 +1399,7 @@ if __name__ == "__main__":
         "--dataset",
         type=str,
         default=None,
-        help="Path to the ShareGPT dataset, will be deprecated in the " "next release.",
+        help="Path to the ShareGPT dataset, will be deprecated in the next release.",
     )
     parser.add_argument(
         "--dataset-name",
@@ -1308,7 +1412,7 @@ if __name__ == "__main__":
         "--dataset-path",
         type=str,
         default=None,
-        help="Path to the sharegpt/sonnet dataset. " "Or the huggingface dataset ID if using HF dataset.",
+        help="Path to the sharegpt/sonnet dataset. Or the huggingface dataset ID if using HF dataset.",
     )
     parser.add_argument(
         "--max-concurrency",
@@ -1362,7 +1466,7 @@ if __name__ == "__main__":
         "--best-of",
         type=int,
         default=1,
-        help="Generates `best_of` sequences per prompt and " "returns the best one.",
+        help="Generates `best_of` sequences per prompt and returns the best one.",
     )
     parser.add_argument("--use-beam-search", action="store_true")
     parser.add_argument(
@@ -1418,7 +1522,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--profile",
         action="store_true",
-        help="Use Torch Profiler. The endpoint must be launched with " "VLLM_TORCH_PROFILER_DIR to enable profiler.",
+        help="Use Torch Profiler. The endpoint must be launched with VLLM_TORCH_PROFILER_DIR to enable profiler.",
     )
     parser.add_argument(
         "--save-result",
@@ -1512,7 +1616,7 @@ if __name__ == "__main__":
         "--sharegpt-output-len",
         type=int,
         default=None,
-        help="Output length for each request. Overrides the output length " "from the ShareGPT dataset.",
+        help="Output length for each request. Overrides the output length from the ShareGPT dataset.",
     )
 
     random_group = parser.add_argument_group("random dataset options")
@@ -1532,7 +1636,7 @@ if __name__ == "__main__":
         "--random-range-ratio",
         type=float,
         default=1.0,
-        help="Range of sampled ratio of input/output length, " "used only for random sampling.",
+        help="Range of sampled ratio of input/output length, used only for random sampling.",
     )
     random_group.add_argument(
         "--random-prefix-len",
@@ -1564,7 +1668,7 @@ if __name__ == "__main__":
         "--hf-output-len",
         type=int,
         default=None,
-        help="Output length for each request. Overrides the output lengths " "from the sampled HF dataset.",
+        help="Output length for each request. Overrides the output lengths from the sampled HF dataset.",
     )
 
     parser.add_argument(

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -38,6 +38,7 @@ import random
 import time
 import warnings
 from collections.abc import AsyncGenerator, Collection
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime
 from multiprocessing import Pool, cpu_count
@@ -50,6 +51,8 @@ from backend_request_func import (
     ASYNC_REQUEST_FUNCS,
     RequestFuncInput,
     RequestFuncOutput,
+)
+from backend_request_func import (
     get_tokenizer as get_sa_bench_tokenizer,
 )
 from datasets import load_dataset
@@ -660,8 +663,8 @@ def calculate_metrics(
             valid_metrics.append(e2els)
             slo_values.append(goodput_config_dict["e2el"] / MILLISECONDS_TO_SECONDS_CONVERSION)
 
-        for req_metric in zip(*valid_metrics):
-            is_good_req = all([s >= r for s, r in zip(slo_values, req_metric)])
+        for req_metric in zip(*valid_metrics, strict=False):
+            is_good_req = all(s >= r for s, r in zip(slo_values, req_metric, strict=False))
             if is_good_req:
                 good_completed += 1
 
@@ -828,10 +831,7 @@ async def benchmark(
         if profile_output.success:
             print("Profiler started")
 
-    if burstiness == 1.0:
-        distribution = "Poisson process"
-    else:
-        distribution = "Gamma distribution"
+    distribution = "Poisson process" if burstiness == 1.0 else "Gamma distribution"
 
     print(f"Traffic request rate: {request_rate}")
     print(f"Burstiness factor: {burstiness} ({distribution})")
@@ -936,10 +936,8 @@ async def benchmark(
 
     if slow_down_task is not None and not slow_down_task.done():
         slow_down_task.cancel()
-        try:
+        with suppress(asyncio.CancelledError):
             await slow_down_task
-        except asyncio.CancelledError:
-            pass
         await _post_slow_down_all_aiohttp(slow_bases, None)
 
     if profile:
@@ -1131,10 +1129,7 @@ def main(args: argparse.Namespace):
     if args.api_urls:
         api_urls = args.api_urls
         api_url = api_urls[0]
-        if api_url.endswith(args.endpoint):
-            base_url = api_url[: -len(args.endpoint)]
-        else:
-            base_url = api_url.rsplit("/", 1)[0]
+        base_url = api_url[: -len(args.endpoint)] if api_url.endswith(args.endpoint) else api_url.rsplit("/", 1)[0]
     elif args.base_url is not None:
         api_url = f"{args.base_url}{args.endpoint}"
         base_url = f"{args.base_url}"

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -333,6 +333,25 @@ class BenchmarkStageMixin:
             "SA_BENCH_SLOW_DOWN_WAIT_TIME": str(b.slow_down_wait_time),
         }
 
+    def _get_sa_bench_api_url_env(self) -> dict[str, str]:
+        """Build SA-Bench sharded API URLs from srt-slurm frontend topology."""
+        b = self.config.benchmark
+        shard_frontends = str(b.env.get("SA_BENCH_SHARD_FRONTENDS", "")).lower() in ("1", "true", "yes", "on")
+        if not shard_frontends or b.env.get("SA_BENCH_API_URLS"):
+            return {}
+
+        topology = self._compute_frontend_topology()
+        urls = [
+            f"http://{get_hostname_ip(node, self.runtime.network_interface)}:{topology.frontend_port}/v1/completions"
+            for node in topology.frontend_nodes
+        ]
+        if not urls:
+            logger.warning("SA_BENCH_SHARD_FRONTENDS requested but no frontend nodes were found")
+            return {}
+
+        logger.info("SA-Bench sharded API targets from frontend topology: %s", ", ".join(urls))
+        return {"SA_BENCH_API_URLS": ",".join(urls)}
+
     def _get_aiperf_server_metrics_env(self) -> dict[str, str]:
         """Build server metrics URLs for AIPerf benchmarks.
 
@@ -375,6 +394,7 @@ class BenchmarkStageMixin:
             env[key] = value
 
         if runner.name == "SA-Bench":
+            env.update(self._get_sa_bench_api_url_env())
             env.update(self._get_sa_bench_slow_down_env())
 
         # Add AIPerf-specific env vars for AIPerf-driven benchmarks only

--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -13,6 +13,7 @@ http {
         {% for frontend_host in frontend_hosts %}
         server {{ frontend_host }}:{{ backend_port | default(8000) }};
         {% endfor %}
+        keepalive 4096;
     }
 
     # The main server block that listens for incoming traffic.
@@ -23,6 +24,8 @@ http {
             # Pass the request to the upstream group defined above.
             proxy_pass http://backend_servers;
 
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
             proxy_buffering off;
             proxy_read_timeout 24h;
             proxy_send_timeout 24h;
@@ -37,7 +40,7 @@ events {
     # (Max clients = worker_connections * worker_processes)
     # Should be equal to `ulimit -n / worker_processes`
     #
-    worker_connections 65535;
+    worker_connections 1048576;
 
     #
     # Let each process accept multiple connections.

--- a/tests/test_frontend_topology.py
+++ b/tests/test_frontend_topology.py
@@ -3,13 +3,14 @@
 
 """Tests for frontend topology logic (nginx + multiple frontends)."""
 
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from srtctl.cli.do_sweep import SweepOrchestrator
 from srtctl.cli.mixins.frontend_stage import FrontendTopology
 from srtctl.core.runtime import Nodes, RuntimeContext
-from srtctl.core.schema import FrontendConfig, ResourceConfig, SrtConfig
+from srtctl.core.schema import BenchmarkConfig, FrontendConfig, ResourceConfig, SrtConfig
 
 
 def make_config(
@@ -191,9 +192,11 @@ class TestNginxConfigGeneration:
             public_port=8000,
         )
 
-        with patch.object(orchestrator, "runtime", runtime):
-            with patch("srtctl.cli.mixins.frontend_stage.get_hostname_ip", side_effect=lambda x: f"10.0.0.{x[-1]}"):
-                nginx_config = orchestrator._generate_nginx_config(topology)
+        with (
+            patch.object(orchestrator, "runtime", runtime),
+            patch("srtctl.cli.mixins.frontend_stage.get_hostname_ip", side_effect=lambda x: f"10.0.0.{x[-1]}"),
+        ):
+            nginx_config = orchestrator._generate_nginx_config(topology)
 
         assert "server 10.0.0.1:8180" in nginx_config
         assert "listen 8000" in nginx_config
@@ -212,9 +215,11 @@ class TestNginxConfigGeneration:
             public_port=8000,
         )
 
-        with patch.object(orchestrator, "runtime", runtime):
-            with patch("srtctl.cli.mixins.frontend_stage.get_hostname_ip", side_effect=lambda x: f"10.0.0.{x[-1]}"):
-                nginx_config = orchestrator._generate_nginx_config(topology)
+        with (
+            patch.object(orchestrator, "runtime", runtime),
+            patch("srtctl.cli.mixins.frontend_stage.get_hostname_ip", side_effect=lambda x: f"10.0.0.{x[-1]}"),
+        ):
+            nginx_config = orchestrator._generate_nginx_config(topology)
 
         assert "worker_rlimit_nofile 1048576" in nginx_config
 
@@ -239,6 +244,47 @@ class TestNginxConfigGeneration:
         assert "server 10.0.0.2:8180" in nginx_config
         assert "server 10.0.0.3:8180" in nginx_config
         assert "listen 8000" in nginx_config
+
+
+class TestSABenchShardedApiUrls:
+    """Tests for SA-Bench API URL generation from frontend topology."""
+
+    def test_generates_sa_bench_urls_from_frontend_topology(self):
+        config = make_config(enable_multiple_frontends=True)
+        config = replace(
+            config,
+            benchmark=BenchmarkConfig(type="sa-bench", env={"SA_BENCH_SHARD_FRONTENDS": "true"}),
+        )
+        runtime = make_runtime(["node0", "node1", "node2", "node3"])
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        with patch("srtctl.cli.mixins.benchmark_stage.get_hostname_ip", side_effect=lambda x, _: f"10.0.0.{x[-1]}"):
+            env = orchestrator._get_sa_bench_api_url_env()
+
+        assert env == {
+            "SA_BENCH_API_URLS": (
+                "http://10.0.0.1:8180/v1/completions,"
+                "http://10.0.0.2:8180/v1/completions,"
+                "http://10.0.0.3:8180/v1/completions"
+            )
+        }
+
+    def test_explicit_sa_bench_urls_win(self):
+        config = make_config(enable_multiple_frontends=True)
+        config = replace(
+            config,
+            benchmark=BenchmarkConfig(
+                type="sa-bench",
+                env={
+                    "SA_BENCH_SHARD_FRONTENDS": "true",
+                    "SA_BENCH_API_URLS": "http://nginx0:8000/v1/completions",
+                },
+            ),
+        )
+        runtime = make_runtime(["node0", "node1", "node2"])
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+
+        assert orchestrator._get_sa_bench_api_url_env() == {}
 
 
 class TestStartFrontendIntegration:

--- a/tests/test_sa_bench_runner.py
+++ b/tests/test_sa_bench_runner.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from srtctl.backends.mocker import MockerProtocol
+from srtctl.benchmarks.sa_bench import SABenchRunner
+from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+
+def test_build_command_mocker_local_model_uses_container_model_name():
+    """Mocker serves local models under the in-container /model name."""
+    runner = SABenchRunner()
+    runtime = MagicMock()
+    runtime.frontend_port = 8000
+    runtime.model_path = Path("/mnt/models/dsv4")
+    runtime.is_hf_model = False
+
+    config = SrtConfig(
+        name="test",
+        model=ModelConfig(path="/mnt/models/dsv4", container="/image", precision="fp4"),
+        resources=ResourceConfig(gpu_type="h100"),
+        backend=MockerProtocol(),
+        benchmark=BenchmarkConfig(type="sa-bench", isl=1024, osl=128, concurrencies="4x8"),
+    )
+
+    cmd = runner.build_command(config, runtime)
+    assert cmd[8] == "/model"


### PR DESCRIPTION
## Summary
- Add repeated `--api-url` support to SA-Bench and round-robin requests across multiple frontend endpoints while sharing one aiohttp session.
- Teach `bench.sh` to populate direct frontend targets from `SA_BENCH_API_URLS` or `/logs/nginx.conf` when `SA_BENCH_SHARD_FRONTENDS=true`.
- Pass `benchmark.env` through benchmark runners so recipes can enable sharded SA-Bench without using custom commands.

## Why
High-concurrency disaggregated serving runs can exhaust ephemeral ports when a single load generator connects to one `host:port` tuple. Sharding request traffic across the deployed frontend endpoints avoids that client-side collapse without changing backend topology.

For conc=32768
Before
<img width="1152" height="563" alt="image" src="https://github.com/user-attachments/assets/70f35c6b-c5c6-4497-8767-2170c7ee7ff2" />

After
<img width="1561" height="539" alt="image" src="https://github.com/user-attachments/assets/46cd86b7-7a99-48f2-8369-3aa64a9d9f6a" />


## Validation
- `uv run ruff check src/srtctl/benchmarks/base.py src/srtctl/benchmarks/custom.py src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py`
- `uv run python -m py_compile src/srtctl/benchmarks/scripts/sa-bench/backend_request_func.py src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py`
- `uv run pytest tests/test_benchmarks.py tests/test_frontends.py`
- CoreWeave validation: job 3487, 6P1D DEP24, conc=36864, sharded SA-Bench, completed 110592/110592 with error=0 and `api_urls=9`.
- CoreWeave validation: job 3528, 4P1D DEP24, conc=32768, sharded SA-Bench, completed 98304/98304 with error=0 and `api_urls=9`.