### PR TITLE
gb300 mxfp4 EPLB: mount tmpfs /dev/shm size=100% for expert loading

### DIFF
--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch16_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch2_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch2_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch4_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch4_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch8_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx1dep4_gen1dep32_batch8_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch32_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep32_batch32_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep8_batch1024_eplb384_mtp1.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx2dep4_gen1dep8_batch1024_eplb384_mtp1.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx3dep4_gen1dep16_batch256_eplb384_mtp1.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx3dep4_gen1dep16_batch256_eplb384_mtp1.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx3dep4_gen1dep16_batch512_eplb384_mtp1.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx3dep4_gen1dep16_batch512_eplb384_mtp1.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx3dep4_gen1dep32_batch64_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx3dep4_gen1dep32_batch64_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx4dep4_gen1dep32_batch128_eplb384_mtp1.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/MTP/ctx4dep4_gen1dep32_batch128_eplb384_mtp1.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch16_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch16_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch32_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch32_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch4_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch4_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch8_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx1dep4_gen1dep32_batch8_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch64_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx2dep4_gen1dep32_batch64_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx3dep4_gen1dep16_batch512_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx3dep4_gen1dep16_batch512_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx3dep4_gen1dep32_batch128_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx3dep4_gen1dep32_batch128_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx4dep4_gen1dep16_batch1024_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx4dep4_gen1dep16_batch1024_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx4dep4_gen1dep32_batch256_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL1K_OSL1K/STP/ctx4dep4_gen1dep32_batch256_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx10dep4_gen1dep16_batch64_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx10dep4_gen1dep16_batch64_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx12dep4_gen1dep8_batch512_eplb384_mtp1.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx12dep4_gen1dep8_batch512_eplb384_mtp1.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep32_batch2_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx2dep4_gen1dep32_batch2_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx3dep4_gen1dep32_batch4_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx3dep4_gen1dep32_batch4_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx4dep4_gen1dep32_batch8_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx4dep4_gen1dep32_batch8_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx6dep4_gen1dep16_batch32_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx6dep4_gen1dep16_batch32_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx7dep4_gen1dep8_batch128_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx7dep4_gen1dep8_batch128_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch16_eplb384_mtp3.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx8dep4_gen1dep32_batch16_eplb384_mtp3.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx9dep4_gen1dep8_batch256_eplb384_mtp1.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/MTP/ctx9dep4_gen1dep8_batch256_eplb384_mtp1.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx10dep4_gen1dep8_batch512_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx10dep4_gen1dep8_batch512_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx1dep4_gen1dep32_batch4_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx1dep4_gen1dep32_batch4_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep32_batch8_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx2dep4_gen1dep32_batch8_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx4dep4_gen1dep32_batch16_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx4dep4_gen1dep32_batch16_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep16_batch64_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx5dep4_gen1dep16_batch64_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx6dep4_gen1dep32_batch32_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx6dep4_gen1dep32_batch32_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx6dep4_gen1dep8_batch256_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx6dep4_gen1dep8_batch256_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx9dep4_gen1dep16_batch128_eplb384_mtp0.yaml
+++ b/recipes/DeepSeek-V4-Pro/disagg/trtllm_dynamo/gb300_mxfp4/ISL8K_OSL1K/STP/ctx9dep4_gen1dep16_batch128_eplb384_mtp0.yaml
@@ -10,6 +10,7 @@ model:
   precision: "fp4"
 
 extra_mount:
+  - "tmpfs:/dev/shm:size=100%"
   - "configs/dsv4-moe-load-balancer-configs:/dsv4-eplb-configs"
 resources:
   gpu_type: "gb300"

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -235,7 +235,12 @@ class RuntimeContext:
         if config.extra_mount:
             for mount_spec in config.extra_mount:
                 host_path, container_path = mount_spec.split(":", 1)
-                container_mounts[Path(host_path).resolve()] = Path(container_path)
+                # tmpfs pseudo-mounts (e.g. "tmpfs:/dev/shm:size=100%") are passed
+                # to pyxis verbatim; "tmpfs" is a fs type, not a host path to resolve.
+                if host_path == "tmpfs":
+                    container_mounts[Path(host_path)] = Path(container_path)
+                else:
+                    container_mounts[Path(host_path).resolve()] = Path(container_path)
 
         # Mount InferenceX workspace if available (for lm-eval support).
         # Skip exists() check: the orchestrator runs on the SLURM head node


### PR DESCRIPTION
EPLB loads all experts into host /dev/shm during moe_load_balancer finalize. With the small default container /dev/shm, large-MoE expert sets overflow it and prefill workers die with SIGBUS ("nonexistent physical address") in UCX, so they never register and the run times out at the health-check ceiling.

Mount a tmpfs at /dev/shm sized to 100% of host RAM on the 36 gb300_mxfp4 EPLB (eplb384) disagg recipes. The eplb0 recipes do not use shared-expert memory and are left unchanged.

Also let srtctl pass a "tmpfs:" extra_mount source through to pyxis verbatim instead of resolving it as a host path.