### PR TITLE
fix(profiling): use Dynamo control/ engine routes for start/stop_profile

### DIFF
--- a/src/srtctl/benchmarks/scripts/lib/profiling.sh
+++ b/src/srtctl/benchmarks/scripts/lib/profiling.sh
@@ -76,7 +76,7 @@ profiling__start_profile_on_worker() {
 
     local start_path=""
     case "${SRTCTL_FRONTEND_TYPE}" in
-        dynamo) start_path="/engine/start_profile" ;;
+        dynamo) start_path="/engine/control/start_profile" ;;
         sglang) start_path="/start_profile" ;;
         *)
             echo "Error: unsupported SRTCTL_FRONTEND_TYPE='${SRTCTL_FRONTEND_TYPE}' (expected 'dynamo' or 'sglang')" >&2
@@ -109,7 +109,7 @@ profiling__stop_profile_on_worker() {
 
     local stop_path=""
     case "${SRTCTL_FRONTEND_TYPE}" in
-        dynamo) stop_path="/engine/stop_profile" ;;
+        dynamo) stop_path="/engine/control/stop_profile" ;;
         sglang) stop_path="/stop_profile" ;;
         *)
             echo "Error: unsupported SRTCTL_FRONTEND_TYPE='${SRTCTL_FRONTEND_TYPE}' (expected 'dynamo' or 'sglang')" >&2


### PR DESCRIPTION
Dynamo moved its control-plane engine routes under a control/ namespace in ai-dynamo/dynamo#10347 (e6fd808c0f, 2026-06-15):

  - register_engine_route("start_profile", ...)
  + register_engine_route("control/start_profile", ...)

  So any Dynamo build ≥ #10347 serves the profiler-trigger at /engine/control/start_profile (and /engine/control/stop_profile), not the old /engine/start_profile.

  srt-slurm's profiling client (lib/profiling.sh) was still POSTing the old paths. Against a current Dynamo this silently 404s → the profiler is never armed → prefill/decode nsys
  (and torch) profiles come out empty. There's no error surfaced because the call is best-effort (curl -f ... || Warning).

  This patch points the dynamo frontend branch at the new control/ routes.

  Scope / safety:
  - Only affects the dynamo frontend profiling path (any backend behind it: sglang, vllm). The sglang native-frontend branch (/start_profile) is unchanged.
  - TRT-LLM is unaffected (it profiles via TLLM_PROFILE_START_STOP, no HTTP call).
  - No effect on non-profiling runs — this code only runs when profiling: is enabled.
  - Requires Dynamo ≥ #10347. Older Dynamo served /engine/start_profile; pairing this with a pre-#10347 Dynamo would 404. In practice any Dynamo new enough to also carry the sglang ProfileReq body fix (ai-dynamo/dynamo#11199, 2026-07-06) is already ≥ #10347, so the two go together.