### PR TITLE
feat(config): add default_health_check cluster-level default in srtslurm.yaml

### DIFF
--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -145,6 +145,10 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         config["reporting"] = cluster_config["reporting"]
         logger.debug("Applied cluster reporting config")
 
+    if "health_check" not in config and cluster_config.get("default_health_check"):
+        config["health_check"] = cluster_config["default_health_check"]
+        logger.debug("Applied default_health_check: %s", config["health_check"])
+
     # Resolve frontend nginx_container alias
     frontend = config.get("frontend", {})
     nginx_container = frontend.get("nginx_container", "")

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -190,6 +190,7 @@ class ClusterConfig:
     use_segment_sbatch_directive: bool = True
     use_exclusive_sbatch_directive: bool = False
     default_sbatch_directives: dict[str, str] | None = None
+    default_health_check: dict[str, int] | None = None
     srtctl_root: str | None = None
     output_dir: str | None = None  # Custom output directory for job logs
     model_paths: dict[str, str] | None = None

--- a/srtslurm.yaml.example
+++ b/srtslurm.yaml.example
@@ -11,6 +11,14 @@ default_account: "your-gpu-account"
 default_partition: "gpu"
 default_time_limit: "04:00:00"
 
+# Default health check window for jobs that don't override `health_check:`
+# in the recipe. Useful on clusters with slow storage where large MoE models
+# need >30 min to cold-load (the schema default is max_attempts=180, ~30 min).
+# Recipes that set their own `health_check:` block override this.
+# default_health_check:
+#   max_attempts: 540        # 540 * 10s = 90 min
+#   interval_seconds: 10
+
 # SLURM directive compatibility
 # Set to false if your cluster doesn't support --gpus-per-node
 use_gpus_per_node_directive: true  # Default: true

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -586,6 +586,41 @@ class TestFrontendConfig:
             "constraint": "h100",
         }
 
+    def test_default_health_check_applies_when_recipe_omits_it(self):
+        """srtslurm.yaml can provide a default health_check block."""
+        from srtctl.core.config import resolve_config_with_defaults
+
+        user_config = {
+            "name": "test",
+            "model": {"path": "/model", "container": "/c.sqsh", "precision": "fp8"},
+            "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
+        }
+
+        resolved = resolve_config_with_defaults(
+            user_config,
+            {"default_health_check": {"max_attempts": 540, "interval_seconds": 10}},
+        )
+
+        assert resolved["health_check"] == {"max_attempts": 540, "interval_seconds": 10}
+
+    def test_default_health_check_does_not_override_recipe(self):
+        """Recipe-level health_check wins over the cluster default."""
+        from srtctl.core.config import resolve_config_with_defaults
+
+        user_config = {
+            "name": "test",
+            "model": {"path": "/model", "container": "/c.sqsh", "precision": "fp8"},
+            "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
+            "health_check": {"max_attempts": 720, "interval_seconds": 10},
+        }
+
+        resolved = resolve_config_with_defaults(
+            user_config,
+            {"default_health_check": {"max_attempts": 540, "interval_seconds": 10}},
+        )
+
+        assert resolved["health_check"] == {"max_attempts": 720, "interval_seconds": 10}
+
     def test_cluster_sbatch_directives_are_not_treated_as_defaults(self):
         """srtslurm.yaml defaults must use default_sbatch_directives explicitly."""
         from srtctl.core.config import resolve_config_with_defaults


### PR DESCRIPTION
## Problem

The `health_check.max_attempts` schema default is 180 (`180 × 10s = 30 min`). For large MoE models on TP≤4, cold-load from slow storage routinely takes >30 min, and `srtctl` kills a healthy server before workers finish registering with the frontend. Ran into this issue for testing Minimax 2.5 on TP=4 B200 (a public run on the InferenceX Dashboard): 

```yaml
health_check:
  max_attempts: 360       # 60 min
  interval_seconds: 10
```

184 recipes in this repo already carry it: **176 at `max_attempts: 360`** and **7 at `720`**. That's the strongest possible signal that the schema default is wrong and there's no cluster-level way to fix it without editing every recipe.

I hit this last night on a Qwen3.5-397B FP8 TP=4 sweep: 9 of 14 jobs were killed by `srtctl` at ~30 min while the engine's stdout had logged `"fired up and ready to roll!"` ~90s before. InferenceX publicly runs the same model at TP=4 conc=256 8k1k @ 8.9k tok/s/gpu, so the engine and recipe are fine — only the orchestration deadline is wrong.

## Fix

Add a `default_health_check:` block to `srtslurm.yaml`, mirroring the existing `default_time_limit` / `default_account` / `default_sbatch_directives` pattern. Cluster admins set the default once, and every recipe that doesn't define its own `health_check:` inherits it.

```yaml
# srtslurm.yaml
default_health_check:
  max_attempts: 540        # 90 min — handles 200B+ FP8 MoE cold-load on TP≤4
  interval_seconds: 10
```

The schema default (`180`, 30 min) is **unchanged** — anyone without a cluster config and without a recipe override sees no behavior difference.

## Precedence chain (now three layers)

| Layer | Source | Wins over |
|---|---|---|
| 1 | Recipe `health_check:` block | everything |
| 2 | `srtslurm.yaml` `default_health_check:` ← **new** | schema default |
| 3 | Schema default `HealthCheckConfig()` | nothing |

## Behavior matrix (covered by new tests)

| Recipe has `health_check` | Cluster `default_health_check` | Result |
|---|---|---|
| yes | yes | recipe wins |
| yes | no | recipe value |
| no | yes | **cluster default** ← new path |
| no | no | schema default (unchanged) |

## Changes

| File | Change |
|---|---|
| `src/srtctl/core/schema.py` | +1 line: `default_health_check: dict[str, int] \| None = None` on `ClusterConfig`, next to the existing `default_sbatch_directives` |
| `src/srtctl/core/config.py` | +4 lines in `resolve_config_with_defaults`: copy the cluster default into `config["health_check"]` when the recipe doesn't have one |
| `srtslurm.yaml.example` | +8 lines documenting the new field with a commented-out example |
| `tests/test_configs.py` | +35 lines: two regression tests covering both branches of the merge |

Total: **+48 lines, -0**. No schema default changed, no existing recipe affected.

## Testing

- `uv run ruff check src/srtctl/` — clean
- `uv run ruff format --check src/srtctl/` — clean
- `uv run pytest tests/` — **697 passed, 2 skipped** (full suite, no regressions)
- Two new tests:
  - `test_default_health_check_applies_when_recipe_omits_it` — cluster default fills when recipe is silent
  - `test_default_health_check_does_not_override_recipe` — recipe wins when both are set

## Why this shape (not a schema-default bump)

I considered raising the schema default from `180` → `540` directly, but that:
- Changes behavior silently for every existing recipe that doesn't override (potentially makes failures slower to surface on clusters where 30 min is the right deadline).
- Doesn't solve the underlying "I keep hitting this on different models on different clusters" problem — the schema is global, the problem is per-cluster.

The cluster-default layer is **additive and opt-in**: existing recipes keep their explicit overrides, EOS-style fast-storage clusters keep the 30-min default, and slow-storage clusters get a one-line knob. No behavior change for anyone who doesn't opt in.