### PR TITLE
Add numa memory bind in trtllm disagg by default

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -178,7 +178,12 @@ class TRTLLMProtocol:
         container_config_path = Path("/logs") / config_filename
         container_model_path = Path("/model")
 
+        numactl_prefix = (
+            ["numactl", "-m", "0,1"] if runtime.gpu_type in ("gb200", "gb300") and mode in ("prefill", "decode") else []
+        )
+
         cmd = [
+            *numactl_prefix,
             "trtllm-llmapi-launch",
             "python3",
             "-m",

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -123,6 +123,9 @@ class RuntimeContext:
     # Request plane for dynamo workers
     request_plane: str = "nats"
 
+    # GPU type (e.g. "gb200", "gb300", "h100")
+    gpu_type: str = ""
+
     @classmethod
     def from_config(
         cls,
@@ -261,6 +264,7 @@ class RuntimeContext:
             environment=dict(config.environment),
             is_hf_model=is_hf_model,
             request_plane=config.dynamo.request_plane,
+            gpu_type=config.resources.gpu_type,
         )
 
         # Expand FormattablePath mounts
@@ -285,6 +289,7 @@ class RuntimeContext:
             environment=dict(config.environment),
             is_hf_model=is_hf_model,
             request_plane=config.dynamo.request_plane,
+            gpu_type=config.resources.gpu_type,
         )
 
     def format_string(self, template: str, **extra_kwargs) -> str:


### PR DESCRIPTION
## Summary

- Adds `gpu_type` field to `RuntimeContext`, propagated from `config.resources.gpu_type`
- Prefixes TRTLLM worker commands with `numactl -m 0,1` when both conditions are met:
  - `gpu_type` is `"gb200"` or `"gb300"`
  - worker mode is `"prefill"` or `"decode"` (disaggregated only — skipped for aggregated)

## Motivation

GB200/GB300 NVLink-Switch systems have a split NUMA topology. Without explicit NUMA binding, TRTLLM worker processes may allocate memory across NUMA nodes, causing remote memory access latency. Binding to nodes 0 and 1 keeps allocations local to the correct socket.

This only applies to disaggregated prefill/decode workers — aggregated mode does not benefit from the same binding and is excluded.

## Changes

| File | Change |
|------|--------|
| `core/runtime.py` | Add `gpu_type: str = ""` field to `RuntimeContext`; populate from `config.resources.gpu_type` in both `from_config()` construction sites |
| `backends/trtllm.py` | Prepend `numactl -m 0,1` to the worker command when `gpu_type in ("gb200", "gb300")` and `mode in ("prefill", "decode")` |
