### PR TITLE
Serialize hash-pinned dynamo install per node (fix concurrent pip race)

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1121,11 +1121,27 @@ def _hash_cached_source_install(dynamo_hash: str) -> str:
         f"cd / && rm -rf $DYN_BUILD_DIR; "
         f"fi "
         f") 200>{lock} && "
-        # Install from the (now warm) cache. Both branches above land here.
+        # Install from the (now warm) cache. The build above is serialized on the
+        # shared /configs lock (one build per job); the pip installs below write
+        # into the container's site-packages, which is SHARED by every task on a
+        # node, so serialize them per node too. Only the first local task
+        # installs; the rest block on the node-local lock, then skip via the
+        # sentinel. Without this, the N concurrent per-task
+        # `pip install --force-reinstall` race on shared dependency files (e.g.
+        # uninstalling typing_extensions) and fail with "OSError: [Errno 2] No
+        # such file" on containers that pre-ship ai-dynamo's Python deps at
+        # conflicting versions (e.g. the TRT-LLM release image). Lock + sentinel
+        # live in node-local /tmp (site-packages is per node), so the install
+        # runs exactly once on each node.
+        f"( flock -x 201; "
+        f"if [ ! -f /tmp/.dynamo-installed-{dynamo_hash} ]; then "
         f"pip install --break-system-packages --force-reinstall {cache}/ai_dynamo_runtime-*.whl && "
         f"rm -rf /tmp/dynamo-src && mkdir -p /tmp/dynamo-src && "
         f"tar -xzf {cache}/dynamo-src.tar.gz -C /tmp/dynamo-src && "
         f"pip install --break-system-packages -e /tmp/dynamo-src/dynamo && "
+        f"touch /tmp/.dynamo-installed-{dynamo_hash}; "
+        f"fi "
+        f") 201>/tmp/.dynamo-install-{dynamo_hash}.lock && "
         f"echo 'Dynamo installed from source ({dynamo_hash})'"
     )
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1194,9 +1194,25 @@ def _live_source_install_for_top_of_tree() -> str:
         "echo 'Dynamo installed from source (HEAD)'"
     )
 
-    return (
+    install_once = (
         "echo 'Installing dynamo from source (HEAD)...' && "
         f"if [ -d /sgl-workspace ]; then {sglang}; else {portable}; fi"
+    )
+    # Serialize per node. Both branches clone/build/pip-install into shared
+    # locations (/sgl-workspace or /tmp, and the container's site-packages) that
+    # every task on a node shares, so N concurrent per-task installs race — one
+    # git-cloning into a dir another is deleting, or --force-reinstall tearing
+    # down a shared dependency file mid-read (OSError). Node-local flock +
+    # sentinel: the first local task does the whole install, the rest block then
+    # skip. No hash key here (this is HEAD), so use a fixed sentinel — a
+    # container instance only ever installs one top-of-tree build. Mirrors the
+    # guard in _hash_cached_source_install.
+    return (
+        "( flock -x 201; "
+        "if [ ! -f /tmp/.dynamo-installed-top-of-tree ]; then "
+        f"{install_once} && touch /tmp/.dynamo-installed-top-of-tree; "
+        "fi "
+        ") 201>/tmp/.dynamo-install-top-of-tree.lock"
     )
 
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -235,6 +235,15 @@ class TestDynamoConfig:
         assert "tar -xzf /configs/dynamo-wheels/abc123/dynamo-src.tar.gz" in cmd
         assert "pip install --break-system-packages -e /tmp/dynamo-src/dynamo" in cmd
 
+        # Post-build pip installs are serialized per node: site-packages is shared
+        # by every task on a node, so only the first local task installs (under a
+        # node-local flock + sentinel) and the rest block then skip. Guards against
+        # concurrent --force-reinstall racing on shared dependency files.
+        assert "flock -x 201" in cmd
+        assert "if [ ! -f /tmp/.dynamo-installed-abc123 ]" in cmd
+        assert "touch /tmp/.dynamo-installed-abc123" in cmd
+        assert "201>/tmp/.dynamo-install-abc123.lock" in cmd
+
     def test_top_of_tree_install_command(self):
         """Top-of-tree config generates source install without checkout."""
         from srtctl.core.schema import DynamoConfig

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -267,6 +267,14 @@ class TestDynamoConfig:
         assert "--force-reinstall --quiet maturin" in sglang_branch
         assert "--force-reinstall --quiet maturin" in portable_branch
 
+        # Per-node serialization guard: both branches clone/build/install into
+        # shared paths (/sgl-workspace or /tmp + site-packages), so only the
+        # first local task installs. No hash key for top-of-tree → fixed sentinel.
+        assert "flock -x 201" in cmd
+        assert "if [ ! -f /tmp/.dynamo-installed-top-of-tree ]" in cmd
+        assert "touch /tmp/.dynamo-installed-top-of-tree" in cmd
+        assert "201>/tmp/.dynamo-install-top-of-tree.lock" in cmd
+
     def test_hash_and_top_of_tree_not_allowed(self):
         """Cannot specify both hash and top_of_tree."""
         from srtctl.core.schema import DynamoConfig


### PR DESCRIPTION
## Problem

srtctl's `dynamo.install: true` runs its `pip install`s (and, for top-of-tree, the whole clone+build) on **every task/rank**. With pyxis/enroot, all tasks on a node that share a `--container-image` share **one** container instance — one rootfs, one `site-packages`, one `/tmp`. So N concurrent installs race on those shared paths.

On containers that **pre-ship ai-dynamo's Python deps at conflicting versions** (e.g. `nvcr.io/nvidia/tensorrt-llm/release`, which carries pydantic / pydantic-core / typing-extensions / uvloop for TRT-LLM), `--force-reinstall` tears those down concurrently and dies:

```
Uninstalling typing_extensions-4.15.0:
ERROR: Could not install packages due to an OSError:
       [Errno 2] No such file or directory: '.../__pycache__/typing_extensions.cpython-312.pyc'
*** STEP … CANCELLED … DUE TO TASK FAILURE ***
```

**Repro:** a Qwen3.5 dynamo-trt disagg sweep on the TRT-LLM rc20 release container (TP2 prefill / TP4 decode → multiple tasks per node) — every worker log shows the doubled `Processing …/ai_dynamo_runtime.whl` and the `OSError` above (NVIDIA/InferenceMAX#133).

SGLang `dynamo.hash` configs run the same code path but don't fail: their container doesn't pre-ship those conflicting deps, so `--force-reinstall` isn't removing shared files out from under a racing sibling.

## Fix

Serialize the install **per node** with a node-local `flock` + sentinel in `/tmp` (site-packages is per node / per container instance): the first local task installs, the rest block on the lock then skip. This is the desired end state anyway — one shared install per node that all ranks import — just without concurrent writers.

Both install paths are guarded:

- **`_hash_cached_source_install`** (`dynamo.hash`) — the shared `/configs` build-flock is unchanged; the new node-local guard wraps only the post-build `pip install`s. Sentinel keyed by hash.
- **`_live_source_install_for_top_of_tree`** (`dynamo.top_of_tree`) — had **no** flock at all, and both the SGLang and portable branches clone/build/install into shared paths (`/sgl-workspace` or `/tmp`, plus site-packages). The whole install is now wrapped in the same node-local guard. Fixed sentinel key (HEAD has no hash; a container instance only ever installs one top-of-tree build).

Successful run: https://github.com/NVIDIA/InferenceMAX/actions/runs/28761452215/job/85277686958?pr=133

## Test

Extended `test_hash_install_command` and `test_top_of_tree_install_command` to assert the node-local guard (`flock -x 201`, the sentinel check/touch, the `201>` lock file); existing substring assertions still hold. `tests/test_configs.py` is fully green (112 passed). Full suite passes except two pre-existing, unrelated console-rendering assertions (`test_apply_json::test_apply_without_json_emits_prose_only`, `test_dry_run::…test_srun_options_shown`) that also fail on clean `main` in a narrow terminal.
