### PR TITLE
Add dynamo request plane tcp/http option (#197)

### DIFF
--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -383,6 +383,10 @@ class SGLangProtocol:
             kv_cfg["endpoint"] = f"tcp://*:{process.kv_events_port}"
             cmd.extend(["--kv-events-config", json.dumps(kv_cfg)])
 
+        # Add request plane (dynamo frontend only)
+        if not use_sglang:
+            cmd.extend(["--request-plane", runtime.request_plane])
+
         # Add all config flags
         cmd.extend(_config_to_cli_args(config))
 

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -239,7 +239,7 @@ class TRTLLMProtocol:
                 "--extra-engine-args",
                 str(container_config_path),
                 "--request-plane",
-                "nats",
+                runtime.request_plane,
             ]
         )
 

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -604,6 +604,9 @@ class VLLMProtocol:
             if node_rank > 0:
                 cmd.append("--headless")
 
+        # Add request plane
+        cmd.extend(["--request-plane", runtime.request_plane])
+
         # Add config dump path
         if dump_config_path:
             cmd.extend(["--dump-config-to", str(dump_config_path)])

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -163,7 +163,7 @@ class WorkerStageMixin:
             "ETCD_ENDPOINTS": f"http://{self.runtime.nodes.infra}:{ETCD_CLIENT_PORT}",
             "NATS_SERVER": f"nats://{self.runtime.nodes.infra}:{NATS_PORT}",
             "DYN_SYSTEM_PORT": str(process.sys_port),
-            "DYN_REQUEST_PLANE": "nats",
+            "DYN_REQUEST_PLANE": self.config.dynamo.request_plane,
             "DYN_SKIP_SGLANG_LOG_FORMATTING": "1",
         }
 

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -197,6 +197,9 @@ class RuntimeContext:
     # Frontend port (for benchmark endpoint)
     frontend_port: int = FRONTEND_PUBLIC_PORT
 
+    # Request plane for dynamo workers
+    request_plane: str = "nats"
+
     @classmethod
     def from_config(
         cls,
@@ -347,6 +350,7 @@ class RuntimeContext:
             srun_options=dict(config.srun_options),
             environment=environment,
             is_hf_model=is_hf_model,
+            request_plane=config.dynamo.request_plane,
         )
 
         # Expand FormattablePath mounts
@@ -371,6 +375,7 @@ class RuntimeContext:
             srun_options=dict(config.srun_options),
             environment=environment,
             is_hf_model=is_hf_model,
+            request_plane=config.dynamo.request_plane,
         )
 
     def format_string(self, template: str, **extra_kwargs) -> str:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1240,15 +1240,19 @@ class DynamoConfig:
         top_of_tree: Clone repo at HEAD (latest)
         wheel: ai-dynamo package version to install via staged wheels. The
                matching ai-dynamo-runtime wheel is installed automatically.
+        request_plane: Request plane to use (default: "nats"). Valid values: "nats", "tcp", "http"
 
     If top_of_tree, hash, or wheel is set, version is automatically cleared.
     """
+
+    _VALID_REQUEST_PLANES: ClassVar[tuple[str, ...]] = ("nats", "tcp", "http")
 
     install: bool = True
     version: str | None = "0.8.0"
     hash: str | None = None
     top_of_tree: bool = False
     wheel: str | None = None
+    request_plane: str = "nats"
 
     def __post_init__(self) -> None:
         install_sources = [
@@ -1271,6 +1275,11 @@ class DynamoConfig:
                 raise ValueError("dynamo.wheel must be a non-empty package version")
             if Path(self.wheel).name.endswith(".whl") or "/" in self.wheel:
                 raise ValueError("dynamo.wheel must be a package version like '1.2.0.dev20260426', not a filename")
+
+        if self.request_plane not in self._VALID_REQUEST_PLANES:
+            raise ValueError(
+                f"Invalid request_plane '{self.request_plane}', must be one of: {', '.join(self._VALID_REQUEST_PLANES)}"
+            )
 
     @property
     def needs_source_install(self) -> bool:

--- a/src/srtctl/frontends/dynamo.py
+++ b/src/srtctl/frontends/dynamo.py
@@ -85,7 +85,7 @@ class DynamoFrontend:
             env_to_set = {
                 "ETCD_ENDPOINTS": f"http://{runtime.nodes.infra}:{ETCD_CLIENT_PORT}",
                 "NATS_SERVER": f"nats://{runtime.nodes.infra}:{NATS_PORT}",
-                "DYN_REQUEST_PLANE": "nats",
+                "DYN_REQUEST_PLANE": config.dynamo.request_plane,
                 "DYN_SKIP_SGLANG_LOG_FORMATTING": "1",
             }
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -327,6 +327,34 @@ class TestDynamoConfig:
             "DYNAMO_WHEEL_NAME": "ai_dynamo-1.2.0.dev20260426-py3-none-any.whl",
         }
 
+    def test_request_plane_default_nats(self):
+        """Default request_plane is 'nats'."""
+        from srtctl.core.schema import DynamoConfig
+
+        config = DynamoConfig()
+        assert config.request_plane == "nats"
+
+    def test_request_plane_tcp(self):
+        """request_plane='tcp' is accepted."""
+        from srtctl.core.schema import DynamoConfig
+
+        config = DynamoConfig(request_plane="tcp")
+        assert config.request_plane == "tcp"
+
+    def test_request_plane_http(self):
+        """request_plane='http' is accepted."""
+        from srtctl.core.schema import DynamoConfig
+
+        config = DynamoConfig(request_plane="http")
+        assert config.request_plane == "http"
+
+    def test_request_plane_invalid(self):
+        """Invalid request_plane raises ValueError."""
+        from srtctl.core.schema import DynamoConfig
+
+        with pytest.raises(ValueError, match="Invalid request_plane"):
+            DynamoConfig(request_plane="grpc")
+
 
 class TestSGLangProtocol:
     """Tests for SGLangProtocol."""

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -524,7 +524,7 @@ def _dynamo_frontend_call(*, dynamo_install: bool):
     config = SimpleNamespace(
         frontend=SimpleNamespace(args=None, env=None),
         observability=ObservabilityConfig(),
-        dynamo=SimpleNamespace(install=dynamo_install, get_install_commands=lambda: "echo install-dynamo"),
+        dynamo=SimpleNamespace(install=dynamo_install, get_install_commands=lambda: "echo install-dynamo", request_plane="nats"),
         setup_script=None,
     )
     with patch("srtctl.frontends.dynamo.start_srun_process") as mock_srun:

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -161,7 +161,7 @@ def test_worker_stage_wraps_nonfatal_fingerprint_hook(tmp_path: Path) -> None:
     mixin.config = SimpleNamespace(
         setup_script="setup.sh",
         frontend=SimpleNamespace(type="sglang"),
-        dynamo=SimpleNamespace(install=False),
+        dynamo=SimpleNamespace(install=False, request_plane="nats"),
         observability=ObservabilityConfig(),
         profiling=SimpleNamespace(enabled=False, is_nsys=False),
         backend=backend,
@@ -212,7 +212,7 @@ def _remap_worker_mixin(tmp_path: Path, *, frontend_type: str, dynamo_install: b
     mixin.config = SimpleNamespace(
         setup_script=None,
         frontend=SimpleNamespace(type=frontend_type),
-        dynamo=SimpleNamespace(install=dynamo_install, get_install_commands=lambda: "echo install-dynamo"),
+        dynamo=SimpleNamespace(install=dynamo_install, get_install_commands=lambda: "echo install-dynamo", request_plane="nats"),
         observability=ObservabilityConfig(),
         profiling=SimpleNamespace(enabled=False, is_nsys=False),
         backend=backend,


### PR DESCRIPTION
(cherry picked from commit 89bd66b82bc53dd28b98989f115ca472337c9234)

## Summary

- Adds a configurable `request_plane` field to `DynamoConfig` (valid values: `"nats"`, `"tcp"`, `"http"`; default: `"nats"`)
- Propagates the configured value through `RuntimeContext` and into all three backends (SGLang, TRTLLM, vLLM) and both the worker environment (`DYN_REQUEST_PLANE`) and dynamo frontend
- Replaces every hardcoded `"nats"` reference with the runtime-resolved value

## Motivation

The request plane was previously hardcoded to `"nats"` in four separate places. Supporting `tcp` and `http` request planes (e.g. for environments without a NATS broker) required no code path — only a config field and plumbing.

## Usage

```yaml
dynamo:
  request_plane: tcp   # or "nats" (default) or "http"