### PR TITLE
Add dynamo request plane tcp/http option

### DIFF
--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -299,6 +299,10 @@ class SGLangProtocol:
             kv_cfg["endpoint"] = f"tcp://*:{process.kv_events_port}"
             cmd.extend(["--kv-events-config", json.dumps(kv_cfg)])
 
+        # Add request plane (dynamo frontend only)
+        if not use_sglang:
+            cmd.extend(["--request-plane", runtime.request_plane])
+
         # Add all config flags
         cmd.extend(_config_to_cli_args(config))
 

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -198,7 +198,7 @@ class TRTLLMProtocol:
                 "--extra-engine-args",
                 str(container_config_path),
                 "--request-plane",
-                "nats",
+                runtime.request_plane,
             ]
         )
 

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -441,6 +441,9 @@ class VLLMProtocol:
             if node_rank > 0:
                 cmd.append("--headless")
 
+        # Add request plane
+        cmd.extend(["--request-plane", runtime.request_plane])
+
         # Add config dump path
         if dump_config_path:
             cmd.extend(["--dump-config-to", str(dump_config_path)])

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -115,7 +115,7 @@ class WorkerStageMixin:
             "ETCD_ENDPOINTS": f"http://{self.runtime.nodes.infra}:2379",
             "NATS_SERVER": f"nats://{self.runtime.nodes.infra}:4222",
             "DYN_SYSTEM_PORT": str(process.sys_port),
-            "DYN_REQUEST_PLANE": "nats",
+            "DYN_REQUEST_PLANE": self.config.dynamo.request_plane,
         }
 
         # Add mode-specific environment variables from backend

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -120,6 +120,9 @@ class RuntimeContext:
     # Frontend port (for benchmark endpoint)
     frontend_port: int = 8000
 
+    # Request plane for dynamo workers
+    request_plane: str = "nats"
+
     @classmethod
     def from_config(
         cls,
@@ -257,6 +260,7 @@ class RuntimeContext:
             srun_options=dict(config.srun_options),
             environment=dict(config.environment),
             is_hf_model=is_hf_model,
+            request_plane=config.dynamo.request_plane,
         )
 
         # Expand FormattablePath mounts
@@ -280,6 +284,7 @@ class RuntimeContext:
             srun_options=dict(config.srun_options),
             environment=dict(config.environment),
             is_hf_model=is_hf_model,
+            request_plane=config.dynamo.request_plane,
         )
 
     def format_string(self, template: str, **extra_kwargs) -> str:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -694,14 +694,19 @@ class DynamoConfig:
         version: Install specific version from PyPI (e.g., "0.8.0")
         hash: Clone repo and checkout specific commit hash
         top_of_tree: Clone repo at HEAD (latest)
+        wheel: Install from a pre-built wheel file
+        request_plane: Request plane to use (default: "nats"). Valid values: "nats", "tcp", "http"
 
     If top_of_tree or hash is set, version is automatically cleared.
     """
+
+    _VALID_REQUEST_PLANES: ClassVar[tuple[str, ...]] = ("nats", "tcp", "http")
 
     install: bool = True
     version: str | None = "0.8.0"
     hash: str | None = None
     top_of_tree: bool = False
+    request_plane: str = "nats"
 
     def __post_init__(self) -> None:
         # Auto-clear version if hash or top_of_tree is set
@@ -711,6 +716,11 @@ class DynamoConfig:
         # Validate only one source option is set
         if self.hash is not None and self.top_of_tree:
             raise ValueError("Cannot specify both hash and top_of_tree")
+
+        if self.request_plane not in self._VALID_REQUEST_PLANES:
+            raise ValueError(
+                f"Invalid request_plane '{self.request_plane}', must be one of: {', '.join(self._VALID_REQUEST_PLANES)}"
+            )
 
     @property
     def needs_source_install(self) -> bool:

--- a/src/srtctl/frontends/dynamo.py
+++ b/src/srtctl/frontends/dynamo.py
@@ -80,7 +80,7 @@ class DynamoFrontend:
             env_to_set = {
                 "ETCD_ENDPOINTS": f"http://{runtime.nodes.infra}:2379",
                 "NATS_SERVER": f"nats://{runtime.nodes.infra}:4222",
-                "DYN_REQUEST_PLANE": "nats",
+                "DYN_REQUEST_PLANE": config.dynamo.request_plane,
             }
 
             # Add frontend env from config

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -156,6 +156,34 @@ class TestDynamoConfig:
         with pytest.raises(ValueError, match="Cannot specify both"):
             DynamoConfig(hash="abc123", top_of_tree=True)
 
+    def test_request_plane_default_nats(self):
+        """Default request_plane is 'nats'."""
+        from srtctl.core.schema import DynamoConfig
+
+        config = DynamoConfig()
+        assert config.request_plane == "nats"
+
+    def test_request_plane_tcp(self):
+        """request_plane='tcp' is accepted."""
+        from srtctl.core.schema import DynamoConfig
+
+        config = DynamoConfig(request_plane="tcp")
+        assert config.request_plane == "tcp"
+
+    def test_request_plane_http(self):
+        """request_plane='http' is accepted."""
+        from srtctl.core.schema import DynamoConfig
+
+        config = DynamoConfig(request_plane="http")
+        assert config.request_plane == "http"
+
+    def test_request_plane_invalid(self):
+        """Invalid request_plane raises ValueError."""
+        from srtctl.core.schema import DynamoConfig
+
+        with pytest.raises(ValueError, match="Invalid request_plane"):
+            DynamoConfig(request_plane="grpc")
+
 
 class TestSGLangProtocol:
     """Tests for SGLangProtocol."""


### PR DESCRIPTION
## Summary

- Adds a configurable `request_plane` field to `DynamoConfig` (valid values: `"nats"`, `"tcp"`, `"http"`; default: `"nats"`)
- Propagates the configured value through `RuntimeContext` and into all three backends (SGLang, TRTLLM, vLLM) and both the worker environment (`DYN_REQUEST_PLANE`) and dynamo frontend
- Replaces every hardcoded `"nats"` reference with the runtime-resolved value

## Motivation

The request plane was previously hardcoded to `"nats"` in four separate places. Supporting `tcp` and `http` request planes (e.g. for environments without a NATS broker) required no code path — only a config field and plumbing.

## Usage

```yaml
dynamo:
  request_plane: tcp   # or "nats" (default) or "http"