### PR TITLE
Add MiniMax-M2.7-NVFP4 disagg trtllm_dynamo recipes (GB300, 1K/1K)

### DIFF
--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep4_batch1024_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep4_batch1024_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,247 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_1_fp4_1_1_false_4_4_true_CUTEDSL_1024_1k_1k_1989238
+# ctx=1 gen=1 prefill_tp/ep=1/1 decode_tp/ep=4/4 moe=cutedsl conc=1024 batch=1024
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen1dep4_batch1024_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 1
+  decode_workers: 1
+  gpus_per_decode: 4
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 1024
+      max_batch_size: 1024
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1024'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep4_batch2048_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep4_batch2048_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,263 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_1_fp4_1_1_false_4_4_true_CUTEDSL_2048_1k_1k_1989239
+# ctx=1 gen=1 prefill_tp/ep=1/1 decode_tp/ep=4/4 moe=cutedsl conc=2048 batch=2048
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen1dep4_batch2048_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 1
+  decode_workers: 1
+  gpus_per_decode: 4
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+        - 1088
+        - 1152
+        - 1216
+        - 1280
+        - 1344
+        - 1408
+        - 1472
+        - 1536
+        - 1600
+        - 1664
+        - 1728
+        - 1792
+        - 1856
+        - 1920
+        - 1984
+        - 2048
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 2048
+      max_batch_size: 2048
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '2048'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep4_batch4096_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep4_batch4096_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,295 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_1_fp4_1_1_false_4_4_true_CUTEDSL_4096_1k_1k_1947261
+# ctx=1 gen=1 prefill_tp/ep=1/1 decode_tp/ep=4/4 moe=cutedsl conc=4096 batch=4096
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen1dep4_batch4096_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 1
+  decode_workers: 1
+  gpus_per_decode: 4
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+        - 1088
+        - 1152
+        - 1216
+        - 1280
+        - 1344
+        - 1408
+        - 1472
+        - 1536
+        - 1600
+        - 1664
+        - 1728
+        - 1792
+        - 1856
+        - 1920
+        - 1984
+        - 2048
+        - 2112
+        - 2176
+        - 2240
+        - 2304
+        - 2368
+        - 2432
+        - 2496
+        - 2560
+        - 2624
+        - 2688
+        - 2752
+        - 2816
+        - 2880
+        - 2944
+        - 3008
+        - 3072
+        - 3136
+        - 3200
+        - 3264
+        - 3328
+        - 3392
+        - 3456
+        - 3520
+        - 3584
+        - 3648
+        - 3712
+        - 3776
+        - 3840
+        - 3904
+        - 3968
+        - 4032
+        - 4096
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 4096
+      max_batch_size: 4096
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '4096'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep4_batch4096_trtllm_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep4_batch4096_trtllm_eplb0_mtp0.yaml
@@ -1,0 +1,281 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_1_fp4_1_1_false_4_4_true_TRTLLM_4096_1k_1k_1921669
+# ctx=1 gen=1 prefill_tp/ep=1/1 decode_tp/ep=4/4 moe=trtllm conc=4096 batch=4096
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen1dep4_batch4096_trtllm_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 1
+  decode_workers: 1
+  gpus_per_decode: 4
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+        - 1088
+        - 1152
+        - 1216
+        - 1280
+        - 1344
+        - 1408
+        - 1472
+        - 1536
+        - 1600
+        - 1664
+        - 1728
+        - 1792
+        - 1856
+        - 1920
+        - 1984
+        - 2048
+        - 2112
+        - 2176
+        - 2240
+        - 2304
+        - 2368
+        - 2432
+        - 2496
+        - 2560
+        - 2624
+        - 2688
+        - 2752
+        - 2816
+        - 2880
+        - 2944
+        - 3008
+        - 3072
+        - 3136
+        - 3200
+        - 3264
+        - 3328
+        - 3392
+        - 3456
+        - 3520
+        - 3584
+        - 3648
+        - 3712
+        - 3776
+        - 3840
+        - 3904
+        - 3968
+        - 4032
+        - 4096
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 4096
+      max_batch_size: 4096
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '4096'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep8_batch1024_trtllm_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep8_batch1024_trtllm_eplb0_mtp0.yaml
@@ -1,0 +1,233 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_1_fp4_1_1_false_8_8_true_TRTLLM_1024_1k_1k_1921670
+# ctx=1 gen=1 prefill_tp/ep=1/1 decode_tp/ep=8/8 moe=trtllm conc=1024 batch=1024
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen1dep8_batch1024_trtllm_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 1024
+      max_batch_size: 1024
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1024'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep8_batch512_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen1dep8_batch512_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,235 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_1_fp4_1_1_false_8_8_true_CUTEDSL_512_1k_1k_1989242
+# ctx=1 gen=1 prefill_tp/ep=1/1 decode_tp/ep=8/8 moe=cutedsl conc=512 batch=512
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen1dep8_batch512_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 512
+      max_batch_size: 512
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '512'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen2dep16_batch512_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen2dep16_batch512_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,235 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_2_fp4_1_1_false_16_16_true_CUTEDSL_512_1k_1k_1989244
+# ctx=1 gen=2 prefill_tp/ep=1/1 decode_tp/ep=16/16 moe=cutedsl conc=512 batch=512
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen2dep16_batch512_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 8
+  decode_workers: 2
+  gpus_per_decode: 16
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 512
+      max_batch_size: 512
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 16
+      moe_expert_parallel_size: 16
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '512'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen2dep8_batch1024_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen2dep8_batch1024_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,247 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_2_fp4_1_1_false_8_8_true_CUTEDSL_1024_1k_1k_1989249
+# ctx=1 gen=2 prefill_tp/ep=1/1 decode_tp/ep=8/8 moe=cutedsl conc=1024 batch=1024
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen2dep8_batch1024_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 4
+  decode_workers: 2
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 1024
+      max_batch_size: 1024
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1024'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen2dep8_batch512_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen2dep8_batch512_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,235 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_2_fp4_1_1_false_8_8_true_CUTEDSL_512_1k_1k_1947341
+# ctx=1 gen=2 prefill_tp/ep=1/1 decode_tp/ep=8/8 moe=cutedsl conc=512 batch=512
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen2dep8_batch512_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 4
+  decode_workers: 2
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 512
+      max_batch_size: 512
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '512'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen2dep8_batch512_trtllm_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen2dep8_batch512_trtllm_eplb0_mtp0.yaml
@@ -1,0 +1,210 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_2_fp4_1_1_false_8_8_true_TRTLLM_512_1k_1k_1966534
+# ctx=1 gen=2 prefill_tp/ep=1/1 decode_tp/ep=8/8 moe=trtllm conc=512 batch=512
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen2dep8_batch512_trtllm_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 4
+  decode_workers: 2
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 1024
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 512
+      max_batch_size: 512
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '512'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen3dep8_batch1024_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen3dep8_batch1024_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,247 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_3_fp4_1_1_false_8_8_true_CUTEDSL_1024_1k_1k_1989261
+# ctx=1 gen=3 prefill_tp/ep=1/1 decode_tp/ep=8/8 moe=cutedsl conc=1024 batch=1024
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen3dep8_batch1024_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 6
+  decode_workers: 3
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 1024
+      max_batch_size: 1024
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1024'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen3tep4_batch1024_trtllm_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen3tep4_batch1024_trtllm_eplb0_mtp0.yaml
@@ -1,0 +1,222 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_3_fp4_1_1_false_4_4_false_TRTLLM_1024_1k_1k_1966538
+# ctx=1 gen=3 prefill_tp/ep=1/1 decode_tp/ep=4/4 moe=trtllm conc=1024 batch=1024
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen3tep4_batch1024_trtllm_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 3
+  decode_workers: 3
+  gpus_per_decode: 4
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 1024
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: false
+      print_iter_log: true
+      max_num_tokens: 1024
+      max_batch_size: 1024
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 4
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1024'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen4tp4ep2_batch128_trtllm_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen4tp4ep2_batch128_trtllm_eplb0_mtp0.yaml
@@ -1,0 +1,189 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_4_fp4_1_1_false_4_2_false_TRTLLM_128_1k_1k_1921675
+# ctx=1 gen=4 prefill_tp/ep=1/1 decode_tp/ep=4/2 moe=trtllm conc=128 batch=128
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen4tp4ep2_batch128_trtllm_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 4
+  decode_workers: 4
+  gpus_per_decode: 4
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: false
+      print_iter_log: true
+      max_num_tokens: 128
+      max_batch_size: 128
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 2
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '128'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen8tp1_batch16_trtllm_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen8tp1_batch16_trtllm_eplb0_mtp0.yaml
@@ -1,0 +1,164 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_8_fp4_1_1_false_1_1_false_TRTLLM_16_1k_1k_1966544
+# ctx=1 gen=8 prefill_tp/ep=1/1 decode_tp/ep=1/1 moe=trtllm conc=16 batch=16
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen8tp1_batch16_trtllm_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 8
+  decode_workers: 8
+  gpus_per_decode: 1
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 1024
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: false
+      print_iter_log: true
+      max_num_tokens: 16
+      max_batch_size: 16
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '16'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen8tp1_batch8_trtllm_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen8tp1_batch8_trtllm_eplb0_mtp0.yaml
@@ -1,0 +1,158 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_8_fp4_1_1_false_1_1_false_TRTLLM_8_1k_1k_1921677
+# ctx=1 gen=8 prefill_tp/ep=1/1 decode_tp/ep=1/1 moe=trtllm conc=8 batch=8
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen8tp1_batch8_trtllm_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 8
+  decode_workers: 8
+  gpus_per_decode: 1
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: false
+      print_iter_log: true
+      max_num_tokens: 8
+      max_batch_size: 8
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '8'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen8tp4_batch128_trtllm_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp1_gen8tp4_batch128_trtllm_eplb0_mtp0.yaml
@@ -1,0 +1,189 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_8_fp4_1_1_false_4_1_false_TRTLLM_128_1k_1k_1921679
+# ctx=1 gen=8 prefill_tp/ep=1/1 decode_tp/ep=4/1 moe=trtllm conc=128 batch=128
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp1_gen8tp4_batch128_trtllm_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 1
+  decode_nodes: 8
+  decode_workers: 8
+  gpus_per_decode: 4
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      tensor_parallel_size: 1
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+      moe_config:
+        backend: TRTLLM
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: false
+      print_iter_log: true
+      max_num_tokens: 128
+      max_batch_size: 128
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      tensor_parallel_size: 4
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '128'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'

--- a/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp2_gen2dep8_batch1024_cutedsl_eplb0_mtp0.yaml
+++ b/recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/ctx1tp2_gen2dep8_batch1024_cutedsl_eplb0_mtp0.yaml
@@ -1,0 +1,247 @@
+# MiniMax-M2.7-NVFP4 dynamo.trtllm disagg, GB300, ISL/OSL 1k/1k.
+# Faithful translation of pcicotti trtllm-serve config: d_1_2_fp4_2_1_false_8_8_true_CUTEDSL_1024_1k_1k_1989254
+# ctx=1 gen=2 prefill_tp/ep=2/1 decode_tp/ep=8/8 moe=cutedsl conc=1024 batch=1024
+name: minimax_m27_nvfp4_ISL1K_OSL1K_ctx1tp2_gen2dep8_batch1024_cutedsl_eplb0_mtp0
+model:
+  path: nvidia/MiniMax-M2.7-NVFP4
+  container: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13
+  precision: fp4
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  gpus_per_prefill: 2
+  decode_nodes: 4
+  decode_workers: 2
+  gpus_per_decode: 8
+backend:
+  type: trtllm
+  prefill_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  decode_environment:
+    ENROOT_ALLOW_DEV: 'yes'
+    PYTHONUNBUFFERED: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TLLM_LOG_LEVEL: INFO
+    TRTLLM_ENABLE_PDL: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_SERVER_DISABLE_GC: '1'
+  trtllm_config:
+    prefill:
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      disable_overlap_scheduler: true
+      torch_compile_config:
+        capture_num_tokens:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 48
+        - 64
+        - 96
+        - 128
+        - 192
+        - 256
+        - 384
+        - 512
+        - 768
+        - 1024
+        - 1152
+        - 1280
+        - 1408
+        - 1536
+        - 1664
+        - 1792
+        - 1920
+        - 2048
+        - 2304
+        - 2560
+        - 2816
+        - 3072
+        - 3328
+        - 3584
+        - 3840
+        - 4096
+        - 4608
+        - 5120
+        - 5632
+        - 6144
+        - 6656
+        - 7168
+        - 7680
+        - 8192
+        - 8704
+        - 9216
+        - 9728
+        - 10240
+        - 10752
+        - 11264
+        - 11776
+        - 12288
+        - 12800
+        - 13312
+        - 13824
+        - 14336
+        - 14848
+        - 15360
+        - 15872
+        - 16384
+        enable_piecewise_cuda_graph: true
+      enable_attention_dp: false
+      max_num_tokens: 16384
+      max_seq_len: 2048
+      print_iter_log: true
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+        context_chunking_policy: FIRST_COME_FIRST_SERVED
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 2
+      moe_expert_parallel_size: 1
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+    decode:
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 12
+        - 16
+        - 24
+        - 32
+        - 40
+        - 48
+        - 56
+        - 64
+        - 72
+        - 80
+        - 88
+        - 96
+        - 104
+        - 112
+        - 120
+        - 128
+        - 136
+        - 144
+        - 152
+        - 160
+        - 168
+        - 176
+        - 184
+        - 192
+        - 200
+        - 208
+        - 216
+        - 224
+        - 232
+        - 240
+        - 248
+        - 256
+        - 272
+        - 288
+        - 304
+        - 320
+        - 336
+        - 352
+        - 368
+        - 384
+        - 400
+        - 416
+        - 432
+        - 448
+        - 464
+        - 480
+        - 496
+        - 512
+        - 544
+        - 576
+        - 608
+        - 640
+        - 672
+        - 704
+        - 736
+        - 768
+        - 832
+        - 896
+        - 960
+        - 1024
+      moe_config:
+        backend: CUTEDSL
+        use_low_precision_moe_combine: true
+      kv_cache_config:
+        enable_block_reuse: false
+        free_gpu_memory_fraction: 0.9
+        dtype: fp8
+      cache_transceiver_config:
+        backend: UCX
+        max_tokens_in_buffer: 1024
+        kv_transfer_timeout_ms: 300000
+      enable_attention_dp: true
+      print_iter_log: true
+      max_num_tokens: 1024
+      max_batch_size: 1024
+      max_seq_len: 2048
+      stream_interval: 100
+      num_postprocess_workers: 4
+      nvfp4_gemm_config:
+        allowed_backends:
+        - cutlass
+        - cublaslt
+        - cutedsl
+        - cuda_core
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      trust_remote_code: true
+benchmark:
+  type: sa-bench
+  isl: 1024
+  osl: 1024
+  concurrencies: '1024'
+  req_rate: inf
+  random_range_ratio: 0.8
+  num_prompts_mult: 10
+  num_warmup_mult: 2
+  use_chat_template: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+dynamo:
+  request_plane: tcp
+  install: false
+slurm:
+  partition: gb300
+  time_limit: '1:00:00'


### PR DESCRIPTION
## Summary
Adds 17 `dynamo.trtllm` disaggregated recipes for **MiniMax-M2.7-NVFP4** on **GB300** at ISL/OSL **1K/1K**, under `recipes/MiniMax-M2.7/disagg/trtllm_dynamo/gb300_nvfp4/ISL1K_OSL1K/STP/`.

- **8 TRTLLM-MoE** + **9 CUTEDSL** configurations spanning the prefill/decode parallelism and per-instance batch-size sweep.
- Faithfully translated from the corresponding trtllm-serve disaggregated configs (prefill/decode engine YAML carried verbatim, with `tensor_parallel_size`/`moe_expert_parallel_size`/`pipeline_parallel_size` added).
- Portable refs only: `model.path: nvidia/MiniMax-M2.7-NVFP4`, container `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0-dev.1-cuda13`.
- Frontend uses the branch-default round-robin router (no KV-event publishing).

## Validation
- All 17 recipes parse cleanly and pass `srtctl dry-run`.
- Full 3-way sweep (dynamo.trtllm vs trtllm-serve in both the dynamo and release containers, all TRT-LLM rc17) completed across all 17 configs; **dynamo.trtllm matches trtllm-serve within ~1-2%** on every config.

## Scope
Recipes only — no `srtctl` source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)