### PR TITLE
Fix the dsr1 accuracy issue with the latest dynamo + trtllm v1.3.0rc17 release 

### DIFF
--- a/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx10_gen1_dep16_batch64_eplb0_mtp1_1229.yaml
+++ b/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx10_gen1_dep16_batch64_eplb0_mtp1_1229.yaml
@@ -37,8 +37,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     ENROOT_ALLOW_DEV: "yes"
     NCCL_GRAPH_MIXING_SUPPORT: "0"
-    TRTLLM_FORCE_COMM_METHOD: "NVLINK_TWO_SIDED"
-    ENABLE_CONFIGURABLE_MOE: "1"
 
   trtllm_config:
     prefill:
@@ -53,7 +51,7 @@ backend:
         enable_block_reuse: false
         free_gpu_memory_fraction: 0.1
       max_batch_size: 2
-      max_num_tokens: 16384
+      max_num_tokens: 8232
       max_seq_len: 8232
       moe_config:
         backend: DEEPGEMM

--- a/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx1_gen4_tep8_batch1_eplb0_mtp3_8.yaml
+++ b/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx1_gen4_tep8_batch1_eplb0_mtp3_8.yaml
@@ -37,8 +37,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     ENROOT_ALLOW_DEV: "yes"
     NCCL_GRAPH_MIXING_SUPPORT: "0"
-    TRTLLM_FORCE_COMM_METHOD: "NVLINK_TWO_SIDED"
-    ENABLE_CONFIGURABLE_MOE: "1"
 
   trtllm_config:
     prefill:
@@ -53,7 +51,7 @@ backend:
         enable_block_reuse: false
         free_gpu_memory_fraction: 0.1
       max_batch_size: 2
-      max_num_tokens: 16384
+      max_num_tokens: 8232
       max_seq_len: 8232
       moe_config:
         backend: DEEPGEMM

--- a/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx1_gen4_tep8_batch4_eplb0_mtp3_24.yaml
+++ b/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx1_gen4_tep8_batch4_eplb0_mtp3_24.yaml
@@ -37,8 +37,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     ENROOT_ALLOW_DEV: "yes"
     NCCL_GRAPH_MIXING_SUPPORT: "0"
-    TRTLLM_FORCE_COMM_METHOD: "NVLINK_TWO_SIDED"
-    ENABLE_CONFIGURABLE_MOE: "1"
 
   trtllm_config:
     prefill:
@@ -53,7 +51,7 @@ backend:
         enable_block_reuse: false
         free_gpu_memory_fraction: 0.1
       max_batch_size: 2
-      max_num_tokens: 16384
+      max_num_tokens: 8232
       max_seq_len: 8232
       moe_config:
         backend: DEEPGEMM

--- a/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx6_gen1_dep32_batch8_eplb0_mtp3_333.yaml
+++ b/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx6_gen1_dep32_batch8_eplb0_mtp3_333.yaml
@@ -37,8 +37,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     ENROOT_ALLOW_DEV: "yes"
     NCCL_GRAPH_MIXING_SUPPORT: "0"
-    TRTLLM_FORCE_COMM_METHOD: "NVLINK_TWO_SIDED"
-    ENABLE_CONFIGURABLE_MOE: "1"
 
   trtllm_config:
     prefill:
@@ -53,7 +51,7 @@ backend:
         enable_block_reuse: false
         free_gpu_memory_fraction: 0.1
       max_batch_size: 2
-      max_num_tokens: 16384
+      max_num_tokens: 8232
       max_seq_len: 8232
       moe_config:
         backend: DEEPGEMM

--- a/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx7_gen1_dep8_batch128_eplb0_mtp1_1229.yaml
+++ b/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx7_gen1_dep8_batch128_eplb0_mtp1_1229.yaml
@@ -37,8 +37,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     ENROOT_ALLOW_DEV: "yes"
     NCCL_GRAPH_MIXING_SUPPORT: "0"
-    TRTLLM_FORCE_COMM_METHOD: "NVLINK_TWO_SIDED"
-    ENABLE_CONFIGURABLE_MOE: "1"
 
   trtllm_config:
     prefill:
@@ -53,7 +51,7 @@ backend:
         enable_block_reuse: false
         free_gpu_memory_fraction: 0.1
       max_batch_size: 2
-      max_num_tokens: 16384
+      max_num_tokens: 8232
       max_seq_len: 8232
       moe_config:
         backend: DEEPGEMM

--- a/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx8_gen1_dep16_batch32_eplb0_mtp3_666.yaml
+++ b/recipes/trtllm/gb300-fp8/8k1k/mtp/ctx8_gen1_dep16_batch32_eplb0_mtp3_666.yaml
@@ -37,8 +37,6 @@ backend:
     TRTLLM_ENABLE_PDL: "1"
     ENROOT_ALLOW_DEV: "yes"
     NCCL_GRAPH_MIXING_SUPPORT: "0"
-    TRTLLM_FORCE_COMM_METHOD: "NVLINK_TWO_SIDED"
-    ENABLE_CONFIGURABLE_MOE: "1"
 
   trtllm_config:
     prefill:
@@ -53,7 +51,7 @@ backend:
         enable_block_reuse: false
         free_gpu_memory_fraction: 0.1
       max_batch_size: 2
-      max_num_tokens: 16384
+      max_num_tokens: 8232
       max_seq_len: 8232
       moe_config:
         backend: DEEPGEMM


### PR DESCRIPTION
1. pin max_num_tokens to 8k to avoid the DEEPDEMM OOM issue
2. remove the TRTLLM_FORCE_COMM_METHOD: "NVLINK_TWO_SIDED" and ENABLE_CONFIGURABLE_MOE: "1" to fix the known accuracy issue with the MOE. 

The image need to be pinned to `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13` to run the workload