### PR TITLE
vllm/dynamo: support time-based nsys profiling

### DIFF
--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -138,7 +138,11 @@ class WorkerStageMixin:
         if profiling.enabled:
             (self.runtime.log_dir / "profiles" / mode).mkdir(parents=True, exist_ok=True)
         if profiling.is_nsys:
-            nsys_output = f"/logs/profiles/{mode}/{process.node}_{mode}_w{index}_profile"
+            # Include CUDA_VISIBLE_DEVICES in the output name so per-DP-rank nsys
+            # files don't collide: with data parallelism (e.g. vLLM DP=4) several
+            # ranks share one logical endpoint and the same worker index on a node,
+            # so without the %q{} GPU qualifier they'd all write the same file.
+            nsys_output = f"/logs/profiles/{mode}/{process.node}_{mode}_w{index}_profile_gpu%q{{CUDA_VISIBLE_DEVICES}}"
             nsys_prefix = profiling.get_nsys_prefix(
                 nsys_output, frontend_type=self.config.frontend.type, backend_type=self.config.backend_type
             )

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -14,6 +14,7 @@ Backend configs are defined in srtctl.backends.configs/ for modularity.
 import builtins
 import itertools
 import logging
+import os
 import shlex
 from collections.abc import Iterator, Mapping
 from dataclasses import field
@@ -830,6 +831,17 @@ class ProfilingConfig:
 
         return env
 
+    @property
+    def nsys_binary(self) -> str:
+        """nsys executable to invoke.
+
+        Defaults to ``nsys`` (resolved on PATH). Override via the
+        ``SRTCTL_NSYS_BIN`` environment variable when running inside a
+        container that doesn't ship nsys on PATH — e.g. mount the host's
+        Nsight Systems install and point this at the absolute path.
+        """
+        return os.environ.get("SRTCTL_NSYS_BIN", "nsys")
+
     def _get_nsys_prefix_trtllm(self, output_file: str) -> list[str]:
         """Get nsys command prefix for TRTLLM workers.
 
@@ -838,7 +850,7 @@ class ProfilingConfig:
         """
         if self.is_nsys_time:
             cmd = [
-                "nsys",
+                self.nsys_binary,
                 "profile",
                 "-t",
                 "cuda,nvtx,ucx",
@@ -852,7 +864,7 @@ class ProfilingConfig:
         else:
             # Iteration-based: TLLM_PROFILE_START_STOP env var triggers cudaProfilerStart/Stop
             cmd = [
-                "nsys",
+                self.nsys_binary,
                 "profile",
                 "-t",
                 "cuda,nvtx,ucx",
@@ -900,9 +912,35 @@ class ProfilingConfig:
         if backend_type == "trtllm":
             return self._get_nsys_prefix_trtllm(output_file)
 
+        # Time-based capture for non-TRTLLM backends (vllm, sglang). Required
+        # for vllm+dynamo because dynamo's HTTP frontend doesn't proxy
+        # /start_profile to the vllm worker (returns 404), so cudaProfilerApi
+        # capture can't be triggered from the bench client — we drive capture
+        # purely by --delay/--duration instead.
+        if self.is_nsys_time:
+            cmd = [
+                self.nsys_binary,
+                "profile",
+                "-t",
+                "cuda,nvtx",
+                "--cuda-graph-trace=node",
+                "--force-overwrite",
+                "true",
+            ]
+            if self.delay_secs is not None:
+                cmd += ["--delay", str(self.delay_secs)]
+            if self.duration_secs is not None:
+                cmd += ["--duration", str(self.duration_secs)]
+            if self.extra_nsys_args:
+                cmd.extend(self.extra_nsys_args)
+            cmd.extend(["-o", output_file])
+            if frontend_type == "dynamo":
+                cmd.insert(-2, "--trace-fork-before-exec=true")
+            return cmd
+
         # SGLang / default path — keep existing behavior
         cmd = [
-            "nsys",
+            self.nsys_binary,
             "profile",
             "-t",
             "cuda,nvtx",
@@ -1464,9 +1502,11 @@ class SrtConfig:
         if prof.is_torch and backend_type == "trtllm":
             raise ValidationError("torch profiling is not supported for the trtllm backend; use nsys instead")
 
-        # nsys-time is TRTLLM-only (time-based capture via nsys --delay/--duration)
-        if prof.is_nsys_time and backend_type != "trtllm":
-            raise ValidationError("nsys-time profiling is only supported for the trtllm backend")
+        # nsys-time (time-based capture via nsys --delay/--duration) is supported
+        # for all backends. get_nsys_prefix() emits a time-based command for the
+        # non-TRTLLM (vllm/sglang) path too, which is the only option for
+        # vllm+dynamo where /start_profile returns 404 and cudaProfilerApi-triggered
+        # capture can't fire.
 
         # nsys-time uses top-level delay/duration — no per-phase step configs needed
         if prof.is_nsys_time:

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -79,6 +79,47 @@ class TestProfilingConfig:
         assert "--stats=true" in prefix
         assert prefix.index("--stats=true") < prefix.index("-o")
 
+    def test_nsys_time_vllm_dynamo_path(self, monkeypatch):
+        """nsys-time on a non-TRTLLM backend (vllm) drives capture purely via
+        --delay/--duration (no cudaProfilerApi range), and adds
+        --trace-fork-before-exec for the dynamo frontend."""
+        from srtctl.core.schema import ProfilingConfig
+
+        monkeypatch.delenv("SRTCTL_NSYS_BIN", raising=False)
+        profiling = ProfilingConfig(type="nsys-time", delay_secs=120, duration_secs=30)
+        assert profiling.is_nsys_time is True
+
+        prefix = profiling.get_nsys_prefix("/out/w0", frontend_type="dynamo", backend_type="vllm")
+        assert prefix[0] == "nsys"
+        assert "profile" in prefix
+        assert "--delay" in prefix and "120" in prefix
+        assert "--duration" in prefix and "30" in prefix
+        # Time-based capture — no cudaProfilerApi capture-range trigger.
+        assert "cudaProfilerApi" not in prefix
+        assert "--capture-range-end" not in prefix
+        assert "--trace-fork-before-exec=true" in prefix
+        # Output file is the last token (-o <output>).
+        assert prefix[-1] == "/out/w0"
+
+        # sglangrouter / non-dynamo frontend omits the fork flag.
+        prefix_router = profiling.get_nsys_prefix("/out/w0", frontend_type="sglangrouter", backend_type="vllm")
+        assert "--trace-fork-before-exec=true" not in prefix_router
+
+    def test_nsys_binary_override(self, monkeypatch):
+        """SRTCTL_NSYS_BIN overrides the nsys executable across every code path."""
+        from srtctl.core.schema import ProfilingConfig
+
+        monkeypatch.setenv("SRTCTL_NSYS_BIN", "/opt/nsight/nsys")
+        # default (vllm/sglang) path
+        assert ProfilingConfig(type="nsys").get_nsys_prefix("/out/w0", backend_type="vllm")[0] == "/opt/nsight/nsys"
+        # time-based path
+        time_prefix = ProfilingConfig(type="nsys-time", delay_secs=1, duration_secs=1).get_nsys_prefix(
+            "/out/w0", backend_type="vllm"
+        )
+        assert time_prefix[0] == "/opt/nsight/nsys"
+        # trtllm path
+        assert ProfilingConfig(type="nsys").get_nsys_prefix("/out/w0", backend_type="trtllm")[0] == "/opt/nsight/nsys"
+
     def test_torch_profiling(self):
         """Test torch profiling configuration."""
         from srtctl.core.schema import ProfilingConfig, ProfilingPhaseConfig
@@ -259,6 +300,32 @@ class TestProfilingValidation:
             ),
         )
         assert config.profiling.enabled
+
+    def test_nsys_time_allowed_for_non_trtllm_backend(self):
+        """nsys-time is no longer TRTLLM-only — it must validate for the default
+        (non-TRTLLM) backend so vllm+dynamo can use time-based capture."""
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        # Should not raise (previously rejected with "only supported for trtllm").
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/container", precision="fp8"),
+            resources=ResourceConfig(
+                gpu_type="gb200",
+                prefill_nodes=1,
+                decode_nodes=1,
+                prefill_workers=1,
+                decode_workers=1,
+            ),
+            profiling=ProfilingConfig(type="nsys-time", delay_secs=120, duration_secs=30),
+        )
+        assert config.profiling.is_nsys_time
+        assert config.backend.type != "trtllm"
 
 
 class TestProfilingIntegration:


### PR DESCRIPTION
## Summary

nsys-time profiling was restricted to the TRTLLM backend. For **vLLM behind the Dynamo HTTP frontend** there's no way to trigger `cudaProfilerStart` from the bench client — Dynamo's frontend doesn't proxy `/start_profile` to the worker (returns 404) — so iteration/range-triggered capture never fires.

This PR enables nsys profiling for vLLM/Dynamo (and SGLang) by driving capture purely via a time window.

## Changes

- **`ProfilingConfig.get_nsys_prefix()`** — new time-based branch for non-TRTLLM backends (`vllm`/`sglang`): emits an nsys command driven by `--delay`/`--duration` (no `cudaProfilerApi` capture range), and adds `--trace-fork-before-exec=true` for the `dynamo` frontend.
- **`_validate_profiling()`** — drop the TRTLLM-only guard for `nsys-time` so it validates for any backend (the time-based path now handles vllm/sglang).
- **`ProfilingConfig.nsys_binary`** — resolve the nsys executable via `SRTCTL_NSYS_BIN` (default `nsys` on PATH), applied across all nsys paths (trtllm, sglang/default, and the new time-based path). Lets profiling work inside containers that don't ship nsys on PATH — mount the host's Nsight Systems install and point the env var at it. Default preserves existing PATH behavior.
- **`worker_stage`** — include `CUDA_VISIBLE_DEVICES` (`%q{...}`) in the nsys output filename so per-DP-rank files don't collide: with data parallelism (e.g. vLLM DP=4) several ranks share one logical endpoint and worker index on a node, so without the GPU qualifier they'd all write the same file.

## Test plan

- [x] `make check` (ruff + pytest, 743 passed / 2 skipped)
- [x] New cases in `tests/test_profiling.py`: vLLM+dynamo time-based prefix (delay/duration, no cudaProfilerApi, fork flag), `SRTCTL_NSYS_BIN` override across all paths, and `nsys-time` validation now passing for a non-TRTLLM backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)