### PR TITLE
Update GB300 FP4 GLM5 low-latency sweep

### DIFF
--- a/recipes/gb300-fp4/glm5.yaml
+++ b/recipes/gb300-fp4/glm5.yaml
@@ -186,8 +186,8 @@ zip_override_8k1k_lowlat:
   resources:
     prefill_nodes:   1
     prefill_workers: 1
-    decode_nodes:   [3, 5, 9, 15]
-    decode_workers: [3, 5, 9, 15]
+    decode_nodes:   [3, 5, 9, 15, 17]
+    decode_workers: [3, 5, 9, 15, 17]
   backend:
     sglang_config:
       decode:
@@ -199,13 +199,13 @@ zip_override_8k1k_lowlat:
 
         moe-runner-backend: "flashinfer_trtllm"
 
-        max-running-requests: 4096
-        cuda-graph-max-bs:    4096
+        max-running-requests: [128, 64, 32, 16, 1]
+        cuda-graph-max-bs:    [128, 64, 32, 16, 1]
 
   benchmark:
     isl: 8192
     osl: 1024
-    concurrencies: ["1024"]
+    concurrencies: ["128", "64", "32", "16", "12"]
 
 
 


### PR DESCRIPTION
Updates the GB300 FP4 GLM5 8k1k low-latency sweep to add a fifth decode point and align max-running-requests, CUDA graph batch sizes, and SA-Bench concurrencies.

Validation:
- Parsed recipes/gb300-fp4/glm5.yaml with Ruby YAML parser.