### PR TITLE
fix(benchmark): count per-node vLLM health entries

### DIFF
--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -46,12 +46,32 @@ def _vllm_data_parallel_size(config: "SrtConfig", mode: str) -> int:
     return int(mode_config.get("data-parallel-size") or mode_config.get("data_parallel_size") or 1)
 
 
-def _get_health_expectations(config: "SrtConfig") -> tuple[int, int, str, int]:
+def _vllm_health_entries(
+    config: "SrtConfig",
+    mode: str,
+    logical_workers: int,
+    backend_processes: list["Process"] | None,
+) -> int:
+    """Return expected Dynamo generate registrations for a vLLM worker mode."""
+    dp_size = _vllm_data_parallel_size(config, mode)
+    if dp_size > 1 and getattr(config.backend, "dp_launch_mode", "per_gpu") == "per_node":
+        if backend_processes is None:
+            raise ValueError("backend_processes are required for per-node DP health expectations")
+        endpoint_mode = "agg" if mode == "aggregated" else mode
+        return sum(process.endpoint_mode == endpoint_mode for process in backend_processes)
+
+    return logical_workers * dp_size
+
+
+def _get_health_expectations(
+    config: "SrtConfig", backend_processes: list["Process"] | None = None
+) -> tuple[int, int, str, int]:
     """Compute expected health counts in the units reported by the frontend.
 
     Dynamo's /health endpoint reports registered generate instances. For vLLM
-    DP workers, that means one entry per DP rank, not one entry per logical
-    srt-slurm worker. Other frontends keep using logical worker counts.
+    DP workers, per-GPU launch registers one entry per DP rank, while per-node
+    launch registers one entry per node-local process. Other frontends keep
+    using logical worker counts.
     """
     r = config.resources
 
@@ -67,10 +87,10 @@ def _get_health_expectations(config: "SrtConfig") -> tuple[int, int, str, int]:
     if config.frontend.type == "dynamo" and getattr(config.backend, "type", None) == "vllm":
         if r.num_agg > 0:
             n_prefill = 0
-            n_decode = logical_decode * _vllm_data_parallel_size(config, "aggregated")
+            n_decode = _vllm_health_entries(config, "aggregated", logical_decode, backend_processes)
         else:
-            n_prefill = logical_prefill * _vllm_data_parallel_size(config, "prefill")
-            n_decode = logical_decode * _vllm_data_parallel_size(config, "decode")
+            n_prefill = _vllm_health_entries(config, "prefill", logical_prefill, backend_processes)
+            n_decode = _vllm_health_entries(config, "decode", logical_decode, backend_processes)
 
         count_desc = f"{n_prefill}P + {n_decode}D Dynamo generate instances; logical workers: {worker_desc}"
         return n_prefill, n_decode, count_desc, n_prefill + n_decode
@@ -131,7 +151,7 @@ class BenchmarkStageMixin:
         """Run the benchmark."""
         logger.info("Waiting for workers to be ready...")
 
-        n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(self.config)
+        n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(self.config, self.backend_processes)
         logger.info("Waiting for server health (expecting %d health entries: %s)...", num_workers, count_desc)
 
         hc = self.config.health_check

--- a/tests/test_health_expectations.py
+++ b/tests/test_health_expectations.py
@@ -8,14 +8,32 @@ from types import SimpleNamespace
 from srtctl.cli.mixins.benchmark_stage import _get_health_expectations, _vllm_data_parallel_size
 
 
-def _config(frontend_type, backend_type, *, num_prefill=0, num_decode=0, num_agg=0, vllm_config=None):
+def _config(
+    frontend_type,
+    backend_type,
+    *,
+    num_prefill=0,
+    num_decode=0,
+    num_agg=0,
+    vllm_config=None,
+    dp_launch_mode="per_gpu",
+):
     """Build a duck-typed stand-in for SrtConfig with only the fields the helpers read."""
-    backend = SimpleNamespace(type=backend_type, vllm_config=vllm_config)
+    backend = SimpleNamespace(type=backend_type, vllm_config=vllm_config, dp_launch_mode=dp_launch_mode)
     return SimpleNamespace(
         frontend=SimpleNamespace(type=frontend_type),
         backend=backend,
         resources=SimpleNamespace(num_prefill=num_prefill, num_decode=num_decode, num_agg=num_agg),
     )
+
+
+def _processes(*, prefill=0, decode=0, agg=0):
+    """Build backend-process stand-ins grouped by endpoint mode."""
+    return [
+        *(SimpleNamespace(endpoint_mode="prefill") for _ in range(prefill)),
+        *(SimpleNamespace(endpoint_mode="decode") for _ in range(decode)),
+        *(SimpleNamespace(endpoint_mode="agg") for _ in range(agg)),
+    ]
 
 
 def test_dynamo_vllm_disagg_multiplies_by_data_parallel_size():
@@ -42,6 +60,45 @@ def test_dynamo_vllm_aggregated_multiplies_by_data_parallel_size():
 
     assert (n_prefill, n_decode, num_workers) == (0, 8, 8)
     assert count_desc == "0P + 8D Dynamo generate instances; logical workers: 1 agg"
+
+
+def test_dynamo_vllm_per_node_disagg_counts_node_processes():
+    """Per-node DEP8/DEP16 registers once per node-local process, not per DP rank."""
+    vllm_config = SimpleNamespace(
+        prefill={"data-parallel-size": 8},
+        decode={"data-parallel-size": 16},
+        aggregated=None,
+    )
+    config = _config(
+        "dynamo",
+        "vllm",
+        num_prefill=3,
+        num_decode=1,
+        vllm_config=vllm_config,
+        dp_launch_mode="per_node",
+    )
+
+    n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(config, _processes(prefill=6, decode=4))
+
+    assert (n_prefill, n_decode, num_workers) == (6, 4, 10)
+    assert count_desc == "6P + 4D Dynamo generate instances; logical workers: 3P + 1D"
+
+
+def test_dynamo_vllm_per_node_aggregated_counts_node_processes():
+    """Per-node aggregated DP workers register as one decode per process."""
+    vllm_config = SimpleNamespace(prefill=None, decode=None, aggregated={"data-parallel-size": 8})
+    config = _config(
+        "dynamo",
+        "vllm",
+        num_agg=1,
+        vllm_config=vllm_config,
+        dp_launch_mode="per_node",
+    )
+
+    n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(config, _processes(agg=2))
+
+    assert (n_prefill, n_decode, num_workers) == (0, 2, 2)
+    assert count_desc == "0P + 2D Dynamo generate instances; logical workers: 1 agg"
 
 
 def test_dynamo_vllm_without_dp_config_defaults_to_logical_counts():


### PR DESCRIPTION
## Summary

- count Dynamo vLLM health registrations from the physical process topology for per-node DP launch
- preserve existing per-rank counting for per-GPU DP launch
- cover disaggregated and aggregated per-node layouts

## Why

The health gate multiplied logical workers by the global DP size for every vLLM DP layout. In `per_node` launch mode, Dynamo registers one generate instance per node-local process instead, so the gate waited for registrations that would never appear.

## Impact

Per-node vLLM jobs can pass the startup health gate once all actual generate processes are registered. Other backends, frontends, and per-GPU vLLM launch behavior are unchanged.

## Validation

- `make check` (867 passed, 2 skipped, 6 deselected)
- focused health-expectation tests
- `git diff --check`
