### PR TITLE
Add numactl prefix for gb200 and gb300 trtllm workers for better perf

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -184,7 +184,10 @@ class TRTLLMProtocol:
         # For local models, model is mounted to /model in the container
         model_arg = str(runtime.model_path) if runtime.is_hf_model else "/model"
 
-        base_prefix = list(nsys_prefix) + ["trtllm-llmapi-launch"] if nsys_prefix else ["trtllm-llmapi-launch"]
+        numactl_prefix = (
+            ["numactl", "-m", "0,1"] if runtime.gpu_type in ("gb200", "gb300") and mode in ("prefill", "decode") else []
+        )
+        base_prefix = list(nsys_prefix or []) + numactl_prefix + ["trtllm-llmapi-launch"]
 
         # trtllm-serve path: launch an OpenAI-compatible trtllm-serve worker. The
         # trtllm_serve frontend fronts these via a static ser.yaml (context/generation

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -183,6 +183,7 @@ class RuntimeContext:
     # Fields with defaults must come after required fields
     # HuggingFace model support - True if model.path was "hf:model/name"
     is_hf_model: bool = False
+    gpu_type: str | None = None
 
     # Container mounts: host_path -> container_path
     container_mounts: dict[Path, Path] = field(default_factory=dict)
@@ -340,6 +341,7 @@ class RuntimeContext:
             model_path=model_path,
             container_image=container_image,
             gpus_per_node=config.resources.gpus_per_node,
+            gpu_type=config.resources.gpu_type,
             network_interface=get_srtslurm_setting("network_interface", "eth0"),
             container_mounts={},
             srun_options=dict(config.srun_options),
@@ -363,6 +365,7 @@ class RuntimeContext:
             model_path=model_path,
             container_image=container_image,
             gpus_per_node=config.resources.gpus_per_node,
+            gpu_type=config.resources.gpu_type,
             network_interface=get_srtslurm_setting("network_interface", "eth0"),
             container_mounts=container_mounts,
             srun_options=dict(config.srun_options),


### PR DESCRIPTION
GB200/GB300 NVLink-Switch systems have a split NUMA topology. Without explicit NUMA binding, TRTLLM worker processes may allocate memory across NUMA nodes, causing remote memory access latency. Binding to nodes 0 and 1 keeps allocations local to the correct socket.

This only applies to disaggregated prefill/decode workers — aggregated mode does not benefit from the same binding and is excluded.