### PR TITLE
fix(vllm): force hybrid LB for per-node DP

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -435,10 +435,8 @@ backend:
   vllm_config:
     prefill:
       data-parallel-size: 8
-      data-parallel-hybrid-lb: true
     decode:
       data-parallel-size: 16
-      data-parallel-hybrid-lb: true
 ```
 
 | Value      | Process layout                                      |
@@ -446,11 +444,21 @@ backend:
 | `per_gpu`  | One process per DP rank/GPU (default)               |
 | `per_node` | One process manages all DP ranks allocated per node |
 
+`per_gpu` remains the compatibility default for now, but srtslurm will switch
+the default to `per_node` in a future release. Existing vLLM DP configurations
+should set `backend.dp_launch_mode: per_node` now; srtslurm emits a
+configuration-time migration warning while they still use `per_gpu`.
+
 In `per_node` mode, srtslurm derives `--data-parallel-size-local` and
 `--data-parallel-start-rank` from the allocated topology. Do not set those
-two flags manually. Set `data-parallel-hybrid-lb: true` when the frontend
-must route to an exact DP rank; without hybrid LB, non-leader node processes
-are launched with `--headless` for vLLM's internal DP load balancer.
+two flags manually. srtslurm also always enables `--data-parallel-hybrid-lb`
+so every node-local process registers with the Dynamo frontend. This is the
+recommended vLLM topology for Dynamo and ensures the frontend can route to
+each node-local DP engine. Do not set `data-parallel-hybrid-lb` manually;
+srtslurm enables it automatically, warns when it is configured, and ignores
+the configured value. `headless` is incompatible with `per_node` DP because a
+headless process does not register with Dynamo, so srtslurm rejects that
+combination during configuration loading.
 
 ### TRTLLM Backend
 

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import builtins
 import json
+import logging
 from collections.abc import Sequence
 from dataclasses import field
 from pathlib import Path
@@ -21,7 +22,7 @@ from typing import (
     Literal,
 )
 
-from marshmallow import Schema
+from marshmallow import Schema, ValidationError
 from marshmallow_dataclass import dataclass
 
 from srtctl.ports import (
@@ -42,6 +43,8 @@ if TYPE_CHECKING:
 # Type alias for worker modes
 WorkerMode = Literal["prefill", "decode", "agg"]
 DPLaunchMode = Literal["per_gpu", "per_node"]
+
+logger = logging.getLogger(__name__)
 
 # Filename for the mooncake-store JSON config srtslurm writes to log_dir at job
 # start. log_dir is mounted into every worker at /logs, so workers read the JSON
@@ -195,9 +198,63 @@ class VLLMProtocol:
 
     # DP process layout. Keep the existing per-GPU behavior by default;
     # per-node lets vLLM manage local DP ranks in one CUDA namespace.
+    # TODO: Change the default to per_node after the per_gpu migration window.
     dp_launch_mode: DPLaunchMode = "per_gpu"
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        """Validate flags whose behavior is fixed by the per-node launch topology."""
+        if self.vllm_config is None:
+            return
+
+        dp_mode_configs: list[tuple[str, dict[str, Any]]] = []
+        for mode_name, mode_config in (
+            ("prefill", self.vllm_config.prefill),
+            ("decode", self.vllm_config.decode),
+            ("aggregated", self.vllm_config.aggregated),
+        ):
+            if mode_config and any(
+                str(key).replace("_", "-") == "data-parallel-size" and value is not None
+                for key, value in mode_config.items()
+            ):
+                dp_mode_configs.append((mode_name, mode_config))
+
+        if not dp_mode_configs:
+            return
+
+        if self.dp_launch_mode == "per_gpu":
+            modes = ", ".join(mode_name for mode_name, _ in dp_mode_configs)
+            logger.warning(
+                "vLLM DP mode(s) %s use dp_launch_mode=per_gpu. per_node is the recommended topology "
+                "and will become the default in a future release; set backend.dp_launch_mode: per_node now",
+                modes,
+            )
+            return
+
+        hybrid_lb_modes: list[str] = []
+        headless_modes: list[str] = []
+        for mode_name, mode_config in dp_mode_configs:
+            normalized_keys = {str(key).replace("_", "-") for key in mode_config}
+            if "headless" in normalized_keys:
+                headless_modes.append(mode_name)
+            if "data-parallel-hybrid-lb" in normalized_keys:
+                hybrid_lb_modes.append(mode_name)
+
+        if headless_modes:
+            fields = ", ".join(f"vllm_config.{mode}.headless" for mode in headless_modes)
+            raise ValidationError(
+                f"{fields} cannot be set when dp_launch_mode=per_node. "
+                "Every node-local process must register with the Dynamo frontend; remove headless."
+            )
+
+        if hybrid_lb_modes:
+            fields = ", ".join(f"vllm_config.{mode}.data-parallel-hybrid-lb" for mode in hybrid_lb_modes)
+            logger.warning(
+                "%s is unnecessary when dp_launch_mode=per_node; "
+                "srtslurm always enables --data-parallel-hybrid-lb and ignores the configured value",
+                fields,
+            )
 
     # =========================================================================
     # BackendProtocol Implementation
@@ -678,11 +735,15 @@ class VLLMProtocol:
             config_dp_rpc_port = rpc_port_kebab or rpc_port_snake
             dp_rpc_port = process.dp_rpc_port or config_dp_rpc_port or VLLM_DATA_PARALLEL_RPC_PORT
 
-            # These values are derived from the allocated process topology.
+            # These values are derived from the allocated process topology. Hybrid LB
+            # is required so every node-local Dynamo runtime registers with the frontend.
             config.pop("data-parallel-size-local", None)
             config.pop("data_parallel_size_local", None)
             config.pop("data-parallel-start-rank", None)
             config.pop("data_parallel_start_rank", None)
+            config.pop("data-parallel-hybrid-lb", None)
+            config.pop("data_parallel_hybrid_lb", None)
+            config.pop("headless", None)
 
             cmd.extend(
                 [
@@ -694,15 +755,9 @@ class VLLMProtocol:
                     leader_ip,
                     "--data-parallel-rpc-port",
                     str(dp_rpc_port),
+                    "--data-parallel-hybrid-lb",
                 ]
             )
-
-            hybrid_lb = config.get("data-parallel-hybrid-lb", config.get("data_parallel_hybrid_lb", False))
-            hybrid_lb_enabled = hybrid_lb is True or (
-                isinstance(hybrid_lb, str) and hybrid_lb.strip().lower() in {"1", "true", "yes", "on"}
-            )
-            if process.node_rank > 0 and not hybrid_lb_enabled:
-                cmd.append("--headless")
         elif is_dp_mode:
             # DP+EP mode: each GPU runs its own process
             # process.node_rank is the dp_rank (set in endpoints_to_processes)

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -46,12 +46,32 @@ def _vllm_data_parallel_size(config: "SrtConfig", mode: str) -> int:
     return int(mode_config.get("data-parallel-size") or mode_config.get("data_parallel_size") or 1)
 
 
-def _get_health_expectations(config: "SrtConfig") -> tuple[int, int, str, int]:
+def _vllm_health_entries(
+    config: "SrtConfig",
+    mode: str,
+    logical_workers: int,
+    backend_processes: list["Process"] | None,
+) -> int:
+    """Return expected Dynamo generate registrations for a vLLM worker mode."""
+    dp_size = _vllm_data_parallel_size(config, mode)
+    if dp_size > 1 and getattr(config.backend, "dp_launch_mode", "per_gpu") == "per_node":
+        if backend_processes is None:
+            raise ValueError("backend_processes are required for per-node DP health expectations")
+        endpoint_mode = "agg" if mode == "aggregated" else mode
+        return sum(process.endpoint_mode == endpoint_mode for process in backend_processes)
+
+    return logical_workers * dp_size
+
+
+def _get_health_expectations(
+    config: "SrtConfig", backend_processes: list["Process"] | None = None
+) -> tuple[int, int, str, int]:
     """Compute expected health counts in the units reported by the frontend.
 
     Dynamo's /health endpoint reports registered generate instances. For vLLM
-    DP workers, that means one entry per DP rank, not one entry per logical
-    srt-slurm worker. Other frontends keep using logical worker counts.
+    DP workers, per-GPU launch registers one entry per DP rank, while per-node
+    launch registers one entry per node-local process. Other frontends keep
+    using logical worker counts.
     """
     r = config.resources
 
@@ -67,10 +87,10 @@ def _get_health_expectations(config: "SrtConfig") -> tuple[int, int, str, int]:
     if config.frontend.type == "dynamo" and getattr(config.backend, "type", None) == "vllm":
         if r.num_agg > 0:
             n_prefill = 0
-            n_decode = logical_decode * _vllm_data_parallel_size(config, "aggregated")
+            n_decode = _vllm_health_entries(config, "aggregated", logical_decode, backend_processes)
         else:
-            n_prefill = logical_prefill * _vllm_data_parallel_size(config, "prefill")
-            n_decode = logical_decode * _vllm_data_parallel_size(config, "decode")
+            n_prefill = _vllm_health_entries(config, "prefill", logical_prefill, backend_processes)
+            n_decode = _vllm_health_entries(config, "decode", logical_decode, backend_processes)
 
         count_desc = f"{n_prefill}P + {n_decode}D Dynamo generate instances; logical workers: {worker_desc}"
         return n_prefill, n_decode, count_desc, n_prefill + n_decode
@@ -131,7 +151,7 @@ class BenchmarkStageMixin:
         """Run the benchmark."""
         logger.info("Waiting for workers to be ready...")
 
-        n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(self.config)
+        n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(self.config, self.backend_processes)
         logger.info("Waiting for server health (expecting %d health entries: %s)...", num_workers, count_desc)
 
         hc = self.config.health_check

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -2003,6 +2003,18 @@ class TestVLLMDataParallelMode:
         with pytest.raises(ValueError, match="data-parallel-size=7"):
             backend.endpoints_to_processes([endpoint])
 
+    def test_dp_per_node_mode_rejects_headless(self):
+        """Headless node processes cannot satisfy per-node Dynamo health expectations."""
+        from marshmallow import ValidationError
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+
+        with pytest.raises(ValidationError, match="remove headless"):
+            VLLMProtocol(
+                dp_launch_mode="per_node",
+                vllm_config=VLLMServerConfig(decode={"data-parallel-size": 8, "headless": True}),
+            )
+
     def test_dp_mode_allocates_unique_ports_for_multiple_endpoints_per_node(self):
         """Test DP endpoints sharing a node get non-colliding coordination ports."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
@@ -2182,8 +2194,8 @@ class TestVLLMDataParallelMode:
         assert "--data-parallel-rank" not in cmd
         assert "--headless" not in cmd
 
-    def test_dp_per_node_internal_lb_follower_is_headless(self):
-        """Non-hybrid per-node DP uses a headless follower process."""
+    def test_dp_per_node_forces_hybrid_lb_for_follower(self):
+        """Per-node DP keeps every node process registered with Dynamo."""
         from unittest.mock import MagicMock, patch
 
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
@@ -2191,7 +2203,7 @@ class TestVLLMDataParallelMode:
 
         backend = VLLMProtocol(
             dp_launch_mode="per_node",
-            vllm_config=VLLMServerConfig(decode={"data-parallel-size": 8}),
+            vllm_config=VLLMServerConfig(decode={"data-parallel-size": 8, "data_parallel_hybrid_lb": False}),
         )
         leader = Process(
             node="node0",
@@ -2221,8 +2233,8 @@ class TestVLLMDataParallelMode:
 
         assert "--data-parallel-size-local" in cmd
         assert "--data-parallel-start-rank" in cmd
-        assert "--data-parallel-hybrid-lb" not in cmd
-        assert "--headless" in cmd
+        assert cmd.count("--data-parallel-hybrid-lb") == 1
+        assert "--headless" not in cmd
 
     def test_standard_tp_mode_still_works(self):
         """Test that standard TP mode (no DP) still creates per-node processes."""

--- a/tests/test_health_expectations.py
+++ b/tests/test_health_expectations.py
@@ -8,14 +8,32 @@ from types import SimpleNamespace
 from srtctl.cli.mixins.benchmark_stage import _get_health_expectations, _vllm_data_parallel_size
 
 
-def _config(frontend_type, backend_type, *, num_prefill=0, num_decode=0, num_agg=0, vllm_config=None):
+def _config(
+    frontend_type,
+    backend_type,
+    *,
+    num_prefill=0,
+    num_decode=0,
+    num_agg=0,
+    vllm_config=None,
+    dp_launch_mode="per_gpu",
+):
     """Build a duck-typed stand-in for SrtConfig with only the fields the helpers read."""
-    backend = SimpleNamespace(type=backend_type, vllm_config=vllm_config)
+    backend = SimpleNamespace(type=backend_type, vllm_config=vllm_config, dp_launch_mode=dp_launch_mode)
     return SimpleNamespace(
         frontend=SimpleNamespace(type=frontend_type),
         backend=backend,
         resources=SimpleNamespace(num_prefill=num_prefill, num_decode=num_decode, num_agg=num_agg),
     )
+
+
+def _processes(*, prefill=0, decode=0, agg=0):
+    """Build backend-process stand-ins grouped by endpoint mode."""
+    return [
+        *(SimpleNamespace(endpoint_mode="prefill") for _ in range(prefill)),
+        *(SimpleNamespace(endpoint_mode="decode") for _ in range(decode)),
+        *(SimpleNamespace(endpoint_mode="agg") for _ in range(agg)),
+    ]
 
 
 def test_dynamo_vllm_disagg_multiplies_by_data_parallel_size():
@@ -42,6 +60,45 @@ def test_dynamo_vllm_aggregated_multiplies_by_data_parallel_size():
 
     assert (n_prefill, n_decode, num_workers) == (0, 8, 8)
     assert count_desc == "0P + 8D Dynamo generate instances; logical workers: 1 agg"
+
+
+def test_dynamo_vllm_per_node_disagg_counts_node_processes():
+    """Per-node DEP8/DEP16 registers once per node-local process, not per DP rank."""
+    vllm_config = SimpleNamespace(
+        prefill={"data-parallel-size": 8},
+        decode={"data-parallel-size": 16},
+        aggregated=None,
+    )
+    config = _config(
+        "dynamo",
+        "vllm",
+        num_prefill=3,
+        num_decode=1,
+        vllm_config=vllm_config,
+        dp_launch_mode="per_node",
+    )
+
+    n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(config, _processes(prefill=6, decode=4))
+
+    assert (n_prefill, n_decode, num_workers) == (6, 4, 10)
+    assert count_desc == "6P + 4D Dynamo generate instances; logical workers: 3P + 1D"
+
+
+def test_dynamo_vllm_per_node_aggregated_counts_node_processes():
+    """Per-node aggregated DP workers register as one decode per process."""
+    vllm_config = SimpleNamespace(prefill=None, decode=None, aggregated={"data-parallel-size": 8})
+    config = _config(
+        "dynamo",
+        "vllm",
+        num_agg=1,
+        vllm_config=vllm_config,
+        dp_launch_mode="per_node",
+    )
+
+    n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(config, _processes(agg=2))
+
+    assert (n_prefill, n_decode, num_workers) == (0, 2, 2)
+    assert count_desc == "0P + 2D Dynamo generate instances; logical workers: 1 agg"
 
 
 def test_dynamo_vllm_without_dp_config_defaults_to_logical_counts():


### PR DESCRIPTION
## Summary

- carry forward the per-node vLLM health-count fix from #273
- always add `--data-parallel-hybrid-lb` for `dp_launch_mode: per_node`
- ignore manually configured hybrid-LB values with a warning and reject `headless` in per-node mode
- warn current `per_gpu` DP users that `per_node` is recommended and will become the default
- document the recommended topology and migration path explicitly

## Why

Per-node DP previously launched non-leader processes with `--headless` unless users manually enabled hybrid load balancing. Those processes do not register with Dynamo, which conflicts with Dynamo routing and the corrected health expectations. Hybrid LB is a property of the per-node topology, so srtslurm should enforce it instead of requiring each recipe to know the implementation detail.

This PR supersedes #273 and includes its health-count correction.

## Validation

- full suite before the upstream rebase: 868 passed, 2 skipped, 6 deselected
- post-rebase targeted config suite: 128 passed
- Ruff check and format check passed
- SA-B300 Kimi K2.6 DEP4 canary job `34576` emitted exactly one `--data-parallel-hybrid-lb` and no `--headless`, initialized all four DP/EP ranks, reached healthy with one Dynamo generate endpoint, and completed a real chat-completions request
- the manual-mode canary was intentionally interrupted after validation; Slurm records the job as failed because the interrupted infra cleanup timed out, not because model startup, health, or inference failed
