### PR TITLE
feat: add kv_events_config support for vLLM

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -94,6 +94,12 @@ class VLLMProtocol:
     # dynamo 1.0.0+: translated to --kv-transfer-config (--connector was removed).
     connector: str | None = "nixl"
 
+    # KV events config - enables --kv-events-config with auto-allocated ports.
+    # Required for Dynamo's event-driven KV-aware routing.
+    # Global true enables defaults for prefill and decode workers.
+    # Per-mode: {"prefill": true, "decode": {"topic": "custom"}}
+    kv_events_config: bool | dict[str, Any] | None = None
+
     # Allow prefill and decode workers to share one node when the combined GPU
     # request fits within gpus_per_node. Defaults off to preserve existing P/D
     # node separation.
@@ -123,6 +129,45 @@ class VLLMProtocol:
         elif mode == "agg":
             return dict(self.vllm_config.aggregated or {})
         return {}
+
+    def get_kv_events_config_for_mode(self, mode: WorkerMode) -> dict[str, Any] | None:
+        """Get --kv-events-config payload for a worker mode."""
+        if not self.kv_events_config:
+            return None
+
+        if self.kv_events_config is True:
+            if mode in ("prefill", "decode"):
+                return {
+                    "publisher": "zmq",
+                    "topic": "kv-events",
+                    "enable_kv_cache_events": True,
+                }
+            return None
+
+        if isinstance(self.kv_events_config, dict):
+            mode_cfg = (
+                self.kv_events_config.get("aggregated")
+                if mode == "agg"
+                else self.kv_events_config.get(mode)
+            )
+            if mode_cfg is None:
+                return None
+            if mode_cfg is True:
+                return {
+                    "publisher": "zmq",
+                    "topic": "kv-events",
+                    "enable_kv_cache_events": True,
+                }
+            if isinstance(mode_cfg, dict):
+                result = {
+                    "publisher": "zmq",
+                    "topic": "kv-events",
+                    "enable_kv_cache_events": True,
+                }
+                result.update(mode_cfg)
+                return result
+
+        return None
 
     def get_environment_for_mode(self, mode: WorkerMode) -> dict[str, str]:
         """Get environment variables for a worker mode."""
@@ -450,6 +495,11 @@ class VLLMProtocol:
         # Add config dump path
         if dump_config_path:
             cmd.extend(["--dump-config-to", str(dump_config_path)])
+
+        kv_cfg = self.get_kv_events_config_for_mode(mode)
+        if kv_cfg and process.kv_events_port is not None:
+            kv_cfg["endpoint"] = f"tcp://*:{process.kv_events_port}"
+            cmd.extend(["--kv-events-config", json.dumps(kv_cfg)])
 
         # Add all config flags from vllm_config
         cmd.extend(_config_to_cli_args(config))

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -145,11 +145,7 @@ class VLLMProtocol:
             return None
 
         if isinstance(self.kv_events_config, dict):
-            mode_cfg = (
-                self.kv_events_config.get("aggregated")
-                if mode == "agg"
-                else self.kv_events_config.get(mode)
-            )
+            mode_cfg = self.kv_events_config.get("aggregated") if mode == "agg" else self.kv_events_config.get(mode)
             if mode_cfg is None:
                 return None
             if mode_cfg is True:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1417,10 +1417,7 @@ class TestVLLMPrefillDecodeColocation:
         assert {p.nixl_port for p in decode} == {VLLM_NIXL_PORT_BASE + 4}
 
         leader_ports = [
-            port
-            for process in prefill + decode
-            for port in (process.http_port, process.bootstrap_port)
-            if port
+            port for process in prefill + decode for port in (process.http_port, process.bootstrap_port) if port
         ]
         assert sorted(leader_ports) == [
             SGLANG_HTTP_PORT_BASE,

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -4,6 +4,7 @@
 """Tests for configuration loading and validation."""
 
 import glob
+import json
 from pathlib import Path
 
 import pytest
@@ -2030,6 +2031,83 @@ class TestVLLMDataParallelMode:
         assert "DYN_VLLM_KV_EVENT_PORT" not in env
         assert "VLLM_NIXL_SIDE_CHANNEL_PORT" not in env
         assert "VLLM_NIXL_SIDE_CHANNEL_HOST" not in env
+
+    def test_vllm_kv_events_config_global_bool(self):
+        """Test kv_events_config=True enables prefill+decode with vLLM defaults."""
+        from srtctl.backends import VLLMProtocol
+
+        config = VLLMProtocol(kv_events_config=True)
+
+        assert config.get_kv_events_config_for_mode("prefill") == {
+            "publisher": "zmq",
+            "topic": "kv-events",
+            "enable_kv_cache_events": True,
+        }
+        assert config.get_kv_events_config_for_mode("decode") == {
+            "publisher": "zmq",
+            "topic": "kv-events",
+            "enable_kv_cache_events": True,
+        }
+        assert config.get_kv_events_config_for_mode("agg") is None
+
+    def test_vllm_kv_events_config_custom_settings(self):
+        """Test kv_events_config per-mode settings merge with vLLM defaults."""
+        from srtctl.backends import VLLMProtocol
+
+        config = VLLMProtocol(
+            kv_events_config={
+                "prefill": {"topic": "prefill-events"},
+                "decode": {"publisher": "custom", "topic": "decode-events"},
+            }
+        )
+
+        prefill_cfg = config.get_kv_events_config_for_mode("prefill")
+        assert prefill_cfg["publisher"] == "zmq"
+        assert prefill_cfg["topic"] == "prefill-events"
+        assert prefill_cfg["enable_kv_cache_events"] is True
+
+        decode_cfg = config.get_kv_events_config_for_mode("decode")
+        assert decode_cfg["publisher"] == "custom"
+        assert decode_cfg["topic"] == "decode-events"
+        assert decode_cfg["enable_kv_cache_events"] is True
+
+    def test_vllm_command_includes_kv_events_config_with_allocated_port(self):
+        """Test vLLM command injects --kv-events-config with the worker port."""
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        from srtctl.backends import VLLMProtocol
+        from srtctl.core.topology import Process
+
+        backend = VLLMProtocol(kv_events_config=True)
+        process = Process(
+            node="node0",
+            gpu_indices=frozenset([0]),
+            sys_port=8081,
+            http_port=30000,
+            endpoint_mode="prefill",
+            endpoint_index=0,
+            node_rank=0,
+            kv_events_port=5550,
+        )
+        mock_runtime = MagicMock()
+        mock_runtime.model_path = Path("/model")
+        mock_runtime.is_hf_model = False
+
+        cmd = backend.build_worker_command(
+            process=process,
+            endpoint_processes=[process],
+            runtime=mock_runtime,
+        )
+
+        flag_index = cmd.index("--kv-events-config")
+        kv_cfg = json.loads(cmd[flag_index + 1])
+        assert kv_cfg == {
+            "publisher": "zmq",
+            "topic": "kv-events",
+            "enable_kv_cache_events": True,
+            "endpoint": "tcp://*:5550",
+        }
 
     def test_tp_mode_command_includes_multinode_flags(self):
         """Test standard TP mode includes multi-node coordination flags."""


### PR DESCRIPTION
## Summary

Add `backend.kv_events_config` support to the vLLM backend, matching the existing structured configuration pattern used by SGLang (e.g. https://github.com/NVIDIA/srt-slurm/blob/a98738de9b2233459b5456e9ed71af09ce893f92/recipes/qwen3-32b/basic-b300/disagg-kv-dynamo.yaml#L35-L39).

When enabled, srt-slurm now emits `--kv-events-config` for vLLM workers with an auto-allocated per-worker ZMQ endpoint:

```yaml
# agg mode
backend:
  kv_events_config:
    aggregated: true

# disagg mode
backend:
  kv_events_config:
    prefill: true 
    decode: true  # Optional; for Dynamo p/d routing, we don't need decode kv events
```

This produces a vLLM config with:

- `publisher: zmq`
- `topic: kv-events`
- `enable_kv_cache_events: true`
- `endpoint: tcp://*:PORT`

where `PORT` comes from the worker’s allocated `kv_events_port`.

**This is required for Dynamo’s event-driven KV-aware routing with vLLM ([Dynamo event plane doc](https://docs.nvidia.com/dynamo/design-docs/communication-planes/event-plane)), since vLLM no longer auto-creates `kv_events_config` from environment variables alone.**

## Validation

- `python3 -m py_compile src/srtctl/backends/vllm.py`
- `uv run pytest tests/test_configs.py -k 'vllm_kv_events' -q -p no:cacheprovider`
- `uv run pytest tests/test_configs.py -k 'vllm_command_includes_kv_events_config' -q -p no:cacheprovider`
- `uv run ruff check src/srtctl/backends/vllm.py tests/test_configs.py`
