### PR TITLE
Fix sa-bench missing dependencies

### DIFF
--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -8,24 +8,20 @@
 set -e
 
 # Ensure benchmark dependencies are available.
-# Creates an isolated venv with --system-site-packages so container packages are
-# reused and only missing deps get installed — without touching system Python.
-SA_BENCH_VENV="/tmp/sa-bench-venv"
 SA_BENCH_DEPS=(aiohttp numpy pandas datasets Pillow tqdm transformers huggingface_hub)
 
 ensure_sa_bench_deps() {
-    # Quick check: if all deps import fine in current Python, skip venv entirely
+    # Quick check: if all deps import fine in current Python, skip install entirely.
     if python3 -c "import aiohttp, numpy, pandas, datasets, PIL, tqdm, transformers, huggingface_hub" 2>/dev/null; then
-        echo "All sa-bench deps already available — skipping venv setup"
+        echo "All sa-bench deps already available"
         return
     fi
 
-    echo "Missing sa-bench deps — installing into venv at $SA_BENCH_VENV ..."
-    if [ ! -d "$SA_BENCH_VENV" ]; then
-        python3 -m venv --system-site-packages "$SA_BENCH_VENV"
+    echo "Missing sa-bench deps; installing into current Python environment ..."
+    if ! python3 -m pip install --break-system-packages "${SA_BENCH_DEPS[@]}"; then
+        python3 -m pip install "${SA_BENCH_DEPS[@]}"
     fi
-    source "$SA_BENCH_VENV/bin/activate"
-    pip install "${SA_BENCH_DEPS[@]}"
+    python3 -c "import aiohttp, numpy, pandas, datasets, PIL, tqdm, transformers, huggingface_hub"
     echo "sa-bench deps ready"
 }
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -629,6 +629,13 @@ class TestScriptsExist:
         script = SCRIPTS_DIR / "sa-bench" / "bench.sh"
         assert script.exists()
 
+    def test_sa_bench_deps_do_not_require_venv(self):
+        """SA-Bench dependency install works in containers without python3-venv."""
+        script = SCRIPTS_DIR / "sa-bench" / "bench.sh"
+        text = script.read_text()
+        assert "python3 -m venv" not in text
+        assert "--break-system-packages" in text
+
     def test_mmlu_script_exists(self):
         """MMLU script exists."""
         script = SCRIPTS_DIR / "mmlu" / "bench.sh"


### PR DESCRIPTION
Problem: sa-bench failed because the container did not have ensurepip/python3.12-venv,

log:
```
Missing sa-bench deps — installing into venv at /tmp/sa-bench-venv ...
The virtual environment was not created successfully because ensurepip is not
available.
...
Failing command: /tmp/sa-bench-venv/bin/python3.12
```

Instead of using python3 -m venv. we use python3 -m pip install. 

Address issue: https://github.com/NVIDIA/srt-slurm/issues/188