### PR TITLE
feat(nginx): configurable session-affinity header (generalizes #233)

### DIFF
--- a/src/srtctl/cli/mixins/frontend_stage.py
+++ b/src/srtctl/cli/mixins/frontend_stage.py
@@ -181,6 +181,8 @@ class FrontendStageMixin:
             backend_port=topology.frontend_port,
             listen_port=topology.public_port,
             nginx_raise_ulimit=self.config.frontend.nginx_raise_ulimit,
+            nginx_session_affinity=self.config.frontend.nginx_session_affinity,
+            nginx_session_affinity_header=self.config.frontend.nginx_session_affinity_header,
         )
 
     def start_frontend(self, registry: "ProcessRegistry") -> list[ManagedProcess]:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1318,6 +1318,11 @@ class FrontendConfig:
         nginx_raise_ulimit: Raise nofile before nginx and set ``worker_rlimit_nofile``
             in generated nginx.conf. Off by default; enable on clusters that allow it.
             Override per job or set ``nginx_raise_ulimit`` in srtslurm.yaml for the cluster.
+        nginx_session_affinity: Consistently hash a per-session HTTP header to one
+            frontend so a conversation's turns stay on the same router. Off by default.
+        nginx_session_affinity_header: Header hashed when affinity is on (default
+            ``X-Dynamo-Session-ID``). Set ``X-Correlation-ID`` for clients (e.g. aiperf)
+            that carry the session id in that header instead.
         args: CLI arguments passed to the frontend/router process
         env: Environment variables for frontend processes
     """
@@ -1327,6 +1332,8 @@ class FrontendConfig:
     num_additional_frontends: int = 9
     nginx_container: str = "nginx:1.27.4"
     nginx_raise_ulimit: bool = False
+    nginx_session_affinity: bool = False
+    nginx_session_affinity_header: str = "X-Dynamo-Session-ID"
     args: dict[str, Any] | None = None
     env: dict[str, str] | None = None
 

--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -15,7 +15,20 @@ http {
     # is never the bottleneck and is never more permissive than the backend.
     client_max_body_size 45m;
     access_log off;
+{% if nginx_session_affinity %}
+{% set _sess_key = "$http_" ~ (nginx_session_affinity_header | lower | replace("-", "_")) %}
+    # Pin a conversation to one frontend so a session-aware router keeps its
+    # per-frontend affinity for the whole conversation. Anonymous requests fall
+    # back to the request id so they stay distributed.
+    map {{ _sess_key }} $frontend_hash_key {
+        default {{ _sess_key }};
+        "" $request_id;
+    }
+{% endif %}
     upstream backend_servers {
+{% if nginx_session_affinity %}
+        hash $frontend_hash_key consistent;
+{% endif %}
         {% for frontend_host in frontend_hosts %}
         server {{ frontend_host }}:{{ backend_port }};
         {% endfor %}


### PR DESCRIPTION
## Summary

Generalizes the nginx session-affinity approach from #233 so the hashed header is **configurable** via `frontend.nginx_session_affinity_header` (default `X-Dynamo-Session-ID`, which preserves #233's behavior).

**Why:** not every client sends `X-Dynamo-Session-ID`. aiperf's conversation-aware routing (`--use-dynamo-conv-aware-routing`) carries the session id in the request **body** (`nvext.session_control.session_id`) and in the **`X-Correlation-ID`** header — it never sets `X-Dynamo-Session-ID`. On an aiperf + body-session Dynamo stack, hashing `X-Dynamo-Session-ID` is therefore a no-op (empty header → falls back to `$request_id` → round-robin). Setting the header to `X-Correlation-ID` pins each conversation to one frontend for such clients.

## Changes
- `FrontendConfig`: add `nginx_session_affinity` (bool) + `nginx_session_affinity_header` (str, default `X-Dynamo-Session-ID`)
- frontend stage passes both into the nginx template
- `nginx.conf.j2`: when enabled, `map` the configured header into a hash key (empty → `$request_id`) and add `hash ... consistent` on the upstream

## Validation (GB300, Qwen3.5-397B-NVFP4, AgentX cc-traces, 3P1D-DEP8, conc 256, 5 frontends)

A/B differ only in `nginx_session_affinity` (B hashes `X-Correlation-ID`):

| Metric | multi-FE, affinity OFF | multi-FE, affinity ON | single-FE ref |
|---|--:|--:|--:|
| cache hit | 56.0% | 93.1% | 93.0% |
| TPS/GPU | 22,012 | 50,521 (2.29×) | 47,589 |
| TTFT p50 | 32.0 s | 7.0 s | — |

Pinning the conversation to one frontend recovers prefix cache to single-frontend level and 2.29× throughput. Rendered `nginx.conf` verified for both header values and the off case.
