### PR TITLE
vllm: set VLLM_NIXL_SIDE_CHANNEL_HOST to node's routable IP

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -132,12 +132,18 @@ class VLLMProtocol:
         vLLM with dynamo requires unique ports for each worker:
         - DYN_VLLM_KV_EVENT_PORT: ZMQ port for KV events publishing
         - VLLM_NIXL_SIDE_CHANNEL_PORT: Port for NIXL side channel transfers
+        - VLLM_NIXL_SIDE_CHANNEL_HOST: Routable IP for NIXL side channel
+          (vLLM defaults to ``0.0.0.0`` / ``localhost`` which breaks the
+          multi-node NIXL handshake)
         """
+        from srtctl.core.slurm import get_hostname_ip
+
         env: dict[str, str] = {}
         if process.kv_events_port is not None:
             env["DYN_VLLM_KV_EVENT_PORT"] = str(process.kv_events_port)
         if process.nixl_port is not None:
             env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(process.nixl_port)
+            env["VLLM_NIXL_SIDE_CHANNEL_HOST"] = get_hostname_ip(process.node)
         return env
 
     def get_served_model_name(self, default: str) -> str:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1297,6 +1297,8 @@ class TestVLLMDataParallelMode:
 
     def test_vllm_get_process_environment(self):
         """Test vLLM sets port environment variables from process."""
+        from unittest.mock import patch
+
         from srtctl.backends import VLLMProtocol
         from srtctl.core.topology import Process
 
@@ -1315,10 +1317,12 @@ class TestVLLMDataParallelMode:
             nixl_port=6550,
         )
 
-        env = backend.get_process_environment(process)
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            env = backend.get_process_environment(process)
 
         assert env["DYN_VLLM_KV_EVENT_PORT"] == "5550"
         assert env["VLLM_NIXL_SIDE_CHANNEL_PORT"] == "6550"
+        assert env["VLLM_NIXL_SIDE_CHANNEL_HOST"] == "10.0.0.1"
 
     def test_vllm_get_process_environment_none_ports(self):
         """Test vLLM handles None ports gracefully."""
@@ -1343,6 +1347,7 @@ class TestVLLMDataParallelMode:
 
         assert "DYN_VLLM_KV_EVENT_PORT" not in env
         assert "VLLM_NIXL_SIDE_CHANNEL_PORT" not in env
+        assert "VLLM_NIXL_SIDE_CHANNEL_HOST" not in env
 
     def test_tp_mode_command_includes_multinode_flags(self):
         """Test standard TP mode includes multi-node coordination flags."""


### PR DESCRIPTION
## Summary

vLLM defaults `VLLM_NIXL_SIDE_CHANNEL_HOST` to `0.0.0.0` / `localhost`, which breaks the NIXL side-channel handshake when prefill and decode workers live on different nodes — the advertised host is unreachable and KV-transfer setup fails.

Set the per-process host to the node's routable IP (the same resolution `build_worker_command` already uses for the distributed-init leader) whenever a process has a `nixl_port` allocated.

## Background

This fix originally landed in #11 ("Add Kimi-K2.5 vLLM recipes and fix NIXL side channel host"), but PR #11 was merged into the `sa-submission-q2-2026` branch and never forward-ported to `main`. Multi-node vLLM disaggregated runs against `main` still hit the handshake failure today.

## Changes

- `src/srtctl/backends/vllm.py` — when `process.nixl_port is not None`, also stamp `VLLM_NIXL_SIDE_CHANNEL_HOST = get_hostname_ip(process.node)` in `get_process_environment()`.
- `tests/test_configs.py` — extend `test_vllm_get_process_environment` to assert the new env var (patches `get_hostname_ip`) and add the negative assertion to `test_vllm_get_process_environment_none_ports`.

`make check` clean (718 passed, 2 skipped).

## Test plan

- [ ] `make check` passes
- [ ] Multi-node vLLM disaggregated run on the cluster reaches `WORKERS_READY` (no NIXL handshake errors in worker logs)