### PR TITLE
Fixing sweep submissions for 'sweep' block

### DIFF
--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -852,25 +852,25 @@ def submit_sweep(
             job_name = config_dict.get("name", f"job_{i}")
             progress.update(task, description=f"[{i}/{len(configs)}] {job_name}")
 
-        # Save temp config and submit
-        fd, temp_config_path = tempfile.mkstemp(suffix=".yaml", prefix="srtctl_sweep_", text=True)
-        try:
-            with os.fdopen(fd, "w") as f:
-                yaml.dump(config_dict, f)
+            # Save temp config and submit
+            fd, temp_config_path = tempfile.mkstemp(suffix=".yaml", prefix="srtctl_sweep_", text=True)
+            try:
+                with os.fdopen(fd, "w") as f:
+                    yaml.dump(config_dict, f)
 
-            config = load_config(Path(temp_config_path))
-            submit_single(
-                config_path=Path(temp_config_path),
-                config=config,
-                dry_run=False,
-                setup_script=setup_script,
-                tags=tags,
-                output_dir=output_dir,
-                enforce_preflight=enforce_preflight,
-            )
-        finally:
-            with contextlib.suppress(OSError):
-                os.remove(temp_config_path)
+                config = load_config(Path(temp_config_path))
+                submit_single(
+                    config_path=Path(temp_config_path),
+                    config=config,
+                    dry_run=False,
+                    setup_script=setup_script,
+                    tags=tags,
+                    output_dir=output_dir,
+                    enforce_preflight=enforce_preflight,
+                )
+            finally:
+                with contextlib.suppress(OSError):
+                    os.remove(temp_config_path)
 
             progress.advance(task)
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -587,7 +587,7 @@ class BenchmarkConfig:
     osl: int | None = None
     concurrencies: list[int] | str | None = None
     req_rate: str | int | None = "inf"
-    sweep: Annotated[SweepConfig, SweepConfigField()] | None = None
+    sweep: Annotated[SweepConfig, SweepConfigField(allow_none=True, load_default=None, dump_default=None)] | None = None
     # Accuracy benchmark fields
     num_examples: int | None = None
     max_tokens: int | None = None


### PR DESCRIPTION
Two bugs are fixed in this PR:
1. According to the [docs](https://srtctl.gitbook.io/srtctl-docs/configuration/sweeps), we should be able to define a sweep block and use it to launch multiple jobs that will sweep over the cartesian product of all of the parameters defined here. However, when running `srtctl apply -f config.yaml --sweep` with a valid config file jobs fail submission with:

```
Error: Invalid config in /lustre/fsw/portfolios/coreai/projects/coreai_prod_infbench/users/sbeldona/tmp/srtctl_sweep_f17dw3s1.yaml: {'benchmark': {'sweep': ['Field may not be null.']}}
```
2. Even with fixing the above with allowing none fields in `SweepConfigField`, there was another bug where the configs were not in the correct for loop and so only the last job would be submitted:
```
⠋ Submitting jobs...2026-05-20 14:54:28 | INFO | Loaded config: nemotron-super-120b-nvfp4-vllm-b200-1k1k_conc1024_tp8_pp8_dp8_epFalse
✓ HF model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 exists, revision 4f0cf9daaeb7 verified
🚀 Submitting: nemotron-super-120b-nvfp4-vllm-b200-1k1k_conc1024_tp8_pp8_dp8_epFalse
✅ Job 141752 submitted!
📁 Logs: /home/sbeldona/.scripts/srt-slurm/outputs/141752/logs
📋 Monitor: tail -f /home/sbeldona/.scripts/srt-slurm/outputs/141752/logs/sweep_141752.log
📊 Queue: squeue --job 141752

Running:
  Model:     hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
  Container: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.3
  Backend:   vllm
  Benchmark: sa-bench
  Identity:  model=nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4, rev=4f0cf9daaeb7, container=...amo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.3, dynamo=1.2.0, vllm=0.20.1
⠧ [1408/1408] nemotron-super-120b-nvfp4-vllm-b200-1k1k_conc1024_tp8_pp8_dp8_epFalse
```
Even though 1408 configs get created (which is the correct amount), only one job gets launched.

With these fixes, sweep job submissions work properly.
