### PR TITLE
Add workflow: auto-release on PR merge to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full tag history
+
+      - name: Compute next version
+        id: ver
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Bump from the latest GitHub Release (independent of the in-code version).
+          # First run only (no release yet): seed the start from pyproject.toml.
+          latest=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+          if [ -z "$latest" ]; then
+            next="v$(grep -m1 -E '^version = ' pyproject.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+          else
+            core=${latest#v}; core=${core%%.post*}; core=${core%%-*}
+            IFS='.' read -r major minor patch <<< "$core"
+            next="v${major}.${minor}.$((patch + 1))"
+          fi
+          echo "Latest release: ${latest:-none}  Next: $next"
+          echo "tag=$next" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.ver.outputs.tag }}" \
+            --target "${{ github.event.pull_request.merge_commit_sha }}" \
+            --title "${{ steps.ver.outputs.tag }}" \
+            --generate-notes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Bump from the latest GitHub Release (independent of the in-code version).
-          # First run only (no release yet): seed the start at v1.0.0.
-          latest=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+          # Bump the patch of the HIGHEST existing GitHub Release (independent of
+          # the in-code version). Only the patch increments, so you can publish a
+          # higher major/minor by hand (e.g. v1.1.0) and the next merge continues
+          # from there (-> v1.1.1). First run only (no release yet): seed v1.0.0.
+          latest=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' | sort -V | tail -n1)
           if [ -z "$latest" ]; then
             next="v1.0.0"
           else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,21 +26,29 @@ jobs:
         id: ver
         env:
           GH_TOKEN: ${{ github.token }}
+          # "true" when the merged PR carries the new-feature label -> minor bump.
+          IS_FEATURE: ${{ contains(github.event.pull_request.labels.*.name, 'new-feature') }}
         run: |
           set -euo pipefail
-          # Bump the patch of the HIGHEST existing GitHub Release (independent of
-          # the in-code version). Only the patch increments, so you can publish a
-          # higher major/minor by hand (e.g. v1.1.0) and the next merge continues
-          # from there (-> v1.1.1). First run only (no release yet): seed v1.0.0.
+          # Bump from the HIGHEST existing GitHub Release (independent of the
+          # in-code version). A PR labeled "new-feature" bumps the MINOR and
+          # resets patch (v1.0.5 -> v1.1.0); otherwise the PATCH bumps
+          # (v1.0.5 -> v1.0.6). MAJOR is never bumped automatically -- publish a
+          # higher major by hand and the next merge continues from there.
+          # First run only (no release yet): seed v1.0.0.
           latest=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' | sort -V | tail -n1)
           if [ -z "$latest" ]; then
             next="v1.0.0"
           else
             core=${latest#v}; core=${core%%.post*}; core=${core%%-*}
             IFS='.' read -r major minor patch <<< "$core"
-            next="v${major}.${minor}.$((patch + 1))"
+            if [ "$IS_FEATURE" = "true" ]; then
+              next="v${major}.$((minor + 1)).0"
+            else
+              next="v${major}.${minor}.$((patch + 1))"
+            fi
           fi
-          echo "Latest release: ${latest:-none}  Next: $next"
+          echo "Latest release: ${latest:-none}  new-feature: $IS_FEATURE  Next: $next"
           echo "tag=$next" >> "$GITHUB_OUTPUT"
 
       - name: Create release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,10 +29,10 @@ jobs:
         run: |
           set -euo pipefail
           # Bump from the latest GitHub Release (independent of the in-code version).
-          # First run only (no release yet): seed the start from pyproject.toml.
+          # First run only (no release yet): seed the start at v1.0.0.
           latest=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
           if [ -z "$latest" ]; then
-            next="v$(grep -m1 -E '^version = ' pyproject.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+            next="v1.0.0"
           else
             core=${latest#v}; core=${core%%.post*}; core=${core%%-*}
             IFS='.' read -r major minor patch <<< "$core"


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yaml` — a GitHub Release is created automatically every time a PR is merged into `main`.

## How it works

- **Trigger**: `pull_request` `closed` on `main`, gated by `merged == true` (fires only on real merges, not closed-without-merge or direct pushes).
- **Versioning**: bumps the **highest existing GitHub Release** (selected via `sort -V`), independent of the in-code version:
  - PR labeled **`new-feature`** → **minor** bump, patch reset (`v1.0.5` → `v1.1.0`).
  - Otherwise → **patch** bump (`v1.0.5` → `v1.0.6`).
  - **Major** is never bumped automatically — publish a higher major release by hand and the next merge continues from there.
  - On the **first run only** (no release exists yet) it seeds the start at `v1.0.0`.
  - Basing on *releases* (not git tags) means the existing orphan `v0.5.5.post2` tag is ignored with no special-casing.
- **Release**: `gh release create <tag> --target <merge_commit_sha> --generate-notes` — tags the merge commit and generates notes from the merged PRs.
- **No write-back**: never commits to `main` (so no trigger loop); `pyproject.toml`/`__init__.py` are untouched. Needs only `contents: write`.
- **Concurrency**: a `release` group serializes near-simultaneous merges so they don't race on the same version.

## Version logic (verified locally)

| Highest release | `new-feature` label | Next |
|-----------------|---------------------|------|
| none (first run) | — | `v1.0.0` |
| `v1.0.5` | no | `v1.0.6` |
| `v1.0.9` | no | `v1.0.10` |
| `v1.0.5` | yes | `v1.1.0` |
| `v1.1.3` | yes | `v1.2.0` |

## Validation

- `yaml.safe_load` parses the workflow cleanly.
- Bump arithmetic + `sort -V` selection dry-run under bash across the scenarios above (incl. numeric ordering `v1.0.10 > v1.0.9`, label-driven minor bumps, and the first-run seed).
- Full end-to-end (tag + release creation) can only run in Actions — it will exercise on the first PR merged after this lands, producing `v1.0.0`.

> Note: `actionlint`/`shellcheck` weren't available locally, so those static checks were skipped.
