### PR TITLE
add aiperf benchmarking backend

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -521,6 +521,7 @@ benchmark:
 | ----------------- | ---------------------------------------------- |
 | `manual`          | No benchmark (default), manual testing mode    |
 | `sa-bench`        | Throughput/latency serving benchmark           |
+| `aiperf`          | Fixed ISL/OSL sweep driven by NVIDIA aiperf    |
 | `sglang-bench`    | SGLang bench_serving benchmark                 |
 | `mmlu`            | MMLU accuracy evaluation                       |
 | `gpqa`            | GPQA (Graduate-level science QA) evaluation    |
@@ -565,6 +566,48 @@ When `reuse_http_connections` is enabled, each `benchmark_serving.py` process
 uses one keep-alive connection pool. Warmup and formal runs remain isolated in
 separate processes and therefore never share a pool. The option currently
 applies only to SA-Bench's Dynamo HTTP adapter.
+
+### aiperf (fixed ISL/OSL sweep)
+
+Same synthetic concurrency sweep as `sa-bench`, but driven by the multi-process NVIDIA
+[aiperf](https://github.com/ai-dynamo/aiperf) client instead of the single-process
+`benchmark_serving.py`. `sa-bench` under-reports high-concurrency throughput for fast models
+because one asyncio process cannot drain hundreds of concurrent SSE streams; `aiperf` uses parallel
+workers. Use this path for **fixed ISL/OSL** measurement — input and output lengths are pinned
+(std=0) and output is forced to exactly `osl` (not merely capped), so a server that stops early at
+EOS cannot truncate it. Emits the same `benchmark-rollup.json`/`.csv` schema as `sa-bench`.
+
+```yaml
+benchmark:
+  type: "aiperf"
+  isl: 1024                          # Required: Input sequence length (std=0)
+  osl: 1024                          # Required: Output sequence length (std=0, forced exactly)
+  concurrencies: "1x32x256x1024"     # Required: Concurrency levels (list or "NxM" format)
+  num_prompts_mult: 3                # Optional: request-count = concurrency * this (default 3)
+  num_warmup_mult: 1                 # Optional: warmup-request-count = concurrency * this (default 1)
+  aiperf_endpoint_type: "chat"       # Optional: aiperf --endpoint-type (default "chat"; "completions" for exact ISL)
+  aiperf_package: "aiperf"           # Optional: pip spec installed into a per-run venv (default "aiperf")
+  aiperf_args:                       # Optional: extra passthrough aiperf flags
+    benchmark-duration: 600
+```
+
+| Field                  | Type        | Required | Default    | Description                                                        |
+| ---------------------- | ----------- | -------- | ---------- | ----------------------------------------------------------------- |
+| `isl`                  | int         | Yes      | -          | Input sequence length (std=0)                                     |
+| `osl`                  | int         | Yes      | -          | Output sequence length (std=0, forced to exactly this many tokens) |
+| `concurrencies`        | list/string | Yes      | -          | Concurrency levels (list or "NxM" format)                         |
+| `num_prompts_mult`     | int         | No       | `3`        | request-count = concurrency × this                                |
+| `num_warmup_mult`      | int         | No       | `1`        | warmup-request-count = concurrency × this                         |
+| `aiperf_endpoint_type` | string      | No       | `"chat"`   | aiperf `--endpoint-type`; use `completions` for exact-ISL (no chat template) |
+| `aiperf_package`       | string      | No       | `"aiperf"` | pip spec for aiperf, installed into a throwaway venv at run time  |
+| `aiperf_args`          | dict        | No       | `{}`       | Extra aiperf CLI flags (`key: value` → `--key value`; `key: true` → `--key`) |
+
+**Fixed-length forcing** is applied automatically and is backend-aware: `--osl` sets the ceiling and
+`ignore_eos` suppresses early EOS on all backends (the same mechanism `sa-bench` uses across
+sglang/trtllm/dynamo); vLLM additionally gets an explicit `min_tokens` floor plus the legacy
+`max_tokens` field it honors. If the server still fails to honor the requested length, the rollup
+prints a warning derived from aiperf's `osl_mismatch_count`. You do not need to set these via
+`aiperf_args`.
 
 ### sglang-bench
 

--- a/src/srtctl/benchmarks/__init__.py
+++ b/src/srtctl/benchmarks/__init__.py
@@ -5,6 +5,7 @@
 
 # Import runners to trigger registration
 from srtctl.benchmarks import (
+    aiperf_bench,
     custom,
     gpqa,
     gsm8k,
@@ -30,6 +31,7 @@ __all__ = [
     "list_benchmarks",
     "register_benchmark",
     # Runners
+    "aiperf_bench",
     "custom",
     "lm_eval",
     "sa_bench",

--- a/src/srtctl/benchmarks/aiperf_bench.py
+++ b/src/srtctl/benchmarks/aiperf_bench.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AIPerf concurrency-sweep benchmark runner.
+
+Same synthetic ISL/OSL concurrency sweep as ``sa-bench``, but driven by NVIDIA ``aiperf``
+instead of the single-process Python ``benchmark_serving.py`` client. ``sa-bench`` under-reports
+high-concurrency throughput for fast models because one asyncio process cannot drain hundreds of
+concurrent SSE streams (streaming backpressure throttles the server). ``aiperf`` uses parallel
+workers and reproduces InferenceX numbers. Targets the same frontend port as ``sa-bench``, so it
+also isolates client cost from serving-stack cost.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from srtctl.benchmarks.base import SCRIPTS_DIR, AIPerfBenchmarkRunner, register_benchmark
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import SrtConfig
+
+
+@register_benchmark("aiperf")
+class AIPerfSweepRunner(AIPerfBenchmarkRunner):
+    """AIPerf synthetic concurrency-sweep benchmark.
+
+    Required config fields:
+        - benchmark.isl / benchmark.osl
+        - benchmark.concurrencies (e.g. "1x8x64x512")
+
+    Optional:
+        - benchmark.num_prompts_mult   (request-count = concurrency * this; default 3)
+        - benchmark.num_warmup_mult    (warmup-request-count = concurrency * this; default 1)
+        - benchmark.aiperf_endpoint_type (aiperf --endpoint-type; default "chat")
+        - benchmark.aiperf_args        (extra passthrough aiperf flags)
+
+    Fixed-length enforcement is handled in bench.sh: input/output std=0 and the output is forced
+    to exactly OSL (not merely capped). The forcing is backend-aware — vLLM gets an explicit
+    min_tokens floor + legacy max_tokens field, others rely on --osl + ignore_eos — so the runner
+    passes ``config.backend_type`` through to the script.
+    """
+
+    @property
+    def name(self) -> str:
+        return "AIPerf"
+
+    @property
+    def script_path(self) -> str:
+        return "/srtctl-benchmarks/aiperf/bench.sh"
+
+    @property
+    def local_script_dir(self) -> str:
+        return str(SCRIPTS_DIR / "aiperf")
+
+    def validate_config(self, config: SrtConfig) -> list[str]:
+        errors = []
+        b = config.benchmark
+        if b.isl is None:
+            errors.append("benchmark.isl is required for aiperf")
+        if b.osl is None:
+            errors.append("benchmark.osl is required for aiperf")
+        if b.concurrencies is None:
+            errors.append("benchmark.concurrencies is required for aiperf")
+        return errors
+
+    def build_command(
+        self,
+        config: SrtConfig,
+        runtime: RuntimeContext,
+    ) -> list[str]:
+        b = config.benchmark
+        endpoint = f"http://localhost:{runtime.frontend_port}"
+
+        concurrencies = b.concurrencies
+        if isinstance(concurrencies, list):
+            concurrencies = "x".join(str(c) for c in concurrencies)
+
+        tokenizer_path = str(runtime.model_path) if runtime.is_hf_model else "/model"
+        endpoint_type = getattr(b, "aiperf_endpoint_type", None) or "chat"
+
+        cmd = [
+            "bash",
+            self.script_path,
+            endpoint,
+            config.served_model_name,
+            tokenizer_path,
+            str(b.isl or 0),
+            str(b.osl or 0),
+            str(concurrencies),
+            str(b.num_prompts_mult) if b.num_prompts_mult is not None else "3",
+            str(b.num_warmup_mult) if b.num_warmup_mult is not None else "1",
+            endpoint_type,
+            config.backend_type,
+        ]
+        self.append_aiperf_args(cmd, config)
+        return cmd
+
+    def get_environment(self, config: SrtConfig, runtime: RuntimeContext) -> dict[str, str]:
+        env: dict[str, str] = {}
+        pkg = getattr(config.benchmark, "aiperf_package", None)
+        if pkg:
+            env["AIPERF_PACKAGE"] = pkg
+        return env

--- a/src/srtctl/benchmarks/scripts/aiperf/bench.sh
+++ b/src/srtctl/benchmarks/scripts/aiperf/bench.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# AIPerf FIXED ISL/OSL concurrency-sweep benchmark.
+#
+# Drives the serving frontend with NVIDIA aiperf (high-performance client) instead of
+# sa-bench's single-process Python client, which under-reports high-concurrency throughput
+# due to SSE streaming backpressure.
+#
+# FIXED-LENGTH GUARANTEE (this is the reason the aiperf path exists — see AIPerfSweepRunner):
+#   * Input/output lengths are pinned: --isl-stddev 0 / --osl-stddev 0 (std=0 on both).
+#   * Output is forced to exactly OSL, not merely capped, so a server that stops early at EOS
+#     cannot truncate it:
+#       - all backends: --osl sets the ceiling (max_tokens/max_completion_tokens) and
+#         --extra-inputs ignore_eos:true suppresses early EOS (the same mechanism sa-bench
+#         uses across sglang/trtllm/dynamo).
+#       - vLLM additionally gets a hard floor: --use-legacy-max-tokens (so --osl emits the
+#         legacy `max_tokens` field vLLM honors) + --extra-inputs min_tokens:OSL. vLLM was
+#         observed truncating/varying OSL without this explicit min/max forcing.
+#   * --use-server-token-count measures the server's own completion-token count.
+#
+# Args (positional, from AIPerfSweepRunner.build_command):
+#   1  ENDPOINT           http://localhost:<frontend_port>
+#   2  MODEL_NAME         served model name
+#   3  TOKENIZER_PATH     HF id or /model
+#   4  ISL                input seq len
+#   5  OSL                output seq len
+#   6  CONCURRENCIES      x-separated list, e.g. "1x8x64x512"
+#   7  NUM_PROMPTS_MULT   request-count = concurrency * this
+#   8  NUM_WARMUP_MULT    warmup-request-count = concurrency * this
+#   9  ENDPOINT_TYPE      aiperf endpoint type (default: chat)
+#   10 BACKEND            backend type (vllm|sglang|trtllm|...); drives backend-aware OSL forcing
+#   11+ passthrough       extra aiperf flags from benchmark.aiperf_args
+set -uo pipefail
+
+ENDPOINT="${1:?endpoint}"
+MODEL_NAME="${2:?model}"
+TOKENIZER_PATH="${3:?tokenizer}"
+ISL="${4:?isl}"
+OSL="${5:?osl}"
+CONCURRENCIES="${6:?concurrencies}"
+NUM_PROMPTS_MULT="${7:-3}"
+NUM_WARMUP_MULT="${8:-1}"
+ENDPOINT_TYPE="${9:-chat}"
+BACKEND="${10:-}"
+# Any args beyond the 10 positional ones are passthrough aiperf flags (benchmark.aiperf_args).
+EXTRA_AIPERF_ARGS=("${@:11}")
+
+ARTIFACT_BASE="/logs/artifacts"
+mkdir -p "$ARTIFACT_BASE"
+
+# Backend-aware output-length forcing. ignore_eos is universal; vLLM also gets an explicit
+# min_tokens floor plus the legacy max_tokens field it honors.
+OSL_FORCE_ARGS=(--extra-inputs ignore_eos:true)
+MAX_TOKENS_ARGS=()
+if [ "$BACKEND" = "vllm" ]; then
+    OSL_FORCE_ARGS+=(--extra-inputs "min_tokens:${OSL}")
+    MAX_TOKENS_ARGS=(--use-legacy-max-tokens)
+fi
+
+echo "=============================================="
+echo "AIPerf fixed ISL/OSL concurrency-sweep benchmark"
+echo "  Endpoint:      $ENDPOINT ($ENDPOINT_TYPE)"
+echo "  Model:         $MODEL_NAME"
+echo "  Backend:       ${BACKEND:-<unset>}"
+echo "  ISL/OSL:       $ISL / $OSL (std=0, output forced to exactly OSL)"
+echo "  Concurrencies: $CONCURRENCIES"
+echo "=============================================="
+
+# Install aiperf into an isolated venv that inherits system site-packages, so we do NOT
+# uninstall distutils-installed packages (e.g. blinker 1.4) inside the serving container,
+# which makes a bare `pip install aiperf` fail.
+AIPERF_VENV="/tmp/aiperf_venv"
+if [ ! -x "$AIPERF_VENV/bin/aiperf" ]; then
+    echo "Installing aiperf into $AIPERF_VENV ..."
+    python3 -m venv --system-site-packages "$AIPERF_VENV"
+    "$AIPERF_VENV/bin/pip" install --no-cache-dir "${AIPERF_PACKAGE:-aiperf}" 2>&1 | tail -3
+fi
+AIPERF="$AIPERF_VENV/bin/aiperf"
+"$AIPERF" --version || { echo "aiperf install failed"; exit 1; }
+
+IFS='x' read -ra CONC_LIST <<< "$CONCURRENCIES"
+FAIL=0
+for conc in "${CONC_LIST[@]}"; do
+    reqcount=$(( conc * NUM_PROMPTS_MULT ))
+    warmup=$(( conc * NUM_WARMUP_MULT ))
+    # aiperf rejects --warmup-request-count 0 (pydantic gt=0); omit the flag entirely for no warmup
+    # (e.g. num_warmup_mult: 0). Passing 0 aborts the whole sweep with a validation error.
+    warmup_args=()
+    if [ "$warmup" -gt 0 ]; then
+        warmup_args=(--warmup-request-count "$warmup")
+    fi
+    outdir="$ARTIFACT_BASE/conc_${conc}"
+    mkdir -p "$outdir"
+    echo ""
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - aiperf concurrency=$conc requests=$reqcount warmup=$warmup"
+    set -x
+    "$AIPERF" profile \
+        -m "$MODEL_NAME" \
+        --tokenizer "$TOKENIZER_PATH" \
+        --url "$ENDPOINT" \
+        --endpoint-type "$ENDPOINT_TYPE" \
+        --ui-type none \
+        --streaming \
+        --concurrency "$conc" \
+        --request-count "$reqcount" \
+        "${warmup_args[@]}" \
+        --isl "$ISL" --isl-stddev 0 \
+        --osl "$OSL" --osl-stddev 0 \
+        --use-server-token-count \
+        "${MAX_TOKENS_ARGS[@]}" \
+        "${OSL_FORCE_ARGS[@]}" \
+        "${EXTRA_AIPERF_ARGS[@]}" \
+        --artifact-dir "$outdir" || FAIL=1
+    set +x
+done
+
+echo ""
+echo "AIPerf sweep complete (fail=$FAIL). Artifacts under $ARTIFACT_BASE"
+exit $FAIL

--- a/src/srtctl/benchmarks/scripts/aiperf/rollup.py
+++ b/src/srtctl/benchmarks/scripts/aiperf/rollup.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate benchmark-rollup.json and benchmark-rollup.csv from aiperf concurrency-sweep results.
+
+Emits the SAME schema as sa-bench's rollup so IBDB ingests aiperf runs identically. One row per
+concurrency, read from ``<log_dir>/artifacts/conc_<c>/**/profile_export_aiperf.json``.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+OUTPUT_FIELDS = [
+    "Config",
+    "Total GPU Count",
+    "Decode GPU Count",
+    "Concurrency",
+    "Total Token Throughput",
+    "Output Token Throughput",
+    "Median TTFT",
+    "Median TPOT",
+    "Median ITL",
+    "P90 Decode Running Requests",
+    "Output Token Throughput per User",
+    "Total Token Throughput per GPU",
+]
+
+CONC_DIR_RE = re.compile(r"conc_(\d+)")
+RUNNING_REQ_PATTERN = re.compile(r"#running-req:\s*(\d+)")
+
+
+def _read_job_metadata(log_dir: Path) -> dict[str, Any] | None:
+    for metadata_path in sorted(log_dir.parent.glob("*.json")):
+        try:
+            data = json.loads(metadata_path.read_text())
+        except Exception as exc:  # noqa: BLE001
+            print(f"Failed to parse {metadata_path}: {exc}", file=sys.stderr)
+            continue
+        if data and "resources" in data:
+            return data
+    return None
+
+
+def _as_int(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _compute_gpu_counts(resources: dict[str, Any]) -> tuple[int | None, int | None]:
+    gpus_per_node = _as_int(resources.get("gpus_per_node"))
+    prefill_nodes = _as_int(resources.get("prefill_nodes"))
+    decode_nodes = _as_int(resources.get("decode_nodes"))
+    agg_nodes = _as_int(resources.get("agg_nodes"))
+    if gpus_per_node <= 0:
+        return None, None
+    if prefill_nodes > 0 or decode_nodes > 0:
+        total = (prefill_nodes + decode_nodes) * gpus_per_node
+    elif agg_nodes > 0:
+        total = agg_nodes * gpus_per_node
+    else:
+        total = gpus_per_node
+    if decode_nodes > 0:
+        return total, decode_nodes * gpus_per_node
+    dw, gpd = _as_int(resources.get("decode_workers")), _as_int(resources.get("gpus_per_decode"))
+    if dw > 0 and gpd > 0:
+        return total, dw * gpd
+    aw, gpa = _as_int(resources.get("agg_workers")), _as_int(resources.get("gpus_per_agg"))
+    if aw > 0 and gpa > 0:
+        return total, aw * gpa
+    if agg_nodes > 0:
+        return total, total
+    return total, None
+
+
+def _extract_p90_decode_running_requests(log_dir: Path, metadata: dict[str, Any] | None) -> int | None:
+    """Stream sglang decode logs and compute the nearest-rank P90 of #running-req values.
+
+    Ported from sa-bench's rollup so aiperf runs on an sglang P/D deployment populate the same
+    column. Returns None for non-sglang / non-disaggregated runs (the decode logs exist for
+    aiperf runs identically to sa-bench runs).
+    """
+    if not metadata or metadata.get("backend_type") != "sglang":
+        return None
+
+    resources = metadata.get("resources")
+    if resources is None:
+        return None
+    if not (_as_int(resources.get("prefill_nodes")) > 0 and _as_int(resources.get("decode_nodes")) > 0):
+        return None
+    if _as_int(resources.get("agg_workers")) > 0:
+        return None
+
+    counts: Counter[int] = Counter()
+    total = 0
+
+    for decode_log in sorted(log_dir.glob("*decode*.out")):
+        try:
+            with decode_log.open("r", errors="replace") as f:
+                for line in f:
+                    match = RUNNING_REQ_PATTERN.search(line)
+                    if not match:
+                        continue
+                    counts[int(match.group(1))] += 1
+                    total += 1
+        except OSError as exc:
+            print(f"Failed to read {decode_log}: {exc}", file=sys.stderr)
+
+    if total == 0:
+        return None
+
+    rank = math.ceil(total * 0.9)
+    cumulative = 0
+    for value in sorted(counts):
+        cumulative += counts[value]
+        if cumulative >= rank:
+            return value
+    return None
+
+
+def _scalar(metric: Any) -> float | None:
+    """aiperf metrics are dicts with 'avg'/'p50'/... ; extract a scalar mean."""
+    if isinstance(metric, dict):
+        return metric.get("avg")
+    if isinstance(metric, (int, float)):
+        return float(metric)
+    return None
+
+
+def _pctl(metric: Any, key: str) -> float | None:
+    return metric.get(key) if isinstance(metric, dict) else None
+
+
+def _safe_ratio(n: float | int | None, d: float | int | None) -> float | None:
+    if n is None or d in (None, 0):
+        return None
+    return float(n) / float(d)
+
+
+def _warn_osl_mismatch(conc: int, data: dict[str, Any]) -> None:
+    """Loudly flag when the server did not emit the requested OSL (truncation/variation).
+
+    aiperf records osl_mismatch_count / osl_mismatch_diff_pct when actual output length differs
+    from the requested value. A nonzero count means the fixed-OSL forcing did not hold for this
+    server, so the throughput numbers are not a clean fixed-length measurement.
+    """
+    count = _scalar(data.get("osl_mismatch_count"))
+    if count:
+        pct = _scalar(data.get("osl_mismatch_diff_pct"))
+        pct_str = f", mean diff {pct:.1f}%" if pct is not None else ""
+        print(
+            f"WARNING: concurrency={conc}: {int(count)} requests did not honor the requested OSL"
+            f"{pct_str}. Output length was not fixed for this run.",
+            file=sys.stderr,
+        )
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return f"{value:.3f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
+def main(log_dir: Path) -> None:
+    artifacts = log_dir / "artifacts"
+    files = sorted(artifacts.glob("conc_*/**/profile_export_aiperf.json")) if artifacts.exists() else []
+    if not files:
+        print("No aiperf results found", file=sys.stderr)
+        return
+
+    metadata = _read_job_metadata(log_dir)
+    config_name = metadata.get("job_name") if metadata else None
+    resources = metadata.get("resources") if metadata else None
+    total_gpu, decode_gpu = _compute_gpu_counts(resources) if resources else (None, None)
+    p90_decode_running = _extract_p90_decode_running_requests(log_dir, metadata)
+    bench = (metadata or {}).get("benchmark", {})
+
+    runs: list[dict[str, Any]] = []
+    csv_rows: list[dict[str, object]] = []
+    config = {"model": (metadata or {}).get("model", {}).get("path"), "isl": bench.get("isl"), "osl": bench.get("osl")}
+
+    # de-dupe by concurrency, keeping the newest export
+    by_conc: dict[int, Path] = {}
+    for f in files:
+        m = CONC_DIR_RE.search(str(f))
+        if not m:
+            continue
+        c = int(m.group(1))
+        if c not in by_conc or f.stat().st_mtime > by_conc[c].stat().st_mtime:
+            by_conc[c] = f
+
+    for conc in sorted(by_conc):
+        try:
+            d = json.loads(by_conc[conc].read_text())
+        except json.JSONDecodeError as exc:
+            print(f"Failed to parse {by_conc[conc]}: {exc}", file=sys.stderr)
+            continue
+        out_tps = _scalar(d.get("output_token_throughput"))
+        tot_tps = _scalar(d.get("total_token_throughput"))
+        ttft = d.get("time_to_first_token", {})
+        # aiperf has no distinct time-per-output-token metric, so TPOT is defined as
+        # inter_token_latency (ITL). The two columns are therefore equal for aiperf runs.
+        itl = d.get("inter_token_latency", {})
+        e2el = d.get("request_latency", {})
+        itl_p50 = _pctl(itl, "p50")
+
+        # completed count: prefer good (non-error) requests, fall back to total request_count.
+        completed = _scalar(d.get("good_request_count"))
+        if completed is None:
+            completed = _scalar(d.get("request_count"))
+        # total input tokens: total_isl is always present (tokenizer-derived) and not inflated
+        # by chat-template / server-usage availability, unlike total_usage_prompt_tokens.
+        total_in = _scalar(d.get("total_isl"))
+        if total_in is None:
+            total_in = _scalar(d.get("total_usage_prompt_tokens"))
+
+        _warn_osl_mismatch(conc, d)
+
+        runs.append(
+            {
+                "concurrency": conc,
+                "throughput_toks": out_tps,
+                "request_throughput": _scalar(d.get("request_throughput")),
+                "ttft_mean_ms": _scalar(ttft),
+                "ttft_p99_ms": _pctl(ttft, "p99"),
+                "tpot_mean_ms": _scalar(itl),
+                "tpot_p99_ms": _pctl(itl, "p99"),
+                "itl_mean_ms": _scalar(itl),
+                "itl_p99_ms": _pctl(itl, "p99"),
+                "e2el_mean_ms": _scalar(e2el),
+                "completed_requests": int(completed) if completed is not None else None,
+                "total_input_tokens": total_in,
+                "total_output_tokens": _scalar(d.get("total_output_tokens")),
+            }
+        )
+
+        csv_rows.append(
+            {
+                k: _fmt(v)
+                for k, v in {
+                    "Config": config_name or str(config.get("model") or "aiperf"),
+                    "Total GPU Count": total_gpu,
+                    "Decode GPU Count": decode_gpu,
+                    "Concurrency": conc,
+                    "Total Token Throughput": tot_tps,
+                    "Output Token Throughput": out_tps,
+                    "Median TTFT": _pctl(ttft, "p50"),
+                    "Median TPOT": itl_p50,
+                    "Median ITL": itl_p50,
+                    "P90 Decode Running Requests": p90_decode_running,
+                    # Match sa-bench's estimator (1000 / median-TPOT-ms) for cross-benchmark continuity.
+                    "Output Token Throughput per User": _safe_ratio(1000.0, itl_p50),
+                    "Total Token Throughput per GPU": _safe_ratio(tot_tps, total_gpu),
+                }.items()
+            }
+        )
+
+    if not runs:
+        print("No valid aiperf results found", file=sys.stderr)
+        return
+
+    rollup = {
+        "benchmark_type": "aiperf",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "config": config,
+        "runs": runs,
+    }
+    (log_dir / "benchmark-rollup.json").write_text(json.dumps(rollup, indent=2))
+    print(f"Wrote {log_dir / 'benchmark-rollup.json'}")
+
+    csv_rows.sort(key=lambda r: int(r["Concurrency"]) if r["Concurrency"] else -1)
+    with (log_dir / "benchmark-rollup.csv").open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=OUTPUT_FIELDS)
+        w.writeheader()
+        w.writerows(csv_rows)
+    print(f"Wrote {log_dir / 'benchmark-rollup.csv'}")
+
+
+if __name__ == "__main__":
+    main(Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/logs"))

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -314,6 +314,7 @@ def show_config_details(config: SrtConfig) -> None:
 
     show_extensions = (
         config.benchmark.type == "custom"
+        or config.benchmark.type == "aiperf"
         or config.benchmark.container_image
         or config.telemetry.enabled
         or mooncake_cfg is not None
@@ -328,6 +329,24 @@ def show_config_details(config: SrtConfig) -> None:
             details.add_row("benchmark", "type", config.benchmark.type)
             if config.benchmark.command:
                 details.add_row("benchmark", "command", config.benchmark.command)
+
+        # AIPerf fixed ISL/OSL sweep: surface the sweep shape and the aiperf-affecting config
+        # (aiperf_package -> AIPERF_PACKAGE env; aiperf_args -> extra CLI flags) so operators can
+        # verify them before submitting.
+        if config.benchmark.type == "aiperf":
+            b = config.benchmark
+            concurrencies = b.concurrencies
+            if isinstance(concurrencies, list):
+                concurrencies = "x".join(str(c) for c in concurrencies)
+            details.add_row("benchmark", "type", b.type)
+            details.add_row("benchmark", "isl / osl", f"{b.isl} / {b.osl}")
+            details.add_row("benchmark", "concurrencies", str(concurrencies))
+            details.add_row("benchmark", "endpoint_type", b.aiperf_endpoint_type or "chat")
+            if b.aiperf_package:
+                details.add_row("benchmark", "aiperf_package", b.aiperf_package)
+            for key, value in (b.aiperf_args or {}).items():
+                rendered = f"--{key}" if isinstance(value, bool) else f"--{key} {value}"
+                details.add_row("benchmark", "aiperf_args", rendered)
 
         # Surface a non-default benchmark container regardless of type — accuracy
         # benchmarks like AIME (run via type: custom + the NeMo Skills container)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -242,6 +242,7 @@ class BenchmarkType(str, Enum):
     MANUAL = "manual"
     CUSTOM = "custom"
     SA_BENCH = "sa-bench"
+    AIPERF = "aiperf"
     ROUTER = "router"
     MOONCAKE_ROUTER = "mooncake-router"
     TRACE_REPLAY = "trace-replay"
@@ -723,6 +724,8 @@ class BenchmarkConfig:
     aiperf_package: str | None = None
     # Extra aiperf CLI flags passed through to bench.sh (e.g., benchmark-duration: 600, workers-max: 200)
     aiperf_args: dict[str, Any] = field(default_factory=dict)
+    # aiperf --endpoint-type for the "aiperf" concurrency-sweep benchmark (default "chat")
+    aiperf_endpoint_type: str | None = None
     # Post-process: export analysis/srtlog per-node batch CSVs + gen_throughput.csv (see postprocess_stage)
     export_node_metrics: bool = False
     # SA-Bench: optional SGLang /slow_down on decode workers (sglang frontend only; see benchmark_stage)

--- a/tests/test_aiperf_rollup.py
+++ b/tests/test_aiperf_rollup.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AIPerf rollup generation (schema/unit parity with sa-bench)."""
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_rollup_module():
+    rollup_path = Path(__file__).parent.parent / "src/srtctl/benchmarks/scripts/aiperf/rollup.py"
+    spec = importlib.util.spec_from_file_location("aiperf_rollup", rollup_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _write_export(artifacts_dir: Path, conc: int, data: dict) -> None:
+    # aiperf writes profile_export_aiperf.json under <artifact-dir>/<run>/ ; the rollup globs
+    # artifacts/conc_*/**/profile_export_aiperf.json, so nest it one level.
+    run_dir = artifacts_dir / f"conc_{conc}" / "profile_export"
+    run_dir.mkdir(parents=True)
+    (run_dir / "profile_export_aiperf.json").write_text(json.dumps(data))
+
+
+def _export(*, ttft_avg, ttft_p50, ttft_p99, itl_avg, itl_p50, itl_p99, out_tps, tot_tps, good, total_isl, total_osl):
+    """Build a minimal profile_export_aiperf.json-shaped dict (metrics are flat stat objects)."""
+    return {
+        "output_token_throughput": {"unit": "tokens/sec", "avg": out_tps},
+        "total_token_throughput": {"unit": "tokens/sec", "avg": tot_tps},
+        "request_throughput": {"unit": "requests/sec", "avg": 1.25},
+        "time_to_first_token": {"unit": "ms", "avg": ttft_avg, "p50": ttft_p50, "p99": ttft_p99},
+        "inter_token_latency": {"unit": "ms", "avg": itl_avg, "p50": itl_p50, "p99": itl_p99},
+        "request_latency": {"unit": "ms", "avg": 200.0},
+        "good_request_count": {"unit": "requests", "avg": good},
+        "total_isl": {"unit": "tokens", "avg": total_isl},
+        "total_output_tokens": {"unit": "tokens", "avg": total_osl},
+    }
+
+
+def test_aiperf_rollup_generates_json_and_csv_without_metadata(tmp_path):
+    """Rollup emits sa-bench-shaped JSON + CSV even when job metadata is absent."""
+    rollup = _load_rollup_module()
+
+    logs_dir = tmp_path / "logs"
+    artifacts = logs_dir / "artifacts"
+    artifacts.mkdir(parents=True)
+
+    _write_export(
+        artifacts, 16,
+        _export(ttft_avg=100.0, ttft_p50=95.0, ttft_p99=150.0, itl_avg=20.0, itl_p50=12.5, itl_p99=30.0,
+                out_tps=1234.5, tot_tps=9876.0, good=160, total_isl=131072, total_osl=16384),
+    )
+    _write_export(
+        artifacts, 32,
+        _export(ttft_avg=110.0, ttft_p50=96.0, ttft_p99=151.0, itl_avg=21.0, itl_p50=13.0, itl_p99=31.0,
+                out_tps=2222.25, tot_tps=11111.0, good=320, total_isl=262144, total_osl=32768),
+    )
+
+    rollup.main(logs_dir)
+
+    json_rollup = logs_dir / "benchmark-rollup.json"
+    csv_rollup = logs_dir / "benchmark-rollup.csv"
+    assert json_rollup.exists()
+    assert csv_rollup.exists()
+
+    json_data = json.loads(json_rollup.read_text())
+    assert json_data["benchmark_type"] == "aiperf"
+    assert [run["concurrency"] for run in json_data["runs"]] == [16, 32]
+
+    first = json_data["runs"][0]
+    assert first["ttft_mean_ms"] == 100.0
+    assert first["ttft_p99_ms"] == 150.0
+    # completed_requests comes from good_request_count (was hardcoded null before the fix).
+    assert first["completed_requests"] == 160
+    # total_input_tokens comes from total_isl (always present, tokenizer-derived).
+    assert first["total_input_tokens"] == 131072
+    assert first["total_output_tokens"] == 16384
+    assert json_data["runs"][1]["ttft_p99_ms"] == 151.0
+
+    rows = _read_csv_rows(csv_rollup)
+    assert [row["Concurrency"] for row in rows] == ["16", "32"]
+
+    row = rows[0]
+    assert row["Total GPU Count"] == ""  # no metadata
+    assert row["Output Token Throughput"] == "1234.5"
+    assert row["Median TTFT"] == "95"
+    # aiperf has no distinct TPOT metric: TPOT is defined as ITL, so the columns are equal.
+    assert row["Median TPOT"] == "12.5"
+    assert row["Median ITL"] == "12.5"
+    assert row["P90 Decode Running Requests"] == ""  # no sglang metadata
+    # Output Token Throughput per User matches sa-bench's estimator: 1000 / median-TPOT-ms.
+    assert row["Output Token Throughput per User"] == "80"
+
+
+def test_aiperf_rollup_uses_metadata_for_gpu_counts_and_p90(tmp_path):
+    """Metadata-driven runs use resource GPU counts and the decode-log P90 (ported from sa-bench)."""
+    rollup = _load_rollup_module()
+
+    logs_dir = tmp_path / "logs"
+    artifacts = logs_dir / "artifacts"
+    artifacts.mkdir(parents=True)
+
+    (tmp_path / "4049.json").write_text(
+        json.dumps(
+            {
+                "job_name": "job-metadata-name",
+                "backend_type": "sglang",
+                "resources": {
+                    "gpus_per_node": 8,
+                    "prefill_nodes": 1,
+                    "decode_nodes": 2,
+                    "decode_workers": 2,
+                    "agg_workers": 0,
+                },
+            }
+        )
+    )
+    (logs_dir / "b300-003_decode_w0.out").write_text(
+        "\n".join(
+            [
+                "[x] Decode batch, #running-req: 4, #token: 100",
+                "[x] Decode batch, #running-req: 8, #token: 100",
+                "[x] Decode batch, #running-req: 8, #token: 100",
+                "[x] Decode batch, #running-req: 16, #token: 100",
+                "[x] Decode batch, #running-req: 32, #token: 100",
+                "[x] unrelated line",
+            ]
+        )
+    )
+
+    _write_export(
+        artifacts, 512,
+        _export(ttft_avg=200.0, ttft_p50=200.0, ttft_p99=250.0, itl_avg=25.0, itl_p50=25.0, itl_p99=40.0,
+                out_tps=100.0, tot_tps=800.0, good=1024, total_isl=4096, total_osl=1024),
+    )
+
+    rollup.main(logs_dir)
+
+    rows = _read_csv_rows(logs_dir / "benchmark-rollup.csv")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["Config"] == "job-metadata-name"
+    assert row["Total GPU Count"] == "24"
+    assert row["Decode GPU Count"] == "16"
+    assert row["P90 Decode Running Requests"] == "32"
+    assert row["Output Token Throughput per User"] == "40"  # 1000 / 25
+    assert row["Total Token Throughput per GPU"] == "33.333"  # 800 / 24
+
+
+def test_aiperf_rollup_warns_on_osl_mismatch(tmp_path, capsys):
+    """A nonzero osl_mismatch_count is surfaced loudly (fixed-OSL forcing did not hold)."""
+    rollup = _load_rollup_module()
+
+    logs_dir = tmp_path / "logs"
+    artifacts = logs_dir / "artifacts"
+    artifacts.mkdir(parents=True)
+
+    export = _export(ttft_avg=100.0, ttft_p50=95.0, ttft_p99=150.0, itl_avg=20.0, itl_p50=12.5, itl_p99=30.0,
+                     out_tps=1234.5, tot_tps=9876.0, good=160, total_isl=131072, total_osl=16384)
+    export["osl_mismatch_count"] = {"unit": "requests", "avg": 5}
+    export["osl_mismatch_diff_pct"] = {"unit": "%", "avg": -12.0}
+    _write_export(artifacts, 16, export)
+
+    rollup.main(logs_dir)
+
+    err = capsys.readouterr().err
+    assert "did not honor the requested OSL" in err

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -17,6 +17,7 @@ class TestBenchmarkRegistry:
         benchmarks = list_benchmarks()
         assert "custom" in benchmarks
         assert "sa-bench" in benchmarks
+        assert "aiperf" in benchmarks
         assert "sglang-bench" in benchmarks
         assert "mmlu" in benchmarks
         assert "gpqa" in benchmarks
@@ -381,6 +382,152 @@ class TestMooncakeRouterRunner:
 
         # Command: bash, script, endpoint, model_name, workload, ttft, itl, tokenizer_path
         assert cmd[7] == "/model"  # tokenizer path
+
+
+class TestAIPerfSweepRunner:
+    """Test AIPerf fixed ISL/OSL concurrency-sweep runner."""
+
+    def test_in_registry(self):
+        """aiperf is registered in benchmark list."""
+        assert "aiperf" in list_benchmarks()
+
+    def test_get_runner(self):
+        """Can get runner for aiperf."""
+        runner = get_runner("aiperf")
+        assert runner.name == "AIPerf"
+        assert "aiperf" in runner.script_path
+
+    def test_validate_missing_fields(self):
+        """isl, osl, and concurrencies are all required."""
+        from srtctl.benchmarks.aiperf_bench import AIPerfSweepRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = AIPerfSweepRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(type="aiperf"),
+        )
+        errors = runner.validate_config(config)
+        assert any("isl" in e for e in errors)
+        assert any("osl" in e for e in errors)
+        assert any("concurrencies" in e for e in errors)
+
+    def test_validate_valid(self):
+        """Valid config passes validation."""
+        from srtctl.benchmarks.aiperf_bench import AIPerfSweepRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = AIPerfSweepRunner()
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(type="aiperf", isl=1024, osl=1024, concurrencies=[1, 8]),
+        )
+        assert runner.validate_config(config) == []
+
+    def test_build_command_defaults(self):
+        """Build command emits the expected positional argv with defaults and backend type."""
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.aiperf_bench import AIPerfSweepRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = AIPerfSweepRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        runtime.is_hf_model = False
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model/test-model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(type="aiperf", isl=1024, osl=1024, concurrencies=[1, 8]),
+        )
+
+        cmd = runner.build_command(config, runtime)
+        assert cmd[0] == "bash"
+        assert "aiperf/bench.sh" in cmd[1]
+        assert cmd[2] == "http://localhost:8000"  # endpoint
+        assert cmd[4] == "/model"  # tokenizer path (local model)
+        assert cmd[5] == "1024"  # isl
+        assert cmd[6] == "1024"  # osl
+        assert cmd[7] == "1x8"  # concurrencies joined
+        assert cmd[8] == "3"  # default num_prompts_mult
+        assert cmd[9] == "1"  # default num_warmup_mult
+        assert cmd[10] == "chat"  # default endpoint type
+        assert cmd[11] == "sglang"  # default backend type (drives OSL forcing in bench.sh)
+
+    def test_build_command_vllm_backend_and_overrides(self):
+        """vLLM backend and non-default endpoint/mults flow into the argv."""
+        from unittest.mock import MagicMock
+
+        from srtctl.backends.vllm import VLLMProtocol
+        from srtctl.benchmarks.aiperf_bench import AIPerfSweepRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = AIPerfSweepRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        runtime.is_hf_model = False
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model/test-model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            backend=VLLMProtocol(),
+            benchmark=BenchmarkConfig(
+                type="aiperf",
+                isl=8192,
+                osl=1024,
+                concurrencies="256x512",
+                num_prompts_mult=5,
+                num_warmup_mult=2,
+                aiperf_endpoint_type="completions",
+            ),
+        )
+
+        cmd = runner.build_command(config, runtime)
+        assert cmd[7] == "256x512"
+        assert cmd[8] == "5"
+        assert cmd[9] == "2"
+        assert cmd[10] == "completions"
+        assert cmd[11] == "vllm"
+
+    def test_build_command_aiperf_args_passthrough(self):
+        """aiperf_args are appended after the positional args as CLI flags."""
+        from unittest.mock import MagicMock
+
+        from srtctl.benchmarks.aiperf_bench import AIPerfSweepRunner
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        runner = AIPerfSweepRunner()
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        runtime.is_hf_model = False
+
+        config = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model/test-model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200"),
+            benchmark=BenchmarkConfig(
+                type="aiperf",
+                isl=1024,
+                osl=1024,
+                concurrencies=[1],
+                aiperf_args={"benchmark-duration": 600, "export-http-trace": True, "disabled": False},
+            ),
+        )
+
+        cmd = runner.build_command(config, runtime)
+        # Backend type is the last positional arg (index 11); passthrough flags follow.
+        extra = cmd[12:]
+        assert "--benchmark-duration" in extra
+        assert extra[extra.index("--benchmark-duration") + 1] == "600"
+        assert "--export-http-trace" in extra
+        assert "--disabled" not in extra
 
 
 class TestTraceReplayRunner:
@@ -880,6 +1027,11 @@ source "$script" "$@"
         assert (SCRIPTS_DIR / "gsm8k" / "sglang-bench.sh").exists()
         assert (SCRIPTS_DIR / "gsm8k" / "vllm-bench.sh").exists()
         assert (SCRIPTS_DIR / "gsm8k" / "gsm8k_eval.py").exists()
+
+    def test_aiperf_scripts_exist(self):
+        """AIPerf bench script and its rollup exist."""
+        assert (SCRIPTS_DIR / "aiperf" / "bench.sh").exists()
+        assert (SCRIPTS_DIR / "aiperf" / "rollup.py").exists()
 
 
 class TestCustomDatasetLoader:

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -247,6 +247,29 @@ class TestDryRunExecutionExtensions:
         assert "container_image" in output
         assert "nvcr.io/nvidia/python:3.11" in output
 
+    def test_aiperf_benchmark_details_shown(self, capsys):
+        """AIPerf fixed ISL/OSL config (sweep shape + aiperf_package/aiperf_args) appears in dry-run."""
+        config = _make_config(
+            {
+                "benchmark": {
+                    "type": "aiperf",
+                    "isl": 1024,
+                    "osl": 1024,
+                    "concurrencies": "1x8x64",
+                    "aiperf_endpoint_type": "completions",
+                    "aiperf_package": "aiperf",
+                    "aiperf_args": {"benchmark-duration": 600},
+                }
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "Execution Extensions" in output
+        assert "aiperf" in output
+        assert "concurrencies" in output
+        assert "endpoint_type" in output
+        assert "aiperf_args" in output
+
     def test_telemetry_details_shown(self, capsys):
         config = _make_config(
             {


### PR DESCRIPTION
adding an `aiperf` benchmark type

Validated on B200 1k/1k · Nemotron-3-Ultra-550B

conc | sa-bench fixed 1024 (2325343) | aiperf fixed 1024 (2325083) | aiperf/sa
-- | -- | -- | --
1 | 70.1 | 69.2 | 0.99×
2 | 132.9 | 131.1 | 0.99×
4 | 252.7 | 236.8 | 0.94×



