### PR TITLE
Add vLLM DeepSeek-R1 128K/8K recipes for GB300 NVL72

### DIFF
--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp2-prefillonly-dp4ep4-chunked-fp8.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp2-prefillonly-dp4ep4-chunked-fp8.yaml
@@ -1,0 +1,80 @@
+name: "gb300-exp2-prefillonly-dp4ep4-chunked-fp8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  aggregated_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  vllm_config:
+    aggregated:
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      enable-chunked-prefill: true
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 1
+  concurrencies: "1x4x8x16x32"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 256
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp2-prefillonly-dp4ep4-fp8.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp2-prefillonly-dp4ep4-fp8.yaml
@@ -1,0 +1,81 @@
+name: "gb300-exp2-prefillonly-dp4ep4-fp8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  aggregated_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  vllm_config:
+    aggregated:
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      # No chunked prefill: stress test whether DP4+EP4 can fit full 128K
+      enable-chunked-prefill: false
+      max-num-batched-tokens: 135000
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.94
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 1
+  concurrencies: "1x4x8x16x32"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 256
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp2-prefillonly-pp4ep1-fp8.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp2-prefillonly-pp4ep1-fp8.yaml
@@ -1,0 +1,81 @@
+name: "gb300-exp2-prefillonly-pp4ep1-fp8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  aggregated_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  vllm_config:
+    aggregated:
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 4
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      # No chunked prefill: batch up to one full 128K sequence per step
+      enable-chunked-prefill: false
+      max-num-batched-tokens: 135000
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      # Keep same gpu-memory-utilization as DP4+EP4 recipe (2B) for fair comparison.
+      # 2B at 0.86 produced "Available KV cache memory: -1.28 GiB" (job 1545902),
+      # so both configs are now at 0.94 to give the same mem budget.
+      gpu-memory-utilization: 0.94
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 1
+  concurrencies: "1x4x8x16x32"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 256
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp3a-pp4-chunk4k-fp8.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp3a-pp4-chunk4k-fp8.yaml
@@ -1,0 +1,82 @@
+name: "gb300-exp3a-pp4-chunk4k-fp8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  aggregated_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  vllm_config:
+    aggregated:
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 4
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      # Chunked prefill ON with 4K chunks (matches SGLang blog's recommended
+      # fixed chunk size for DeepSeek-V3.1 PP4). max-num-batched-tokens is set
+      # to PP_size * chunk_size so the scheduler can admit up to 4 chunks per
+      # step, giving PP4 multiple in-flight items (approximating SGLang's CPP).
+      enable-chunked-prefill: true
+      max-num-batched-tokens: 16384
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      # Match 2A exactly for apples-to-apples comparison.
+      gpu-memory-utilization: 0.94
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 1
+  concurrencies: "1x4x8x16x32"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 256
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp3b-pp4-chunk12k-fp8.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp3b-pp4-chunk12k-fp8.yaml
@@ -1,0 +1,81 @@
+name: "gb300-exp3b-pp4-chunk12k-fp8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  aggregated_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  vllm_config:
+    aggregated:
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 4
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      # Chunked prefill ON with 12K chunks — direct analog of SGLang's DCK 12K
+      # configuration for DeepSeek-V3.1 PP4 (their headline 3.31× result).
+      # max-num-batched-tokens = PP_size * chunk_size = 4 * 12288.
+      enable-chunked-prefill: true
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      # Match 2A exactly for apples-to-apples comparison.
+      gpu-memory-utilization: 0.94
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 1
+  concurrencies: "1x4x8x16x32"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 256
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp3c-pp4-chunk32k-fp8.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp3c-pp4-chunk32k-fp8.yaml
@@ -1,0 +1,81 @@
+name: "gb300-exp3c-pp4-chunk32k-fp8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  aggregated_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  vllm_config:
+    aggregated:
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 4
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      # Chunked prefill ON with 32K chunks (larger than SGLang's recommendation).
+      # max-num-batched-tokens = PP_size * chunk_size = 4 * 32768 = 131072,
+      # so one full 128K prompt fits across all 4 PP ranks per step.
+      enable-chunked-prefill: true
+      max-num-batched-tokens: 131072
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      # Match 2A exactly for apples-to-apples comparison.
+      gpu-memory-utilization: 0.94
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 1
+  concurrencies: "1x4x8x16x32"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 256
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp3d-pp4-chunk12k-osl8k-fp8.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/exp/gb300-exp3d-pp4-chunk12k-osl8k-fp8.yaml
@@ -1,0 +1,88 @@
+name: "gb300-exp3d-pp4-chunk12k-osl8k-fp8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  aggregated_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  vllm_config:
+    aggregated:
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 4
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      # Chunked prefill ON with 12K chunks — SARATHI's piggyback mechanism
+      # can only trigger when decodes are present, which requires OSL > 1
+      # (see benchmark section below).
+      # max-num-batched-tokens = PP_size * chunk_size = 4 * 12288 = 49152.
+      enable-chunked-prefill: true
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.94
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  # KEY CHANGE vs 3B: OSL=8K gives SARATHI the P:D ratio (~16:1) it needs
+  # to exercise decode-maximal batching. This matches production workload
+  # 1543168 (ISL=128K, OSL=8K) so results are directly interpretable as
+  # "if we added PP+NIXL to prod, would SARATHI reduce bubbles?"
+  osl: 8000
+  # Reduced sweep: at OSL=8K each request ~150s, so full 1x4x8x16x32 sweep
+  # with 256 prompts would exceed 60min wallclock. Focus on conc≥8 where
+  # SARATHI has the most in-flight decodes to piggyback.
+  concurrencies: "8x16x32"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 64
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0.yaml
@@ -1,0 +1,122 @@
+name: "gb300-disagg-dep8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.90
+      stream-interval: 10
+      max-cudagraph-capture-size: 256
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "64x128x256x512x1024"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_gcap090.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_gcap090.yaml
@@ -1,0 +1,122 @@
+name: "deepseek-r1-vllm-disagg-gb300-4p2d-dep8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+  
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.68
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.90
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x512"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_gcap092.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_gcap092.yaml
@@ -1,0 +1,122 @@
+name: "deepseek-r1-vllm-disagg-gb300-4p2d-dep8"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+  
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.92
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x512"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_longbenchv2.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_longbenchv2.yaml
@@ -1,0 +1,116 @@
+name: "gb300-disagg-dp4-dep8-longbenchv2"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 136001
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.90
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "longbenchv2"
+  max_context_length: 118000
+  num_threads: 16
+  max_tokens: 16384

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_nvlink1s.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_nvlink1s.yaml
@@ -1,0 +1,122 @@
+name: "deepseek-r1-vllm-disagg-gb300-4p2d-dep8-nvlink1s"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+  
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "flashinfer_nvlink_one_sided"
+      gpu-memory-utilization: 0.92
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x512"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_nvlink1s_cutedsl.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0_nvlink1s_cutedsl.yaml
@@ -1,0 +1,123 @@
+name: "gb300-disagg-4p2d-dep8-nvlink1s-cutedsl"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      moe-backend: "flashinfer_cutedsl"
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "flashinfer_nvlink_one_sided"
+      gpu-memory-utilization: 0.92
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x512"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp1_nvlink1s.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp1_nvlink1s.yaml
@@ -1,0 +1,123 @@
+name: "deepseek-r1-vllm-disagg-gb300-4p2d-dep8-nvlink1s-mtp1"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+  
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "flashinfer_nvlink_one_sided"
+      gpu-memory-utilization: 0.92
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+      speculative_config: '{"method":"mtp","num_speculative_tokens":1}'
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x512"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen3_dep12_batch256_eplb0_mtp0.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-disagg_ctx4_ctx_dp4_gen3_dep12_batch256_eplb0_mtp0.yaml
@@ -1,0 +1,122 @@
+name: "deepseek-r1-vllm-disagg-gb300-4p3d-dep12"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+  
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 3
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 12
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.80
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 12
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.93
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x512"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-wideep-disagg_ctx4_ctx_dp4_gen4_dep16_batch512_eplb0_mtp0_nvlink1s.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-wideep-disagg_ctx4_ctx_dp4_gen4_dep16_batch512_eplb0_mtp0_nvlink1s.yaml
@@ -1,0 +1,122 @@
+name: "gb300-wideep-disagg-dep16-nixl"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 4
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 16
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 16
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 512
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "flashinfer_nvlink_one_sided"
+      gpu-memory-utilization: 0.92
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x384x512x640x768"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-wideep-disagg_ctx4_ctx_dp4_gen8_dep32_batch1024_eplb0_mtp0_nvlink1s.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/gb300-wideep-disagg_ctx4_ctx_dp4_gen8_dep32_batch1024_eplb0_mtp0_nvlink1s.yaml
@@ -1,0 +1,122 @@
+name: "gb300-wideep-disagg-dep32-nixl"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 8
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 32
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true, "use_prefill_query_quantization": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 32
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 1024
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "flashinfer_nvlink_one_sided"
+      gpu-memory-utilization: 0.92
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x384x512x640x768x1024x1280"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/rate-matching/gb300-ratematch-decodeonly_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/rate-matching/gb300-ratematch-decodeonly_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0.yaml
@@ -1,0 +1,122 @@
+name: "gb300-rate-match-decode-only"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "DecodeBenchConnector", "kv_role": "kv_both"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.90
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "32x64x128x176x256x320"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/rate-matching/gb300-ratematch-decodeonly_ctx4_ctx_dp4_gen4_dep16_batch512_eplb0_mtp0_wideep.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/rate-matching/gb300-ratematch-decodeonly_ctx4_ctx_dp4_gen4_dep16_batch512_eplb0_mtp0_wideep.yaml
@@ -1,0 +1,122 @@
+name: "gb300-wideep-decode-only-dep16"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 4
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 16
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "DecodeBenchConnector", "kv_role": "kv_both"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 16
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 512
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "flashinfer_nvlink_one_sided"
+      gpu-memory-utilization: 0.92
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x384x512x640"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/rate-matching/gb300-ratematch-fulldisagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/rate-matching/gb300-ratematch-fulldisagg_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0.yaml
@@ -1,0 +1,122 @@
+name: "gb300-rate-match-full-disagg"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.90
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 8000
+  concurrencies: "128x256x512"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1

--- a/recipes/vllm/deepseek-r1/GB300/128K-8K/rate-matching/gb300-ratematch-prefillonly_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0.yaml
+++ b/recipes/vllm/deepseek-r1/GB300/128K-8K/rate-matching/gb300-ratematch-prefillonly_ctx4_ctx_dp4_gen2_dep8_batch256_eplb0_mtp0.yaml
@@ -1,0 +1,122 @@
+name: "gb300-rate-match-prefill-only"
+
+model:
+  path: "deepseek-r1-0528-fp4-v2"
+  container: ""
+  precision: "fp4"
+
+dynamo:
+  version: 1.0.0
+  install: true
+
+setup_script: configs/patches/vllm-container-deps.sh
+
+slurm:
+  partition: "gb300"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 4
+  decode_nodes: 2
+  prefill_workers: 4
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_ENABLE_MOE_DP_CHUNK: "0"
+
+  decode_environment:
+    TRITON_PTXAS_PATH: "/usr/local/cuda/bin/ptxas"
+    FLASHINFER_WORKSPACE_BASE: "/configs/flashinfer-cache"
+    VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    VLLM_ENGINE_READY_TIMEOUT_S: "1200"
+    VLLM_MOE_DP_CHUNK_SIZE: "1024"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 32
+      enforce-eager: true
+      async-scheduling: true
+      compilation-config: '{"custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      max-num-batched-tokens: 49152
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      enable-chunked-prefill: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      attention-config: '{"use_trtllm_ragged_deepseek_prefill": true}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.86
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "deepseek-r1-0528-fp4"
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      max-model-len: 136001
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      attention-backend: "FLASHINFER_MLA"
+      block-size: 64
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+quant_fp8","+rms_norm","+rotary_embedding"],"pass_config":{"fuse_attn_quant":true,"fuse_allreduce_rms":true}}'
+      all2all-backend: "allgather_reducescatter"
+      gpu-memory-utilization: 0.90
+      stream-interval: 10
+      max-cudagraph-capture-size: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 128000
+  osl: 1
+  concurrencies: "32x64x128x256x512"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  use_chat_template: false
+  num_prompts: 1024
+  warmup_prompts: 1


### PR DESCRIPTION
Draft recipes for DeepSeek-R1 long-context disaggregated serving on GB300 NVL72 with vLLM. Covers:

  - Canonical DEP8 disagg config (4 prefill / 2 decode nodes)
  - Wide-EP scaling: DEP16 / DEP32 with flashinfer_nvlink_one_sided A2A
  - MTP(speculative decoding)
  - Rate-matching ablations (prefill-only / decode-only / full-disagg)
  - Prefill experiments (DP4+EP4 vs PP4, chunked prefill 4K/12K/32K)
  - LongBench v2 accuracy recipe

Related upstream work:
  - vLLM PR #39841 (FP8 cast-order fix for chunked prefill)
  - FlashInfer PR #3129 (FP8 E4M3/E5M2 in concat_mla_k)
  - vLLM issues #41687 (DeepEP), #41685 (long-context PP), #41682 (PP scheduler), #40674 (NixlConnector + PP)