### PR TITLE
Force-reinstall maturin in portable top_of_tree dynamo source build

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1049,9 +1049,9 @@ def _live_source_install_for_top_of_tree() -> str:
         "if ! command -v cargo &> /dev/null || ! command -v maturin &> /dev/null; then "
         "apt-get update -qq && apt-get install -y -qq git curl libclang-dev protobuf-compiler > /dev/null 2>&1 && "
         "if ! command -v cargo &> /dev/null; then "
-        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env; fi && "
-        "if ! command -v maturin &> /dev/null; then "
-        "pip install --break-system-packages maturin; fi; fi && "
+        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env; fi; fi && "
+        # Force-reinstall maturin: see _hash_cached_source_install.
+        "pip install --break-system-packages --force-reinstall --quiet maturin && "
         "ORIG_DIR=$(pwd) && rm -rf /tmp/dynamo_build && mkdir -p /tmp/dynamo_build && cd /tmp/dynamo_build && "
         "git clone https://github.com/ai-dynamo/dynamo.git && "
         "cd dynamo && "

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -217,6 +217,10 @@ class TestDynamoConfig:
         assert "maturin build" in cmd
         assert "protobuf-compiler" in cmd
 
+        # maturin must be force-reinstalled — a plain install no-ops on images
+        # shipping the module without a console script (see schema.py).
+        assert "--force-reinstall --quiet maturin" in cmd
+
         # Cache populate: wheel + tarball + sentinel
         assert "ai_dynamo_runtime*.whl" in cmd
         assert "dynamo-src.tar.gz" in cmd
@@ -242,6 +246,13 @@ class TestDynamoConfig:
         assert "/tmp/dynamo_build" in cmd
         assert "--break-system-packages" in cmd
         assert "--force-reinstall" in cmd
+
+        # Both branches (sglang + portable) must force-reinstall maturin — the
+        # portable branch previously used a guarded plain install that no-ops on
+        # images shipping maturin without a console script.
+        sglang_branch, portable_branch = cmd.split("else", 1)
+        assert "--force-reinstall --quiet maturin" in sglang_branch
+        assert "--force-reinstall --quiet maturin" in portable_branch
 
     def test_hash_and_top_of_tree_not_allowed(self):
         """Cannot specify both hash and top_of_tree."""


### PR DESCRIPTION
## Problem

The **portable** (non-SGLang) branch of the `top_of_tree` dynamo source install guarded maturin behind `command -v maturin` and ran a plain `pip install`:

```bash
if ! command -v maturin &> /dev/null; then pip install --break-system-packages maturin; fi
```

On images that ship the `maturin` Python module **without a console script**, the guard trips (`command -v maturin` fails) but pip reports *"already satisfied"* — so no binary is created and the later `maturin build` dies with `maturin: command not found`. The `hash` and SGLang paths already avoid this with `--force-reinstall`; the portable branch was the only one missing it.

## Changes

- **`schema.py`** — portable branch now force-reinstalls maturin unconditionally, matching the other two source-install paths:
  ```bash
  pip install --break-system-packages --force-reinstall --quiet maturin
  ```
- **`test_configs.py`** — branch-pinned assertions so the same regression is caught on **all three** paths (`hash`, `top_of_tree` sglang, `top_of_tree` portable).

## Before / After

Generated `top_of_tree` portable branch:

```diff
- if ! command -v maturin &> /dev/null; then pip install --break-system-packages maturin; fi; fi &&
+ ...; fi &&
+ pip install --break-system-packages --force-reinstall --quiet maturin &&
```

`bash -n` confirms the generated command still parses cleanly.

## Tests

The new portable assertion **fails on the old code** (proving it catches the bug) and passes after the fix:

```
# fix reverted:
tests/test_configs.py:255: assert "--force-reinstall --quiet maturin" in portable_branch  -> FAILED
```

Full suite with this PR — no tests broken:

```
705 passed, 2 skipped in make check
```

> Note: one unrelated, pre-existing failure (`test_mcp_spec.py::test_explain_field_resolves_nested_reporting_endpoint`, a `Union` vs `UnionType` string-repr quirk under local Python 3.14) is present on `main` independent of this change.
