### PR TITLE
fix(slurm): use --key=value for srun options (Slurm 25.11 cpu-bind regression)

### DIFF
--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -276,8 +276,10 @@ def show_config_details(config: SrtConfig) -> None:
         console.print("[dim]No custom environment variables configured.[/]")
 
     # --- srun options ---
+    # Render with `=` to mirror what core/slurm.py emits at runtime; the
+    # space-separated form misparses `cpu-bind` on Slurm 25.11.x.
     if config.srun_options:
-        opts = " ".join(f"--{k} {v}" if v else f"--{k}" for k, v in config.srun_options.items())
+        opts = " ".join(f"--{k}={v}" if v else f"--{k}" for k, v in config.srun_options.items())
         console.print(f"[dim]srun options:[/] {opts}")
 
     show_extensions = (

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -276,8 +276,6 @@ def show_config_details(config: SrtConfig) -> None:
         console.print("[dim]No custom environment variables configured.[/]")
 
     # --- srun options ---
-    # Render with `=` to mirror what core/slurm.py emits at runtime; the
-    # space-separated form misparses `cpu-bind` on Slurm 25.11.x.
     if config.srun_options:
         opts = " ".join(f"--{k}={v}" if v else f"--{k}" for k, v in config.srun_options.items())
         console.print(f"[dim]srun options:[/] {opts}")

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -220,7 +220,14 @@ def start_srun_process(
     if oversubscribe:
         srun_cmd.append("--oversubscribe")
     if cpu_bind:
-        srun_cmd.extend(["--cpu-bind", cpu_bind])
+        # Use `--cpu-bind=<value>` (single argv token) rather than
+        # `--cpu-bind <value>` (two tokens). Slurm 25.11.x has a regression
+        # where the space-separated form slurps the *next* argv token (e.g.
+        # `--job-name=...` inherited from the sbatch allocation) as part of
+        # the cpu-bind value, failing with
+        # `srun.real: error: unrecognized --cpu-bind argument "--job-name"`.
+        # The `=` form parses unambiguously on all Slurm versions.
+        srun_cmd.append(f"--cpu-bind={cpu_bind}")
 
     srun_cmd.extend(["--nodes", str(nodes)])
     srun_cmd.extend(["--ntasks", str(ntasks)])
@@ -244,11 +251,13 @@ def start_srun_process(
             mount_str = ",".join(f"{host}:{container}" for host, container in container_mounts.items())
             srun_cmd.extend(["--container-mounts", mount_str])
 
-    # Additional srun options
+    # Additional srun options. Use `--key=value` (single argv token) so
+    # options like `cpu-bind` parse correctly on Slurm 25.11.x; see the
+    # `cpu_bind` block above for the regression details.
     if srun_options:
         for key, value in srun_options.items():
             if value:
-                srun_cmd.extend([f"--{key}", value])
+                srun_cmd.append(f"--{key}={value}")
             else:
                 srun_cmd.append(f"--{key}")
 

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -220,13 +220,6 @@ def start_srun_process(
     if oversubscribe:
         srun_cmd.append("--oversubscribe")
     if cpu_bind:
-        # Use `--cpu-bind=<value>` (single argv token) rather than
-        # `--cpu-bind <value>` (two tokens). Slurm 25.11.x has a regression
-        # where the space-separated form slurps the *next* argv token (e.g.
-        # `--job-name=...` inherited from the sbatch allocation) as part of
-        # the cpu-bind value, failing with
-        # `srun.real: error: unrecognized --cpu-bind argument "--job-name"`.
-        # The `=` form parses unambiguously on all Slurm versions.
         srun_cmd.append(f"--cpu-bind={cpu_bind}")
 
     srun_cmd.extend(["--nodes", str(nodes)])
@@ -251,9 +244,6 @@ def start_srun_process(
             mount_str = ",".join(f"{host}:{container}" for host, container in container_mounts.items())
             srun_cmd.extend(["--container-mounts", mount_str])
 
-    # Additional srun options. Use `--key=value` (single argv token) so
-    # options like `cpu-bind` parse correctly on Slurm 25.11.x; see the
-    # `cpu_bind` block above for the regression details.
     if srun_options:
         for key, value in srun_options.items():
             if value:

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -218,8 +218,6 @@ class TestDryRunSrunOptions:
         config = _make_config({"srun_options": {"export": "ALL", "cpu-bind": "none"}})
         show_config_details(config)
         output = capsys.readouterr().out
-        # `=` form, not space, because Slurm 25.11.x misparses
-        # `--cpu-bind <value>` and slurps the next argv token.
         assert "--export=ALL" in output
         assert "--cpu-bind=none" in output
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -218,8 +218,10 @@ class TestDryRunSrunOptions:
         config = _make_config({"srun_options": {"export": "ALL", "cpu-bind": "none"}})
         show_config_details(config)
         output = capsys.readouterr().out
-        assert "--export ALL" in output
-        assert "--cpu-bind none" in output
+        # `=` form, not space, because Slurm 25.11.x misparses
+        # `--cpu-bind <value>` and slurps the next argv token.
+        assert "--export=ALL" in output
+        assert "--cpu-bind=none" in output
 
     def test_no_srun_options_no_output(self, capsys):
         config = _make_config()

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -96,37 +96,7 @@ def test_cluster_bash_preamble_warns_when_bash_wrapper_disabled(caplog) -> None:
     assert any("default_bash_preamble" in record.message for record in caplog.records)
 
 
-def test_cpu_bind_uses_equals_separator() -> None:
-    """`--cpu-bind` must be emitted as a single argv token (`--cpu-bind=<v>`).
-
-    Slurm 25.11.x has a regression where the space-separated form slurps the
-    next argv token (e.g. `--job-name=...` inherited from the sbatch
-    allocation) as part of the cpu-bind value and dies with:
-
-        srun.real: error: unrecognized --cpu-bind argument "--job-name"
-
-    This bites TRT-LLM (the only backend that sets cpu_bind="verbose,none";
-    see backends/trtllm.py). The `=` form parses unambiguously on all Slurm
-    versions, so we use it everywhere.
-    """
-    with (
-        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
-        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
-        patch("subprocess.Popen") as mock_popen,
-    ):
-        mock_popen.return_value = MagicMock()
-        start_srun_process(["python3", "-m", "server"], cpu_bind="verbose,none")
-
-    srun_cmd = mock_popen.call_args.args[0]
-    assert "--cpu-bind=verbose,none" in srun_cmd
-    # No bare "--cpu-bind" token followed by a separate value token.
-    assert "--cpu-bind" not in srun_cmd
-
-
 def test_srun_options_use_equals_separator() -> None:
-    """`srun_options` entries must also be emitted with `=` for the same
-    reason as `cpu_bind` above (users can route `cpu-bind` through this
-    path via YAML and hit the identical Slurm 25.11 regression)."""
     with (
         patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
         patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
@@ -141,7 +111,6 @@ def test_srun_options_use_equals_separator() -> None:
     srun_cmd = mock_popen.call_args.args[0]
     assert "--cpu-bind=none" in srun_cmd
     assert "--export=ALL" in srun_cmd
-    # Valueless options stay as bare flags.
     assert "--exclusive" in srun_cmd
 
 

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -96,6 +96,55 @@ def test_cluster_bash_preamble_warns_when_bash_wrapper_disabled(caplog) -> None:
     assert any("default_bash_preamble" in record.message for record in caplog.records)
 
 
+def test_cpu_bind_uses_equals_separator() -> None:
+    """`--cpu-bind` must be emitted as a single argv token (`--cpu-bind=<v>`).
+
+    Slurm 25.11.x has a regression where the space-separated form slurps the
+    next argv token (e.g. `--job-name=...` inherited from the sbatch
+    allocation) as part of the cpu-bind value and dies with:
+
+        srun.real: error: unrecognized --cpu-bind argument "--job-name"
+
+    This bites TRT-LLM (the only backend that sets cpu_bind="verbose,none";
+    see backends/trtllm.py). The `=` form parses unambiguously on all Slurm
+    versions, so we use it everywhere.
+    """
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(["python3", "-m", "server"], cpu_bind="verbose,none")
+
+    srun_cmd = mock_popen.call_args.args[0]
+    assert "--cpu-bind=verbose,none" in srun_cmd
+    # No bare "--cpu-bind" token followed by a separate value token.
+    assert "--cpu-bind" not in srun_cmd
+
+
+def test_srun_options_use_equals_separator() -> None:
+    """`srun_options` entries must also be emitted with `=` for the same
+    reason as `cpu_bind` above (users can route `cpu-bind` through this
+    path via YAML and hit the identical Slurm 25.11 regression)."""
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(
+            ["python3", "-m", "server"],
+            srun_options={"cpu-bind": "none", "export": "ALL", "exclusive": ""},
+        )
+
+    srun_cmd = mock_popen.call_args.args[0]
+    assert "--cpu-bind=none" in srun_cmd
+    assert "--export=ALL" in srun_cmd
+    # Valueless options stay as bare flags.
+    assert "--exclusive" in srun_cmd
+
+
 def test_wrapped_nonfatal_hook_does_not_mask_prior_preamble_failure() -> None:
     bash_cmd = "false && ( false || true ) && echo main"
 


### PR DESCRIPTION
**Problem**
Slurm 25.11.x has a regression where space-separated long options (--cpu-bind verbose,none) slurp the next argv token (e.g. --job-name=... from the sbatch allocation) as part of the value, failing with:

```
srun.real: error: unrecognized --cpu-bind argument "--job-name"
srun.real: fatal: Failed to parse --cpu-bind= values.
```
This breaks every TRT-LLM job (it's the only backend that sets cpu_bind="verbose,none" in backends/trtllm.py). I hit this during a gpt-oss-120b sweep — workers died in zero seconds with no log file ever created. Same bug independently reported in [#127](https://github.com/NVIDIA/srt-slurm/issues/127) by @faradawn.

**Fix**
Emit srun options as a single argv token (--key=value) instead of two (--key value) in src/srtctl/core/slurm.py. The = form is canonical Unix long-option syntax, parses unambiguously on all Slurm versions, and is already used elsewhere in the file (--container-image=, --mpi=, etc.).

Both code paths fixed:

- The dedicated cpu_bind parameter (used by TRT-LLM)
- The generic srun_options dict (any user routing cpu-bind through YAML hits the same crash)

Also updates show_config_details() in submit.py so srtctl dry-run shows what actually runs, and adds a regression test in tests/test_slurm.py.

Closes #127.