### PR TITLE
Cherry-pick Dynamo wheel install support to Q2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ configs/etcdctl
 configs/*.whl
 configs/*.deb
 configs/*.tar.gz
+wheelhouse/
 
 .ruff_cache/
 *.egg-info/

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -115,7 +116,8 @@ def show_config_details(config: SrtConfig) -> None:
     console.print(Panel(mounts_table, border_style="green"))
 
     # --- Environment Variables ---
-    has_env = bool(config.environment)
+    dynamo_environment = config.dynamo.get_wheel_environment()
+    has_env = bool(config.environment or dynamo_environment)
     backend = config.backend
     mode_envs: list[tuple[str, dict[str, str]]] = []
     for mode_name, attr in [
@@ -133,6 +135,9 @@ def show_config_details(config: SrtConfig) -> None:
         env_table.add_column("Scope", style="dim", width=14)
         env_table.add_column("Variable", style="yellow")
         env_table.add_column("Value", style="white")
+
+        for var, val in sorted(dynamo_environment.items()):
+            env_table.add_row("dynamo", var, val)
 
         for var, val in sorted(config.environment.items()):
             env_table.add_row("global", var, val)
@@ -207,6 +212,8 @@ def generate_minimal_sbatch_script(
     container_image = os.path.expandvars(config.model.container)
 
     job_name = get_job_name(config)
+    config_environment = config.dynamo.get_wheel_environment()
+    config_environment.update(config.environment)
 
     rendered = template.render(
         job_name=job_name,
@@ -227,6 +234,7 @@ def generate_minimal_sbatch_script(
         srtctl_source=str(srtctl_source.resolve()),
         output_base=output_base,
         setup_script=setup_script,
+        config_environment={key: shlex.quote(str(value)) for key, value in config_environment.items()},
     )
 
     return rendered

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -212,6 +212,14 @@ class RuntimeContext:
             if configs_dir.exists():
                 container_mounts[configs_dir.resolve()] = Path("/configs")
 
+            wheelhouse_dir = Path(source_dir) / "wheelhouse" / "dynamo"
+            if wheelhouse_dir.exists():
+                container_mounts[wheelhouse_dir.resolve()] = Path("/srtctl-wheels")
+
+        runtime_scripts_dir = Path(__file__).resolve().parent.parent / "runtime_scripts"
+        if runtime_scripts_dir.exists():
+            container_mounts[runtime_scripts_dir.resolve()] = Path("/srtctl-runtime")
+
         # Mount srtctl benchmark scripts
         from srtctl.benchmarks.base import SCRIPTS_DIR
 
@@ -242,6 +250,9 @@ class RuntimeContext:
         # Add FormattablePath mounts from config.container_mounts
         # These need to be expanded with the runtime context, so we create a
         # temporary context first and then update
+        environment = config.dynamo.get_wheel_environment()
+        environment.update(config.environment)
+
         temp_context = cls(
             job_id=job_id,
             run_name=run_name,
@@ -255,7 +266,7 @@ class RuntimeContext:
             network_interface=get_srtslurm_setting("network_interface", "eth0"),
             container_mounts={},
             srun_options=dict(config.srun_options),
-            environment=dict(config.environment),
+            environment=environment,
             is_hf_model=is_hf_model,
         )
 
@@ -278,7 +289,7 @@ class RuntimeContext:
             network_interface=get_srtslurm_setting("network_interface", "eth0"),
             container_mounts=container_mounts,
             srun_options=dict(config.srun_options),
-            environment=dict(config.environment),
+            environment=environment,
             is_hf_model=is_hf_model,
         )
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -14,6 +14,7 @@ Backend configs are defined in srtctl.backends.configs/ for modularity.
 import builtins
 import itertools
 import logging
+import shlex
 from collections.abc import Iterator, Mapping
 from dataclasses import field
 from enum import Enum
@@ -685,7 +686,7 @@ class ProfilingConfig:
 class DynamoConfig:
     """Dynamo installation configuration.
 
-    Only one of version, hash, or top_of_tree should be specified.
+    Only one of version, hash, top_of_tree, or wheel should be specified.
     Defaults to version="0.8.0" (pip install).
 
     Options:
@@ -694,31 +695,88 @@ class DynamoConfig:
         version: Install specific version from PyPI (e.g., "0.8.0")
         hash: Clone repo and checkout specific commit hash
         top_of_tree: Clone repo at HEAD (latest)
+        wheel: ai-dynamo package version to install via staged wheels. The
+               matching ai-dynamo-runtime wheel is installed automatically.
 
-    If top_of_tree or hash is set, version is automatically cleared.
+    If top_of_tree, hash, or wheel is set, version is automatically cleared.
     """
 
     install: bool = True
     version: str | None = "0.8.0"
     hash: str | None = None
     top_of_tree: bool = False
+    wheel: str | None = None
 
     def __post_init__(self) -> None:
-        # Auto-clear version if hash or top_of_tree is set
-        if self.hash is not None or self.top_of_tree:
+        install_sources = [
+            ("hash", self.hash is not None),
+            ("top_of_tree", self.top_of_tree),
+            ("wheel", self.wheel is not None),
+        ]
+        enabled_sources = [name for name, enabled in install_sources if enabled]
+
+        # Auto-clear version if another install source is set.
+        if enabled_sources:
             object.__setattr__(self, "version", None)
 
         # Validate only one source option is set
-        if self.hash is not None and self.top_of_tree:
-            raise ValueError("Cannot specify both hash and top_of_tree")
+        if len(enabled_sources) > 1:
+            raise ValueError(f"Cannot specify both Dynamo install sources: {', '.join(enabled_sources)}")
+
+        if self.wheel is not None:
+            if not self.wheel.strip():
+                raise ValueError("dynamo.wheel must be a non-empty package version")
+            if Path(self.wheel).name.endswith(".whl") or "/" in self.wheel:
+                raise ValueError("dynamo.wheel must be a package version like '1.2.0.dev20260426', not a filename")
 
     @property
     def needs_source_install(self) -> bool:
         """Whether this config requires a source install (git clone + maturin)."""
-        return self.hash is not None or self.top_of_tree
+        return self.wheel is None and (self.hash is not None or self.top_of_tree)
+
+    @property
+    def wheel_version(self) -> str | None:
+        """Package version requested for staged wheel installation."""
+        return self.wheel
+
+    @property
+    def wheel_name(self) -> str | None:
+        """Return the ai-dynamo wheel filename for the requested package version."""
+        if not self.wheel:
+            return None
+        return f"ai_dynamo-{self.wheel}-py3-none-any.whl"
+
+    def get_wheel_environment(self) -> dict[str, str]:
+        """Environment variables consumed by ai-dynamo prefetch/setup scripts."""
+        if not self.wheel:
+            return {}
+        wheel_name = self.wheel_name
+        env = {"DYNAMO_WHEEL_NAME": wheel_name} if wheel_name else {}
+        version = self.wheel_version
+        if version:
+            env["DYNAMO_VERSION"] = version
+        return env
 
     def get_install_commands(self) -> str:
         """Get the bash commands to install dynamo."""
+        if self.wheel is not None:
+            wheel_name = self.wheel_name or Path(self.wheel).name
+            version = self.wheel_version
+            if not version:
+                raise ValueError("dynamo.wheel must provide an exact package version")
+            start_message = shlex.quote(f"Installing ai-dynamo-runtime and ai-dynamo from wheel {wheel_name}...")
+            done_message = shlex.quote(f"ai-dynamo-runtime and ai-dynamo install path completed for {wheel_name}")
+            return (
+                f"echo {start_message} && "
+                "if [ -f /srtctl-runtime/dynamo_wheels.py ]; then "
+                "python3 /srtctl-runtime/dynamo_wheels.py install; "
+                "else "
+                "echo 'ERROR: /srtctl-runtime/dynamo_wheels.py not found for ai-dynamo wheel install' >&2; "
+                "exit 1; "
+                "fi && "
+                f"echo {done_message}"
+            )
+
         if self.version is not None:
             return (
                 f"echo 'Installing dynamo {self.version}...' && "

--- a/src/srtctl/frontends/dynamo.py
+++ b/src/srtctl/frontends/dynamo.py
@@ -83,6 +83,10 @@ class DynamoFrontend:
                 "DYN_REQUEST_PLANE": "nats",
             }
 
+            # Add global recipe environment, including values derived from
+            # dynamo.wheel, before frontend-specific overrides.
+            env_to_set.update(runtime.environment)
+
             # Add frontend env from config
             if config.frontend.env:
                 env_to_set.update(config.frontend.env)

--- a/src/srtctl/runtime_scripts/__init__.py
+++ b/src/srtctl/runtime_scripts/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime helper scripts mounted into worker containers."""

--- a/src/srtctl/runtime_scripts/dynamo_wheels.py
+++ b/src/srtctl/runtime_scripts/dynamo_wheels.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stage and install exact ai-dynamo wheels for benchmark jobs."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import importlib.metadata
+import os
+import platform
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DEFAULT_INDEX_URL = "https://pypi.org/simple"
+DEFAULT_EXTRA_INDEX_URL = "https://pypi.nvidia.com"
+DEFAULT_PYTHON_VERSION = "3.12"
+Env = Mapping[str, str]
+
+
+def normalize_arch(arch: str) -> str:
+    match arch:
+        case "aarch64" | "arm64":
+            return "aarch64"
+        case "x86_64" | "amd64" | "x64":
+            return "x86_64"
+        case _:
+            raise ValueError(f"unsupported Dynamo wheel arch {arch!r}; expected x86_64 or aarch64")
+
+
+def _describe_file(path: Path) -> str:
+    try:
+        result = subprocess.run(["file", "-b", str(path)], check=False, capture_output=True, text=True)
+    except FileNotFoundError:
+        return ""
+    return result.stdout.strip()
+
+
+def arch_from_uv_binary(source_dir: Path) -> str | None:
+    """Infer compute arch from the uv binary installed by make setup ARCH=..."""
+    uv_bin = source_dir / "bin" / "uv"
+    if not uv_bin.exists():
+        return None
+
+    description = _describe_file(uv_bin)
+    if "aarch64" in description or "ARM aarch64" in description:
+        return "aarch64"
+    if "x86-64" in description or "x86_64" in description:
+        return "x86_64"
+    return None
+
+
+def _get_env(env: Env | None) -> Env:
+    return os.environ if env is None else env
+
+
+def detect_target_arch(source_dir: Path, env: Env | None = None) -> str:
+    runtime_env = _get_env(env)
+    if arch := runtime_env.get("DYNAMO_WHEEL_ARCH"):
+        return normalize_arch(arch)
+    if arch := runtime_env.get("SRTCTL_COMPUTE_ARCH"):
+        return normalize_arch(arch)
+    if arch := arch_from_uv_binary(source_dir):
+        return arch
+    return normalize_arch(platform.machine())
+
+
+def runtime_wheel_pattern(version: str, arch: str) -> str:
+    return f"ai_dynamo_runtime-{version}-*{arch}.whl"
+
+
+def platform_args_for_arch(arch: str) -> list[str]:
+    match arch:
+        case "aarch64":
+            platforms = ["manylinux_2_28_aarch64", "manylinux2014_aarch64"]
+        case "x86_64":
+            platforms = ["manylinux_2_28_x86_64", "manylinux2014_x86_64"]
+        case _:
+            raise ValueError(f"unsupported Dynamo wheel arch {arch!r}")
+
+    args: list[str] = []
+    for platform_tag in platforms:
+        args.extend(["--platform", platform_tag])
+    return args
+
+
+def build_download_command(
+    *,
+    version: str,
+    wheel_dir: Path,
+    arch: str,
+    python_version: str,
+    index_url: str,
+    extra_index_url: str,
+) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "pip",
+        "download",
+        "--no-deps",
+        "--pre",
+        "--only-binary=:all:",
+        "--implementation",
+        "cp",
+        "--python-version",
+        python_version,
+        *platform_args_for_arch(arch),
+        "--index-url",
+        index_url,
+        "--extra-index-url",
+        extra_index_url,
+        "--dest",
+        str(wheel_dir),
+        f"ai-dynamo-runtime=={version}",
+        f"ai-dynamo=={version}",
+    ]
+
+
+def _find_one(wheel_dirs: list[Path], pattern: str) -> Path | None:
+    for wheel_dir in wheel_dirs:
+        if not wheel_dir.is_dir():
+            continue
+        match = next(wheel_dir.glob(pattern), None)
+        if match is not None:
+            return match
+    return None
+
+
+def _runtime_wheel_exists(wheel_dir: Path, version: str, arch: str, pattern_override: str | None = None) -> bool:
+    pattern = pattern_override or runtime_wheel_pattern(version, arch)
+    return next(wheel_dir.glob(pattern), None) is not None
+
+
+def prefetch(env: Env | None = None) -> None:
+    runtime_env = _get_env(env)
+    version = runtime_env.get("DYNAMO_VERSION", "")
+    if not version:
+        raise SystemExit("ERROR: DYNAMO_VERSION must be set for ai-dynamo wheel prefetch")
+
+    source_dir = Path(runtime_env.get("SRTCTL_SOURCE_DIR", os.getcwd()))
+    arch = detect_target_arch(source_dir, runtime_env)
+    python_version = runtime_env.get("DYNAMO_PYTHON_VERSION", DEFAULT_PYTHON_VERSION)
+    wheel_name = runtime_env.get("DYNAMO_WHEEL_NAME", f"ai_dynamo-{version}-py3-none-any.whl")
+    runtime_pattern = runtime_env.get("DYNAMO_RUNTIME_WHEEL_PATTERN") or runtime_wheel_pattern(version, arch)
+    wheel_dir = Path(runtime_env.get("DYNAMO_WHEEL_HOST_DIR", source_dir / "wheelhouse" / "dynamo"))
+    wheel_path = wheel_dir / wheel_name
+    lock_path = wheel_dir / f".{version}.{arch}.lock"
+
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+
+    def wheels_are_ready() -> bool:
+        return wheel_path.exists() and _runtime_wheel_exists(wheel_dir, version, arch, runtime_pattern)
+
+    if wheels_are_ready():
+        print(f"ai-dynamo wheels already staged for {arch}: {wheel_dir}")
+        return
+
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        if not wheels_are_ready():
+            print(f"Staging ai-dynamo wheels for {arch} / CPython {python_version}: {wheel_dir}")
+            subprocess.run(
+                build_download_command(
+                    version=version,
+                    wheel_dir=wheel_dir,
+                    arch=arch,
+                    python_version=python_version,
+                    index_url=runtime_env.get("DYNAMO_INDEX_URL", DEFAULT_INDEX_URL),
+                    extra_index_url=runtime_env.get("DYNAMO_EXTRA_INDEX_URL", DEFAULT_EXTRA_INDEX_URL),
+                ),
+                check=True,
+            )
+
+    if not wheel_path.exists():
+        raise SystemExit(f"ERROR: expected {wheel_path} after download")
+    if not _runtime_wheel_exists(wheel_dir, version, arch, runtime_pattern):
+        raise SystemExit(f"ERROR: expected {runtime_pattern} in {wheel_dir} after download")
+
+
+def _already_installed(version: str) -> bool:
+    for package in ("ai-dynamo", "ai-dynamo-runtime"):
+        try:
+            installed = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            return False
+        if installed != version:
+            return False
+
+    try:
+        importlib.import_module("dynamo.llm")
+    except Exception:
+        return False
+    return True
+
+
+def install(env: Env | None = None) -> None:
+    runtime_env = _get_env(env)
+    version = runtime_env.get("DYNAMO_VERSION", "")
+    if not version:
+        raise SystemExit("ERROR: DYNAMO_VERSION must be set for ai-dynamo wheel install")
+
+    if _already_installed(version):
+        print(f"ai-dynamo and ai-dynamo-runtime {version} already installed")
+        return
+
+    arch = normalize_arch(
+        runtime_env.get("DYNAMO_WHEEL_ARCH") or runtime_env.get("SRTCTL_COMPUTE_ARCH") or platform.machine()
+    )
+    wheel_name = runtime_env.get("DYNAMO_WHEEL_NAME", f"ai_dynamo-{version}-py3-none-any.whl")
+    runtime_pattern = runtime_env.get("DYNAMO_RUNTIME_WHEEL_PATTERN") or runtime_wheel_pattern(version, arch)
+    wheel_dirs = [Path(item) for item in runtime_env.get("DYNAMO_WHEEL_DIRS", "/srtctl-wheels").split()]
+
+    dynamo_wheel = _find_one(wheel_dirs, wheel_name)
+    runtime_wheel = _find_one(wheel_dirs, runtime_pattern)
+    if dynamo_wheel is None or runtime_wheel is None:
+        dirs = " ".join(str(path) for path in wheel_dirs)
+        raise SystemExit(
+            f"ERROR: exact ai-dynamo wheels for {version} were not found in {dirs}\n"
+            f"ERROR: expected {wheel_name} and {runtime_pattern}"
+        )
+
+    find_links_args: list[str] = []
+    for wheel_dir in wheel_dirs:
+        if wheel_dir.is_dir():
+            find_links_args.extend(["--find-links", str(wheel_dir)])
+
+    print(f"Installing ai-dynamo-runtime and ai-dynamo {version} from local wheels")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--pre",
+            "--no-deps",
+            "--no-index",
+            *find_links_args,
+            f"ai-dynamo-runtime=={version}",
+            f"ai-dynamo=={version}",
+        ],
+        check=True,
+    )
+
+    importlib.import_module("dynamo.llm")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("prefetch", help="Download exact ai-dynamo wheels for the compute architecture")
+    subparsers.add_parser("install", help="Install exact staged ai-dynamo wheels inside a container")
+    args = parser.parse_args()
+
+    if args.command == "prefetch":
+        prefetch()
+    elif args.command == "install":
+        install()
+    else:
+        parser.error(f"unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -75,6 +75,10 @@ echo "Head node: ${HEAD_NODE}"
 # Set source directory for container mounts (/configs)
 export SRTCTL_SOURCE_DIR="${SRTCTL_SOURCE}"
 
+{% for key, value in config_environment.items() %}
+export {{ key }}={{ value }}
+{% endfor %}
+
 echo ""
 echo "Preparing srtctl environment..."
 
@@ -86,6 +90,14 @@ if ! command -v uv &> /dev/null; then
 fi
 
 echo "Using uv with Python 3.12..."
+
+if [ -n "${DYNAMO_WHEEL_NAME:-}" ] || [ "${SRTCTL_PREFETCH_AI_DYNAMO:-0}" = "1" ]; then
+    if [ -f "${SRTCTL_SOURCE}/src/srtctl/runtime_scripts/dynamo_wheels.py" ]; then
+        python3 "${SRTCTL_SOURCE}/src/srtctl/runtime_scripts/dynamo_wheels.py" prefetch
+    else
+        echo "WARNING: ${SRTCTL_SOURCE}/src/srtctl/runtime_scripts/dynamo_wheels.py not found"
+    fi
+fi
 
 {% if setup_script %}
 # Custom setup script override from CLI

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -104,6 +104,7 @@ class TestDynamoConfig:
         assert config.version == "0.8.0"
         assert config.hash is None
         assert config.top_of_tree is False
+        assert config.wheel is None
         assert not config.needs_source_install
 
     def test_version_install_command(self):
@@ -115,6 +116,24 @@ class TestDynamoConfig:
         assert "pip install" in cmd
         assert "ai-dynamo-runtime==0.8.0" in cmd
         assert "ai-dynamo==0.8.0" in cmd
+
+    def test_wheel_install_command(self):
+        """Wheel config installs ai-dynamo plus runtime without source build."""
+        from srtctl.core.schema import DynamoConfig
+
+        config = DynamoConfig(wheel="1.2.0.dev20260426")
+        cmd = config.get_install_commands()
+
+        assert config.version is None
+        assert config.needs_source_install is False
+        assert "/srtctl-runtime/dynamo_wheels.py" in cmd
+        assert "ai_dynamo-1.2.0.dev20260426-py3-none-any.whl" in cmd
+        assert "install-ai-dynamo.sh" not in cmd
+        assert "--find-links" not in cmd
+        assert "configs/wheels" not in cmd
+        assert "--extra-index-url" not in cmd
+        assert "maturin" not in cmd
+        assert "git clone" not in cmd
 
     def test_hash_install_command(self):
         """Hash config generates source install command."""
@@ -155,6 +174,40 @@ class TestDynamoConfig:
 
         with pytest.raises(ValueError, match="Cannot specify both"):
             DynamoConfig(hash="abc123", top_of_tree=True)
+
+    def test_hash_and_wheel_not_allowed(self):
+        """Cannot specify both hash and wheel."""
+        from srtctl.core.schema import DynamoConfig
+
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            DynamoConfig(hash="abc123", wheel="1.2.0.dev20260426")
+
+    def test_wheel_filename_not_allowed(self):
+        """Wheel config takes a package version, not an artifact filename."""
+        from srtctl.core.schema import DynamoConfig
+
+        with pytest.raises(ValueError, match="package version"):
+            DynamoConfig(wheel="ai_dynamo-1.2.0.dev20260426-py3-none-any.whl")
+
+    def test_wheel_version_required(self):
+        """Wheel config must provide an exact package version."""
+        from srtctl.core.schema import DynamoConfig
+
+        with pytest.raises(ValueError, match="non-empty package version"):
+            DynamoConfig(wheel="")
+
+    def test_wheel_environment_from_version(self):
+        """Wheel version is converted to setup/prefetch environment."""
+        from srtctl.core.schema import DynamoConfig
+
+        config = DynamoConfig(wheel="1.2.0.dev20260426")
+
+        assert config.wheel_version == "1.2.0.dev20260426"
+        assert config.wheel_name == "ai_dynamo-1.2.0.dev20260426-py3-none-any.whl"
+        assert config.get_wheel_environment() == {
+            "DYNAMO_VERSION": "1.2.0.dev20260426",
+            "DYNAMO_WHEEL_NAME": "ai_dynamo-1.2.0.dev20260426-py3-none-any.whl",
+        }
 
 
 class TestSGLangProtocol:
@@ -478,6 +531,30 @@ class TestSetupScript:
             setup_script="install-sglang-main.sh",
         )
         assert 'export SRTCTL_SETUP_SCRIPT="install-sglang-main.sh"' in script
+
+    def test_sbatch_template_prefetches_dynamo_wheel(self):
+        """dynamo.wheel is exported and prefetched before orchestrator launch."""
+        from pathlib import Path
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+        from srtctl.core.schema import DynamoConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/container.sqsh", precision="fp8"),
+            resources=ResourceConfig(gpu_type="h100", gpus_per_node=8, agg_nodes=1),
+            dynamo=DynamoConfig(
+                install=True,
+                wheel="1.2.0.dev20260426",
+            ),
+        )
+
+        script = generate_minimal_sbatch_script(config, Path("/tmp/test.yaml"))
+
+        assert "export DYNAMO_VERSION=1.2.0.dev20260426" in script
+        assert "export DYNAMO_WHEEL_NAME=ai_dynamo-1.2.0.dev20260426-py3-none-any.whl" in script
+        assert "src/srtctl/runtime_scripts/dynamo_wheels.py" in script
+        assert "configs/prefetch-ai-dynamo-wheel.sh" not in script
 
     def test_setup_script_env_var_override(self, monkeypatch):
         """Test that SRTCTL_SETUP_SCRIPT env var overrides config."""

--- a/tests/test_dynamo_wheels.py
+++ b/tests/test_dynamo_wheels.py
@@ -1,0 +1,91 @@
+"""Tests for staged ai-dynamo wheel helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from srtctl.runtime_scripts import dynamo_wheels
+
+
+def test_detect_target_arch_uses_make_setup_compute_arch(monkeypatch, tmp_path: Path):
+    """prefetch derives target arch from bin/uv installed by make setup ARCH=..."""
+    source_dir = tmp_path / "source"
+    source_dir.joinpath("bin").mkdir(parents=True)
+    source_dir.joinpath("bin", "uv").touch()
+
+    monkeypatch.setattr(
+        dynamo_wheels,
+        "_describe_file",
+        lambda _path: "ELF 64-bit LSB executable, ARM aarch64",
+    )
+
+    assert dynamo_wheels.detect_target_arch(source_dir, env={}) == "aarch64"
+
+
+def test_download_command_uses_target_arch(tmp_path: Path):
+    """pip download is constrained to the compute architecture."""
+    command = dynamo_wheels.build_download_command(
+        version="1.2.0.dev20260426",
+        wheel_dir=tmp_path,
+        arch="aarch64",
+        python_version="3.12",
+        index_url="https://pypi.org/simple",
+        extra_index_url="https://pypi.nvidia.com",
+    )
+
+    assert "--platform" in command
+    assert "manylinux_2_28_aarch64" in command
+    assert "manylinux2014_aarch64" in command
+    assert "manylinux_2_28_x86_64" not in command
+    assert "--python-version" in command
+    assert "3.12" in command
+
+
+def test_prefetch_does_not_accept_runtime_wheel_for_wrong_arch(monkeypatch, tmp_path: Path):
+    """An existing x86 runtime wheel does not satisfy an aarch64 prefetch."""
+    wheel_dir = tmp_path / "wheels"
+    wheel_dir.mkdir()
+    version = "1.2.0.dev20260426"
+    (wheel_dir / f"ai_dynamo-{version}-py3-none-any.whl").touch()
+    (wheel_dir / f"ai_dynamo_runtime-{version}-cp312-abi3-manylinux_2_28_x86_64.whl").touch()
+
+    calls = []
+
+    def fake_run(command, check):
+        assert check is True
+        calls.append(command)
+        (wheel_dir / f"ai_dynamo_runtime-{version}-cp312-abi3-manylinux_2_28_aarch64.whl").touch()
+
+    monkeypatch.setattr(dynamo_wheels.subprocess, "run", fake_run)
+
+    dynamo_wheels.prefetch(
+        env={
+            "DYNAMO_VERSION": version,
+            "DYNAMO_WHEEL_ARCH": "aarch64",
+            "DYNAMO_WHEEL_HOST_DIR": str(wheel_dir),
+        }
+    )
+
+    assert calls
+    assert "manylinux_2_28_aarch64" in calls[0]
+    assert (wheel_dir / f"ai_dynamo_runtime-{version}-cp312-abi3-manylinux_2_28_aarch64.whl").exists()
+
+
+def test_install_requires_runtime_wheel_for_compute_arch(monkeypatch, tmp_path: Path):
+    """Install rejects a staged runtime wheel for the wrong compute architecture."""
+    wheel_dir = tmp_path / "wheels"
+    wheel_dir.mkdir()
+    version = "1.2.0.dev20260426"
+    (wheel_dir / f"ai_dynamo-{version}-py3-none-any.whl").touch()
+    (wheel_dir / f"ai_dynamo_runtime-{version}-cp312-abi3-manylinux_2_28_x86_64.whl").touch()
+
+    monkeypatch.setattr(dynamo_wheels, "_already_installed", lambda _version: False)
+
+    with pytest.raises(SystemExit, match="aarch64"):
+        dynamo_wheels.install(
+            env={
+                "DYNAMO_VERSION": version,
+                "SRTCTL_COMPUTE_ARCH": "aarch64",
+                "DYNAMO_WHEEL_DIRS": str(wheel_dir),
+            }
+        )


### PR DESCRIPTION
## Summary
- Cherry-pick `f6cc66b3` from `main`: `[codex] Add Dynamo nightly wheel install support (#99)`.
- Adds `dynamo.wheel` config support, wheel prefetch/staging, runtime wheel mounts, and install helpers.
- Resolves the Q2-only frontend conflict by propagating `runtime.environment` without pulling unrelated `main` observability changes.

## Validation
- `uv run pytest tests/test_configs.py tests/test_dynamo_wheels.py -q`
- `make check`

## Notes
- Targets `NVIDIA/srt-slurm:sa-submission-q2-2026`.
- This is a narrow cherry-pick PR, not a merge or rebase of `main`.