### PR TITLE
Add spread worker placement and vLLM colocation

### DIFF
--- a/src/srtctl/backends/base.py
+++ b/src/srtctl/backends/base.py
@@ -82,6 +82,7 @@ class BackendProtocol(Protocol):
         gpus_per_agg: int,
         gpus_per_node: int,
         available_nodes: Sequence[str],
+        spread_workers: bool = False,
     ) -> list["Endpoint"]:
         """Allocate logical endpoints based on resource requirements."""
         ...

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -179,6 +179,7 @@ class SGLangProtocol:
         gpus_per_agg: int,
         gpus_per_node: int,
         available_nodes: Sequence[str],
+        spread_workers: bool = False,
     ) -> list["Endpoint"]:
         """Allocate endpoints to nodes."""
         from srtctl.core.topology import allocate_endpoints
@@ -192,6 +193,7 @@ class SGLangProtocol:
             gpus_per_agg=gpus_per_agg,
             gpus_per_node=gpus_per_node,
             available_nodes=available_nodes,
+            spread_workers=spread_workers,
         )
 
     def endpoints_to_processes(

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -127,6 +127,7 @@ class TRTLLMProtocol:
         gpus_per_agg: int,
         gpus_per_node: int,
         available_nodes: Sequence[str],
+        spread_workers: bool = False,
     ) -> list["Endpoint"]:
         """Allocate endpoints to nodes."""
         from srtctl.core.topology import allocate_endpoints
@@ -140,6 +141,7 @@ class TRTLLMProtocol:
             gpus_per_agg=gpus_per_agg,
             gpus_per_node=gpus_per_node,
             available_nodes=available_nodes,
+            spread_workers=spread_workers,
         )
 
     def endpoints_to_processes(

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -177,9 +177,7 @@ class VLLMProtocol:
         if num_prefill <= 0 or num_decode <= 0 or gpus_per_node <= 0:
             return False
 
-        total_worker_gpus = (
-            num_prefill * gpus_per_prefill + num_decode * gpus_per_decode + num_agg * gpus_per_agg
-        )
+        total_worker_gpus = num_prefill * gpus_per_prefill + num_decode * gpus_per_decode + num_agg * gpus_per_agg
         return total_worker_gpus <= gpus_per_node
 
     def allocate_endpoints(
@@ -405,7 +403,11 @@ class VLLMProtocol:
             dp_rank = process.node_rank
             # Use the per-endpoint dp_rpc_port allocated by NodePortAllocator
             # (avoids port collisions when multiple endpoints share a node)
-            dp_rpc_port = process.dp_rpc_port or config.pop("data-parallel-rpc-port", None) or config.pop("data_parallel_rpc_port", 13345)
+            dp_rpc_port = (
+                process.dp_rpc_port
+                or config.pop("data-parallel-rpc-port", None)
+                or config.pop("data_parallel_rpc_port", 13345)
+            )
             # Pop from config so it doesn't get added again by _config_to_cli_args
             config.pop("data-parallel-rpc-port", None)
             config.pop("data_parallel_rpc_port", None)

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -164,6 +164,7 @@ class VLLMProtocol:
         gpus_per_agg: int,
         gpus_per_node: int,
         available_nodes: Sequence[str],
+        spread_workers: bool = False,
     ) -> list[Endpoint]:
         """Allocate endpoints to nodes."""
         from srtctl.core.topology import allocate_endpoints
@@ -177,6 +178,7 @@ class VLLMProtocol:
             gpus_per_agg=gpus_per_agg,
             gpus_per_node=gpus_per_node,
             available_nodes=available_nodes,
+            spread_workers=spread_workers,
         )
 
     def _is_dp_mode(self, mode: WorkerMode) -> bool:

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -63,6 +63,7 @@ class VLLMProtocol:
         backend:
           type: vllm
           connector: nixl  # translated to --kv-transfer-config JSON
+          allow_prefill_decode_colocation: true  # pack P/D on one node when all workers fit
           prefill_environment:
             PYTHONUNBUFFERED: "1"
           vllm_config:
@@ -90,6 +91,11 @@ class VLLMProtocol:
     # Can be overridden per mode by setting "connector" in vllm_config.prefill/decode/aggregated.
     # dynamo 1.0.0+: translated to --kv-transfer-config (--connector was removed).
     connector: str | None = "nixl"
+
+    # Allow prefill and decode workers to share one node when the combined GPU
+    # request fits within gpus_per_node. Defaults off to preserve existing P/D
+    # node separation.
+    allow_prefill_decode_colocation: bool = False
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
@@ -154,6 +160,28 @@ class VLLMProtocol:
                         return name
         return default
 
+    def should_colocate_prefill_decode(
+        self,
+        *,
+        num_prefill: int,
+        num_decode: int,
+        num_agg: int,
+        gpus_per_prefill: int,
+        gpus_per_decode: int,
+        gpus_per_agg: int,
+        gpus_per_node: int,
+    ) -> bool:
+        """Whether all vLLM workers should be packed onto one node."""
+        if not self.allow_prefill_decode_colocation:
+            return False
+        if num_prefill <= 0 or num_decode <= 0 or gpus_per_node <= 0:
+            return False
+
+        total_worker_gpus = (
+            num_prefill * gpus_per_prefill + num_decode * gpus_per_decode + num_agg * gpus_per_agg
+        )
+        return total_worker_gpus <= gpus_per_node
+
     def allocate_endpoints(
         self,
         num_prefill: int,
@@ -179,6 +207,15 @@ class VLLMProtocol:
             gpus_per_node=gpus_per_node,
             available_nodes=available_nodes,
             spread_workers=spread_workers,
+            allow_prefill_decode_colocation=self.should_colocate_prefill_decode(
+                num_prefill=num_prefill,
+                num_decode=num_decode,
+                num_agg=num_agg,
+                gpus_per_prefill=gpus_per_prefill,
+                gpus_per_decode=gpus_per_decode,
+                gpus_per_agg=gpus_per_agg,
+                gpus_per_node=gpus_per_node,
+            ),
         )
 
     def _is_dp_mode(self, mode: WorkerMode) -> bool:

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -251,6 +251,8 @@ class VLLMProtocol:
                 # DP+EP mode: one process per GPU
                 # Each process gets a single GPU and a unique dp_rank
                 dp_rank = 0
+                # Allocate a unique DP RPC port for this endpoint's leader node
+                dp_rpc_port = port_allocator.next_dp_rpc_port(endpoint.leader_node)
                 for _node_rank, node in enumerate(endpoint.nodes):
                     for gpu_idx in sorted(endpoint.gpu_indices):
                         is_leader = dp_rank == 0
@@ -275,6 +277,7 @@ class VLLMProtocol:
                                 bootstrap_port=bootstrap_port,
                                 kv_events_port=kv_events_port,
                                 nixl_port=nixl_port,
+                                dp_rpc_port=dp_rpc_port,
                             )
                         )
                         current_sys_port += 1
@@ -358,7 +361,12 @@ class VLLMProtocol:
             # DP+EP mode: each GPU runs its own process
             # process.node_rank is the dp_rank (set in endpoints_to_processes)
             dp_rank = process.node_rank
-            dp_rpc_port = config.pop("data-parallel-rpc-port", None) or config.pop("data_parallel_rpc_port", 13345)
+            # Use the per-endpoint dp_rpc_port allocated by NodePortAllocator
+            # (avoids port collisions when multiple endpoints share a node)
+            dp_rpc_port = process.dp_rpc_port or config.pop("data-parallel-rpc-port", None) or config.pop("data_parallel_rpc_port", 13345)
+            # Pop from config so it doesn't get added again by _config_to_cli_args
+            config.pop("data-parallel-rpc-port", None)
+            config.pop("data_parallel_rpc_port", None)
 
             cmd.extend(
                 [

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -253,6 +253,11 @@ class VLLMProtocol:
                 dp_rank = 0
                 # Allocate a unique DP RPC port for this endpoint's leader node
                 dp_rpc_port = port_allocator.next_dp_rpc_port(endpoint.leader_node)
+                # Allocate a single NIXL base port for this endpoint.
+                # vLLM internally computes: actual_port = base + data_parallel_rank
+                # so all DP ranks in the endpoint share the same base port.
+                dp_size = self._get_dp_size(endpoint.mode) or len(endpoint.gpu_indices)
+                nixl_base_port = port_allocator.next_nixl_port_block(dp_size)
                 for _node_rank, node in enumerate(endpoint.nodes):
                     for gpu_idx in sorted(endpoint.gpu_indices):
                         is_leader = dp_rank == 0
@@ -263,7 +268,7 @@ class VLLMProtocol:
                             else None
                         )
                         kv_events_port = port_allocator.next_kv_events_port()
-                        nixl_port = port_allocator.next_nixl_port()
+                        nixl_port = nixl_base_port
 
                         processes.append(
                             Process(

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -76,6 +76,7 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
             gpus_per_agg=r.gpus_per_agg,
             gpus_per_node=r.gpus_per_node,
             available_nodes=self.runtime.nodes.worker,
+            spread_workers=r.spread_workers,
         )
 
     @functools.cached_property

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -197,7 +197,7 @@ def generate_minimal_sbatch_script(
     env = Environment(loader=FileSystemLoader(str(template_dir)))
     template = env.get_template("job_script_minimal.j2")
 
-    total_nodes = config.resources.total_nodes
+    total_nodes = config.total_nodes
     # Add extra node for dedicated etcd/nats infrastructure
     if config.infra.etcd_nats_dedicated_node:
         total_nodes += 1

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -940,6 +940,21 @@ class SrtConfig:
         return self.backend.get_served_model_name(default)
 
     @property
+    def total_nodes(self) -> int:
+        """Worker node count, adjusted for backend-specific packing."""
+        if isinstance(self.backend, VLLMProtocol) and self.backend.should_colocate_prefill_decode(
+            num_prefill=self.resources.num_prefill,
+            num_decode=self.resources.num_decode,
+            num_agg=self.resources.num_agg,
+            gpus_per_prefill=self.resources.gpus_per_prefill,
+            gpus_per_decode=self.resources.gpus_per_decode,
+            gpus_per_agg=self.resources.gpus_per_agg,
+            gpus_per_node=self.resources.gpus_per_node,
+        ):
+            return 1
+        return self.resources.total_nodes
+
+    @property
     def backend_type(self) -> str:
         """Get the backend type string."""
         return self.backend.type

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -396,6 +396,11 @@ class ResourceConfig:
     agg_nodes: int | None = None
     agg_workers: int | None = None
 
+    # If True, place each partial-node worker on its own node instead of
+    # packing multiple onto the same node. Caller must reserve enough nodes
+    # (e.g. set decode_nodes=decode_workers when gpus_per_decode<gpus_per_node).
+    spread_workers: bool = False
+
     # Explicit GPUs per worker (override computed values)
     # Use data_key to map from YAML field names to internal attribute names
     _explicit_gpus_per_prefill: int | None = field(

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -96,6 +96,20 @@ class NodePortAllocator:
         self._next_nixl_port += 1
         return port
 
+    def next_nixl_port_block(self, size: int) -> int:
+        """Reserve a block of consecutive NIXL ports, return the base port.
+
+        Used in DP mode where vLLM computes:
+            actual_port = VLLM_NIXL_SIDE_CHANNEL_PORT + data_parallel_rank
+        All DP ranks within an endpoint share the same base port, so we
+        must reserve `size` ports to avoid collisions with other endpoints.
+        """
+        if self._next_nixl_port == 0:
+            self._next_nixl_port = self.base_nixl_port
+        port = self._next_nixl_port
+        self._next_nixl_port += size
+        return port
+
     def next_dp_rpc_port(self, node: str) -> int:
         """Get next available DP RPC port for a node.
 

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -363,10 +363,7 @@ def allocate_endpoints(
                 gpu_indices = frozenset(range(gpu_offset, gpu_offset + gpus_per_worker))
                 gpu_offset += gpus_per_worker
 
-                if gpu_offset >= gpus_per_node:
-                    node_idx += 1
-                    gpu_offset = 0
-                elif spread_workers:
+                if gpu_offset >= gpus_per_node or spread_workers:
                     node_idx += 1
                     gpu_offset = 0
 

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -35,8 +35,8 @@ class NodePortAllocator:
     assignments per node and hands out the next available port.
 
     Port ranges (non-overlapping):
-        - kv_events_port: 5550+  (global) - ZMQ port for kv-events publishing
-        - nixl_port:      6550+  (global) - NIXL side channel for KV transfers (vLLM)
+        - kv_events_port: 20000+ (global) - ZMQ port for kv-events publishing
+        - nixl_port:      21000+ (global) - NIXL side channel for KV transfers (vLLM)
         - http_port:      30000+ (per node) - HTTP serving port
         - bootstrap_port: 31000+ (per node) - P/D coordination port (prefill only)
 
@@ -53,8 +53,8 @@ class NodePortAllocator:
 
     base_http_port: int = 30000
     base_bootstrap_port: int = 31000
-    base_kv_events_port: int = 5550
-    base_nixl_port: int = 6550  # NIXL side channel ports (must not overlap with kv_events)
+    base_kv_events_port: int = 20000
+    base_nixl_port: int = 21000  # NIXL side channel ports (must not overlap with kv_events)
 
     _http_ports: dict[str, int] = field(default_factory=dict, repr=False)
     _bootstrap_ports: dict[str, int] = field(default_factory=dict, repr=False)

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -69,7 +69,7 @@ class NodePortAllocator:
         if node not in self._http_ports:
             self._http_ports[node] = self.base_http_port
         port = self._http_ports[node]
-        self._http_ports[node] += 1000
+        self._http_ports[node] += 1
         return port
 
     def next_bootstrap_port(self, node: str) -> int:

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -219,6 +219,7 @@ def allocate_endpoints(
     gpus_per_node: int,
     available_nodes: Sequence[str],
     spread_workers: bool = False,
+    allow_prefill_decode_colocation: bool = False,
 ) -> list[Endpoint]:
     """Allocate endpoints to nodes based on GPU requirements.
 
@@ -236,6 +237,8 @@ def allocate_endpoints(
         spread_workers: If True, place each partial-node worker on its own
             node instead of packing multiple onto the same node. Requires the
             caller to reserve enough nodes (one per worker per mode).
+        allow_prefill_decode_colocation: If True, decode workers may use
+            remaining GPUs on a node already used by prefill workers.
 
     Returns:
         List of Endpoint objects with node assignments
@@ -383,13 +386,13 @@ def allocate_endpoints(
     if num_prefill > 0:
         endpoints.extend(allocate_workers_simple("prefill", num_prefill, gpus_per_prefill))
 
-    # When there's a partial allocation on the current node (gpu_offset > 0) and
-    # there are more nodes available, advance to ensure prefill and decode don't
-    # share a node. This prevents the bug where a multi-node decode worker overlaps
-    # with a partial-node prefill worker.
+    # By default, when there's a partial allocation on the current node
+    # (gpu_offset > 0) and there are more nodes available, advance to ensure
+    # prefill and decode don't share a node. This prevents the bug where a
+    # multi-node decode worker overlaps with a partial-node prefill worker.
     # When there are no more nodes (decode_nodes=0 config), allow sharing.
     if num_decode > 0:
-        if gpu_offset > 0 and (node_idx + 1) < len(available_nodes):
+        if not allow_prefill_decode_colocation and gpu_offset > 0 and (node_idx + 1) < len(available_nodes):
             node_idx += 1
             gpu_offset = 0
         endpoints.extend(allocate_workers_simple("decode", num_decode, gpus_per_decode))

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -37,6 +37,7 @@ class NodePortAllocator:
     Port ranges (non-overlapping):
         - kv_events_port: 20000+ (global) - ZMQ port for kv-events publishing
         - nixl_port:      21000+ (global) - NIXL side channel for KV transfers (vLLM)
+        - dp_rpc_port:    13345+ (per node) - DP coordination port (vLLM data-parallel)
         - http_port:      30000+ (per node) - HTTP serving port
         - bootstrap_port: 31000+ (per node) - P/D coordination port (prefill only)
 
@@ -55,9 +56,11 @@ class NodePortAllocator:
     base_bootstrap_port: int = 31000
     base_kv_events_port: int = 20000
     base_nixl_port: int = 21000  # NIXL side channel ports (must not overlap with kv_events)
+    base_dp_rpc_port: int = 13345  # DP coordination port for vLLM data-parallel
 
     _http_ports: dict[str, int] = field(default_factory=dict, repr=False)
     _bootstrap_ports: dict[str, int] = field(default_factory=dict, repr=False)
+    _dp_rpc_ports: dict[str, int] = field(default_factory=dict, repr=False)
     _next_kv_events_port: int = field(default=0, repr=False)  # Global counter
     _next_nixl_port: int = field(default=0, repr=False)  # Global counter for NIXL
 
@@ -91,6 +94,18 @@ class NodePortAllocator:
             self._next_nixl_port = self.base_nixl_port
         port = self._next_nixl_port
         self._next_nixl_port += 1
+        return port
+
+    def next_dp_rpc_port(self, node: str) -> int:
+        """Get next available DP RPC port for a node.
+
+        When multiple DP endpoints share a node, each needs a unique
+        data-parallel-rpc-port to avoid bind collisions.
+        """
+        if node not in self._dp_rpc_ports:
+            self._dp_rpc_ports[node] = self.base_dp_rpc_port
+        port = self._dp_rpc_ports[node]
+        self._dp_rpc_ports[node] += 1
         return port
 
 
@@ -167,6 +182,7 @@ class Process:
     bootstrap_port: int | None = None
     kv_events_port: int | None = None
     nixl_port: int | None = None
+    dp_rpc_port: int | None = None
 
     @property
     def is_leader(self) -> bool:

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -188,6 +188,7 @@ def allocate_endpoints(
     gpus_per_agg: int,
     gpus_per_node: int,
     available_nodes: Sequence[str],
+    spread_workers: bool = False,
 ) -> list[Endpoint]:
     """Allocate endpoints to nodes based on GPU requirements.
 
@@ -202,6 +203,9 @@ def allocate_endpoints(
         gpus_per_agg: GPUs per agg worker
         gpus_per_node: GPUs available per node
         available_nodes: List of available node hostnames
+        spread_workers: If True, place each partial-node worker on its own
+            node instead of packing multiple onto the same node. Requires the
+            caller to reserve enough nodes (one per worker per mode).
 
     Returns:
         List of Endpoint objects with node assignments
@@ -327,6 +331,9 @@ def allocate_endpoints(
                 gpu_offset += gpus_per_worker
 
                 if gpu_offset >= gpus_per_node:
+                    node_idx += 1
+                    gpu_offset = 0
+                elif spread_workers:
                     node_idx += 1
                     gpu_offset = 0
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -891,6 +891,128 @@ class TestSbatchNodeCount:
         # Should request 2 nodes: just the workers
         assert "#SBATCH --nodes=2" in script
 
+    def test_vllm_colocation_reduces_sbatch_to_one_node_when_fit(self):
+        """Test vLLM P/D colocation requests one worker node when all workers fit."""
+        from pathlib import Path
+
+        from srtctl.backends import VLLMProtocol
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+        from srtctl.core.schema import InfraConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/container.sqsh", precision="fp8"),
+            resources=ResourceConfig(
+                gpu_type="h100",
+                gpus_per_node=8,
+                prefill_nodes=1,
+                decode_nodes=1,
+                prefill_workers=1,
+                decode_workers=1,
+                _explicit_gpus_per_prefill=4,
+                _explicit_gpus_per_decode=4,
+            ),
+            backend=VLLMProtocol(allow_prefill_decode_colocation=True),
+            infra=InfraConfig(etcd_nats_dedicated_node=False),
+        )
+
+        assert config.resources.total_nodes == 2
+        assert config.total_nodes == 1
+
+        script = generate_minimal_sbatch_script(config, Path("/tmp/test.yaml"))
+
+        assert "#SBATCH --nodes=1" in script
+
+    def test_vllm_colocation_keeps_normal_node_count_when_not_fit(self):
+        """Test vLLM P/D colocation does not reduce nodes when workers exceed one node."""
+        from srtctl.backends import VLLMProtocol
+        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/container.sqsh", precision="fp8"),
+            resources=ResourceConfig(
+                gpu_type="h100",
+                gpus_per_node=8,
+                prefill_nodes=1,
+                decode_nodes=1,
+                prefill_workers=1,
+                decode_workers=1,
+                _explicit_gpus_per_prefill=6,
+                _explicit_gpus_per_decode=4,
+            ),
+            backend=VLLMProtocol(allow_prefill_decode_colocation=True),
+        )
+
+        assert config.total_nodes == 2
+
+
+class TestVLLMPrefillDecodeColocation:
+    """Tests for vLLM prefill/decode same-node packing."""
+
+    def test_disabled_by_default_keeps_prefill_and_decode_separate(self):
+        """Test vLLM preserves default P/D node separation."""
+        from srtctl.backends import VLLMProtocol
+
+        endpoints = VLLMProtocol().allocate_endpoints(
+            num_prefill=1,
+            num_decode=1,
+            num_agg=0,
+            gpus_per_prefill=4,
+            gpus_per_decode=4,
+            gpus_per_agg=0,
+            gpus_per_node=8,
+            available_nodes=("node0", "node1"),
+        )
+
+        assert endpoints[0].mode == "prefill"
+        assert endpoints[0].nodes == ("node0",)
+        assert endpoints[1].mode == "decode"
+        assert endpoints[1].nodes == ("node1",)
+
+    def test_enabled_packs_prefill_and_decode_when_one_node_fits(self):
+        """Test vLLM packs P/D workers together when requested and all fit."""
+        from srtctl.backends import VLLMProtocol
+
+        endpoints = VLLMProtocol(allow_prefill_decode_colocation=True).allocate_endpoints(
+            num_prefill=2,
+            num_decode=2,
+            num_agg=0,
+            gpus_per_prefill=2,
+            gpus_per_decode=2,
+            gpus_per_agg=0,
+            gpus_per_node=8,
+            available_nodes=("node0", "node1"),
+        )
+
+        prefill_eps = [ep for ep in endpoints if ep.mode == "prefill"]
+        decode_eps = [ep for ep in endpoints if ep.mode == "decode"]
+
+        assert [ep.nodes for ep in prefill_eps] == [("node0",), ("node0",)]
+        assert [ep.gpu_indices for ep in prefill_eps] == [frozenset({0, 1}), frozenset({2, 3})]
+        assert [ep.nodes for ep in decode_eps] == [("node0",), ("node0",)]
+        assert [ep.gpu_indices for ep in decode_eps] == [frozenset({4, 5}), frozenset({6, 7})]
+
+    def test_enabled_does_not_pack_when_one_node_does_not_fit(self):
+        """Test vLLM falls back to separated P/D nodes when total GPUs do not fit."""
+        from srtctl.backends import VLLMProtocol
+
+        endpoints = VLLMProtocol(allow_prefill_decode_colocation=True).allocate_endpoints(
+            num_prefill=1,
+            num_decode=1,
+            num_agg=0,
+            gpus_per_prefill=6,
+            gpus_per_decode=4,
+            gpus_per_agg=0,
+            gpus_per_node=8,
+            available_nodes=("node0", "node1"),
+        )
+
+        assert endpoints[0].mode == "prefill"
+        assert endpoints[0].nodes == ("node0",)
+        assert endpoints[1].mode == "decode"
+        assert endpoints[1].nodes == ("node1",)
+
 
 class TestVLLMDataParallelMode:
     """Tests for vLLM DP+EP (Data Parallel + Expert Parallel) mode."""

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -970,6 +970,23 @@ class TestVLLMPrefillDecodeColocation:
         assert endpoints[1].mode == "decode"
         assert endpoints[1].nodes == ("node1",)
 
+    def test_colocation_requires_prefill_decode_and_valid_node_size(self):
+        """Test vLLM colocation stays off for incomplete or invalid P/D topology."""
+        from srtctl.backends import VLLMProtocol
+
+        backend = VLLMProtocol(allow_prefill_decode_colocation=True)
+
+        for num_prefill, num_decode, gpus_per_node in ((0, 1, 8), (1, 0, 8), (1, 1, 0)):
+            assert not backend.should_colocate_prefill_decode(
+                num_prefill=num_prefill,
+                num_decode=num_decode,
+                num_agg=0,
+                gpus_per_prefill=4,
+                gpus_per_decode=4,
+                gpus_per_agg=0,
+                gpus_per_node=gpus_per_node,
+            )
+
     def test_enabled_packs_prefill_and_decode_when_one_node_fits(self):
         """Test vLLM packs P/D workers together when requested and all fit."""
         from srtctl.backends import VLLMProtocol

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1057,8 +1057,8 @@ class TestVLLMPrefillDecodeColocation:
         assert {p.node for p in prefill + decode} == {"node0"}
         assert {p.dp_rpc_port for p in prefill} == {13345}
         assert {p.dp_rpc_port for p in decode} == {13346}
-        assert {p.nixl_port for p in prefill} == {6550}
-        assert {p.nixl_port for p in decode} == {6554}
+        assert {p.nixl_port for p in prefill} == {21000}
+        assert {p.nixl_port for p in decode} == {21004}
 
         leader_ports = [
             port
@@ -1070,8 +1070,8 @@ class TestVLLMPrefillDecodeColocation:
 
         prefill_actual_nixl_ports = {next(iter(p.nixl_port for p in prefill)) + p.node_rank for p in prefill}
         decode_actual_nixl_ports = {next(iter(p.nixl_port for p in decode)) + p.node_rank for p in decode}
-        assert prefill_actual_nixl_ports == {6550, 6551, 6552, 6553}
-        assert decode_actual_nixl_ports == {6554, 6555, 6556, 6557}
+        assert prefill_actual_nixl_ports == {21000, 21001, 21002, 21003}
+        assert decode_actual_nixl_ports == {21004, 21005, 21006, 21007}
         assert prefill_actual_nixl_ports.isdisjoint(decode_actual_nixl_ports)
 
     def test_enabled_does_not_pack_when_one_node_does_not_fit(self):
@@ -1203,8 +1203,8 @@ class TestVLLMDataParallelMode:
 
         assert {p.dp_rpc_port for p in first_endpoint} == {13345}
         assert {p.dp_rpc_port for p in second_endpoint} == {13346}
-        assert {p.nixl_port for p in first_endpoint} == {6550}
-        assert {p.nixl_port for p in second_endpoint} == {6554}
+        assert {p.nixl_port for p in first_endpoint} == {21000}
+        assert {p.nixl_port for p in second_endpoint} == {21004}
         assert [p.node_rank for p in first_endpoint] == list(range(4))
         assert [p.node_rank for p in second_endpoint] == list(range(4))
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -965,6 +965,46 @@ class TestVLLMDataParallelMode:
         dp_ranks = [p.node_rank for p in processes]
         assert dp_ranks == list(range(16))
 
+    def test_dp_mode_allocates_unique_ports_for_multiple_endpoints_per_node(self):
+        """Test DP endpoints sharing a node get non-colliding coordination ports."""
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                decode={"data-parallel-size": 4, "enable-expert-parallel": True},
+            )
+        )
+
+        endpoints = [
+            Endpoint(
+                mode="decode",
+                index=0,
+                nodes=("node0",),
+                gpu_indices=frozenset(range(4)),
+                gpus_per_node=8,
+            ),
+            Endpoint(
+                mode="decode",
+                index=1,
+                nodes=("node0",),
+                gpu_indices=frozenset(range(4, 8)),
+                gpus_per_node=8,
+            ),
+        ]
+
+        processes = backend.endpoints_to_processes(endpoints)
+
+        first_endpoint = [p for p in processes if p.endpoint_index == 0]
+        second_endpoint = [p for p in processes if p.endpoint_index == 1]
+
+        assert {p.dp_rpc_port for p in first_endpoint} == {13345}
+        assert {p.dp_rpc_port for p in second_endpoint} == {13346}
+        assert {p.nixl_port for p in first_endpoint} == {6550}
+        assert {p.nixl_port for p in second_endpoint} == {6554}
+        assert [p.node_rank for p in first_endpoint] == list(range(4))
+        assert [p.node_rank for p in second_endpoint] == list(range(4))
+
     def test_dp_mode_command_includes_dp_flags(self):
         """Test that DP mode command includes correct DP flags instead of TP flags."""
         from pathlib import Path

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -993,6 +993,87 @@ class TestVLLMPrefillDecodeColocation:
         assert [ep.nodes for ep in decode_eps] == [("node0",), ("node0",)]
         assert [ep.gpu_indices for ep in decode_eps] == [frozenset({4, 5}), frozenset({6, 7})]
 
+    def test_same_node_prefill_decode_ports_do_not_collide(self):
+        """Test same-node vLLM P/D workers get distinct listener ports."""
+        from srtctl.backends import VLLMProtocol
+
+        backend = VLLMProtocol(allow_prefill_decode_colocation=True)
+        endpoints = backend.allocate_endpoints(
+            num_prefill=1,
+            num_decode=1,
+            num_agg=0,
+            gpus_per_prefill=4,
+            gpus_per_decode=4,
+            gpus_per_agg=0,
+            gpus_per_node=8,
+            available_nodes=("node0", "node1"),
+        )
+
+        processes = backend.endpoints_to_processes(endpoints)
+        prefill = next(p for p in processes if p.endpoint_mode == "prefill")
+        decode = next(p for p in processes if p.endpoint_mode == "decode")
+
+        assert prefill.node == decode.node == "node0"
+        assert prefill.http_port == 30000
+        assert decode.http_port == 30001
+        assert prefill.bootstrap_port == 31000
+
+        bound_ports = [
+            port
+            for process in processes
+            for port in (process.http_port, process.bootstrap_port, process.kv_events_port, process.nixl_port)
+            if port
+        ]
+        assert len(bound_ports) == len(set(bound_ports))
+
+    def test_same_node_dp_prefill_decode_ports_do_not_collide(self):
+        """Test same-node DP P/D endpoints get distinct per-endpoint port ranges."""
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+
+        backend = VLLMProtocol(
+            allow_prefill_decode_colocation=True,
+            vllm_config=VLLMServerConfig(
+                prefill={"data-parallel-size": 4, "enable-expert-parallel": True},
+                decode={"data-parallel-size": 4, "enable-expert-parallel": True},
+            ),
+        )
+        endpoints = backend.allocate_endpoints(
+            num_prefill=1,
+            num_decode=1,
+            num_agg=0,
+            gpus_per_prefill=4,
+            gpus_per_decode=4,
+            gpus_per_agg=0,
+            gpus_per_node=8,
+            available_nodes=("node0", "node1"),
+        )
+
+        processes = backend.endpoints_to_processes(endpoints)
+        prefill = [p for p in processes if p.endpoint_mode == "prefill"]
+        decode = [p for p in processes if p.endpoint_mode == "decode"]
+
+        assert len(prefill) == 4
+        assert len(decode) == 4
+        assert {p.node for p in prefill + decode} == {"node0"}
+        assert {p.dp_rpc_port for p in prefill} == {13345}
+        assert {p.dp_rpc_port for p in decode} == {13346}
+        assert {p.nixl_port for p in prefill} == {6550}
+        assert {p.nixl_port for p in decode} == {6554}
+
+        leader_ports = [
+            port
+            for process in prefill + decode
+            for port in (process.http_port, process.bootstrap_port)
+            if port
+        ]
+        assert sorted(leader_ports) == [30000, 30001, 31000]
+
+        prefill_actual_nixl_ports = {next(iter(p.nixl_port for p in prefill)) + p.node_rank for p in prefill}
+        decode_actual_nixl_ports = {next(iter(p.nixl_port for p in decode)) + p.node_rank for p in decode}
+        assert prefill_actual_nixl_ports == {6550, 6551, 6552, 6553}
+        assert decode_actual_nixl_ports == {6554, 6555, 6556, 6557}
+        assert prefill_actual_nixl_ports.isdisjoint(decode_actual_nixl_ports)
+
     def test_enabled_does_not_pack_when_one_node_does_not_fit(self):
         """Test vLLM falls back to separated P/D nodes when total GPUs do not fit."""
         from srtctl.backends import VLLMProtocol

--- a/tests/test_endpoint_allocation.py
+++ b/tests/test_endpoint_allocation.py
@@ -356,9 +356,9 @@ class TestEndpointsToProcesses:
         assert all(port is not None for port in kv_ports), "All processes should have kv_events_port"
         assert len(kv_ports) == len(set(kv_ports)), "All kv_events_ports should be globally unique"
 
-        # Ports should be sequential starting from 5550
+        # Ports should be sequential starting from 20000
         # With 2 prefill + 2 decode workers, each on single node = 4 processes = 4 ports
-        assert sorted(kv_ports) == [5550, 5551, 5552, 5553]
+        assert sorted(kv_ports) == [20000, 20001, 20002, 20003]
 
     def test_kv_events_port_same_node_unique(self):
         """Test kv_events_port is unique even when workers share a node."""
@@ -380,11 +380,11 @@ class TestEndpointsToProcesses:
         assert len(processes) == 2
         assert processes[0].node == processes[1].node == "node0"
         assert processes[0].kv_events_port != processes[1].kv_events_port
-        assert processes[0].kv_events_port == 5550
-        assert processes[1].kv_events_port == 5551
+        assert processes[0].kv_events_port == 20000
+        assert processes[1].kv_events_port == 20001
 
     def test_nixl_port_allocation(self):
-        """Test NIXL ports are allocated globally unique starting at 6550."""
+        """Test NIXL ports are allocated globally unique starting at 21000."""
         from srtctl.core.topology import Endpoint
 
         endpoints = [
@@ -410,5 +410,5 @@ class TestEndpointsToProcesses:
         nixl_ports = [p.nixl_port for p in processes]
         assert all(port is not None for port in nixl_ports), "All processes should have nixl_port"
         assert len(nixl_ports) == len(set(nixl_ports))  # All unique
-        assert min(nixl_ports) == 6550  # Starts at base
-        assert nixl_ports == [6550, 6551]  # Sequential
+        assert min(nixl_ports) == 21000  # Starts at base
+        assert nixl_ports == [21000, 21001]  # Sequential

--- a/tests/test_endpoint_allocation.py
+++ b/tests/test_endpoint_allocation.py
@@ -137,6 +137,45 @@ class TestAllocateEndpoints:
             assert ep.mode == "agg"
             assert ep.total_gpus == 4
 
+    def test_spread_workers_partial_node(self):
+        """spread_workers=True forces each partial-node worker onto its own node."""
+        endpoints = allocate_endpoints(
+            num_prefill=1,
+            num_decode=2,
+            num_agg=0,
+            gpus_per_prefill=1,
+            gpus_per_decode=2,
+            gpus_per_agg=0,
+            gpus_per_node=4,
+            available_nodes=("node0", "node1", "node2"),
+            spread_workers=True,
+        )
+
+        decode_eps = [e for e in endpoints if e.mode == "decode"]
+        assert len(decode_eps) == 2
+        # Without spread_workers both decode workers would land on node1.
+        assert decode_eps[0].nodes == ("node1",)
+        assert decode_eps[1].nodes == ("node2",)
+        assert decode_eps[0].gpu_indices == frozenset({0, 1})
+        assert decode_eps[1].gpu_indices == frozenset({0, 1})
+
+    def test_spread_workers_default_packs(self):
+        """spread_workers=False (default) packs partial-node workers onto the same node."""
+        endpoints = allocate_endpoints(
+            num_prefill=0,
+            num_decode=2,
+            num_agg=0,
+            gpus_per_prefill=0,
+            gpus_per_decode=2,
+            gpus_per_agg=0,
+            gpus_per_node=4,
+            available_nodes=("node0", "node1"),
+        )
+
+        decode_eps = [e for e in endpoints if e.mode == "decode"]
+        assert decode_eps[0].nodes == ("node0",)
+        assert decode_eps[1].nodes == ("node0",)
+
     def test_prefill_decode_never_share_node_partial_allocation(self):
         """Test that prefill and decode workers are never colocated on the same node.
 


### PR DESCRIPTION
## Summary
- Add a `spread_workers` resource option to place partial-node workers on separate nodes when requested.
- Add vLLM prefill/decode one-node colocation support when worker GPU usage fits on a single node.
- Avoid same-node worker port collisions for KV events, NIXL, and vLLM data-parallel RPC ports.

## Validation
- `uv run pytest tests/test_configs.py tests/test_endpoint_allocation.py -q` (81 passed)
- `make check` (395 passed, 2 skipped; `ty` diagnostics are currently non-fatal in the Makefile)

## Notes
- This PR is based on `NVIDIA/srt-slurm:sa-submission-q2-2026`.
- The head branch was rebuilt on the q2 submission branch and excludes the MiniMax recipe files.
