### PR TITLE
Preserve sweep placeholder value types

### DIFF
--- a/src/srtctl/core/sweep.py
+++ b/src/srtctl/core/sweep.py
@@ -32,13 +32,12 @@ def expand_template(template: Any, values: dict[str, Any]) -> Any:
         result = template
         for key, value in values.items():
             placeholder = f"{{{key}}}"
+            if result == placeholder:
+                return value
             # Handle list values specially - convert to comma-separated string or keep as list
             if isinstance(value, list):
                 # For YAML lists, we want to keep them as lists, not convert to string
-                if placeholder in result and result == placeholder:
-                    # If the entire string is just the placeholder, replace with the list
-                    return value
-                else:
+                if placeholder in result:
                     # If it's embedded in a string, convert to comma-separated
                     result = result.replace(placeholder, ",".join(str(v) for v in value))
             else:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1938,6 +1938,8 @@ class TestVLLMDataParallelMode:
         assert "13345" in cmd
         assert "--data-parallel-size" in cmd
         assert "16" in cmd
+        expert_parallel_idx = cmd.index("--enable-expert-parallel")
+        assert expert_parallel_idx == len(cmd) - 1 or cmd[expert_parallel_idx + 1].startswith("--")
 
         # Should NOT include TP multi-node flags
         assert "--master-addr" not in cmd

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -27,14 +27,19 @@ class TestExpandTemplate:
         assert result == "x-y"
 
     def test_numeric_value(self):
-        """Test that numeric values are converted to strings."""
+        """Test that numeric whole-placeholder values preserve their type."""
         result = expand_template("{num}", {"num": 42})
-        assert result == "42"
+        assert result == 42
 
     def test_float_value(self):
-        """Test float value conversion."""
+        """Test that float whole-placeholder values preserve their type."""
         result = expand_template("{val}", {"val": 0.85})
-        assert result == "0.85"
+        assert result == 0.85
+
+    def test_bool_value_as_whole_placeholder(self):
+        """Test that boolean whole-placeholder values preserve their type."""
+        assert expand_template("{enabled}", {"enabled": True}) is True
+        assert expand_template("{enabled}", {"enabled": False}) is False
 
     def test_nested_dict(self):
         """Test placeholder replacement in nested dicts."""
@@ -73,7 +78,7 @@ class TestExpandTemplate:
         assert result["level1"]["level2"]["value"] == "c"
 
     def test_list_value_as_whole_placeholder(self):
-        """Test that list values replace entire placeholder."""
+        """Test that list whole-placeholder values preserve their type."""
         result = expand_template("{items}", {"items": [1, 2, 3]})
         assert result == [1, 2, 3]
 
@@ -278,12 +283,12 @@ class TestGenerateSweepConfigs:
         }
         results = generate_sweep_configs(config)
 
-        # Check that values are substituted (note: they become strings)
+        # Check that whole-placeholder values are substituted with their original types.
         config1 = results[0][0]
         config2 = results[1][0]
 
         prefill1 = config1["backend"]["sglang_config"]["prefill"]
         prefill2 = config2["backend"]["sglang_config"]["prefill"]
 
-        assert prefill1["mem-fraction-static"] == "0.85"
-        assert prefill2["mem-fraction-static"] == "0.9"
+        assert prefill1["mem-fraction-static"] == 0.85
+        assert prefill2["mem-fraction-static"] == 0.9


### PR DESCRIPTION
## Summary

Preserve the original type when a sweep placeholder is the entire config value, instead of stringifying booleans and numbers. This lets vLLM boolean flags such as `enable-expert-parallel: "{ep}"` expand to real booleans, so `True` emits `--enable-expert-parallel` without an extra positional value and `False` omits the flag.

Fixes #186.

## Tests

- `uv run pytest tests/test_sweep.py tests/test_configs.py::TestVLLMDataParallelMode::test_dp_mode_command_includes_dp_flags -q`
- `uv run ruff check src/srtctl/core/sweep.py tests/test_sweep.py tests/test_configs.py`
- `uv run pytest tests -q`