### PR TITLE
fix(sglang): override recipe-pinned disaggregation-bootstrap-port

### DIFF
--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -9,6 +9,7 @@ Implements BackendProtocol for SGLang inference serving with prefill/decode disa
 
 import builtins
 import json
+import logging
 from collections.abc import Sequence
 from dataclasses import field
 from pathlib import Path
@@ -26,6 +27,8 @@ if TYPE_CHECKING:
     from srtctl.backends.base import SrunConfig
     from srtctl.core.runtime import RuntimeContext
     from srtctl.core.topology import Endpoint, NodePortAllocator, Process
+
+logger = logging.getLogger(__name__)
 
 # Type alias for worker modes
 WorkerMode = Literal["prefill", "decode", "agg"]
@@ -321,6 +324,42 @@ class SGLangProtocol:
         config.pop("model_path", None)
         config.pop("served-model-name", None)
         config.pop("served_model_name", None)
+
+        # disaggregation-bootstrap-port should NOT be set in recipes — it is owned by
+        # NodePortAllocator (jittered per-job) and injected below from
+        # process.bootstrap_port. The override-and-warn logic here exists only for
+        # backward compatibility with legacy recipes that still pin the value: without
+        # the pop, the recipe value would land *after* the explicit flag in
+        # _config_to_cli_args output and argparse last-wins would silently override the
+        # jittered port — leaving router/decode trying to reach the prefill on a port
+        # it isn't listening on.
+        recipe_bootstrap = config.pop("disaggregation-bootstrap-port", None)
+        recipe_bootstrap_snake = config.pop("disaggregation_bootstrap_port", None)
+        recipe_bootstrap = recipe_bootstrap or recipe_bootstrap_snake
+        if recipe_bootstrap is None:
+            pass  # no recipe override — jittered allocator value is the only source
+        elif mode == "prefill" and process.bootstrap_port is not None:
+            if str(recipe_bootstrap) != str(process.bootstrap_port):
+                logger.warning(
+                    "sglang[%s on %s]: ignoring recipe disaggregation-bootstrap-port=%s; "
+                    "using NodePortAllocator value %s (job-jittered)",
+                    mode,
+                    process.node,
+                    recipe_bootstrap,
+                    process.bootstrap_port,
+                )
+        else:
+            # Entered when the recipe pinned a value AND this process is not a prefill
+            # leader (decode/agg mode, or a prefill follower with no allocated bootstrap
+            # port). Only prefill leaders bind the bootstrap server, so the value would
+            # be silently ignored anyway — warn so the recipe author can clean it up.
+            logger.warning(
+                "sglang[%s on %s]: ignoring recipe disaggregation-bootstrap-port=%s; "
+                "bootstrap server is bound only by prefill workers",
+                mode,
+                process.node,
+                recipe_bootstrap,
+            )
 
         # Determine if multi-node
         endpoint_nodes = list(dict.fromkeys(p.node for p in endpoint_processes))

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1733,6 +1733,54 @@ class TestHuggingFaceModelSupport:
         count = cmd.count("--served-model-name")
         assert count == 1, f"--served-model-name appears {count} times: {cmd}"
 
+    def test_sglang_bootstrap_port_recipe_value_is_overridden_by_jitter(self, caplog):
+        """Recipe-pinned disaggregation-bootstrap-port must be overridden by the jittered allocator value.
+
+        Recipes should NOT specify ``disaggregation-bootstrap-port`` — the port is
+        owned by ``NodePortAllocator`` (per-job jitter) so cross-job leaked
+        processes don't collide. This test exists to guard the
+        backward-compatibility override for legacy recipes that still pin it:
+        without the pop+override, argparse last-wins would silently restore the
+        recipe value, leaving prefill bound to the recipe port while router/decode
+        connect to the jittered port (connection refused).
+        """
+        import logging
+        from unittest.mock import patch
+
+        from srtctl.backends import SGLangProtocol, SGLangServerConfig
+        from srtctl.core.topology import Process
+
+        backend = SGLangProtocol(
+            sglang_config=SGLangServerConfig(prefill={"disaggregation-bootstrap-port": 31000}),
+        )
+        process = Process(
+            node="node0",
+            gpu_indices=frozenset([0, 1, 2, 3]),
+            sys_port=8081,
+            http_port=34399,  # jittered
+            endpoint_mode="prefill",
+            endpoint_index=0,
+            node_rank=0,
+            bootstrap_port=35399,  # jittered, must win
+        )
+        runtime = self._make_runtime(is_hf=False)
+
+        with caplog.at_level(logging.WARNING, logger="srtctl.backends.sglang"):
+            with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+                cmd = backend.build_worker_command(
+                    process=process, endpoint_processes=[process], runtime=runtime
+                )
+
+        count = cmd.count("--disaggregation-bootstrap-port")
+        assert count == 1, f"--disaggregation-bootstrap-port appears {count} times: {cmd}"
+        idx = cmd.index("--disaggregation-bootstrap-port")
+        assert cmd[idx + 1] == "35399", f"expected jittered 35399, got {cmd[idx + 1]}"
+        assert any(
+            "ignoring recipe disaggregation-bootstrap-port=31000" in r.message
+            and "35399" in r.message
+            for r in caplog.records
+        ), f"expected warning naming both ports, got: {[r.message for r in caplog.records]}"
+
     # --- TRTLLM ---
 
     def test_trtllm_hf_model_uses_model_id(self):


### PR DESCRIPTION
## Summary

After the SGLang port jitter change (#134), prefill leaders inject a per-job-jittered `--disaggregation-bootstrap-port` derived from `process.bootstrap_port`. However, recipes that still pin `disaggregation-bootstrap-port: <fixed>` have that value re-appended by `_config_to_cli_args` at the end of the command line, and argparse last-wins silently restores the recipe value. The prefill ends up listening on the recipe port (e.g. `31000`) while the router and decode workers connect to the jittered port (e.g. `35399`) — manifesting as `Connection refused` in the decode log roughly 15 min into the run, after engine init.

The user-visible symptom: any sglang frontend + PD job using a recipe that still pins `disaggregation-bootstrap-port` hangs at the bootstrap fetch loop.

### Fix

- In `SGLangProtocol.build_worker_command`, pop both `disaggregation-bootstrap-port` and `disaggregation_bootstrap_port` from the per-mode config before `_config_to_cli_args` runs, so the explicit jittered flag is the only `--disaggregation-bootstrap-port` on the command line.
- When a recipe still pins the field, log a `WARNING` naming both the ignored recipe value and the actual jittered port being used (or, for decode/agg modes where the bootstrap server is not bound at all, a separate warning explaining the value would be silently ignored anyway).
- Recipes themselves are **not** touched — the override is a backward-compatibility shim for existing recipes. New recipes should never set this field.

### Files changed

- `src/srtctl/backends/sglang.py`: pop + warn logic, module-level `logger`.
- `tests/test_configs.py`: regression test confirming the recipe value is overridden by the jittered allocator value and a warning naming both ports is emitted.