### PR TITLE
Isolate RuntimeContext tests from repository outputs

### DIFF
--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -975,7 +975,7 @@ class TestWorkerEnvironmentTemplating:
                 ),
             )
 
-            runtime = RuntimeContext.from_config(config, job_id="12345")
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
 
             # Create a mock worker stage
             class MockWorkerStage(WorkerStageMixin):
@@ -1115,7 +1115,7 @@ class TestWorkerEnvironmentTemplating:
                 ),
             )
 
-            runtime = RuntimeContext.from_config(config, job_id="12345")
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
 
             class MockWorkerStage(WorkerStageMixin):
                 def __init__(self, config, runtime):
@@ -2660,7 +2660,7 @@ class TestInfmaxWorkspaceMount:
                     decode_nodes=1,
                 ),
             )
-            runtime = RuntimeContext.from_config(config, job_id="12345")
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
 
             assert Path("/infmax-workspace") in runtime.container_mounts.values()
 
@@ -2715,7 +2715,7 @@ class TestInfmaxWorkspaceMount:
                         decode_nodes=1,
                     ),
                 )
-                runtime = RuntimeContext.from_config(config, job_id="12345")
+                runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
 
                 assert Path("/infmax-workspace") not in runtime.container_mounts.values()
 
@@ -2776,7 +2776,7 @@ class TestExtraMountExpansion:
                 ),
                 extra_mount=("$SRT_EXTRA_ROOT:/extra",),
             )
-            runtime = RuntimeContext.from_config(config, job_id="12345")
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
 
             assert extra_root.resolve() in runtime.container_mounts
             assert runtime.container_mounts[extra_root.resolve()] == Path("/extra")

--- a/tests/test_hf_cache.py
+++ b/tests/test_hf_cache.py
@@ -59,7 +59,7 @@ def _make_orchestrator(config_path: str, hf_model: bool = True) -> SweepOrchestr
         patch("subprocess.run", TestCluster.mock_scontrol()),
     ):
         config = load_config(Path(config_path))
-        runtime = RuntimeContext.from_config(config, "99999")
+        runtime = RuntimeContext.from_config(config, "99999", log_dir_base=Path(config_path).parent / "outputs")
         return SweepOrchestrator(config=config, runtime=runtime)
 
 
@@ -627,6 +627,7 @@ resources:
 """
         )
         orch = _make_orchestrator(str(config_file))
+        assert orch.runtime.log_dir == tmp_path / "outputs" / "99999" / "logs"
 
         with (
             patch.object(orch, "_clean_stale_hf_locks") as mock_clean,


### PR DESCRIPTION
## Summary

- route RuntimeContext instances created by tests to pytest-managed temporary directories
- add a regression assertion for the sweep orchestrator output path
- prevent simulated job output directories from being left in the repository checkout

## Root cause

Several tests constructed RuntimeContext without `log_dir_base`. The runtime default therefore resolved relative to the repository working directory and created persistent test artifacts under `outputs/`.

## Validation

- `uv run pytest tests/test_hf_cache.py::TestRunHfModelGuard::test_local_model_skips_hf_cache_operations tests/test_configs.py -q` (119 passed)
- `make lint`
