### PR TITLE
dynamo: remap container root on dynamo-install sruns via ENROOT_REMAP_ROOT

### DIFF
--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from srtctl.core.fingerprint import generate_capture_script
 from srtctl.core.processes import ManagedProcess, NamedProcesses
 from srtctl.core.schema import build_otel_env
-from srtctl.core.slurm import get_hostname_ip, start_srun_process
+from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, get_hostname_ip, start_srun_process
 from srtctl.ports import ETCD_CLIENT_PORT, KV_EVENTS_PORT_BASE, KVBM_ZMQ_PORT_BASE, NATS_PORT
 
 if TYPE_CHECKING:
@@ -59,6 +59,14 @@ class WorkerStageMixin:
         """Endpoint allocation topology."""
         raise NotImplementedError
 
+    def _installs_dynamo(self) -> bool:
+        """Whether worker containers run the dynamo install (needs root inside the container).
+
+        Single source of truth for both the preamble gate and the ENROOT_REMAP_ROOT
+        srun injection, so they cannot drift.
+        """
+        return self.config.frontend.type == "dynamo" and self.config.dynamo.install
+
     def _build_worker_preamble(self) -> str | None:
         """Build bash preamble for worker processes.
 
@@ -84,7 +92,7 @@ class WorkerStageMixin:
 
         # 2. Dynamo installation (required for dynamo.sglang when using dynamo frontend)
         # Skip if dynamo.install is False (container already has dynamo installed)
-        if self.config.frontend.type == "dynamo" and self.config.dynamo.install:
+        if self._installs_dynamo():
             parts.append(self.config.dynamo.get_install_commands())
 
         if not parts:
@@ -237,6 +245,7 @@ class WorkerStageMixin:
             env_to_set=env_to_set,
             bash_preamble=bash_preamble,
             srun_options=self.runtime.srun_options,
+            srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if self._installs_dynamo() else None,
             het_group=process.het_group,
         )
 
@@ -366,6 +375,7 @@ class WorkerStageMixin:
             container_mounts=self.runtime.container_mounts,
             env_to_set=env_to_set,
             bash_preamble=bash_preamble,
+            srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if self._installs_dynamo() else None,
             mpi=srun_config.mpi,
             oversubscribe=srun_config.oversubscribe,
             cpu_bind=srun_config.cpu_bind,

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from srtctl.core.fingerprint import generate_capture_script
 from srtctl.core.processes import ManagedProcess, NamedProcesses
-from srtctl.core.schema import build_otel_env
+from srtctl.core.schema import build_otel_env, installs_dynamo
 from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, get_hostname_ip, start_srun_process
 from srtctl.ports import ETCD_CLIENT_PORT, KV_EVENTS_PORT_BASE, KVBM_ZMQ_PORT_BASE, NATS_PORT
 
@@ -59,14 +59,6 @@ class WorkerStageMixin:
         """Endpoint allocation topology."""
         raise NotImplementedError
 
-    def _installs_dynamo(self) -> bool:
-        """Whether worker containers run the dynamo install (needs root inside the container).
-
-        Single source of truth for both the preamble gate and the ENROOT_REMAP_ROOT
-        srun injection, so they cannot drift.
-        """
-        return self.config.frontend.type == "dynamo" and self.config.dynamo.install
-
     def _build_worker_preamble(self) -> str | None:
         """Build bash preamble for worker processes.
 
@@ -92,7 +84,7 @@ class WorkerStageMixin:
 
         # 2. Dynamo installation (required for dynamo.sglang when using dynamo frontend)
         # Skip if dynamo.install is False (container already has dynamo installed)
-        if self._installs_dynamo():
+        if installs_dynamo(self.config):
             parts.append(self.config.dynamo.get_install_commands())
 
         if not parts:
@@ -245,7 +237,7 @@ class WorkerStageMixin:
             env_to_set=env_to_set,
             bash_preamble=bash_preamble,
             srun_options=self.runtime.srun_options,
-            srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if self._installs_dynamo() else None,
+            srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if installs_dynamo(self.config) else None,
             het_group=process.het_group,
         )
 
@@ -375,7 +367,7 @@ class WorkerStageMixin:
             container_mounts=self.runtime.container_mounts,
             env_to_set=env_to_set,
             bash_preamble=bash_preamble,
-            srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if self._installs_dynamo() else None,
+            srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if installs_dynamo(self.config) else None,
             mpi=srun_config.mpi,
             oversubscribe=srun_config.oversubscribe,
             cpu_bind=srun_config.cpu_bind,

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -305,6 +305,13 @@ def show_config_details(config: SrtConfig) -> None:
         opts = " ".join(f"--{k}={v}" if v else f"--{k}" for k, v in config.srun_options.items())
         console.print(f"[dim]srun options:[/] {opts}")
 
+    # Dynamo install runs apt-get/pip as root inside the container, so srtctl injects
+    # ENROOT_REMAP_ROOT=yes (via srun --export) on the worker + dynamo-frontend launches.
+    if config.frontend.type == "dynamo" and config.dynamo.install:
+        console.print(
+            "[dim]srun --export (dynamo install):[/] ALL,ENROOT_REMAP_ROOT=yes [dim](workers + dynamo frontend)[/]"
+        )
+
     show_extensions = (
         config.benchmark.type == "custom"
         or config.benchmark.container_image

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -55,7 +55,7 @@ from srtctl.core.git_state import (
     write_git_state_snapshot,
 )
 from srtctl.core.lockfile import load_lockfile_fingerprints
-from srtctl.core.schema import SrtConfig
+from srtctl.core.schema import SrtConfig, installs_dynamo
 from srtctl.core.status import create_job_record
 from srtctl.core.validation import preflight_config_variants
 from srtctl.ports import MOONCAKE_MASTER_PORT
@@ -307,7 +307,7 @@ def show_config_details(config: SrtConfig) -> None:
 
     # Dynamo install runs apt-get/pip as root inside the container, so srtctl injects
     # ENROOT_REMAP_ROOT=yes (via srun --export) on the worker + dynamo-frontend launches.
-    if config.frontend.type == "dynamo" and config.dynamo.install:
+    if installs_dynamo(config):
         console.print(
             "[dim]srun --export (dynamo install):[/] ALL,ENROOT_REMAP_ROOT=yes [dim](workers + dynamo frontend)[/]"
         )

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1601,3 +1601,13 @@ class SrtConfig:
     def backend_type(self) -> str:
         """Get the backend type string."""
         return self.backend.type
+
+
+def installs_dynamo(config: SrtConfig) -> bool:
+    """Whether this config installs dynamo into its containers (needs root inside).
+
+    Single source of truth for the ENROOT_REMAP_ROOT srun injection (workers +
+    dynamo frontend) and its dry-run display: dynamo is only installed when the
+    dynamo frontend is selected and install isn't disabled.
+    """
+    return config.frontend.type == "dynamo" and config.dynamo.install

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -173,6 +173,13 @@ def get_node_ips(
 # Process Launching
 # ============================================================================
 
+# enroot env var that remaps the unprivileged user to root inside the container
+# at container-creation time. Injected (via srun --export) only on launches that
+# install dynamo, whose cold build needs apt-get/pip-to-system as root. Passing an
+# env var (not the pyxis --container-remap-root flag) degrades gracefully: srun
+# never parses it, so an unsupporting cluster no-ops instead of failing the step.
+CONTAINER_REMAP_ROOT_EXPORT = {"ENROOT_REMAP_ROOT": "yes"}
+
 
 def start_srun_process(
     command: list[str],
@@ -188,6 +195,7 @@ def start_srun_process(
     env_to_set: dict[str, str] | None = None,
     bash_preamble: str | None = None,
     srun_options: dict[str, str] | None = None,
+    srun_export_env: dict[str, str] | None = None,
     overlap: bool = True,
     use_bash_wrapper: bool = True,
     mpi: str | None = None,
@@ -213,6 +221,10 @@ def start_srun_process(
         env_to_set: Environment variables to set (name -> value)
         bash_preamble: Bash commands to run before the main command
         srun_options: Additional srun options as dict
+        srun_export_env: Env vars to set in the srun *task* environment (rendered as
+            ``--export=ALL,K=V,...``). Unlike env_to_set (which exports inside the
+            container after it starts), these reach the container runtime at creation
+            time — required for vars like ENROOT_REMAP_ROOT that enroot reads up front.
         overlap: Use --overlap flag (default: True)
         use_bash_wrapper: Wrap command in bash -c (default: True)
         mpi: MPI type (e.g., "pmix" for TRTLLM)
@@ -283,6 +295,13 @@ def start_srun_process(
                 srun_cmd.append(f"--{key}={value}")
             else:
                 srun_cmd.append(f"--{key}")
+
+    # Set env vars in the task environment so the container runtime (enroot/pyxis)
+    # sees them at container-creation time. Prefix ALL to preserve srun's normal
+    # full-environment propagation and only add these on top.
+    if srun_export_env:
+        exports = ",".join(f"{k}={v}" for k, v in srun_export_env.items())
+        srun_cmd.append(f"--export=ALL,{exports}")
 
     # Build the actual command to run
     if use_bash_wrapper:

--- a/src/srtctl/frontends/dynamo.py
+++ b/src/srtctl/frontends/dynamo.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from srtctl.core.health import WorkerHealthResult, check_dynamo_health
 from srtctl.core.schema import build_otel_env
-from srtctl.core.slurm import start_srun_process
+from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, start_srun_process
 from srtctl.ports import ETCD_CLIENT_PORT, NATS_PORT
 
 if TYPE_CHECKING:
@@ -109,6 +109,9 @@ class DynamoFrontend:
                 container_mounts=runtime.container_mounts,
                 env_to_set=env_to_set,
                 bash_preamble=bash_preamble,
+                # Frontend container runs the dynamo install (see _build_preamble), whose
+                # cold build needs root inside the container. Remap via enroot env var.
+                srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if config.dynamo.install else None,
                 # TODO(jthomson): I don't have the faintest clue of
                 # why this is needed in later versions of Dynamo, but it is.
                 mpi="pmix",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -364,3 +364,25 @@ class TestDryRunHetJobs:
         output = capsys.readouterr().out
         assert "Heterogeneous Job" in output
         assert "first node" in output  # infra note on the prefill row
+
+
+class TestDryRunRemapRoot:
+    """ENROOT_REMAP_ROOT is surfaced only when dynamo will be installed."""
+
+    def test_remap_root_shown_for_dynamo_install(self, capsys):
+        config = _make_config({"frontend": {"type": "dynamo"}, "dynamo": {"install": True}})
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "ENROOT_REMAP_ROOT" in output
+
+    def test_remap_root_absent_for_sglang_frontend(self, capsys):
+        config = _make_config({"frontend": {"type": "sglang"}})
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "ENROOT_REMAP_ROOT" not in output
+
+    def test_remap_root_absent_when_install_false(self, capsys):
+        config = _make_config({"frontend": {"type": "dynamo"}, "dynamo": {"install": False}})
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "ENROOT_REMAP_ROOT" not in output

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -4,10 +4,13 @@
 """Tests for frontend implementations (SGLang and Dynamo)."""
 
 from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from srtctl.core.schema import ObservabilityConfig
 from srtctl.frontends import DynamoFrontend, SGLangFrontend, get_frontend
 
 # ============================================================================
@@ -500,3 +503,43 @@ class TestFrontendEnvHandling:
         assert "--policy" in cmd
         assert "cache_aware" in cmd
         assert "--verbose" in cmd
+
+
+# ============================================================================
+# Dynamo Frontend ENROOT_REMAP_ROOT injection Tests
+# ============================================================================
+
+
+def _dynamo_frontend_call(*, dynamo_install: bool):
+    """Invoke DynamoFrontend.start_frontends with a minimal config; return the mock srun call."""
+    frontend = DynamoFrontend()
+    topology = SimpleNamespace(frontend_nodes=["node0"], frontend_port=8180)
+    runtime = SimpleNamespace(
+        log_dir=Path("/logs"),
+        nodes=SimpleNamespace(infra="infra-node", het_group_for=lambda node: None),
+        container_image=Path("/container.sqsh"),
+        container_mounts={},
+        environment={},
+    )
+    config = SimpleNamespace(
+        frontend=SimpleNamespace(args=None, env=None),
+        observability=ObservabilityConfig(),
+        dynamo=SimpleNamespace(install=dynamo_install, get_install_commands=lambda: "echo install-dynamo"),
+        setup_script=None,
+    )
+    with patch("srtctl.frontends.dynamo.start_srun_process") as mock_srun:
+        mock_srun.return_value = MagicMock()
+        frontend.start_frontends(topology, runtime, config, MagicMock(), [])
+    return mock_srun
+
+
+class TestDynamoFrontendRemapRoot:
+    """Dynamo frontend injects ENROOT_REMAP_ROOT only when it installs dynamo."""
+
+    def test_injects_remap_root_when_install(self):
+        mock_srun = _dynamo_frontend_call(dynamo_install=True)
+        assert mock_srun.call_args.kwargs["srun_export_env"] == {"ENROOT_REMAP_ROOT": "yes"}
+
+    def test_no_remap_root_when_install_false(self):
+        mock_srun = _dynamo_frontend_call(dynamo_install=False)
+        assert mock_srun.call_args.kwargs["srun_export_env"] is None

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -114,6 +114,34 @@ def test_srun_options_use_equals_separator() -> None:
     assert "--exclusive" in srun_cmd
 
 
+def test_srun_export_env_renders_export_with_all_prefix() -> None:
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(
+            ["python3", "-m", "server"],
+            srun_export_env={"ENROOT_REMAP_ROOT": "yes"},
+        )
+    srun_cmd = mock_popen.call_args.args[0]
+    # ALL prefix preserves srun's normal full-env propagation; the var is added on top.
+    assert "--export=ALL,ENROOT_REMAP_ROOT=yes" in srun_cmd
+
+
+def test_srun_export_env_omitted_adds_no_export_flag() -> None:
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(["python3", "-m", "server"])
+    srun_cmd = mock_popen.call_args.args[0]
+    assert not any(str(arg).startswith("--export") for arg in srun_cmd)
+
+
 def test_wrapped_nonfatal_hook_does_not_mask_prior_preamble_failure() -> None:
     bash_cmd = "false && ( false || true ) && echo main"
 
@@ -171,6 +199,83 @@ def test_worker_stage_wraps_nonfatal_fingerprint_hook(tmp_path: Path) -> None:
     assert "setup.sh" in bash_preamble
     assert "/configs/patches/${setup_script}" in bash_preamble
     assert bash_preamble.endswith("&& ( fingerprint || true )")
+
+
+def _remap_worker_mixin(tmp_path: Path, *, frontend_type: str, dynamo_install: bool):
+    """Build a WorkerStageMixin with a minimal config for remap-root injection tests."""
+    backend = MagicMock()
+    backend.build_worker_command.return_value = ["python3", "-m", "worker"]
+    backend.get_environment_for_mode.return_value = {}
+    backend.get_process_environment.return_value = {}
+
+    mixin = WorkerStageMixin()
+    mixin.config = SimpleNamespace(
+        setup_script=None,
+        frontend=SimpleNamespace(type=frontend_type),
+        dynamo=SimpleNamespace(install=dynamo_install, get_install_commands=lambda: "echo install-dynamo"),
+        observability=ObservabilityConfig(),
+        profiling=SimpleNamespace(enabled=False, is_nsys=False),
+        backend=backend,
+    )
+    mixin.runtime = SimpleNamespace(
+        log_dir=tmp_path,
+        head_node_ip="10.0.0.1",
+        infra_node_ip="10.0.0.1",
+        network_interface=None,
+        nodes=SimpleNamespace(infra="infra-node", worker=["node-a"]),
+        gpus_per_node=8,
+        environment={},
+        container_image=Path("/container.sqsh"),
+        container_mounts={},
+        srun_options=[],
+    )
+    process = SimpleNamespace(
+        endpoint_mode="prefill",
+        endpoint_index=0,
+        node="node-a",
+        sys_port=5000,
+        gpu_indices=list(range(8)),
+        cuda_visible_devices="0,1,2,3,4,5,6,7",
+        het_group=None,
+    )
+    return mixin, process
+
+
+def test_worker_stage_injects_remap_root_for_dynamo_install(tmp_path: Path) -> None:
+    mixin, process = _remap_worker_mixin(tmp_path, frontend_type="dynamo", dynamo_install=True)
+    with (
+        patch("srtctl.cli.mixins.worker_stage.generate_capture_script", return_value="fingerprint || true"),
+        patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
+    ):
+        mock_srun.return_value = MagicMock()
+        mixin.start_worker(process, [process])
+
+    assert mock_srun.call_args.kwargs["srun_export_env"] == {"ENROOT_REMAP_ROOT": "yes"}
+
+
+def test_worker_stage_no_remap_root_for_sglang_frontend(tmp_path: Path) -> None:
+    mixin, process = _remap_worker_mixin(tmp_path, frontend_type="sglang", dynamo_install=False)
+    with (
+        patch("srtctl.cli.mixins.worker_stage.generate_capture_script", return_value="fingerprint || true"),
+        patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
+    ):
+        mock_srun.return_value = MagicMock()
+        mixin.start_worker(process, [process])
+
+    assert mock_srun.call_args.kwargs["srun_export_env"] is None
+
+
+def test_worker_stage_no_remap_root_when_dynamo_install_false(tmp_path: Path) -> None:
+    # Dynamo frontend but container already has dynamo (install=False) → no install, no remap.
+    mixin, process = _remap_worker_mixin(tmp_path, frontend_type="dynamo", dynamo_install=False)
+    with (
+        patch("srtctl.cli.mixins.worker_stage.generate_capture_script", return_value="fingerprint || true"),
+        patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
+    ):
+        mock_srun.return_value = MagicMock()
+        mixin.start_worker(process, [process])
+
+    assert mock_srun.call_args.kwargs["srun_export_env"] is None
 
 
 # ---- Heterogeneous-job nodelist parsing ----


### PR DESCRIPTION
## Problem

The `dsv4 fp4 gb300 dynamo-sglang` sweep failed 4/4 configs at "Installing dynamo from source" (exit 100). Failing run: [SemiAnalysisAI/InferenceX Actions run 27657243156](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27657243156) (PR SemiAnalysisAI/InferenceX#1697) — e.g. `dsv4_1k1k fp4 gb300-nv dynamo-sglang | P(tp4/ep4) D(tp8/ep8) | disagg-true spec-mtp conc-8192`, which fails at the "Launch multi-node job script" step. Root cause (A/B-proven):

- A cold dynamo source build runs `apt-get install` / `pip install --break-system-packages` — which need **root**.
- srtctl launches its containers as the **unprivileged** user, so the install dies with `dpkg: requires superuser privilege` (the worker log is SIGKILL-truncated mid-install).
- Clean A/B in the same container as the real CI user: **without** root remap → exit 100; **with** it → RC 0.

## Fix

Inject `ENROOT_REMAP_ROOT=yes` (the enroot var that remaps the container user to root at container-creation time) **only on the sruns that install dynamo**, and a no-op everywhere else. Recipe authors set nothing.

The dynamo install (`DynamoConfig.get_install_commands()`) runs in exactly two places, both of which previously launched as the unprivileged user:

1. **Backend workers** — `worker_stage.py`, gated on `frontend.type == "dynamo" and dynamo.install` (both the SGLang per-node and TRTLLM/MPI launch paths).
2. **Dynamo frontend** — `frontends/dynamo.py`, gated on `dynamo.install`.

Everything else (etcd/nats, mooncake, model pre-download, post-eval, benchmark, telemetry, nginx, sglang frontend) is untouched.

## Why an env var, not the `--container-remap-root` pyxis flag

This was the key design decision. pyxis exposes a `--container-remap-root` srun flag that does the same remap, but we deliberately use the enroot env var instead:

| | `--container-remap-root` (pyxis flag) | `ENROOT_REMAP_ROOT=yes` (enroot env var) ✅ |
|---|---|---|
| Cluster doesn't support it | **srun hard-fails**: an unrecognized option makes srun print `unrecognized option` and **exit non-zero before the step launches** — it does not degrade to a no-op. Blindly adding it would break every dynamo srun on a cluster whose pyxis predates the flag. | **Graceful no-op**: srun never parses the var, so an unsupporting cluster simply ignores it (the container starts unprivileged as before) instead of failing the step. |
| Layer it talks to | pyxis (the SLURM SPANK plugin) — the scheduler's flag surface. | enroot directly, which actually performs the uid remap. enroot reads `ENROOT_REMAP_ROOT` (enroot.conf default `no`), and per the enroot docs *"environment variables take precedence over the configuration file."* |
| Scope | per-srun. | per-srun, and **does not** touch the cluster-wide enroot.conf default. |

"Don't let the srun fail" was the hard requirement, and only the env var satisfies it.

### Why `--export`, not the existing `env_to_set`

enroot reads `ENROOT_REMAP_ROOT` when it **creates** the container. srtctl's `env_to_set` becomes `export NAME=value` statements **inside** the container's `bash -c` wrapper — i.e. *after* the container already exists, far too late for the remap. So the var must reach the **task/step** environment, which we do with `--export=ALL,ENROOT_REMAP_ROOT=yes`:

- `ALL` preserves srun's normal full-environment propagation (its usual default), and we only add the one var on top — no change to non-dynamo sruns.
- It's visible in the logged srun command and in `srtctl dry-run`, so it's debuggable rather than hidden.

## Changes

- `core/slurm.py`: new `srun_export_env` param on `start_srun_process` → renders `--export=ALL,K=V,…`; `CONTAINER_REMAP_ROOT_EXPORT` constant.
- `cli/mixins/worker_stage.py`: `_installs_dynamo()` as the single source of truth (reused by the preamble gate and both worker srun calls).
- `frontends/dynamo.py`: inject on the frontend srun when `dynamo.install`.
- `cli/submit.py`: `dry-run` surfaces the injected export line.
- Tests: argv rendering (present/absent), worker + frontend wiring (dynamo / sglang / `install: false`), and dry-run visibility — 8 new tests.

## Testing

- New tests pass; full suite **751 passed** (the 2 unrelated failures are pre-existing and reproduce on `main`: local ANSI-color substring matching, and Python 3.14's `UnionType[...]` repr vs the repo's 3.10 target). `ruff check` + `ruff format` clean.
- **Cluster checks (recommended before merge):**
  1. Confirm pyxis forwards the var to enroot: `srun --jobid=$JOB_ID --overlap --container-image=$IMG --export=ALL,ENROOT_REMAP_ROOT=yes bash -c 'whoami'` → expect `root`.
  2. Re-run the previously failing `dsv4 fp4 gb300 dynamo-sglang` config (cold cache) → expect the source install completes (RC 0).
