### PR TITLE
Fix vLLM DP+EP health check expected worker counts

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -216,6 +216,32 @@ class VLLMProtocol:
             ),
         )
 
+    def get_expected_health_counts(
+        self,
+        num_prefill: int,
+        num_decode: int,
+        num_agg: int,
+        gpus_per_prefill: int = 1,
+        gpus_per_decode: int = 1,
+        gpus_per_agg: int = 1,
+    ) -> tuple[int, int]:
+        """Return (n_prefill, n_decode) expected for health checks.
+
+        In DP+EP mode each logical endpoint spawns one vLLM process per DP rank,
+        and each process registers independently with the frontend (Dynamo/SGLang).
+        The expected counts must be scaled accordingly so wait_for_model knows when
+        all workers are truly ready.
+        """
+        if num_agg > 0:
+            if self._is_dp_mode("agg"):
+                dp = self._get_dp_size("agg") or gpus_per_agg
+                return 0, num_agg * dp
+            return 0, num_agg
+
+        prefill_dp = (self._get_dp_size("prefill") or gpus_per_prefill) if self._is_dp_mode("prefill") else 1
+        decode_dp = (self._get_dp_size("decode") or gpus_per_decode) if self._is_dp_mode("decode") else 1
+        return num_prefill * prefill_dp, num_decode * decode_dp
+
     def _is_dp_mode(self, mode: WorkerMode) -> bool:
         """Check if this mode uses Data Parallel + Expert Parallel pattern.
 

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -191,8 +191,16 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
         # check is sufficient since the server already served traffic.
         if os.environ.get("EVAL_ONLY", "false").lower() == "true":
             r = self.config.resources
-            n_prefill = 0 if r.num_agg > 0 else r.num_prefill
-            n_decode = r.num_agg if r.num_agg > 0 else r.num_decode
+            from srtctl.backends.vllm import VLLMProtocol
+
+            if isinstance(self.config.backend, VLLMProtocol):
+                n_prefill, n_decode = self.config.backend.get_expected_health_counts(
+                    r.num_prefill, r.num_decode, r.num_agg,
+                    r.gpus_per_prefill, r.gpus_per_decode, r.gpus_per_agg,
+                )
+            else:
+                n_prefill = 0 if r.num_agg > 0 else r.num_prefill
+                n_decode = r.num_agg if r.num_agg > 0 else r.num_decode
             hc = self.config.health_check
             logger.info("EVAL_ONLY: Waiting for server health before eval...")
             if not wait_for_model(

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -195,8 +195,12 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
 
             if isinstance(self.config.backend, VLLMProtocol):
                 n_prefill, n_decode = self.config.backend.get_expected_health_counts(
-                    r.num_prefill, r.num_decode, r.num_agg,
-                    r.gpus_per_prefill, r.gpus_per_decode, r.gpus_per_agg,
+                    r.num_prefill,
+                    r.num_decode,
+                    r.num_agg,
+                    r.gpus_per_prefill,
+                    r.gpus_per_decode,
+                    r.gpus_per_agg,
                 )
             else:
                 n_prefill = 0 if r.num_agg > 0 else r.num_prefill

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -74,8 +74,12 @@ class BenchmarkStageMixin:
 
         if isinstance(self.config.backend, VLLMProtocol):
             n_prefill, n_decode = self.config.backend.get_expected_health_counts(
-                r.num_prefill, r.num_decode, r.num_agg,
-                r.gpus_per_prefill, r.gpus_per_decode, r.gpus_per_agg,
+                r.num_prefill,
+                r.num_decode,
+                r.num_agg,
+                r.gpus_per_prefill,
+                r.gpus_per_decode,
+                r.gpus_per_agg,
             )
         elif r.num_agg > 0:
             n_prefill = 0

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -66,9 +66,18 @@ class BenchmarkStageMixin:
 
         logger.info("Waiting for server health (expecting %d workers: %s)...", num_workers, worker_desc)
 
-        # For aggregated mode: expect 0 prefill, N decode (backend workers count as decode)
-        # For disaggregated mode: expect N prefill, M decode
-        if r.num_agg > 0:
+        # For disaggregated mode: expect N prefill, M decode.
+        # For aggregated mode: expect 0 prefill, N decode.
+        # In vLLM DP+EP mode each logical endpoint registers once per DP rank, so
+        # the expected counts are scaled by dp_size to match actual registrations.
+        from srtctl.backends.vllm import VLLMProtocol
+
+        if isinstance(self.config.backend, VLLMProtocol):
+            n_prefill, n_decode = self.config.backend.get_expected_health_counts(
+                r.num_prefill, r.num_decode, r.num_agg,
+                r.gpus_per_prefill, r.gpus_per_decode, r.gpus_per_agg,
+            )
+        elif r.num_agg > 0:
             n_prefill = 0
             n_decode = r.num_agg
         else:

--- a/src/srtctl/core/health.py
+++ b/src/srtctl/core/health.py
@@ -164,8 +164,8 @@ def check_dynamo_health(
     else:
         message = (
             f"Model is not ready, waiting for "
-            f"{expected_prefill - prefill_count} prefills and "
-            f"{expected_decode - decode_count} decodes. "
+            f"{max(0, expected_prefill - prefill_count)} prefills and "
+            f"{max(0, expected_decode - decode_count)} decodes. "
             f"Have {prefill_count} prefills and {decode_count} decodes."
         )
 


### PR DESCRIPTION
### Problem

When vLLM is configured with `data-parallel-size` (DP+EP mode), the health check
wait loop never converges. Each logical endpoint spawns one vLLM process per DP
rank, and each process registers independently with Dynamo. But `wait_for_model`
was still expecting `num_prefill` / `num_decode` registrations (logical endpoint
count), not `num_prefill × dp_size` (actual registration count).

This caused two visible symptoms:
- Prefill count immediately exceeded the expected threshold, showing confusing
  negative values: `waiting for -4 prefills and 2 decodes. Have 10 prefills and 0 decodes.`
- The loop would wait indefinitely for decodes that had already registered at
  the correct scaled count

### Changes

**`backends/vllm.py`** — Added `get_expected_health_counts()` to `VLLMProtocol`.
In DP+EP mode each logical endpoint produces `data-parallel-size` (or
`gpus_per_endpoint` as fallback) independent registrations, so the expected count
is scaled accordingly. Non-DP modes return counts unchanged.

**`core/health.py`** — Fixed `check_dynamo_health` message to use
`max(0, expected - actual)` in the "waiting for N workers" line, matching the
existing behavior in `check_sglang_router_health`.

**`cli/mixins/benchmark_stage.py`** and **`cli/do_sweep.py`** — Both
`wait_for_model` call sites now check for `VLLMProtocol` and use
`get_expected_health_counts()` to pass DP-aware expected counts.