### PR TITLE
feat(nginx): make session-affinity header configurable

### DIFF
--- a/src/srtctl/cli/mixins/frontend_stage.py
+++ b/src/srtctl/cli/mixins/frontend_stage.py
@@ -182,6 +182,7 @@ class FrontendStageMixin:
             listen_port=topology.public_port,
             nginx_raise_ulimit=self.config.frontend.nginx_raise_ulimit,
             nginx_session_affinity=self.config.frontend.nginx_session_affinity,
+            nginx_session_affinity_header=self.config.frontend.nginx_session_affinity_header,
         )
 
     def start_frontend(self, registry: "ProcessRegistry") -> list[ManagedProcess]:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1318,8 +1318,11 @@ class FrontendConfig:
         nginx_raise_ulimit: Raise nofile before nginx and set ``worker_rlimit_nofile``
             in generated nginx.conf. Off by default; enable on clusters that allow it.
             Override per job or set ``nginx_raise_ulimit`` in srtslurm.yaml for the cluster.
-        nginx_session_affinity: Consistently hash ``X-Dynamo-Session-ID`` to a frontend.
-            Requests without a session ID use a generated request ID and remain distributed.
+        nginx_session_affinity: Consistently hash ``nginx_session_affinity_header`` to a
+            frontend. Requests without that header use a generated request ID and stay distributed.
+        nginx_session_affinity_header: Header hashed when affinity is on (default
+            ``X-Dynamo-Session-ID``). Set ``X-Correlation-ID`` for clients (e.g. aiperf) that
+            carry the session id in that header instead.
         args: CLI arguments passed to the frontend/router process
         env: Environment variables for frontend processes
     """
@@ -1330,6 +1333,7 @@ class FrontendConfig:
     nginx_container: str = "nginx:1.27.4"
     nginx_raise_ulimit: bool = False
     nginx_session_affinity: bool = False
+    nginx_session_affinity_header: str = "X-Dynamo-Session-ID"
     args: dict[str, Any] | None = None
     env: dict[str, str] | None = None
 

--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -18,8 +18,9 @@ http {
 {% if nginx_session_affinity %}
     # Keep a Dynamo session on one frontend. Anonymous requests use NGINX's
     # generated request ID so an empty session header cannot pin all traffic.
-    map $http_x_dynamo_session_id $frontend_hash_key {
-        default $http_x_dynamo_session_id;
+{% set _sess_key = "$http_" ~ (nginx_session_affinity_header | lower | replace("-", "_")) %}
+    map {{ _sess_key }} $frontend_hash_key {
+        default {{ _sess_key }};
         "" $request_id;
     }
 {% endif %}


### PR DESCRIPTION
## Summary

**Stacked on #233.** Makes the hashed session header configurable via `frontend.nginx_session_affinity_header` (default `X-Dynamo-Session-ID`, so #233's behavior is unchanged).

**Why:** not every client sends `X-Dynamo-Session-ID`. aiperf's conversation-aware routing (`--use-dynamo-conv-aware-routing`) carries the session id in the request **body** (`nvext.session_control.session_id`) and in the **`X-Correlation-ID`** header — it never sets `X-Dynamo-Session-ID`. On such a stack, hashing `X-Dynamo-Session-ID` is a no-op (empty header → `$request_id` → round-robin). Setting the header to `X-Correlation-ID` pins each conversation to one frontend.

## Delta on top of #233
- `FrontendConfig.nginx_session_affinity_header` (str, default `X-Dynamo-Session-ID`)
- frontend stage passes it into the nginx template
- `nginx.conf.j2`: hash the configured header (name → `$http_<lower,-→_>`) instead of the hardcoded `X-Dynamo-Session-ID`

## Validation (GB300, Qwen3.5-397B-NVFP4, AgentX cc-traces, 3P1D-DEP8, conc 256, 5 frontends)

A/B differ only in `nginx_session_affinity` (B hashes `X-Correlation-ID`):

| Metric | multi-FE, affinity OFF | multi-FE, affinity ON | single-FE ref |
|---|--:|--:|--:|
| cache hit | 56.0% | 93.1% | 93.0% |
| TPS/GPU | 22,012 | 50,521 (2.29×) | 47,589 |
| TTFT p50 | 32.0 s | 7.0 s | — |

Pinning the conversation to one frontend recovers prefix cache to single-frontend level and 2.29× throughput. Rendered nginx.conf verified for both header values and the off case.
