### PR TITLE
feat(nginx): add session-affinity hashing

### DIFF
--- a/src/srtctl/cli/mixins/frontend_stage.py
+++ b/src/srtctl/cli/mixins/frontend_stage.py
@@ -181,6 +181,7 @@ class FrontendStageMixin:
             backend_port=topology.frontend_port,
             listen_port=topology.public_port,
             nginx_raise_ulimit=self.config.frontend.nginx_raise_ulimit,
+            nginx_session_affinity=self.config.frontend.nginx_session_affinity,
         )
 
     def start_frontend(self, registry: "ProcessRegistry") -> list[ManagedProcess]:

--- a/src/srtctl/cli/mixins/frontend_stage.py
+++ b/src/srtctl/cli/mixins/frontend_stage.py
@@ -182,6 +182,7 @@ class FrontendStageMixin:
             listen_port=topology.public_port,
             nginx_raise_ulimit=self.config.frontend.nginx_raise_ulimit,
             nginx_session_affinity=self.config.frontend.nginx_session_affinity,
+            nginx_session_affinity_header=self.config.frontend.nginx_session_affinity_header,
         )
 
     def start_frontend(self, registry: "ProcessRegistry") -> list[ManagedProcess]:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1318,8 +1318,11 @@ class FrontendConfig:
         nginx_raise_ulimit: Raise nofile before nginx and set ``worker_rlimit_nofile``
             in generated nginx.conf. Off by default; enable on clusters that allow it.
             Override per job or set ``nginx_raise_ulimit`` in srtslurm.yaml for the cluster.
-        nginx_session_affinity: Consistently hash ``X-Dynamo-Session-ID`` to a frontend.
-            Requests without a session ID use a generated request ID and remain distributed.
+        nginx_session_affinity: Consistently hash ``nginx_session_affinity_header`` to a
+            frontend. Requests without that header use a generated request ID and stay distributed.
+        nginx_session_affinity_header: Header hashed when affinity is on (default
+            ``X-Dynamo-Session-ID``). Set ``X-Correlation-ID`` for clients (e.g. aiperf) that
+            carry the session id in that header instead.
         args: CLI arguments passed to the frontend/router process
         env: Environment variables for frontend processes
     """
@@ -1330,6 +1333,7 @@ class FrontendConfig:
     nginx_container: str = "nginx:1.27.4"
     nginx_raise_ulimit: bool = False
     nginx_session_affinity: bool = False
+    nginx_session_affinity_header: str = "X-Dynamo-Session-ID"
     args: dict[str, Any] | None = None
     env: dict[str, str] | None = None
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1318,6 +1318,8 @@ class FrontendConfig:
         nginx_raise_ulimit: Raise nofile before nginx and set ``worker_rlimit_nofile``
             in generated nginx.conf. Off by default; enable on clusters that allow it.
             Override per job or set ``nginx_raise_ulimit`` in srtslurm.yaml for the cluster.
+        nginx_session_affinity: Consistently hash ``X-Dynamo-Session-ID`` to a frontend.
+            Requests without a session ID use a generated request ID and remain distributed.
         args: CLI arguments passed to the frontend/router process
         env: Environment variables for frontend processes
     """
@@ -1327,6 +1329,7 @@ class FrontendConfig:
     num_additional_frontends: int = 9
     nginx_container: str = "nginx:1.27.4"
     nginx_raise_ulimit: bool = False
+    nginx_session_affinity: bool = False
     args: dict[str, Any] | None = None
     env: dict[str, str] | None = None
 

--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -15,7 +15,19 @@ http {
     # is never the bottleneck and is never more permissive than the backend.
     client_max_body_size 45m;
     access_log off;
+{% if nginx_session_affinity %}
+    # Keep a Dynamo session on one frontend. Anonymous requests use NGINX's
+    # generated request ID so an empty session header cannot pin all traffic.
+    map $http_x_dynamo_session_id $frontend_hash_key {
+        default $http_x_dynamo_session_id;
+        "" $request_id;
+    }
+{% endif %}
+
     upstream backend_servers {
+{% if nginx_session_affinity %}
+        hash $frontend_hash_key consistent;
+{% endif %}
         {% for frontend_host in frontend_hosts %}
         server {{ frontend_host }}:{{ backend_port }};
         {% endfor %}

--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -18,8 +18,9 @@ http {
 {% if nginx_session_affinity %}
     # Keep a Dynamo session on one frontend. Anonymous requests use NGINX's
     # generated request ID so an empty session header cannot pin all traffic.
-    map $http_x_dynamo_session_id $frontend_hash_key {
-        default $http_x_dynamo_session_id;
+{% set _sess_key = "$http_" ~ (nginx_session_affinity_header | lower | replace("-", "_")) %}
+    map {{ _sess_key }} $frontend_hash_key {
+        default {{ _sess_key }};
         "" $request_id;
     }
 {% endif %}

--- a/tests/test_frontend_topology.py
+++ b/tests/test_frontend_topology.py
@@ -18,6 +18,7 @@ def make_config(
     num_additional_frontends: int = 9,
     frontend_type: str = "dynamo",
     nginx_raise_ulimit: bool = False,
+    nginx_session_affinity: bool = False,
 ) -> SrtConfig:
     """Create a minimal SrtConfig for testing."""
     return SrtConfig(
@@ -34,6 +35,7 @@ def make_config(
             enable_multiple_frontends=enable_multiple_frontends,
             num_additional_frontends=num_additional_frontends,
             nginx_raise_ulimit=nginx_raise_ulimit,
+            nginx_session_affinity=nginx_session_affinity,
         ),
     )
 
@@ -198,6 +200,26 @@ class TestNginxConfigGeneration:
         assert "server 10.0.0.1:8180" in nginx_config
         assert "listen 8000" in nginx_config
         assert "worker_rlimit_nofile" not in nginx_config
+        assert "hash $frontend_hash_key consistent" not in nginx_config
+
+    def test_nginx_config_session_affinity(self):
+        """Session affinity hashes session IDs and keeps anonymous traffic distributed."""
+        config = make_config(enable_multiple_frontends=True, nginx_session_affinity=True)
+        runtime = make_runtime(["node0", "node1"])
+        topology = FrontendTopology(
+            nginx_node="node0",
+            frontend_nodes=["node1"],
+            frontend_port=8180,
+            public_port=8000,
+        )
+
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+        with patch("srtctl.cli.mixins.frontend_stage.get_hostname_ip", return_value="10.0.0.1"):
+            nginx_config = orchestrator._generate_nginx_config(topology)
+
+        assert "map $http_x_dynamo_session_id $frontend_hash_key" in nginx_config
+        assert '"" $request_id' in nginx_config
+        assert "hash $frontend_hash_key consistent" in nginx_config
 
     def test_nginx_config_raises_nofile_when_enabled(self):
         """worker_rlimit_nofile appears only when nginx_raise_ulimit is set."""


### PR DESCRIPTION
<!-- codex-pr-description:start -->
### Summary

Adds an opt-in `frontend.nginx_session_affinity` setting that consistently hashes `X-Dynamo-Session-ID` to one Dynamo frontend. Requests without that header hash by NGINX's generated request ID, so existing anonymous traffic remains distributed.

### How This Was Implemented

- Added a disabled-by-default frontend configuration field.
- Rendered a `map` plus `hash ... consistent` only when the field is enabled.
- Added focused coverage for both default round-robin and enabled affinity rendering.

<details>
<summary>Walkthrough</summary>

- `FrontendConfig` exposes `nginx_session_affinity`.
- The frontend stage passes it to the existing NGINX template.
- NGINX hashes session-bearing requests to a frontend; Dynamo can then apply its local worker affinity.

</details>

### Validation

- `.venv/bin/pytest tests -q` — 744 passed, 2 skipped.
- `.venv/bin/ruff check src/srtctl` and `.venv/bin/ruff format --check src/srtctl tests/test_frontend_topology.py`.
- `nginx:1.27.4 nginx -t` with the affinity `map`/consistent-hash configuration.
<!-- codex-pr-description:end -->
