### PR TITLE
Accept remote telemetry container aliases in preflight

### DIFF
--- a/src/srtctl/core/validation.py
+++ b/src/srtctl/core/validation.py
@@ -92,6 +92,10 @@ def _check_path(path_str: str, *, expect: str) -> tuple[bool, str]:
     return True, f"exists: {path}"
 
 
+def _is_container_uri(value: Any) -> bool:
+    return isinstance(value, str) and not value.startswith(("/", "./")) and ":" in value
+
+
 def _preflight_model(
     raw_config: dict[str, Any],
     resolved_config: dict[str, Any],
@@ -299,6 +303,9 @@ def _preflight_telemetry(
             raw_value = (raw_value or {}).get(key) if isinstance(raw_value, dict) else None
         if not resolved_value:
             continue  # schema-level validator handles required-when-enabled
+
+        if _is_container_uri(resolved_value):
+            continue
 
         ok, _ = _check_path(_expand_path(resolved_value), expect="file")
         if ok:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -506,6 +506,41 @@ class TestPreflightConfigVariants:
         assert results[0].ok is True
         assert results[0].errors == []
 
+    def test_telemetry_accepts_alias_resolving_to_remote_image(self, tmp_path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        container_file = tmp_path / "container.sqsh"
+        container_file.write_text("sqsh")
+        scraper_file = tmp_path / "scraper.sqsh"
+        scraper_file.write_text("sqsh")
+        node_file = tmp_path / "node.sqsh"
+        node_file.write_text("sqsh")
+
+        results = preflight_config_variants(
+            {
+                "name": "telemetry-remote-image",
+                "model": {"path": str(model_dir), "container": str(container_file), "precision": "bf16"},
+                "resources": {
+                    "gpu_type": "gb200",
+                    "gpus_per_node": 4,
+                    "prefill_nodes": 1,
+                    "decode_nodes": 1,
+                    "prefill_workers": 1,
+                    "decode_workers": 1,
+                },
+                "telemetry": {
+                    "enabled": True,
+                    "container_image": str(scraper_file),
+                    "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},
+                    "node_exporter": {"container_image": str(node_file), "port": 9101},
+                },
+            },
+            cluster_config={"containers": {"dcgm-exporter": "nvcr.io/nvidia/k8s/dcgm-exporter:latest"}},
+        )
+
+        assert results[0].ok is True
+        assert results[0].errors == []
+
     def test_telemetry_missing_sqsh_fails_preflight(self, tmp_path):
         model_dir = tmp_path / "model"
         model_dir.mkdir()


### PR DESCRIPTION
## Summary
- treat URI-shaped telemetry container images as valid during preflight
- allow telemetry container aliases from `srtslurm.yaml containers` to resolve to remote images
- add regression coverage for a DCGM exporter alias resolving to an `nvcr.io` image

## Why
Telemetry container fields are resolved through the same `containers` map as model containers, but telemetry preflight always checked the resolved value as a local file. That rejected remote image aliases even though they are still container images that can be pulled by the runtime container support.

## Test plan
- `PYTHONPATH=src uv run --no-project --with pytest --with pyyaml --with jinja2 --with marshmallow --with marshmallow-dataclass --with requests --with rich --with questionary --with ruamel.yaml --with pydantic --with mcp --with matplotlib -- python -m pytest tests/test_validation.py -v`
- `uv run --no-project --with ruff -- ruff check src/srtctl/core/validation.py tests/test_validation.py`