### PR TITLE
fix(vllm): increase DeepGEMM NVLink barrier timeout for GB200

### DIFF
--- a/configs/patches/vllm-container-deps-deepgemm-timeout.sh
+++ b/configs/patches/vllm-container-deps-deepgemm-timeout.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+bash /configs/patches/vllm-container-deps.sh
+python3 /configs/patches/vllm_deepgemm_timeout_fix.py

--- a/configs/patches/vllm_deepgemm_timeout_fix.py
+++ b/configs/patches/vllm_deepgemm_timeout_fix.py
@@ -88,4 +88,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/configs/patches/vllm_deepgemm_timeout_fix.py
+++ b/configs/patches/vllm_deepgemm_timeout_fix.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Increase vLLM's vendored DeepGEMM NVLink barrier timeout to 300 seconds.
+
+This adapts sgl-project/DeepGEMM#57 to the DeepGEMM source layout vendored by
+the vLLM image used by midcurve.yaml. DeepGEMM hashes included headers for its
+JIT cache, so changing this file before importing vLLM causes affected kernels
+to be recompiled automatically on first use.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+RELATIVE_TARGET = Path("third_party/deep_gemm/include/deep_gemm/comm/barrier.cuh")
+
+OLD_TIMEOUT = (
+    "        // Update status and wait arrival (with 30s timeout, at 2 GHz)\n"
+    "        constexpr int64_t kNumTimeoutCycles = 30ll * 2000000000ll;"
+)
+NEW_TIMEOUT = (
+    "        // Update status and wait arrival (with 300s timeout, at 2 GHz)\n"
+    "        constexpr int64_t kNumTimeoutCycles = 300ll * 2000000000ll;"
+)
+OLD_DIAGNOSTIC = "DeepGEMM NVLink barrier timeout (30s):"
+NEW_DIAGNOSTIC = "DeepGEMM NVLink barrier timeout (300s):"
+
+
+def find_target() -> Path:
+    """Locate barrier.cuh without importing vLLM or DeepGEMM."""
+    spec = importlib.util.find_spec("vllm")
+    if spec is not None and spec.submodule_search_locations:
+        for package_dir in spec.submodule_search_locations:
+            candidate = Path(package_dir) / RELATIVE_TARGET
+            if candidate.exists():
+                return candidate
+
+    candidates = (
+        Path("/usr/local/lib/python3.12/dist-packages/vllm") / RELATIVE_TARGET,
+        Path("/usr/local/lib/python3.12/site-packages/vllm") / RELATIVE_TARGET,
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def patch_target(target: Path) -> bool:
+    """Patch target and return True, or return False if already patched."""
+    if not target.exists():
+        raise RuntimeError(f"Target not found: {target}")
+
+    content = target.read_text()
+    old_counts = (content.count(OLD_TIMEOUT), content.count(OLD_DIAGNOSTIC))
+    new_counts = (content.count(NEW_TIMEOUT), content.count(NEW_DIAGNOSTIC))
+
+    if new_counts == (1, 1) and old_counts == (0, 0):
+        return False
+    if old_counts != (1, 1) or new_counts != (0, 0):
+        raise RuntimeError(
+            "Expected exactly one unpatched timeout and diagnostic anchor; "
+            f"found old={old_counts}, new={new_counts}. The vendored DeepGEMM source may have drifted."
+        )
+
+    patched = content.replace(OLD_TIMEOUT, NEW_TIMEOUT, 1).replace(OLD_DIAGNOSTIC, NEW_DIAGNOSTIC, 1)
+    target.write_text(patched)
+    return True
+
+
+def main() -> None:
+    if len(sys.argv) > 2:
+        print(f"Usage: {Path(sys.argv[0]).name} [barrier.cuh]", file=sys.stderr)
+        raise SystemExit(2)
+
+    target = Path(sys.argv[1]) if len(sys.argv) == 2 else find_target()
+    try:
+        changed = patch_target(target)
+    except (OSError, RuntimeError) as exc:
+        print(f"[vllm-deepgemm-timeout-fix] {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    if changed:
+        print(f"[vllm-deepgemm-timeout-fix] Increased NVLink barrier timeout to 300s in {target}", file=sys.stderr)
+    else:
+        print("[vllm-deepgemm-timeout-fix] Already patched, skipping.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -226,6 +226,13 @@ class WorkerStageMixin:
         fp_cmd = f"( {fp_cmd} )"
         bash_preamble = f"{bash_preamble} && {fp_cmd}" if bash_preamble else fp_cmd
 
+        # vLLM uses VLLM_PORT as the initial port for its internal message
+        # queues. In a multi-node endpoint, concurrent TP ranks inherit the
+        # same value and can race while probing and binding remote TCP queues.
+        # Let vLLM choose an ephemeral base port instead.
+        endpoint_nodes = {endpoint_process.node for endpoint_process in endpoint_processes}
+        env_to_unset = ["VLLM_PORT"] if self.backend.type == "vllm" and len(endpoint_nodes) > 1 else None
+
         proc = start_srun_process(
             command=cmd,
             nodelist=[process.node],
@@ -233,6 +240,7 @@ class WorkerStageMixin:
             container_image=str(self.runtime.container_image),
             container_mounts=self.runtime.container_mounts,
             env_to_set=env_to_set,
+            env_to_unset=env_to_unset,
             bash_preamble=bash_preamble,
             srun_options=self.runtime.srun_options,
             srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if installs_dynamo(self.config) else None,

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -193,6 +193,7 @@ def start_srun_process(
     container_mounts: dict[Path, Path] | None = None,
     env_to_pass_through: list[str] | None = None,
     env_to_set: dict[str, str] | None = None,
+    env_to_unset: list[str] | None = None,
     bash_preamble: str | None = None,
     srun_options: dict[str, str] | None = None,
     srun_export_env: dict[str, str] | None = None,
@@ -219,6 +220,7 @@ def start_srun_process(
         container_mounts: Dict of host_path -> container_path mounts
         env_to_pass_through: Environment variable names to pass through
         env_to_set: Environment variables to set (name -> value)
+        env_to_unset: Environment variable names to unset before the preamble and command
         bash_preamble: Bash commands to run before the main command
         srun_options: Additional srun options as dict
         srun_export_env: Env vars to set in the srun *task* environment (rendered as
@@ -319,8 +321,14 @@ def start_srun_process(
         if cluster_preamble:
             bash_parts.insert(0, cluster_preamble)
 
-        # Add per-call preamble if provided. It runs after exports so setup
-        # / fingerprint hooks observe the same environment as the main command.
+        # Explicitly clear inherited variables after setting worker-specific
+        # values so the preamble and main command see the intended environment.
+        if env_to_unset:
+            for name in env_to_unset:
+                bash_parts.append(f"unset -- {shlex.quote(name)}")
+
+        # Add per-call preamble if provided. It runs after exports/unsets so
+        # setup / fingerprint hooks observe the same environment as the main command.
         if bash_preamble:
             bash_parts.append(bash_preamble)
 

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -142,6 +142,26 @@ def test_srun_export_env_omitted_adds_no_export_flag() -> None:
     assert not any(str(arg).startswith("--export") for arg in srun_cmd)
 
 
+def test_start_srun_unsets_env_after_exports_before_preamble() -> None:
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(
+            ["python3", "-m", "server"],
+            env_to_set={"VLLM_PORT": "20000"},
+            env_to_unset=["VLLM_PORT"],
+            bash_preamble="echo preamble",
+        )
+
+    bash_cmd = _built_bash_command(mock_popen)
+    assert bash_cmd.index("export VLLM_PORT=20000") < bash_cmd.index("unset -- VLLM_PORT")
+    assert bash_cmd.index("unset -- VLLM_PORT") < bash_cmd.index("echo preamble")
+    assert bash_cmd.index("echo preamble") < bash_cmd.index("python3 -m server")
+
+
 def test_wrapped_nonfatal_hook_does_not_mask_prior_preamble_failure() -> None:
     bash_cmd = "false && ( false || true ) && echo main"
 
@@ -156,6 +176,7 @@ def test_worker_stage_wraps_nonfatal_fingerprint_hook(tmp_path: Path) -> None:
     backend.build_worker_command.return_value = ["python3", "-m", "worker"]
     backend.get_environment_for_mode.return_value = {}
     backend.get_process_environment.return_value = {}
+    backend.type = "vllm"
 
     mixin = WorkerStageMixin()
     mixin.config = SimpleNamespace(
@@ -199,6 +220,7 @@ def test_worker_stage_wraps_nonfatal_fingerprint_hook(tmp_path: Path) -> None:
     assert "setup.sh" in bash_preamble
     assert "/configs/patches/${setup_script}" in bash_preamble
     assert bash_preamble.endswith("&& ( fingerprint || true )")
+    assert mock_srun.call_args.kwargs["env_to_unset"] is None
 
 
 def _remap_worker_mixin(tmp_path: Path, *, frontend_type: str, dynamo_install: bool):
@@ -345,3 +367,52 @@ def test_start_srun_omits_het_group_when_none() -> None:
     srun_cmd = mock_popen.call_args.args[0]
     for arg in srun_cmd:
         assert not str(arg).startswith("--het-group")
+
+
+def test_worker_stage_unsets_vllm_port_for_multinode_endpoint(tmp_path: Path) -> None:
+    backend = MagicMock()
+    backend.type = "vllm"
+    backend.build_worker_command.return_value = ["python3", "-m", "worker"]
+    backend.get_environment_for_mode.return_value = {}
+    backend.get_process_environment.return_value = {}
+
+    mixin = WorkerStageMixin()
+    mixin.config = SimpleNamespace(
+        setup_script=None,
+        frontend=SimpleNamespace(type="sglang"),
+        dynamo=SimpleNamespace(install=False, request_plane="nats"),
+        observability=ObservabilityConfig(),
+        profiling=SimpleNamespace(enabled=False, is_nsys=False),
+        backend=backend,
+    )
+    mixin.runtime = SimpleNamespace(
+        log_dir=tmp_path,
+        head_node_ip="10.0.0.1",
+        infra_node_ip="10.0.0.1",
+        network_interface=None,
+        nodes=SimpleNamespace(infra="infra-node", worker=["node-a", "node-b"]),
+        gpus_per_node=8,
+        environment={},
+        container_image=Path("/container.sqsh"),
+        container_mounts={},
+        srun_options=[],
+    )
+    process = SimpleNamespace(
+        endpoint_mode="decode",
+        endpoint_index=0,
+        node="node-a",
+        sys_port=5000,
+        gpu_indices=list(range(8)),
+        cuda_visible_devices="0,1,2,3,4,5,6,7",
+        het_group=None,
+    )
+    peer_process = SimpleNamespace(node="node-b")
+
+    with (
+        patch("srtctl.cli.mixins.worker_stage.generate_capture_script", return_value="fingerprint || true"),
+        patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
+    ):
+        mock_srun.return_value = MagicMock()
+        mixin.start_worker(process, [process, peer_process])
+
+    assert mock_srun.call_args.kwargs["env_to_unset"] == ["VLLM_PORT"]

--- a/tests/test_vllm_deepgemm_timeout_fix.py
+++ b/tests/test_vllm_deepgemm_timeout_fix.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the midcurve DeepGEMM startup hotfix."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from srtctl.cli.mixins.worker_stage import WorkerStageMixin
+from srtctl.core.schema import SrtConfig
+
+REPO_ROOT = Path(__file__).parents[1]
+PATCHER = REPO_ROOT / "configs/patches/vllm_deepgemm_timeout_fix.py"
+WRAPPER = REPO_ROOT / "configs/patches/vllm-container-deps-deepgemm-timeout.sh"
+
+UNPATCHED_SOURCE = """\
+        // Update status and wait arrival (with 30s timeout, at 2 GHz)
+        constexpr int64_t kNumTimeoutCycles = 30ll * 2000000000ll;
+                    printf("DeepGEMM NVLink barrier timeout (30s): rank=%d\\n", rank);
+"""
+
+
+def run_patcher(target: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(PATCHER), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_patches_timeout_and_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "barrier.cuh"
+    target.write_text(UNPATCHED_SOURCE)
+
+    first = run_patcher(target)
+
+    assert first.returncode == 0
+    assert "Increased NVLink barrier timeout to 300s" in first.stderr
+    patched = target.read_text()
+    assert "300ll * 2000000000ll" in patched
+    assert "timeout (300s)" in patched
+    assert "timeout (30s)" not in patched
+
+    second = run_patcher(target)
+
+    assert second.returncode == 0
+    assert "Already patched, skipping" in second.stderr
+    assert target.read_text() == patched
+
+
+def test_rejects_drifted_source_without_modifying_it(tmp_path: Path) -> None:
+    target = tmp_path / "barrier.cuh"
+    drifted = UNPATCHED_SOURCE.replace("30ll * 2000000000ll", "45ll * 2000000000ll")
+    target.write_text(drifted)
+
+    result = run_patcher(target)
+
+    assert result.returncode == 1
+    assert "vendored DeepGEMM source may have drifted" in result.stderr
+    assert target.read_text() == drifted
+
+
+def test_rejects_ambiguous_anchors_without_modifying_source(tmp_path: Path) -> None:
+    target = tmp_path / "barrier.cuh"
+    ambiguous = UNPATCHED_SOURCE + UNPATCHED_SOURCE
+    target.write_text(ambiguous)
+
+    result = run_patcher(target)
+
+    assert result.returncode == 1
+    assert "found old=(2, 2)" in result.stderr
+    assert target.read_text() == ambiguous
+
+
+def test_midcurve_uses_wrapper_after_base_setup() -> None:
+    config = SrtConfig.from_yaml(REPO_ROOT / "midcurve.yaml")
+    wrapper = WRAPPER.read_text()
+    mixin = WorkerStageMixin()
+    mixin.config = config
+    preamble = mixin._build_worker_preamble()
+
+    assert config.setup_script == WRAPPER.name
+    assert wrapper.index("vllm-container-deps.sh") < wrapper.index("vllm_deepgemm_timeout_fix.py")
+    assert preamble is not None
+    assert WRAPPER.name in preamble
+

--- a/tests/test_vllm_deepgemm_timeout_fix.py
+++ b/tests/test_vllm_deepgemm_timeout_fix.py
@@ -7,9 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-from srtctl.cli.mixins.worker_stage import WorkerStageMixin
-from srtctl.core.schema import SrtConfig
-
 REPO_ROOT = Path(__file__).parents[1]
 PATCHER = REPO_ROOT / "configs/patches/vllm_deepgemm_timeout_fix.py"
 WRAPPER = REPO_ROOT / "configs/patches/vllm-container-deps-deepgemm-timeout.sh"
@@ -74,15 +71,7 @@ def test_rejects_ambiguous_anchors_without_modifying_source(tmp_path: Path) -> N
     assert target.read_text() == ambiguous
 
 
-def test_midcurve_uses_wrapper_after_base_setup() -> None:
-    config = SrtConfig.from_yaml(REPO_ROOT / "midcurve.yaml")
+def test_wrapper_runs_base_setup_before_timeout_patch() -> None:
     wrapper = WRAPPER.read_text()
-    mixin = WorkerStageMixin()
-    mixin.config = config
-    preamble = mixin._build_worker_preamble()
 
-    assert config.setup_script == WRAPPER.name
     assert wrapper.index("vllm-container-deps.sh") < wrapper.index("vllm_deepgemm_timeout_fix.py")
-    assert preamble is not None
-    assert WRAPPER.name in preamble
-


### PR DESCRIPTION
## Summary

- Increase the vendored DeepGEMM NVLink barrier timeout from 30 seconds to 300 seconds for GB200 vLLM startup.
- Add a vLLM setup wrapper that runs the existing container dependency setup before applying the timeout patch.
- Make the DeepGEMM patcher idempotent and fail safely when the vendored source has drifted or contains ambiguous anchors.
- Prevent multi-node vLLM workers from inheriting a shared `VLLM_PORT`, allowing vLLM to choose an ephemeral base port for its internal message queues.
- Add generic `env_to_unset` support to `start_srun_process()`, applied after explicit exports and before the setup preamble and worker command.
- Add tests for timeout patching, idempotency, source-drift handling, wrapper ordering, environment-unset ordering, and multi-node vLLM behavior.

## Motivation

This addresses two startup failure modes seen with multi-node GB200 vLLM deployments:

1. DeepGEMM initialization can exceed its default 30-second NVLink barrier timeout. The setup patch raises that timeout to 300 seconds before vLLM imports the vendored DeepGEMM sources.
2. Tensor-parallel workers spanning multiple nodes can inherit the same `VLLM_PORT`. Because vLLM uses this value as the base port for internal message queues, concurrent workers can race while probing and binding ports. The worker stage now unsets `VLLM_PORT` only for vLLM endpoints spanning more than one node so vLLM can select an available ephemeral port.

Recipe selection remains in downstream repositories and is intentionally outside this PR.

## Provenance

- DeepGEMM timeout fix ported from @jthomson04's [original source branch](https://github.com/jthomson04/srt-slurm/tree/jthomson04/vllm-gb200-v0.1.dev18219%2Bg4ba0a72a4) and [source commit `0835fd5`](https://github.com/jthomson04/srt-slurm/commit/0835fd5141f6bf5b5e3b6d53850a84617bff23a5).
- The follow-up multi-node `VLLM_PORT` fix was also authored by @jthomson04 in [commit `9908c4d`](https://github.com/NVIDIA/srt-slurm/commit/9908c4ddffa3d6ffc1ff36a740d4d8f9610037a4).

## Validation

- `uv run pytest tests/test_vllm_deepgemm_timeout_fix.py tests/test_slurm.py -q` — 23 passed
- `uv run ruff check configs/patches/vllm_deepgemm_timeout_fix.py src/srtctl/cli/mixins/worker_stage.py src/srtctl/core/slurm.py tests/test_vllm_deepgemm_timeout_fix.py tests/test_slurm.py`
- `bash -n configs/patches/vllm-container-deps-deepgemm-timeout.sh`
- `git diff --check origin/main...HEAD`
- GitHub CI at head `5993f75`: `lint`, `typecheck`, `test`, `mock-and-server`, `validate-recipes`, and `copyright-check` passed.
