### PR TITLE
Copy resolved override/zip config into log dir for S3 upload

### DIFF
--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -129,9 +129,15 @@ class PostProcessStageMixin:
         At submit time, config.yaml, sbatch_script.sh, and {job_id}.json are saved
         to outputs/{job_id}/, but S3 syncs outputs/{job_id}/logs/. This copies them
         into logs/ so they get uploaded alongside benchmark results and worker logs.
+
+        Override/zip submissions also write a resolved runtime config next to the
+        source as config_{suffix}.yaml (or config_resolved.yaml). Glob all
+        config*.yaml files so the actually-executed resolved config is uploaded
+        too, not just the unresolved source config.yaml.
         """
         output_dir = self.runtime.log_dir.parent
-        files_to_copy = ["config.yaml", "sbatch_script.sh", f"{self.runtime.job_id}.json", GIT_STATE_FILENAME]
+        config_files = sorted(p.name for p in output_dir.glob("config*.yaml"))
+        files_to_copy = [*config_files, "sbatch_script.sh", f"{self.runtime.job_id}.json", GIT_STATE_FILENAME]
         for name in files_to_copy:
             src = output_dir / name
             if not src.exists():

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -749,6 +749,26 @@ class TestCopyConfigToLogs:
         assert (log_dir / "config.yaml").exists()
         assert (log_dir / "config.yaml").read_text() == "name: test-config\n"
 
+    def test_copies_resolved_override_config(self, tmp_path):
+        """Test resolved override/zip configs (config_{suffix}.yaml) are copied too.
+
+        Override/zip submissions write the unresolved source as config.yaml and the
+        actually-executed resolved variant as config_{suffix}.yaml. Both must reach
+        the log dir so the resolved config is uploaded to S3, not just the source.
+        """
+        mixin, log_dir = self._create_mixin_with_runtime(tmp_path)
+
+        (tmp_path / "config.yaml").write_text("base:\n  name: test\n")
+        (tmp_path / "config_tp_0.yaml").write_text("name: test\ntensor_parallel_size: 4\n")
+        (tmp_path / "config_resolved.yaml").write_text("name: test\nresolved: true\n")
+
+        mixin._copy_config_to_logs()
+
+        assert (log_dir / "config.yaml").exists()
+        assert (log_dir / "config_tp_0.yaml").exists()
+        assert (log_dir / "config_tp_0.yaml").read_text() == "name: test\ntensor_parallel_size: 4\n"
+        assert (log_dir / "config_resolved.yaml").exists()
+
     def test_copies_sbatch_script(self, tmp_path):
         """Test sbatch_script.sh is also copied."""
         mixin, log_dir = self._create_mixin_with_runtime(tmp_path)


### PR DESCRIPTION
The new override/zip config flow writes the unresolved source as config.yaml and the actually-executed resolved variant as config_{suffix}.yaml (or config_resolved.yaml) in the job output dir. _copy_config_to_logs() only copied the hardcoded "config.yaml", so the resolved config that was actually run never made it into logs/ and was absent from the S3 upload, breaking reproducibility.

Glob config*.yaml so every config artifact (source + resolved variants) is copied into the log directory before the S3 sync.