### PR TITLE
Fix release workflow 403 by using pull_request_target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,12 @@
 name: Release
 
+# pull_request_target (not pull_request): on a fork-PR merge, the plain
+# pull_request token is forced read-only and ignores `permissions:`, so
+# `gh release create` 403s. pull_request_target runs in the base-repo context
+# with a write-capable token. Safe here: we never check out or run PR code,
+# only call the GitHub API.
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
 


### PR DESCRIPTION
## Problem

The `Release` workflow added in #185 failed on its first run ([run 26985800473](https://github.com/NVIDIA/srt-slurm/actions/runs/26985800473)). The `Checkout` step succeeded — the failure was in `Create release`:

```
HTTP 403: Resource not accessible by integration (.../repos/NVIDIA/srt-slurm/releases)
```

Root cause is in the run header:

```
GITHUB_TOKEN Permissions
  Contents: read     ← workflow declared contents: write, but got read
```

That run was a **fork-PR merge**. For `pull_request` events whose head is a fork, GitHub forces `GITHUB_TOKEN` to **read-only** and ignores the workflow's `permissions: contents: write` block (security measure). So `gh release create` was denied.

## Fix

Switch the trigger from `pull_request` → **`pull_request_target`**:

```diff
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
```

`pull_request_target` runs in the **base-repo context** with a write-capable token that honors `permissions: contents: write`, even when the merged PR came from a fork.

- The PR payload is still available, so the `new-feature` minor-bump logic (`github.event.pull_request.labels`) and `merge_commit_sha` are unchanged.
- **Safe**: this workflow never checks out or executes PR-provided code — it only calls the GitHub API (`gh release list` / `gh release create`) and does shell arithmetic. The usual `pull_request_target` risk (running untrusted code with an elevated token) does not apply.

No other logic changed. `actions/checkout@v4` is left as-is (it was never the problem and matches the other workflows).

## Validation

- `yaml.safe_load` parses the workflow cleanly.
- The 403 was reproduced/confirmed from the failed run logs above; this trigger change is the documented remedy for write access on (fork) PR-merge events.
- Full end-to-end can only run once merged — the next PR merged to `main` after this lands should create `v1.0.0`.
