### PR TITLE
[vLLM] Allow colocation of P/D workers across nodes

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -355,17 +355,14 @@ class VLLMProtocol:
         gpus_per_agg: int,
         gpus_per_node: int,
     ) -> bool:
-        """Whether all vLLM workers should be packed onto one node."""
+        """Whether prefill and decode workers should be packed contiguously."""
         if not self.allow_prefill_decode_colocation:
             return False
         if num_prefill <= 0 or num_decode <= 0 or gpus_per_node <= 0:
             return False
 
         total_worker_gpus = num_prefill * gpus_per_prefill + num_decode * gpus_per_decode + num_agg * gpus_per_agg
-        return (
-            total_worker_gpus <= gpus_per_node
-            or self.allow_prefill_decode_colocation_across_nodes
-        )
+        return total_worker_gpus <= gpus_per_node or self.allow_prefill_decode_colocation_across_nodes
 
     def allocate_endpoints(
         self,

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -137,6 +137,7 @@ class VLLMProtocol:
           type: vllm
           connector: nixl  # translated to --kv-transfer-config JSON
           allow_prefill_decode_colocation: true  # pack P/D on one node when all workers fit
+          allow_prefill_decode_colocation_across_nodes: true  # continue packing on later nodes
           prefill_environment:
             PYTHONUNBUFFERED: "1"
           vllm_config:
@@ -183,6 +184,12 @@ class VLLMProtocol:
     # request fits within gpus_per_node. Defaults off to preserve existing P/D
     # node separation.
     allow_prefill_decode_colocation: bool = False
+
+    # Extend P/D colocation to multi-node topologies. When enabled together
+    # with allow_prefill_decode_colocation, workers are packed contiguously
+    # across the minimum number of nodes instead of reserving separate P/D
+    # node pools. Defaults off to preserve the original one-node-only policy.
+    allow_prefill_decode_colocation_across_nodes: bool = False
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
@@ -355,7 +362,10 @@ class VLLMProtocol:
             return False
 
         total_worker_gpus = num_prefill * gpus_per_prefill + num_decode * gpus_per_decode + num_agg * gpus_per_agg
-        return total_worker_gpus <= gpus_per_node
+        return (
+            total_worker_gpus <= gpus_per_node
+            or self.allow_prefill_decode_colocation_across_nodes
+        )
 
     def allocate_endpoints(
         self,

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1781,7 +1781,12 @@ class SrtConfig:
             gpus_per_agg=self.resources.gpus_per_agg,
             gpus_per_node=self.resources.gpus_per_node,
         ):
-            return 1
+            total_worker_gpus = (
+                self.resources.prefill_gpus
+                + self.resources.decode_gpus
+                + self.resources.num_agg * self.resources.gpus_per_agg
+            )
+            return (total_worker_gpus + self.resources.gpus_per_node - 1) // self.resources.gpus_per_node
         return self.resources.total_nodes
 
     @property

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1514,63 +1514,6 @@ class TestVLLMPrefillDecodeColocation:
         assert endpoints[1].mode == "decode"
         assert endpoints[1].nodes == ("node1",)
 
-    def test_cross_node_colocation_packs_partial_prefill_with_first_decode(self):
-        """Explicit cross-node packing uses the prefill node's remaining GPUs."""
-        from srtctl.backends import VLLMProtocol
-
-        endpoints = VLLMProtocol(
-            allow_prefill_decode_colocation=True,
-            allow_prefill_decode_colocation_across_nodes=True,
-        ).allocate_endpoints(
-            num_prefill=1,
-            num_decode=3,
-            num_agg=0,
-            gpus_per_prefill=4,
-            gpus_per_decode=4,
-            gpus_per_agg=0,
-            gpus_per_node=8,
-            available_nodes=("node0", "node1"),
-        )
-
-        assert [ep.nodes for ep in endpoints] == [
-            ("node0",),
-            ("node0",),
-            ("node1",),
-            ("node1",),
-        ]
-        assert [ep.gpu_indices for ep in endpoints] == [
-            frozenset({0, 1, 2, 3}),
-            frozenset({4, 5, 6, 7}),
-            frozenset({0, 1, 2, 3}),
-            frozenset({4, 5, 6, 7}),
-        ]
-
-    def test_cross_node_colocation_requests_minimum_node_count(self):
-        """Sbatch node count follows the packed P+D GPU total."""
-        from srtctl.backends import VLLMProtocol
-        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
-
-        config = SrtConfig(
-            name="test",
-            model=ModelConfig(path="/model", container="/container.sqsh", precision="fp8"),
-            resources=ResourceConfig(
-                gpu_type="h100",
-                gpus_per_node=8,
-                prefill_nodes=1,
-                decode_nodes=1,
-                prefill_workers=1,
-                decode_workers=3,
-                _explicit_gpus_per_prefill=4,
-                _explicit_gpus_per_decode=4,
-            ),
-            backend=VLLMProtocol(
-                allow_prefill_decode_colocation=True,
-                allow_prefill_decode_colocation_across_nodes=True,
-            ),
-        )
-
-        assert config.total_nodes == 2
-
 
 class TestHetJobsValidation:
     """SrtConfig.__post_init__ validation for `resources.het_jobs: true`."""

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1514,6 +1514,63 @@ class TestVLLMPrefillDecodeColocation:
         assert endpoints[1].mode == "decode"
         assert endpoints[1].nodes == ("node1",)
 
+    def test_cross_node_colocation_packs_partial_prefill_with_first_decode(self):
+        """Explicit cross-node packing uses the prefill node's remaining GPUs."""
+        from srtctl.backends import VLLMProtocol
+
+        endpoints = VLLMProtocol(
+            allow_prefill_decode_colocation=True,
+            allow_prefill_decode_colocation_across_nodes=True,
+        ).allocate_endpoints(
+            num_prefill=1,
+            num_decode=3,
+            num_agg=0,
+            gpus_per_prefill=4,
+            gpus_per_decode=4,
+            gpus_per_agg=0,
+            gpus_per_node=8,
+            available_nodes=("node0", "node1"),
+        )
+
+        assert [ep.nodes for ep in endpoints] == [
+            ("node0",),
+            ("node0",),
+            ("node1",),
+            ("node1",),
+        ]
+        assert [ep.gpu_indices for ep in endpoints] == [
+            frozenset({0, 1, 2, 3}),
+            frozenset({4, 5, 6, 7}),
+            frozenset({0, 1, 2, 3}),
+            frozenset({4, 5, 6, 7}),
+        ]
+
+    def test_cross_node_colocation_requests_minimum_node_count(self):
+        """Sbatch node count follows the packed P+D GPU total."""
+        from srtctl.backends import VLLMProtocol
+        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/container.sqsh", precision="fp8"),
+            resources=ResourceConfig(
+                gpu_type="h100",
+                gpus_per_node=8,
+                prefill_nodes=1,
+                decode_nodes=1,
+                prefill_workers=1,
+                decode_workers=3,
+                _explicit_gpus_per_prefill=4,
+                _explicit_gpus_per_decode=4,
+            ),
+            backend=VLLMProtocol(
+                allow_prefill_decode_colocation=True,
+                allow_prefill_decode_colocation_across_nodes=True,
+            ),
+        )
+
+        assert config.total_nodes == 2
+
 
 class TestHetJobsValidation:
     """SrtConfig.__post_init__ validation for `resources.het_jobs: true`."""


### PR DESCRIPTION
E.g., 1p-tp4, 3d-tp4, b300

Previously, 3 nodes will be allocated:
node0: P0 [0–3] | unused [4–7]
node1: D0 [0–3] | D1 [4–7]
node2: D2 [0–3] | unused [4–7]


With this patch, only 2 nodes will be allocated:
node0: P0 [0–3] | D0 [4–7]
node1: D1 [0–3] | D2 [4–7]