### PR TITLE
Support to EP sweeps for vLLM

### DIFF
--- a/src/srtctl/core/sweep.py
+++ b/src/srtctl/core/sweep.py
@@ -32,15 +32,12 @@ def expand_template(template: Any, values: dict[str, Any]) -> Any:
         result = template
         for key, value in values.items():
             placeholder = f"{{{key}}}"
-            # Handle list values specially - convert to comma-separated string or keep as list
+            # Preserve non-string values when a YAML value is exactly one placeholder.
+            if placeholder in result and result == placeholder and isinstance(value, (bool, list)):
+                return value
             if isinstance(value, list):
-                # For YAML lists, we want to keep them as lists, not convert to string
-                if placeholder in result and result == placeholder:
-                    # If the entire string is just the placeholder, replace with the list
-                    return value
-                else:
-                    # If it's embedded in a string, convert to comma-separated
-                    result = result.replace(placeholder, ",".join(str(v) for v in value))
+                # If it's embedded in a string, convert to comma-separated.
+                result = result.replace(placeholder, ",".join(str(v) for v in value))
             else:
                 result = result.replace(placeholder, str(value))
         return result

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -36,6 +36,23 @@ class TestExpandTemplate:
         result = expand_template("{val}", {"val": 0.85})
         assert result == "0.85"
 
+    def test_bool_value_as_whole_placeholder(self):
+        """Test that boolean values replace entire placeholder without stringifying."""
+        result = expand_template("{enabled}", {"enabled": True})
+        assert result is True
+
+    def test_bool_value_embedded_in_string(self):
+        """Test that boolean values are stringified when embedded in text."""
+        result = expand_template("enabled-{enabled}", {"enabled": True})
+        assert result == "enabled-True"
+
+    def test_bool_placeholder_becomes_vllm_flag(self):
+        """Test vLLM boolean flags from sweeps don't receive a string value."""
+        from srtctl.backends.vllm import _config_to_cli_args
+
+        config = expand_template({"enable-expert-parallel": "{ep}"}, {"ep": True})
+        assert _config_to_cli_args(config) == ["--enable-expert-parallel"]
+
     def test_nested_dict(self):
         """Test placeholder replacement in nested dicts."""
         template = {


### PR DESCRIPTION
Previously we couldn't sweep EP values [true, false] for vLLM. This PR added the support. 

Address issue: https://github.com/NVIDIA/srt-slurm/issues/186