### PR TITLE
nginx: set client_max_body_size to allow large agentic requests

### DIFF
--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -8,6 +8,12 @@ worker_rlimit_nofile 1048576;
 {% endif %}
 
 http {
+    # Raise the request-body cap (nginx default is 1 MiB) so the load balancer
+    # does not reject large client requests with 413 before they reach the
+    # frontend. Agentic replay traces (e.g. multi-turn cc-traces warmup bodies)
+    # exceed 1 MiB; this mirrors the dynamo frontend's own body limit so nginx
+    # is never the bottleneck and is never more permissive than the backend.
+    client_max_body_size 45m;
     access_log off;
     upstream backend_servers {
         {% for frontend_host in frontend_hosts %}


### PR DESCRIPTION
The current nginx.conf left client_max_body_size unset, so nginx uses its 1 MiB default. When the frontend topology puts nginx in front of the dynamo frontend(s) (multi-node + multiple frontends), any client request body over 1 MiB is rejected with 413 before reaching the backend. Agentic replay warmup bodies (multi-turn cc-traces, >1 MiB) hit this and fail instantly.

Add client_max_body_size in the http block, defaulting to 45m (mirrors the dynamo frontend's own body limit so nginx is neither the bottleneck nor more permissive than the backend). Raising the cap is purely permissive: requests under 1 MiB are unaffected.

Passing agentic disagg CI run with this change: https://github.com/NVIDIA/InferenceMAX/actions/runs/28130070284/job/83303895421?pr=106