### PR TITLE
fix: use flock to limit the concurrent installation for pip wheel when ntasks > 1 in srun

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1212,11 +1212,7 @@ def _serialize_node_install(install_cmd: str) -> str:
     """
     # Resolve the env dir at runtime; fall back to $HOME (also container-private)
     # if python3 is somehow unavailable before the install runs.
-    resolve_dir = (
-        'DYN_LOCK_DIR="$(python3 -c '
-        "'import sys; print(sys.prefix)'"
-        ' 2>/dev/null || echo "${HOME:-/root}")"'
-    )
+    resolve_dir = 'DYN_LOCK_DIR="$(python3 -c \'import sys; print(sys.prefix)\' 2>/dev/null || echo "${HOME:-/root}")"'
     lock = '"$DYN_LOCK_DIR/.srtctl_dynamo_install.lock"'
     sentinel = '"$DYN_LOCK_DIR/.srtctl_dynamo_install.complete"'
     return (

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1081,6 +1081,9 @@ def _hash_cached_source_install(dynamo_hash: str) -> str:
     (``dynamo-src.tar.gz``), and a ``.complete`` sentinel that's only touched
     on a successful build. flock on the per-hash lock file serializes the
     cold-cache build across multiple frontends starting in parallel.
+
+    Uses FD 201 (not 200) so it nests cleanly inside the node-local
+    ``flock -x 200`` from ``_serialize_node_install``.
     """
     cache = f"{_DYNAMO_CACHE_ROOT}/{dynamo_hash}"
     lock = f"{_DYNAMO_CACHE_ROOT}/.{dynamo_hash}.lock"
@@ -1090,7 +1093,7 @@ def _hash_cached_source_install(dynamo_hash: str) -> str:
         # Subshell + flock-FD pattern: only the first frontend in a cold-cache
         # job builds; later frontends block on the lock then read .complete.
         f"( "
-        f"flock -x 200; "
+        f"flock -x 201; "
         f"if [ ! -f {cache}/.complete ]; then "
         # Build tools — install on cold cache only. apt + protoc + cargo + maturin.
         f"apt-get update -qq && apt-get install -y -qq libclang-dev curl git protobuf-compiler > /dev/null 2>&1 && "
@@ -1120,7 +1123,7 @@ def _hash_cached_source_install(dynamo_hash: str) -> str:
         f"touch {cache}/.complete && "
         f"cd / && rm -rf $DYN_BUILD_DIR; "
         f"fi "
-        f") 200>{lock} && "
+        f") 201>{lock} && "
         # Install from the (now warm) cache. Both branches above land here.
         f"pip install --break-system-packages --force-reinstall {cache}/ai_dynamo_runtime-*.whl && "
         f"rm -rf /tmp/dynamo-src && mkdir -p /tmp/dynamo-src && "
@@ -1181,6 +1184,48 @@ def _live_source_install_for_top_of_tree() -> str:
     return (
         "echo 'Installing dynamo from source (HEAD)...' && "
         f"if [ -d /sgl-workspace ]; then {sglang}; else {portable}; fi"
+    )
+
+
+def _serialize_node_install(install_cmd: str) -> str:
+    """Serialize a node-shared dynamo install across co-located srun tasks.
+
+    With ``--ntasks-per-node > 1`` (e.g. TRTLLM's MPI-style launch, one task
+    per GPU), every task on a node runs the worker preamble concurrently
+    against the same shared container root. Concurrent pip installs into the
+    same site-packages race and corrupt each other. An exclusive ``flock``
+    serializes them; a sentinel lets every task after the first short-circuit
+    the (idempotent) install entirely.
+
+    The lock/sentinel are anchored in the active Python environment
+    (``sys.prefix``) — the exact resource being protected. That location is
+    part of the container root filesystem, so it is:
+      * shared by every task sharing that site-packages (correct serialization),
+      * private to each container instance, so co-located containers with a
+        bind-mounted /tmp neither over-serialize nor wrongly skip each other's
+        install, and distinct across jobs (no cross-job/version staleness).
+
+    FD 200 (node-local) is kept distinct from the ``flock -x 201`` that the
+    hash-pinned source install nests on the /configs cache lock inside a
+    subshell. Distinct FDs keep the two node-local and cross-node locks
+    independent and refactor-proof even if that inner subshell is removed.
+    """
+    # Resolve the env dir at runtime; fall back to $HOME (also container-private)
+    # if python3 is somehow unavailable before the install runs.
+    resolve_dir = (
+        'DYN_LOCK_DIR="$(python3 -c '
+        "'import sys; print(sys.prefix)'"
+        ' 2>/dev/null || echo "${HOME:-/root}")"'
+    )
+    lock = '"$DYN_LOCK_DIR/.srtctl_dynamo_install.lock"'
+    sentinel = '"$DYN_LOCK_DIR/.srtctl_dynamo_install.complete"'
+    return (
+        f"{resolve_dir} && "
+        f"( flock -x 200; "
+        f"if [ -f {sentinel} ]; then "
+        f"echo 'dynamo install already completed in this environment, skipping'; "
+        f"else {{ {install_cmd} ; }} && touch {sentinel}; fi "
+        f") 200>{lock}"
     )
 
 
@@ -1260,7 +1305,17 @@ class DynamoConfig:
         return env
 
     def get_install_commands(self) -> str:
-        """Get the bash commands to install dynamo."""
+        """Get the bash commands to install dynamo.
+
+        The returned command is wrapped in a node-local flock + sentinel so
+        that co-located srun tasks (``--ntasks-per-node > 1``, e.g. TRTLLM)
+        install once per node instead of racing concurrent pip installs into
+        the shared container site-packages. See ``_serialize_node_install``.
+        """
+        return _serialize_node_install(self._build_install_commands())
+
+    def _build_install_commands(self) -> str:
+        """Build the raw (unserialized) dynamo install command."""
         if self.wheel is not None:
             wheel_name = self.wheel_name or Path(self.wheel).name
             version = self.wheel_version

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -192,6 +192,34 @@ class TestDynamoConfig:
         assert "maturin" not in cmd
         assert "git clone" not in cmd
 
+    def test_install_command_serialized_with_flock(self):
+        """Install command is wrapped in a per-environment flock + sentinel.
+
+        With --ntasks-per-node > 1 (e.g. TRTLLM), co-located tasks race
+        concurrent pip installs into the shared container site-packages. The
+        wrapper serializes them and lets tasks after the first skip. The lock
+        is anchored in the Python env (sys.prefix), NOT /tmp, so co-located
+        containers with a bind-mounted /tmp don't collide.
+        """
+        from srtctl.core.schema import DynamoConfig
+
+        for config in (
+            DynamoConfig(version="0.8.0"),
+            DynamoConfig(wheel="1.2.0.dev20260426"),
+        ):
+            cmd = config.get_install_commands()
+            # Lock dir resolved from the active Python env, not /tmp.
+            assert "sys.prefix" in cmd
+            assert "/tmp/srtctl_dynamo_install" not in cmd
+            # FD 200 node-local; the hash source install nests flock -x 201 on
+            # the /configs cache lock; distinct FDs keep the locks independent.
+            assert "flock -x 200" in cmd
+            assert '$DYN_LOCK_DIR/.srtctl_dynamo_install.lock' in cmd
+            assert '$DYN_LOCK_DIR/.srtctl_dynamo_install.complete' in cmd
+            # Sentinel short-circuits repeat installs; touched on success.
+            assert 'touch "$DYN_LOCK_DIR/.srtctl_dynamo_install.complete"' in cmd
+            assert '200>"$DYN_LOCK_DIR/.srtctl_dynamo_install.lock"' in cmd
+
     def test_hash_install_command(self):
         """Hash config generates a cache-aware source-install command.
 
@@ -209,7 +237,7 @@ class TestDynamoConfig:
         # Cache lookup + flock-protected cold build
         assert "/configs/dynamo-wheels/abc123" in cmd
         assert "/configs/dynamo-wheels/abc123/.complete" in cmd
-        assert "flock -x 200" in cmd
+        assert "flock -x 201" in cmd
         assert "/configs/dynamo-wheels/.abc123.lock" in cmd
 
         # Cold-cache build still does git clone + checkout + maturin build
@@ -254,7 +282,7 @@ class TestDynamoConfig:
         # Both branches (sglang + portable) must force-reinstall maturin — the
         # portable branch previously used a guarded plain install that no-ops on
         # images shipping maturin without a console script.
-        sglang_branch, portable_branch = cmd.split("else", 1)
+        sglang_branch, portable_branch = config._build_install_commands().split("else", 1)
         assert "--force-reinstall --quiet maturin" in sglang_branch
         assert "--force-reinstall --quiet maturin" in portable_branch
 


### PR DESCRIPTION
## Serialize dynamo install across co-located srun tasks (fix TRTLLM `ntasks-per-node > 1`)

### Problem

TRTLLM launches one endpoint as a single MPI-style `srun` spanning all its nodes, with one task per GPU (e.g. a TP32 decode worker = `--nodes 8 --ntasks 32` → 4 tasks per node). All tasks on a node share the same pyxis container root and the same Python `site-packages`.

When `dynamo.install` is enabled, every task runs the worker preamble concurrently — so all 4 tasks per node fire `pip install ai-dynamo` at the same time into one shared environment. Concurrent pip installs race and corrupt each other, causing flaky/failed worker startup on any recipe with `--ntasks-per-node > 1`.

### Fix

Wrap the generated dynamo install command in a per-environment `flock` + sentinel (`_serialize_node_install`):

- **Exclusive `flock`** serializes co-located tasks — the first task installs, the rest block.
- **Sentinel file** lets every task after the first short-circuit the (idempotent) install entirely, so it runs once per node instead of N times.
- **Lock/sentinel anchored in the active Python env (`sys.prefix`)**, not `/tmp`. `sys.prefix` is the exact resource being protected, so the lock scope automatically matches the site-packages scope:
  - shared by every task sharing that environment (correct serialization),
  - private to each container instance — co-located containers with a bind-mounted `/tmp` don't over-serialize or wrongly skip each other's install,
  - distinct across jobs (no cross-job/version staleness).

### FD hygiene

The node-local wrapper uses `flock -x 200`; the pre-existing hash-pinned source install (`_hash_cached_source_install`, which flocks the shared `/configs` cache) is moved to `flock -x 201`. Distinct FDs keep the node-local and cross-node locks independent and refactor-proof when one nests inside the other.

### Refactor

`get_install_commands()` now wraps the result of a new `_build_install_commands()` (the previous body, unchanged). All install paths — version, wheel, hash source build, top-of-tree — go through the same serialization.