### PR TITLE
Run worker fingerprint capture from mounted script

### DIFF
--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -12,7 +12,7 @@ import shlex
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
-from srtctl.core.fingerprint import generate_capture_script
+from srtctl.core.fingerprint import generate_capture_command
 from srtctl.core.processes import ManagedProcess, NamedProcesses
 from srtctl.core.schema import build_otel_env, installs_dynamo
 from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, get_hostname_ip, start_srun_process
@@ -223,7 +223,7 @@ class WorkerStageMixin:
 
         # Build bash preamble (setup script + dynamo install + fingerprint)
         bash_preamble = self._build_worker_preamble()
-        fp_cmd = generate_capture_script(f"/logs/fingerprint_{mode}_w{index}.json")
+        fp_cmd = generate_capture_command(f"/logs/fingerprint_{mode}_w{index}.json")
         # Keep fingerprint failures non-fatal, but do not let its `|| true`
         # mask failures from setup/dynamo install commands before it.
         fp_cmd = f"( {fp_cmd} )"
@@ -350,7 +350,7 @@ class WorkerStageMixin:
 
         # Build bash preamble (setup script + dynamo install + fingerprint)
         bash_preamble = self._build_worker_preamble()
-        fp_cmd = generate_capture_script(f"/logs/fingerprint_{mode}_w{index}.json")
+        fp_cmd = generate_capture_command(f"/logs/fingerprint_{mode}_w{index}.json")
         # Keep fingerprint failures non-fatal, but do not let its `|| true`
         # mask failures from setup/dynamo install commands before it.
         fp_cmd = f"( {fp_cmd} )"

--- a/src/srtctl/core/fingerprint.py
+++ b/src/srtctl/core/fingerprint.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import platform
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -34,79 +35,20 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from srtctl.runtime_scripts import FINGERPRINT_SCRIPT_CONTAINER_PATH
+from srtctl.runtime_scripts.fingerprint import (
+    FRAMEWORK_PACKAGES,
+    UNAVAILABLE,
+    cpu_model_from_cpuinfo,
+)
+from srtctl.runtime_scripts.fingerprint import (
+    format_cpu_ids as _format_cpu_ids,
+)
+
 logger = logging.getLogger(__name__)
 
 # Timeout for external commands (seconds)
 _CMD_TIMEOUT = 5
-
-# Sentinel for probes that failed
-UNAVAILABLE = "unavailable"
-
-# Framework name -> pip package name mapping.
-# Used in both native Python probes and the bash capture script.
-FRAMEWORK_PACKAGES: dict[str, str] = {
-    "vllm": "vllm",
-    "sglang": "sglang",
-    "tensorrt_llm": "tensorrt-llm",
-    "dynamo": "ai-dynamo",
-}
-
-_CPU_MODEL_KEYS = {"model name", "cpu model", "hardware"}
-_ARM_CPUINFO_KEYS = {
-    "cpu implementer",
-    "cpu architecture",
-    "cpu variant",
-    "cpu part",
-    "cpu revision",
-}
-
-
-def cpu_model_from_cpuinfo(cpuinfo: str) -> str | None:
-    """Extract a useful CPU model string from Linux ``/proc/cpuinfo`` text."""
-    arm_fields: dict[str, str] = {}
-    processor_label: str | None = None
-
-    for line in cpuinfo.splitlines():
-        key, separator, value = line.partition(":")
-        if not separator:
-            continue
-        normalized_key = key.strip().lower()
-        normalized_value = value.strip()
-        if not normalized_value:
-            continue
-
-        if normalized_key in _CPU_MODEL_KEYS:
-            return normalized_value
-
-        if normalized_key == "processor" and not normalized_value.isdecimal():
-            processor_label = processor_label or normalized_value
-        elif normalized_key in _ARM_CPUINFO_KEYS:
-            arm_fields.setdefault(normalized_key, normalized_value)
-
-    if processor_label:
-        return processor_label
-
-    implementer = arm_fields.get("cpu implementer")
-    part = arm_fields.get("cpu part")
-    if not implementer and not part:
-        return None
-
-    pieces = ["ARM CPU"]
-    if implementer:
-        pieces.append(f"implementer {implementer}")
-    if part:
-        pieces.append(f"part {part}")
-
-    details = [
-        ("architecture", arm_fields.get("cpu architecture")),
-        ("variant", arm_fields.get("cpu variant")),
-        ("revision", arm_fields.get("cpu revision")),
-    ]
-    detail_text = ", ".join(f"{label} {value}" for label, value in details if value)
-    if detail_text:
-        return f"{' '.join(pieces)} ({detail_text})"
-    return " ".join(pieces)
-
 
 # ============================================================================
 # Data Types
@@ -305,23 +247,6 @@ def probe_cpu() -> ProbeResult:
         )
     except Exception as e:
         return ProbeResult.failure(str(e))
-
-
-def _format_cpu_ids(cpu_ids: list[int]) -> str:
-    """Format sorted CPU IDs as a compact Linux cpuset string."""
-    if not cpu_ids:
-        return ""
-
-    ranges: list[str] = []
-    start = previous = cpu_ids[0]
-    for cpu_id in cpu_ids[1:]:
-        if cpu_id == previous + 1:
-            previous = cpu_id
-            continue
-        ranges.append(str(start) if start == previous else f"{start}-{previous}")
-        start = previous = cpu_id
-    ranges.append(str(start) if start == previous else f"{start}-{previous}")
-    return ",".join(ranges)
 
 
 def probe_gpu() -> ProbeResult:
@@ -855,232 +780,19 @@ def format_identity_verification(results: list[IdentityCheckResult], identity: A
 
 
 # ============================================================================
-# Bash preamble generation — for injection into worker startup
+# Worker capture command generation
 # ============================================================================
 
 
-def generate_capture_script(output_path: str) -> str:
-    """Generate a bash one-liner that captures a fingerprint inside a container.
-
-    The generated command:
-    - Runs the fingerprint capture as a Python script
-    - Is wrapped in || true so it never blocks the worker
-    - Takes ~2 seconds
-
-    Args:
-        output_path: Path inside the container where fingerprint JSON is written,
-                     e.g. "/logs/fingerprint_prefill_w0.json"
-
-    Returns:
-        Bash command string safe for inclusion in a preamble chain.
-    """
-    # We write a temp Python script and execute it, rather than using
-    # python3 -c with inline code. This avoids escaping nightmares when
-    # the command passes through bash → srun → bash → python.
-    script = f"""\
-import json, os, subprocess, platform, socket, sys
-from pathlib import Path
-from datetime import datetime, timezone
-
-def run(cmd, timeout=3):
-    try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
-        return r.stdout.strip() if r.returncode == 0 else None
-    except Exception:
-        return None
-
-def find_python():
-    for p in ['/opt/dynamo/venv/bin/python3', '/opt/venv/bin/python3']:
-        if Path(p).exists():
-            return p
-    return 'python3'
-
-PY = find_python()
-
-def pip_pkgs():
-    result = {{}}
-    for label, cmd in [
-        (PY, f'{{PY}} -m pip freeze 2>/dev/null'.format(PY=PY)),
-        ('python3', 'python3 -m pip freeze 2>/dev/null'),
-        ('pip', 'pip freeze 2>/dev/null'),
-        ('uv', 'uv pip freeze 2>/dev/null'),
-    ]:
-        out = run(cmd)
-        if out:
-            pkgs = sorted([l.strip() for l in out.splitlines() if l.strip() and not l.startswith('#')], key=lambda s: s.lower())
-            if pkgs:
-                result[label] = pkgs
-    return result
-
-def gpu_info():
-    out = run('nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader')
-    if not out: return {{'available': False}}
-    gpus = []
-    for line in out.splitlines():
-        parts = [p.strip() for p in line.split(',')]
-        if len(parts) >= 3:
-            gpus.append({{'name': parts[0], 'driver': parts[1], 'memory': parts[2]}})
-    return {{'available': True, 'driver': gpus[0]['driver'] if gpus else 'unknown', 'gpus': gpus}}
-
-def cpu_model_from_cpuinfo(cpuinfo_text):
-    arm_fields = {{}}
-    processor_label = None
-    for line in cpuinfo_text.splitlines():
-        key, separator, value = line.partition(':')
-        if not separator:
-            continue
-        key = key.strip().lower()
-        value = value.strip()
-        if not value:
-            continue
-        if key in ('model name', 'cpu model', 'hardware'):
-            return value
-        if key == 'processor' and not value.isdecimal():
-            processor_label = processor_label or value
-        elif key in ('cpu implementer', 'cpu architecture', 'cpu variant', 'cpu part', 'cpu revision'):
-            arm_fields.setdefault(key, value)
-    if processor_label:
-        return processor_label
-    implementer = arm_fields.get('cpu implementer')
-    part = arm_fields.get('cpu part')
-    if not implementer and not part:
-        return None
-    pieces = ['ARM CPU']
-    if implementer:
-        pieces.append(f'implementer {{implementer}}')
-    if part:
-        pieces.append(f'part {{part}}')
-    details = [
-        ('architecture', arm_fields.get('cpu architecture')),
-        ('variant', arm_fields.get('cpu variant')),
-        ('revision', arm_fields.get('cpu revision')),
+def generate_capture_command(output_path: str) -> str:
+    """Generate the non-fatal worker command for mounted fingerprint capture."""
+    command = [
+        "python3",
+        str(FINGERPRINT_SCRIPT_CONTAINER_PATH),
+        "--output",
+        output_path,
     ]
-    detail_text = ', '.join(f'{{label}} {{value}}' for label, value in details if value)
-    if detail_text:
-        return f"{{' '.join(pieces)}} ({{detail_text}})"
-    return ' '.join(pieces)
-
-def cpu_info():
-    model = 'unavailable'
-    cpuinfo = Path('/proc/cpuinfo')
-    if cpuinfo.exists():
-        model = cpu_model_from_cpuinfo(cpuinfo.read_text(errors='replace')) or 'unavailable'
-    try:
-        affinity_ids = sorted(os.sched_getaffinity(0))
-    except (AttributeError, OSError):
-        affinity_ids = []
-    affinity_ranges = []
-    if affinity_ids:
-        start = previous = affinity_ids[0]
-        for cpu_id in affinity_ids[1:]:
-            if cpu_id == previous + 1:
-                previous = cpu_id
-                continue
-            affinity_ranges.append(str(start) if start == previous else f'{{start}}-{{previous}}')
-            start = previous = cpu_id
-        affinity_ranges.append(str(start) if start == previous else f'{{start}}-{{previous}}')
-    slurm_keys = ('SLURM_CPUS_ON_NODE', 'SLURM_CPUS_PER_GPU', 'SLURM_CPUS_PER_TASK', 'SLURM_JOB_CPUS_PER_NODE')
-    return {{
-        'model': model,
-        'logical_cpus': os.cpu_count(),
-        'affinity_cpus': len(affinity_ids) if affinity_ids else None,
-        'affinity_list': ','.join(affinity_ranges) if affinity_ranges else None,
-        'slurm': {{key: os.environ[key] for key in slurm_keys if key in os.environ}},
-    }}
-
-def framework_versions():
-    # Use importlib.metadata for all packages — avoids loading native CUDA
-    # extensions (tensorrt_llm, torch) which fail without GPU context.
-    versions = {{}}
-    for name, pkg in [{", ".join(f"('{n}', '{p}')" for n, p in FRAMEWORK_PACKAGES.items())}]:
-        v = run(f"{{PY}} -c \\"import importlib.metadata; print(importlib.metadata.version('{{pkg}}'))\\"".format(PY=PY, pkg=pkg))
-        if v:
-            versions[name] = v
-    return versions
-
-def model_identity(model_path):
-    info = {{}}
-    mp = Path(model_path) if model_path else None
-    if not mp or not mp.exists():
-        return None
-    # HuggingFace snapshot_download: refs/main has commit SHA
-    for refs_path in [mp / '.huggingface' / 'refs' / 'main', mp / 'refs' / 'main']:
-        if refs_path.exists():
-            info['hf_revision'] = refs_path.read_text().strip()
-            break
-    # HuggingFace hf download --local-dir: .cache/huggingface/download/*.metadata
-    # Line 1 of each .metadata file is the commit hash
-    if 'hf_revision' not in info:
-        cache_dl = mp / '.cache' / 'huggingface' / 'download'
-        if cache_dl.is_dir():
-            for meta_file in sorted(cache_dl.glob('*.metadata')):
-                try:
-                    first_line = meta_file.read_text().splitlines()[0].strip()
-                    if len(first_line) == 40 and all(c in '0123456789abcdef' for c in first_line):
-                        info['hf_revision'] = first_line
-                        break
-                except Exception:
-                    pass
-    # HuggingFace: check .huggingface/download_metadata.json (older format)
-    meta = mp / '.huggingface' / 'download_metadata.json'
-    if meta.exists():
-        try:
-            m = json.loads(meta.read_text())
-            if 'commit_hash' in m:
-                info['hf_revision'] = m['commit_hash']
-            if 'repo_id' in m:
-                info['hf_repo'] = m['repo_id']
-        except Exception:
-            pass
-    # config.json often has _name_or_path
-    config_json = mp / 'config.json'
-    if config_json.exists():
-        try:
-            cfg = json.loads(config_json.read_text())
-            if '_name_or_path' in cfg:
-                info['model_id'] = cfg['_name_or_path']
-        except Exception:
-            pass
-    return info or None
-
-def env_vars():
-    import os
-    prefixes = ('CUDA_', 'TORCH_', 'PYTORCH_', 'NCCL_', 'VLLM_', 'SGLANG_', 'SGL_',
-                'TRTLLM_', 'TRT_LLM_', 'TENSORRT_', 'HF_', 'TRANSFORMERS_', 'DYN_',
-                'NVIDIA_', 'OMPI_', 'UCX_', 'NVSHMEM_')
-    secrets = ('TOKEN', 'KEY', 'SECRET', 'PASSWORD', 'CREDENTIAL', 'AUTH')
-    result = {{}}
-    for k, v in sorted(os.environ.items()):
-        if any(k.startswith(p) for p in prefixes):
-            if any(s in k.upper() for s in secrets):
-                result[k] = '***REDACTED***'
-            else:
-                result[k] = v
-    return result
-
-fp = {{
-    'hostname': socket.gethostname(),
-    'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-    'arch': platform.machine(),
-    'os': next((l.split('=',1)[1].strip('"') for l in Path('/etc/os-release').read_text().splitlines() if l.startswith('PRETTY_NAME=')), platform.platform()) if Path('/etc/os-release').exists() else platform.platform(),
-    'cpu': cpu_info(),
-    'gpu': gpu_info(),
-    'python_version': platform.python_version(),
-    'cuda_version': run('nvcc --version 2>/dev/null | grep release') or 'unavailable',
-    'nccl_version': run(f'{{PY}} -c "import torch; print(torch.cuda.nccl.version())"'.format(PY=PY)) or 'unavailable',
-    'frameworks': framework_versions(),
-    'model': model_identity('/model'),
-    'env': env_vars(),
-    'pip_packages': pip_pkgs(),
-}}
-Path('{output_path}').parent.mkdir(parents=True, exist_ok=True)
-Path('{output_path}').write_text(json.dumps(fp, indent=2) + '\\n')
-"""
-    # Use a heredoc via process substitution to pass the script to python3.
-    # This is immune to quoting/escaping issues in the bash → srun chain.
-    # NOTE: <(...) requires bash (not POSIX sh/dash). srun containers use bash.
-    # The || true suffix means non-bash shells silently skip fingerprinting.
-    return f"python3 <(cat <<'__FINGERPRINT_EOF__'\n{script}__FINGERPRINT_EOF__\n) || true"
+    return f"{shlex.join(command)} || true"
 
 
 # ============================================================================

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from srtctl.ports import FRONTEND_PUBLIC_PORT
+from srtctl.runtime_scripts import RUNTIME_SCRIPTS_CONTAINER_DIR, RUNTIME_SCRIPTS_HOST_DIR
 
 from .config import get_srtslurm_setting
 from .slurm import get_hostname_ip, get_slurm_het_nodelists, get_slurm_nodelist
@@ -310,9 +311,8 @@ class RuntimeContext:
             if wheelhouse_dir.exists():
                 container_mounts[wheelhouse_dir.resolve()] = Path("/srtctl-wheels")
 
-        runtime_scripts_dir = Path(__file__).resolve().parent.parent / "runtime_scripts"
-        if runtime_scripts_dir.exists():
-            container_mounts[runtime_scripts_dir.resolve()] = Path("/srtctl-runtime")
+        if RUNTIME_SCRIPTS_HOST_DIR.exists():
+            container_mounts[RUNTIME_SCRIPTS_HOST_DIR] = RUNTIME_SCRIPTS_CONTAINER_DIR
 
         # Mount srtctl benchmark scripts
         from srtctl.benchmarks.base import SCRIPTS_DIR

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -340,10 +340,6 @@ def start_srun_process(
             )
         srun_cmd.extend(command)
 
-    # Demoted to debug — every worker srun line is multi-KB once the
-    # fingerprint heredoc is inlined (see core/fingerprint.generate_capture_script),
-    # which dominates the orchestrator log. Re-enable with `--verbose` / by setting
-    # the srtctl logger to DEBUG when troubleshooting srun arg construction.
     logger.debug("srun command: %s", shlex.join(srun_cmd))
 
     # Start the process

--- a/src/srtctl/runtime_scripts/__init__.py
+++ b/src/srtctl/runtime_scripts/__init__.py
@@ -2,3 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Runtime helper scripts mounted into worker containers."""
+
+from pathlib import Path
+
+RUNTIME_SCRIPTS_HOST_DIR = Path(__file__).resolve().parent
+RUNTIME_SCRIPTS_CONTAINER_DIR = Path("/srtctl-runtime")
+FINGERPRINT_SCRIPT_NAME = "fingerprint.py"
+FINGERPRINT_SCRIPT_HOST_PATH = RUNTIME_SCRIPTS_HOST_DIR / FINGERPRINT_SCRIPT_NAME
+FINGERPRINT_SCRIPT_CONTAINER_PATH = RUNTIME_SCRIPTS_CONTAINER_DIR / FINGERPRINT_SCRIPT_NAME

--- a/src/srtctl/runtime_scripts/fingerprint.py
+++ b/src/srtctl/runtime_scripts/fingerprint.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capture a worker container's runtime environment as JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import socket
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TypeVar
+
+COMMAND_TIMEOUT_SECONDS = 3
+UNAVAILABLE = "unavailable"
+DEFAULT_MODEL_PATH = Path("/model")
+DEFAULT_CPUINFO_PATH = Path("/proc/cpuinfo")
+
+FRAMEWORK_PACKAGES: dict[str, str] = {
+    "vllm": "vllm",
+    "sglang": "sglang",
+    "tensorrt_llm": "tensorrt-llm",
+    "dynamo": "ai-dynamo",
+}
+
+CPU_MODEL_KEYS = {"model name", "cpu model", "hardware"}
+ARM_CPUINFO_KEYS = {
+    "cpu implementer",
+    "cpu architecture",
+    "cpu variant",
+    "cpu part",
+    "cpu revision",
+}
+SLURM_CPU_ENV_KEYS = (
+    "SLURM_CPUS_ON_NODE",
+    "SLURM_CPUS_PER_GPU",
+    "SLURM_CPUS_PER_TASK",
+    "SLURM_JOB_CPUS_PER_NODE",
+)
+ENV_PREFIXES = (
+    "CUDA_",
+    "TORCH_",
+    "PYTORCH_",
+    "NCCL_",
+    "VLLM_",
+    "SGLANG_",
+    "SGL_",
+    "TRTLLM_",
+    "TRT_LLM_",
+    "TENSORRT_",
+    "HF_",
+    "TRANSFORMERS_",
+    "DYN_",
+    "NVIDIA_",
+    "OMPI_",
+    "UCX_",
+    "NVSHMEM_",
+)
+SECRET_MARKERS = ("TOKEN", "KEY", "SECRET", "PASSWORD", "CREDENTIAL", "AUTH")
+T = TypeVar("T")
+
+
+def best_effort(probe: Callable[[], T], fallback: T) -> T:
+    """Run one fingerprint probe without letting it abort the full capture."""
+    try:
+        return probe()
+    except Exception:
+        return fallback
+
+
+def run(command: Sequence[str], timeout: int = COMMAND_TIMEOUT_SECONDS) -> str | None:
+    """Run a probe command and return stripped stdout on success."""
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except Exception:
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def find_python() -> str:
+    """Prefer the Python environment used by common Dynamo containers."""
+    for candidate in ("/opt/dynamo/venv/bin/python3", "/opt/venv/bin/python3"):
+        if Path(candidate).exists():
+            return candidate
+    return "python3"
+
+
+def pip_packages(python: str) -> dict[str, list[str]]:
+    """Capture package inventories from every available package frontend."""
+    result: dict[str, list[str]] = {}
+    commands = (
+        (python, [python, "-m", "pip", "freeze"]),
+        ("python3", ["python3", "-m", "pip", "freeze"]),
+        ("pip", ["pip", "freeze"]),
+        ("uv", ["uv", "pip", "freeze"]),
+    )
+    for label, command in commands:
+        output = run(command)
+        if not output:
+            continue
+        packages = sorted(
+            (line.strip() for line in output.splitlines() if line.strip() and not line.startswith("#")),
+            key=str.lower,
+        )
+        if packages:
+            result[label] = packages
+    return result
+
+
+def gpu_info() -> dict[str, object]:
+    output = run(
+        [
+            "nvidia-smi",
+            "--query-gpu=name,driver_version,memory.total",
+            "--format=csv,noheader",
+        ]
+    )
+    if not output:
+        return {"available": False}
+
+    gpus: list[dict[str, str]] = []
+    for line in output.splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) >= 3:
+            gpus.append({"name": parts[0], "driver": parts[1], "memory": parts[2]})
+    return {
+        "available": True,
+        "driver": gpus[0]["driver"] if gpus else "unknown",
+        "gpus": gpus,
+    }
+
+
+def cpu_model_from_cpuinfo(cpuinfo: str) -> str | None:
+    """Extract a useful CPU model from x86 or ARM ``/proc/cpuinfo`` text."""
+    arm_fields: dict[str, str] = {}
+    processor_label: str | None = None
+
+    for line in cpuinfo.splitlines():
+        key, separator, value = line.partition(":")
+        if not separator:
+            continue
+        normalized_key = key.strip().lower()
+        normalized_value = value.strip()
+        if not normalized_value:
+            continue
+        if normalized_key in CPU_MODEL_KEYS:
+            return normalized_value
+        if normalized_key == "processor" and not normalized_value.isdecimal():
+            processor_label = processor_label or normalized_value
+        elif normalized_key in ARM_CPUINFO_KEYS:
+            arm_fields.setdefault(normalized_key, normalized_value)
+
+    if processor_label:
+        return processor_label
+
+    implementer = arm_fields.get("cpu implementer")
+    part = arm_fields.get("cpu part")
+    if not implementer and not part:
+        return None
+
+    pieces = ["ARM CPU"]
+    if implementer:
+        pieces.append(f"implementer {implementer}")
+    if part:
+        pieces.append(f"part {part}")
+
+    details = (
+        ("architecture", arm_fields.get("cpu architecture")),
+        ("variant", arm_fields.get("cpu variant")),
+        ("revision", arm_fields.get("cpu revision")),
+    )
+    detail_text = ", ".join(f"{label} {value}" for label, value in details if value)
+    if detail_text:
+        return f"{' '.join(pieces)} ({detail_text})"
+    return " ".join(pieces)
+
+
+def format_cpu_ids(cpu_ids: list[int]) -> str:
+    if not cpu_ids:
+        return ""
+
+    ranges: list[str] = []
+    start = previous = cpu_ids[0]
+    for cpu_id in cpu_ids[1:]:
+        if cpu_id == previous + 1:
+            previous = cpu_id
+            continue
+        ranges.append(str(start) if start == previous else f"{start}-{previous}")
+        start = previous = cpu_id
+    ranges.append(str(start) if start == previous else f"{start}-{previous}")
+    return ",".join(ranges)
+
+
+def cpu_info(
+    cpuinfo_path: Path = DEFAULT_CPUINFO_PATH,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    model = UNAVAILABLE
+    try:
+        if cpuinfo_path.exists():
+            model = cpu_model_from_cpuinfo(cpuinfo_path.read_text(errors="replace")) or UNAVAILABLE
+    except OSError:
+        pass
+
+    try:
+        affinity_ids = sorted(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        affinity_ids = []
+
+    runtime_env = os.environ if env is None else env
+    return {
+        "model": model,
+        "logical_cpus": os.cpu_count(),
+        "affinity_cpus": len(affinity_ids) if affinity_ids else None,
+        "affinity_list": format_cpu_ids(affinity_ids) if affinity_ids else None,
+        "slurm": {key: runtime_env[key] for key in SLURM_CPU_ENV_KEYS if key in runtime_env},
+    }
+
+
+def framework_versions(python: str) -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for name, package in FRAMEWORK_PACKAGES.items():
+        output = run(
+            [
+                python,
+                "-c",
+                f"import importlib.metadata; print(importlib.metadata.version({package!r}))",
+            ]
+        )
+        if output:
+            versions[name] = output
+    return versions
+
+
+def model_identity(model_path: Path) -> dict[str, str] | None:
+    if not model_path.exists():
+        return None
+
+    info: dict[str, str] = {}
+    for refs_path in (model_path / ".huggingface" / "refs" / "main", model_path / "refs" / "main"):
+        if refs_path.exists():
+            try:
+                info["hf_revision"] = refs_path.read_text().strip()
+                break
+            except (OSError, UnicodeError):
+                continue
+
+    if "hf_revision" not in info:
+        cache_download = model_path / ".cache" / "huggingface" / "download"
+        if cache_download.is_dir():
+            for metadata_file in sorted(cache_download.glob("*.metadata")):
+                try:
+                    first_line = metadata_file.read_text().splitlines()[0].strip()
+                except (IndexError, OSError, UnicodeError):
+                    continue
+                if len(first_line) == 40 and all(character in "0123456789abcdef" for character in first_line):
+                    info["hf_revision"] = first_line
+                    break
+
+    metadata_path = model_path / ".huggingface" / "download_metadata.json"
+    if metadata_path.exists():
+        metadata = read_json_object(metadata_path)
+        revision = metadata.get("commit_hash")
+        repo_id = metadata.get("repo_id")
+        if isinstance(revision, str):
+            info["hf_revision"] = revision
+        if isinstance(repo_id, str):
+            info["hf_repo"] = repo_id
+
+    config_path = model_path / "config.json"
+    if config_path.exists():
+        config = read_json_object(config_path)
+        model_id = config.get("_name_or_path")
+        if isinstance(model_id, str):
+            info["model_id"] = model_id
+
+    return info or None
+
+
+def read_json_object(path: Path) -> dict[str, object]:
+    """Read a JSON object, treating malformed or differently shaped data as absent."""
+    try:
+        value = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError, UnicodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def environment_variables(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    runtime_env = os.environ if env is None else env
+    result: dict[str, str] = {}
+    for key, value in sorted(runtime_env.items()):
+        if not any(key.startswith(prefix) for prefix in ENV_PREFIXES):
+            continue
+        result[key] = "***REDACTED***" if any(marker in key.upper() for marker in SECRET_MARKERS) else value
+    return result
+
+
+def os_description() -> str:
+    os_release = Path("/etc/os-release")
+    if os_release.exists():
+        try:
+            for line in os_release.read_text().splitlines():
+                if line.startswith("PRETTY_NAME="):
+                    return line.split("=", 1)[1].strip('"')
+        except OSError:
+            pass
+    return platform.platform()
+
+
+def cuda_version() -> str:
+    output = run(["nvcc", "--version"])
+    if output:
+        for line in output.splitlines():
+            if "release" in line:
+                return line.strip()
+    return UNAVAILABLE
+
+
+def nccl_version(python: str) -> str:
+    return run([python, "-c", "import torch; print(torch.cuda.nccl.version())"]) or UNAVAILABLE
+
+
+def capture_fingerprint(
+    model_path: Path = DEFAULT_MODEL_PATH,
+    cpuinfo_path: Path = DEFAULT_CPUINFO_PATH,
+) -> dict[str, object]:
+    python = find_python()
+    return {
+        "hostname": best_effort(socket.gethostname, UNAVAILABLE),
+        "timestamp": best_effort(
+            lambda: datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            UNAVAILABLE,
+        ),
+        "arch": best_effort(platform.machine, UNAVAILABLE),
+        "os": best_effort(os_description, UNAVAILABLE),
+        "cpu": best_effort(
+            lambda: cpu_info(cpuinfo_path),
+            {
+                "model": UNAVAILABLE,
+                "logical_cpus": None,
+                "affinity_cpus": None,
+                "affinity_list": None,
+                "slurm": {},
+            },
+        ),
+        "gpu": best_effort(gpu_info, {"available": False}),
+        "python_version": best_effort(platform.python_version, UNAVAILABLE),
+        "cuda_version": best_effort(cuda_version, UNAVAILABLE),
+        "nccl_version": best_effort(lambda: nccl_version(python), UNAVAILABLE),
+        "frameworks": best_effort(lambda: framework_versions(python), {}),
+        "model": best_effort(lambda: model_identity(model_path), None),
+        "env": best_effort(environment_variables, {}),
+        "pip_packages": best_effort(lambda: pip_packages(python), {}),
+    }
+
+
+def write_fingerprint(output_path: Path, model_path: Path = DEFAULT_MODEL_PATH) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(capture_fingerprint(model_path), indent=2) + "\n")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path, help="Fingerprint JSON output path")
+    parser.add_argument("--model-path", type=Path, default=DEFAULT_MODEL_PATH, help="Mounted model path")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    write_fingerprint(args.output, args.model_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -13,11 +13,12 @@ Every test runs without network, GPU, or special packages — probes are mocked.
 
 from __future__ import annotations
 
-import json
+import shlex
 from pathlib import Path
 from unittest.mock import patch
 
 from srtctl.core.fingerprint import (
+    FRAMEWORK_PACKAGES,
     UNAVAILABLE,
     CheckResult,
     CheckStatus,
@@ -30,11 +31,13 @@ from srtctl.core.fingerprint import (
     diff_fingerprints,
     format_check_results,
     format_diff,
-    generate_capture_script,
+    generate_capture_command,
     load_fingerprint,
     probe_cpu,
     write_fingerprint,
 )
+from srtctl.runtime_scripts import FINGERPRINT_SCRIPT_CONTAINER_PATH, FINGERPRINT_SCRIPT_HOST_PATH
+from srtctl.runtime_scripts.fingerprint import FRAMEWORK_PACKAGES as RUNTIME_FRAMEWORK_PACKAGES
 
 ARM_CPUINFO = """\
 processor       : 0
@@ -581,127 +584,41 @@ class TestFileIO:
 
 
 # ============================================================================
-# Bash script generation
+# Worker capture command generation
 # ============================================================================
 
 
-class TestBashGeneration:
-    """generate_capture_script produces valid, safe bash."""
+class TestCaptureCommand:
+    """generate_capture_command invokes the mounted runtime script safely."""
 
-    def test_script_ends_with_or_true(self):
-        """Script is wrapped in || true so it never blocks the worker."""
-        script = generate_capture_script("/logs/fingerprint.json")
-        assert script.rstrip().endswith("|| true")
+    def test_command_is_non_fatal(self):
+        command = generate_capture_command("/logs/fingerprint.json")
+        assert command.endswith(" || true")
 
-    def test_script_contains_output_path(self):
-        """Output path appears in the generated script."""
-        script = generate_capture_script("/logs/fingerprint_prefill_w0.json")
-        assert "/logs/fingerprint_prefill_w0.json" in script
+    def test_command_invokes_mounted_script(self):
+        command = generate_capture_command("/logs/fingerprint_prefill_w0.json")
+        argv = shlex.split(command.removesuffix(" || true"))
 
-    def test_script_starts_with_python(self):
-        """Script invokes python3."""
-        script = generate_capture_script("/logs/fp.json")
-        assert script.startswith("python3")
+        assert argv == [
+            "python3",
+            str(FINGERPRINT_SCRIPT_CONTAINER_PATH),
+            "--output",
+            "/logs/fingerprint_prefill_w0.json",
+        ]
 
-    def test_script_includes_pip_freeze(self):
-        """Script captures pip packages via pip freeze."""
-        script = generate_capture_script("/logs/fp.json")
-        assert "pip freeze" in script
+    def test_mounted_script_exists_in_package(self):
+        assert FINGERPRINT_SCRIPT_HOST_PATH.is_file()
 
-    def test_script_includes_sorted(self):
-        """Script sorts pip output for deterministic diffs."""
-        script = generate_capture_script("/logs/fp.json")
-        assert "sorted" in script
+    def test_framework_registry_is_shared(self):
+        assert FRAMEWORK_PACKAGES is RUNTIME_FRAMEWORK_PACKAGES
 
-    def test_script_captures_cpu_visibility(self):
-        script = generate_capture_script("/logs/fp.json")
-        assert "def cpu_info():" in script
-        assert "'cpu': cpu_info()" in script
-        assert "SLURM_JOB_CPUS_PER_NODE" in script
+    def test_output_path_is_shell_quoted(self):
+        output_path = "/logs/fingerprint worker; false.json"
+        command = generate_capture_command(output_path)
+        argv = shlex.split(command.removesuffix(" || true"))
 
-    def test_embedded_python_is_syntactically_valid(self):
-        """The Python code inside the script must parse without SyntaxError.
-
-        This is the test that would have caught the \\n escaping bug where
-        literal backslash-n characters were passed to python3 -c instead of
-        real newlines, causing a SyntaxError at runtime.
-        """
-        import ast
-        import re
-
-        script = generate_capture_script("/logs/fingerprint.json")
-        # Extract the Python source from between the heredoc markers
-        match = re.search(
-            r"<<'__FINGERPRINT_EOF__'\n(.+?)__FINGERPRINT_EOF__",
-            script,
-            re.DOTALL,
-        )
-        assert match, f"Could not find heredoc Python source in script:\n{script[:200]}"
-        python_source = match.group(1)
-        # ast.parse raises SyntaxError if the code is invalid
-        ast.parse(python_source)
-
-    def test_embedded_python_produces_json(self):
-        """The embedded script runs and produces valid JSON output."""
-        import re
-        import subprocess
-        import tempfile
-
-        script = generate_capture_script("/tmp/test_fingerprint_output.json")
-        match = re.search(
-            r"<<'__FINGERPRINT_EOF__'\n(.+?)__FINGERPRINT_EOF__",
-            script,
-            re.DOTALL,
-        )
-        assert match
-        python_source = match.group(1)
-
-        # Run the script in a subprocess — probes will return "unavailable"
-        # on a dev machine (no GPU, etc.) but the script must not crash
-        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
-            # Rewrite output path to a temp location
-            f.write(python_source.replace("/tmp/test_fingerprint_output.json", f.name + ".out"))
-            f.flush()
-            result = subprocess.run(
-                ["python3", f.name],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-        assert result.returncode == 0, f"Fingerprint script failed:\n{result.stderr}"
-
-    def test_embedded_python_uses_arm_cpuinfo_fallback(self, tmp_path):
-        """The worker-container script handles ARM cpuinfo without model name."""
-        import re
-        import subprocess
-
-        output_path = tmp_path / "fingerprint.json"
-        cpuinfo_path = tmp_path / "cpuinfo"
-        cpuinfo_path.write_text(ARM_CPUINFO)
-
-        script = generate_capture_script("/tmp/test_fingerprint_output.json")
-        match = re.search(
-            r"<<'__FINGERPRINT_EOF__'\n(.+?)__FINGERPRINT_EOF__",
-            script,
-            re.DOTALL,
-        )
-        assert match
-        python_source = match.group(1)
-        python_source = python_source.replace("/tmp/test_fingerprint_output.json", str(output_path))
-        python_source = python_source.replace("/proc/cpuinfo", str(cpuinfo_path))
-        script_path = tmp_path / "fingerprint.py"
-        script_path.write_text(python_source)
-
-        result = subprocess.run(
-            ["python3", str(script_path)],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        assert result.returncode == 0, f"Fingerprint script failed:\n{result.stderr}"
-
-        data = json.loads(output_path.read_text())
-        assert data["cpu"]["model"] == ARM_CPU_MODEL
+        assert argv[-1] == output_path
+        assert "\n" not in command
 
 
 # ============================================================================

--- a/tests/test_runtime_fingerprint.py
+++ b/tests/test_runtime_fingerprint.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the standalone fingerprint script mounted into workers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from srtctl.runtime_scripts import fingerprint as runtime_fingerprint
+
+ARM_CPUINFO = """\
+processor       : 0
+BogoMIPS        : 2000.00
+Features        : fp asimd evtstrm
+CPU implementer : 0x41
+CPU architecture: 8
+CPU variant     : 0x1
+CPU part        : 0xd49
+CPU revision    : 1
+"""
+
+ARM_CPU_MODEL = "ARM CPU implementer 0x41 part 0xd49 (architecture 8, variant 0x1, revision 1)"
+
+
+def test_cpu_info_uses_arm_fallback(tmp_path, monkeypatch):
+    cpuinfo_path = tmp_path / "cpuinfo"
+    cpuinfo_path.write_text(ARM_CPUINFO)
+    monkeypatch.setattr(runtime_fingerprint.os, "sched_getaffinity", lambda _pid: {0, 1, 3})
+    monkeypatch.setattr(runtime_fingerprint.os, "cpu_count", lambda: 8)
+
+    cpu = runtime_fingerprint.cpu_info(
+        cpuinfo_path,
+        {"SLURM_CPUS_ON_NODE": "3", "IGNORED": "value"},
+    )
+
+    assert cpu == {
+        "model": ARM_CPU_MODEL,
+        "logical_cpus": 8,
+        "affinity_cpus": 3,
+        "affinity_list": "0-1,3",
+        "slurm": {"SLURM_CPUS_ON_NODE": "3"},
+    }
+
+
+def test_environment_variables_redacts_secrets():
+    captured = runtime_fingerprint.environment_variables(
+        {
+            "CUDA_VISIBLE_DEVICES": "0,1",
+            "HF_TOKEN": "secret-value",
+            "UNRELATED": "ignored",
+        }
+    )
+
+    assert captured == {
+        "CUDA_VISIBLE_DEVICES": "0,1",
+        "HF_TOKEN": "***REDACTED***",
+    }
+
+
+def test_model_identity_reads_huggingface_metadata(tmp_path):
+    revision = "a" * 40
+    refs_path = tmp_path / ".huggingface" / "refs" / "main"
+    refs_path.parent.mkdir(parents=True)
+    refs_path.write_text(revision)
+    (tmp_path / "config.json").write_text(json.dumps({"_name_or_path": "org/model"}))
+
+    assert runtime_fingerprint.model_identity(tmp_path) == {
+        "hf_revision": revision,
+        "model_id": "org/model",
+    }
+
+
+def test_model_identity_ignores_wrong_shaped_json(tmp_path):
+    metadata_path = tmp_path / ".huggingface" / "download_metadata.json"
+    metadata_path.parent.mkdir(parents=True)
+    metadata_path.write_text("null")
+    (tmp_path / "config.json").write_text(json.dumps("_name_or_path"))
+
+    assert runtime_fingerprint.model_identity(tmp_path) is None
+
+
+def test_run_contains_unexpected_probe_errors(monkeypatch):
+    def fail(*_args, **_kwargs):
+        raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte")
+
+    monkeypatch.setattr(runtime_fingerprint.subprocess, "run", fail)
+
+    assert runtime_fingerprint.run(["probe"]) is None
+
+
+def test_capture_isolates_probe_failures(tmp_path, monkeypatch):
+    def fail(_model_path):
+        raise RuntimeError("broken model metadata")
+
+    monkeypatch.setattr(runtime_fingerprint, "find_python", lambda: "python3")
+    monkeypatch.setattr(runtime_fingerprint, "os_description", lambda: "Test OS")
+    monkeypatch.setattr(runtime_fingerprint, "cpu_info", lambda _path: {"model": "Test CPU"})
+    monkeypatch.setattr(runtime_fingerprint, "gpu_info", lambda: {"available": False})
+    monkeypatch.setattr(runtime_fingerprint, "cuda_version", lambda: "unavailable")
+    monkeypatch.setattr(runtime_fingerprint, "nccl_version", lambda _python: "unavailable")
+    monkeypatch.setattr(runtime_fingerprint, "framework_versions", lambda _python: {})
+    monkeypatch.setattr(runtime_fingerprint, "model_identity", fail)
+    monkeypatch.setattr(runtime_fingerprint, "environment_variables", lambda: {})
+    monkeypatch.setattr(runtime_fingerprint, "pip_packages", lambda _python: {})
+
+    fingerprint = runtime_fingerprint.capture_fingerprint(tmp_path)
+
+    assert fingerprint["model"] is None
+    assert fingerprint["cpu"] == {"model": "Test CPU"}
+
+
+def test_main_writes_capture_result(tmp_path, monkeypatch):
+    output_path = tmp_path / "fingerprint.json"
+    expected = {"hostname": "worker-0", "cpu": {"model": "test"}}
+    monkeypatch.setattr(runtime_fingerprint, "capture_fingerprint", lambda _model_path: expected)
+
+    runtime_fingerprint.main(
+        [
+            "--output",
+            str(output_path),
+            "--model-path",
+            str(tmp_path / "model"),
+        ]
+    )
+
+    assert json.loads(output_path.read_text()) == expected
+
+
+def test_runtime_script_executes_directly(tmp_path):
+    output_path = tmp_path / "fingerprint.json"
+    script_path = Path(runtime_fingerprint.__file__)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script_path),
+            "--output",
+            str(output_path),
+            "--model-path",
+            str(tmp_path / "missing-model"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert result.returncode == 0, result.stderr
+    fingerprint = json.loads(output_path.read_text())
+    assert list(fingerprint) == [
+        "hostname",
+        "timestamp",
+        "arch",
+        "os",
+        "cpu",
+        "gpu",
+        "python_version",
+        "cuda_version",
+        "nccl_version",
+        "frameworks",
+        "model",
+        "env",
+        "pip_packages",
+    ]
+    assert fingerprint["hostname"]

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -37,6 +37,22 @@ def test_start_srun_exports_env_before_preamble() -> None:
     assert bash_cmd.index("echo preamble") < bash_cmd.index("python3 -m server")
 
 
+def test_start_srun_does_not_log_exported_secrets_at_info(caplog) -> None:
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+        caplog.at_level("INFO", logger="srtctl.core.slurm"),
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(
+            ["python3", "-m", "server"],
+            env_to_set={"AWS_SECRET_ACCESS_KEY": "do-not-log-this"},
+        )
+
+    assert "do-not-log-this" not in caplog.text
+
+
 def test_cluster_bash_preamble_runs_before_exports_and_local_preamble() -> None:
     with (
         patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
@@ -189,7 +205,7 @@ def test_worker_stage_wraps_nonfatal_fingerprint_hook(tmp_path: Path) -> None:
     )
 
     with (
-        patch("srtctl.cli.mixins.worker_stage.generate_capture_script", return_value="fingerprint || true"),
+        patch("srtctl.cli.mixins.worker_stage.generate_capture_command", return_value="fingerprint || true"),
         patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
     ):
         mock_srun.return_value = MagicMock()
@@ -212,7 +228,9 @@ def _remap_worker_mixin(tmp_path: Path, *, frontend_type: str, dynamo_install: b
     mixin.config = SimpleNamespace(
         setup_script=None,
         frontend=SimpleNamespace(type=frontend_type),
-        dynamo=SimpleNamespace(install=dynamo_install, get_install_commands=lambda: "echo install-dynamo", request_plane="nats"),
+        dynamo=SimpleNamespace(
+            install=dynamo_install, get_install_commands=lambda: "echo install-dynamo", request_plane="nats"
+        ),
         observability=ObservabilityConfig(),
         profiling=SimpleNamespace(enabled=False, is_nsys=False),
         backend=backend,
@@ -244,7 +262,7 @@ def _remap_worker_mixin(tmp_path: Path, *, frontend_type: str, dynamo_install: b
 def test_worker_stage_injects_remap_root_for_dynamo_install(tmp_path: Path) -> None:
     mixin, process = _remap_worker_mixin(tmp_path, frontend_type="dynamo", dynamo_install=True)
     with (
-        patch("srtctl.cli.mixins.worker_stage.generate_capture_script", return_value="fingerprint || true"),
+        patch("srtctl.cli.mixins.worker_stage.generate_capture_command", return_value="fingerprint || true"),
         patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
     ):
         mock_srun.return_value = MagicMock()
@@ -256,7 +274,7 @@ def test_worker_stage_injects_remap_root_for_dynamo_install(tmp_path: Path) -> N
 def test_worker_stage_no_remap_root_for_sglang_frontend(tmp_path: Path) -> None:
     mixin, process = _remap_worker_mixin(tmp_path, frontend_type="sglang", dynamo_install=False)
     with (
-        patch("srtctl.cli.mixins.worker_stage.generate_capture_script", return_value="fingerprint || true"),
+        patch("srtctl.cli.mixins.worker_stage.generate_capture_command", return_value="fingerprint || true"),
         patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
     ):
         mock_srun.return_value = MagicMock()
@@ -269,7 +287,7 @@ def test_worker_stage_no_remap_root_when_dynamo_install_false(tmp_path: Path) ->
     # Dynamo frontend but container already has dynamo (install=False) → no install, no remap.
     mixin, process = _remap_worker_mixin(tmp_path, frontend_type="dynamo", dynamo_install=False)
     with (
-        patch("srtctl.cli.mixins.worker_stage.generate_capture_script", return_value="fingerprint || true"),
+        patch("srtctl.cli.mixins.worker_stage.generate_capture_command", return_value="fingerprint || true"),
         patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
     ):
         mock_srun.return_value = MagicMock()


### PR DESCRIPTION
## Summary

- extract worker-container fingerprint capture from an embedded Python heredoc into `runtime_scripts/fingerprint.py`
- invoke the existing `/srtctl-runtime` mount with a short, shell-quoted command
- keep framework and CPU parsing definitions shared between host and worker capture paths
- preserve best-effort probe isolation and the existing fingerprint JSON contract
- retain `srun` command logging at its existing DEBUG level while removing the stale heredoc explanation

## Why

Worker startup previously generated an entire Python program as a string and passed it through bash, srun, container bash, and Python. The nested quoting made the capture path difficult to review and required tests to extract and parse generated source code.

`runtime_scripts/` is already mounted into every worker container at `/srtctl-runtime`. Running a normal packaged script makes the execution path direct and keeps the generated worker command small without changing fingerprint filenames or consumers.

## User impact

There is no configuration or JSON schema change. Workers continue writing `fingerprint_<mode>_w<index>.json` under `/logs`, and fingerprint failures remain non-fatal.

## Validation

- `ruff check src/srtctl/`
- `ruff format --check src/srtctl/`
- modified-file `ty check`
- `pytest -q tests --ignore=tests/test_integration_status.py`: 828 passed, 2 skipped, 6 deselected
- direct standalone-script execution and malformed-probe regression coverage
- wheel build verified `srtctl/runtime_scripts/fingerprint.py` is packaged
- deep and general review findings addressed before commit

## Live canary

Job `21231` completed `COMPLETED 0:0` in 55 seconds on Watchtower GB200 node `watchtower-blue-cn01`, using a checkout synced from this PR commit.

The generated connection command included:

```text
.../src/srtctl/runtime_scripts:/srtctl-runtime
```

The custom benchmark failed unless `/logs/fingerprint_agg_w0.json` existed, parsed as JSON, and contained CPU and framework mappings. It completed with:

```text
LIVE_FP_PATH=/logs/fingerprint_agg_w0.json
LIVE_FP_CPU_MODEL=ARM CPU implementer 0x41 part 0xd4f (architecture 8, variant 0x0, revision 0)
LIVE_FP_FRAMEWORKS=dynamo,tensorrt_llm
LIVE_FP_STATUS=ok
```

Canary output: `/mnt/lustre01/users/slurm-shared/aflowers/srt-slurm-fingerprint-runtime-script-smoke/outputs/21231`
