### PR TITLE
fix(vllm): increase DeepGEMM NVLink barrier timeout for GB200

### DIFF
--- a/configs/patches/vllm-container-deps-deepgemm-timeout.sh
+++ b/configs/patches/vllm-container-deps-deepgemm-timeout.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+bash /configs/patches/vllm-container-deps.sh
+python3 /configs/patches/vllm_deepgemm_timeout_fix.py

--- a/configs/patches/vllm_deepgemm_timeout_fix.py
+++ b/configs/patches/vllm_deepgemm_timeout_fix.py
@@ -88,4 +88,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/configs/patches/vllm_deepgemm_timeout_fix.py
+++ b/configs/patches/vllm_deepgemm_timeout_fix.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Increase vLLM's vendored DeepGEMM NVLink barrier timeout to 300 seconds.
+
+This adapts sgl-project/DeepGEMM#57 to the DeepGEMM source layout vendored by
+the vLLM image used by midcurve.yaml. DeepGEMM hashes included headers for its
+JIT cache, so changing this file before importing vLLM causes affected kernels
+to be recompiled automatically on first use.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+RELATIVE_TARGET = Path("third_party/deep_gemm/include/deep_gemm/comm/barrier.cuh")
+
+OLD_TIMEOUT = (
+    "        // Update status and wait arrival (with 30s timeout, at 2 GHz)\n"
+    "        constexpr int64_t kNumTimeoutCycles = 30ll * 2000000000ll;"
+)
+NEW_TIMEOUT = (
+    "        // Update status and wait arrival (with 300s timeout, at 2 GHz)\n"
+    "        constexpr int64_t kNumTimeoutCycles = 300ll * 2000000000ll;"
+)
+OLD_DIAGNOSTIC = "DeepGEMM NVLink barrier timeout (30s):"
+NEW_DIAGNOSTIC = "DeepGEMM NVLink barrier timeout (300s):"
+
+
+def find_target() -> Path:
+    """Locate barrier.cuh without importing vLLM or DeepGEMM."""
+    spec = importlib.util.find_spec("vllm")
+    if spec is not None and spec.submodule_search_locations:
+        for package_dir in spec.submodule_search_locations:
+            candidate = Path(package_dir) / RELATIVE_TARGET
+            if candidate.exists():
+                return candidate
+
+    candidates = (
+        Path("/usr/local/lib/python3.12/dist-packages/vllm") / RELATIVE_TARGET,
+        Path("/usr/local/lib/python3.12/site-packages/vllm") / RELATIVE_TARGET,
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def patch_target(target: Path) -> bool:
+    """Patch target and return True, or return False if already patched."""
+    if not target.exists():
+        raise RuntimeError(f"Target not found: {target}")
+
+    content = target.read_text()
+    old_counts = (content.count(OLD_TIMEOUT), content.count(OLD_DIAGNOSTIC))
+    new_counts = (content.count(NEW_TIMEOUT), content.count(NEW_DIAGNOSTIC))
+
+    if new_counts == (1, 1) and old_counts == (0, 0):
+        return False
+    if old_counts != (1, 1) or new_counts != (0, 0):
+        raise RuntimeError(
+            "Expected exactly one unpatched timeout and diagnostic anchor; "
+            f"found old={old_counts}, new={new_counts}. The vendored DeepGEMM source may have drifted."
+        )
+
+    patched = content.replace(OLD_TIMEOUT, NEW_TIMEOUT, 1).replace(OLD_DIAGNOSTIC, NEW_DIAGNOSTIC, 1)
+    target.write_text(patched)
+    return True
+
+
+def main() -> None:
+    if len(sys.argv) > 2:
+        print(f"Usage: {Path(sys.argv[0]).name} [barrier.cuh]", file=sys.stderr)
+        raise SystemExit(2)
+
+    target = Path(sys.argv[1]) if len(sys.argv) == 2 else find_target()
+    try:
+        changed = patch_target(target)
+    except (OSError, RuntimeError) as exc:
+        print(f"[vllm-deepgemm-timeout-fix] {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    if changed:
+        print(f"[vllm-deepgemm-timeout-fix] Increased NVLink barrier timeout to 300s in {target}", file=sys.stderr)
+    else:
+        print("[vllm-deepgemm-timeout-fix] Already patched, skipping.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_vllm_deepgemm_timeout_fix.py
+++ b/tests/test_vllm_deepgemm_timeout_fix.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the midcurve DeepGEMM startup hotfix."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from srtctl.cli.mixins.worker_stage import WorkerStageMixin
+from srtctl.core.schema import SrtConfig
+
+REPO_ROOT = Path(__file__).parents[1]
+PATCHER = REPO_ROOT / "configs/patches/vllm_deepgemm_timeout_fix.py"
+WRAPPER = REPO_ROOT / "configs/patches/vllm-container-deps-deepgemm-timeout.sh"
+
+UNPATCHED_SOURCE = """\
+        // Update status and wait arrival (with 30s timeout, at 2 GHz)
+        constexpr int64_t kNumTimeoutCycles = 30ll * 2000000000ll;
+                    printf("DeepGEMM NVLink barrier timeout (30s): rank=%d\\n", rank);
+"""
+
+
+def run_patcher(target: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(PATCHER), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_patches_timeout_and_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "barrier.cuh"
+    target.write_text(UNPATCHED_SOURCE)
+
+    first = run_patcher(target)
+
+    assert first.returncode == 0
+    assert "Increased NVLink barrier timeout to 300s" in first.stderr
+    patched = target.read_text()
+    assert "300ll * 2000000000ll" in patched
+    assert "timeout (300s)" in patched
+    assert "timeout (30s)" not in patched
+
+    second = run_patcher(target)
+
+    assert second.returncode == 0
+    assert "Already patched, skipping" in second.stderr
+    assert target.read_text() == patched
+
+
+def test_rejects_drifted_source_without_modifying_it(tmp_path: Path) -> None:
+    target = tmp_path / "barrier.cuh"
+    drifted = UNPATCHED_SOURCE.replace("30ll * 2000000000ll", "45ll * 2000000000ll")
+    target.write_text(drifted)
+
+    result = run_patcher(target)
+
+    assert result.returncode == 1
+    assert "vendored DeepGEMM source may have drifted" in result.stderr
+    assert target.read_text() == drifted
+
+
+def test_rejects_ambiguous_anchors_without_modifying_source(tmp_path: Path) -> None:
+    target = tmp_path / "barrier.cuh"
+    ambiguous = UNPATCHED_SOURCE + UNPATCHED_SOURCE
+    target.write_text(ambiguous)
+
+    result = run_patcher(target)
+
+    assert result.returncode == 1
+    assert "found old=(2, 2)" in result.stderr
+    assert target.read_text() == ambiguous
+
+
+def test_midcurve_uses_wrapper_after_base_setup() -> None:
+    config = SrtConfig.from_yaml(REPO_ROOT / "midcurve.yaml")
+    wrapper = WRAPPER.read_text()
+    mixin = WorkerStageMixin()
+    mixin.config = config
+    preamble = mixin._build_worker_preamble()
+
+    assert config.setup_script == WRAPPER.name
+    assert wrapper.index("vllm-container-deps.sh") < wrapper.index("vllm_deepgemm_timeout_fix.py")
+    assert preamble is not None
+    assert WRAPPER.name in preamble
+

--- a/tests/test_vllm_deepgemm_timeout_fix.py
+++ b/tests/test_vllm_deepgemm_timeout_fix.py
@@ -7,9 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-from srtctl.cli.mixins.worker_stage import WorkerStageMixin
-from srtctl.core.schema import SrtConfig
-
 REPO_ROOT = Path(__file__).parents[1]
 PATCHER = REPO_ROOT / "configs/patches/vllm_deepgemm_timeout_fix.py"
 WRAPPER = REPO_ROOT / "configs/patches/vllm-container-deps-deepgemm-timeout.sh"
@@ -74,15 +71,7 @@ def test_rejects_ambiguous_anchors_without_modifying_source(tmp_path: Path) -> N
     assert target.read_text() == ambiguous
 
 
-def test_midcurve_uses_wrapper_after_base_setup() -> None:
-    config = SrtConfig.from_yaml(REPO_ROOT / "midcurve.yaml")
+def test_wrapper_runs_base_setup_before_timeout_patch() -> None:
     wrapper = WRAPPER.read_text()
-    mixin = WorkerStageMixin()
-    mixin.config = config
-    preamble = mixin._build_worker_preamble()
 
-    assert config.setup_script == WRAPPER.name
     assert wrapper.index("vllm-container-deps.sh") < wrapper.index("vllm_deepgemm_timeout_fix.py")
-    assert preamble is not None
-    assert WRAPPER.name in preamble
-


### PR DESCRIPTION
## Summary

- Port @jthomson04's DeepGEMM timeout fix from `0835fd5` onto the current `NVIDIA/srt-slurm` `main` branch.
- Add a vLLM setup wrapper that runs the existing container dependency setup before applying the DeepGEMM patch.
- Increase the vendored DeepGEMM NVLink barrier timeout from 30 seconds to 300 seconds, with idempotency and source-drift checks.
- Add self-contained tests for patching, idempotency, drift detection, and wrapper ordering.

## Motivation

The GB200 vLLM container can exceed DeepGEMM's 30-second NVLink barrier timeout. This adapts the upstream DeepGEMM timeout change to the source layout vendored in the target vLLM image. Recipe selection remains in downstream repositories and is intentionally outside this PR.

## Validation

- `uv run ruff check configs/patches/vllm_deepgemm_timeout_fix.py tests/test_vllm_deepgemm_timeout_fix.py`
- `uv run ruff format --check configs/patches/vllm_deepgemm_timeout_fix.py tests/test_vllm_deepgemm_timeout_fix.py`
- `bash -n configs/patches/vllm-container-deps-deepgemm-timeout.sh`
- `uv run pytest tests/test_vllm_deepgemm_timeout_fix.py -q` — 4 passed
- `git diff --check origin/main...HEAD`
- `make check` on macOS reached 858 passed and 2 skipped, with 6 failures outside this PR's changed files due existing platform/path assumptions; all tests introduced by this PR passed in that run.

Review requested from @jthomson04, whose source branch provided the original patch.
