### PR TITLE
feat(vllm): support direct aggregate serving

### DIFF
--- a/src/srtctl/backends/base.py
+++ b/src/srtctl/backends/base.py
@@ -97,6 +97,7 @@ class BackendProtocol(Protocol):
         endpoints: list["Endpoint"],
         base_sys_port: int = DYN_SYSTEM_PORT_BASE,
         port_allocator: Optional["NodePortAllocator"] = None,
+        frontend_type: str = "dynamo",
     ) -> list["Process"]:
         """Convert logical endpoints to physical processes."""
         ...

--- a/src/srtctl/backends/mocker.py
+++ b/src/srtctl/backends/mocker.py
@@ -190,6 +190,7 @@ class MockerProtocol:
         endpoints: list["Endpoint"],
         base_sys_port: int = DYN_SYSTEM_PORT_BASE,
         port_allocator: "NodePortAllocator | None" = None,
+        frontend_type: str = "dynamo",
     ) -> list["Process"]:
         """Convert endpoints to processes."""
         from srtctl.core.topology import endpoints_to_processes

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -272,6 +272,7 @@ class SGLangProtocol:
         endpoints: list["Endpoint"],
         base_sys_port: int = DYN_SYSTEM_PORT_BASE,
         port_allocator: "NodePortAllocator | None" = None,
+        frontend_type: str = "dynamo",
     ) -> list["Process"]:
         """Convert endpoints to processes."""
         from srtctl.core.topology import endpoints_to_processes

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -159,6 +159,7 @@ class TRTLLMProtocol:
         endpoints: list["Endpoint"],
         base_sys_port: int = DYN_SYSTEM_PORT_BASE,
         port_allocator: "NodePortAllocator | None" = None,
+        frontend_type: str = "dynamo",
     ) -> list["Process"]:
         """Convert endpoints to processes."""
         from srtctl.core.topology import endpoints_to_processes

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -4,7 +4,8 @@
 vLLM backend configuration.
 
 Implements BackendProtocol for vLLM inference serving with prefill/decode disaggregation.
-Uses dynamo.vllm integration module.
+Supports either Dynamo's vLLM integration module or direct `vllm serve` for
+aggregate jobs.
 """
 
 from __future__ import annotations
@@ -491,13 +492,19 @@ class VLLMProtocol:
         endpoints: list[Endpoint],
         base_sys_port: int = DYN_SYSTEM_PORT_BASE,
         port_allocator: NodePortAllocator | None = None,
+        frontend_type: str = "dynamo",
     ) -> list[Process]:
         """Convert endpoints to processes.
 
-        DP+EP mode uses the configured per-GPU or per-node process layout.
+        Dynamo DP+EP mode uses the configured per-GPU or per-node process layout.
+        For direct vLLM aggregate jobs, `vllm serve` manages local DP ranks from
+        one process, so keep the standard one-process-per-node topology.
         For standard TP mode, creates one process per node.
         """
         from srtctl.core.topology import NodePortAllocator, Process, endpoints_to_processes
+
+        if frontend_type == "vllm":
+            return endpoints_to_processes(endpoints, base_sys_port=base_sys_port, port_allocator=port_allocator)
 
         # Check if any endpoint uses DP mode
         has_dp_mode = any(self._is_dp_mode(ep.mode) for ep in endpoints)
@@ -667,7 +674,7 @@ class VLLMProtocol:
             process: The process to start
             endpoint_processes: All processes for this endpoint (for multi-node)
             runtime: Runtime context with paths and settings
-            frontend_type: Frontend type (currently only "dynamo" supported for vLLM)
+            frontend_type: Frontend type ("dynamo" or direct "vllm")
             nsys_prefix: Optional nsys profiling command prefix
             dump_config_path: Path to dump config JSON
             profiling: Profiling config; drives --profiler-config for iteration-based nsys
@@ -694,6 +701,46 @@ class VLLMProtocol:
 
         # Start with nsys prefix if provided
         cmd: list[str] = list(nsys_prefix) if nsys_prefix else []
+
+        if profiling is not None and profiling.is_nsys and not profiling.is_nsys_time:
+            phase = profiling._get_phase_config(mode)
+            if phase is not None and phase.start_step is not None and phase.stop_step is not None:
+                config["profiler-config"] = json.dumps(
+                    {
+                        "profiler": "cuda",
+                        "delay_iterations": phase.vllm_nsys_delay_iterations,
+                        "max_iterations": phase.vllm_nsys_max_iterations,
+                    }
+                )
+
+        if frontend_type == "vllm":
+            if mode != "agg":
+                raise ValueError("frontend.type: vllm supports aggregate vLLM jobs only")
+            if is_multi_node:
+                raise ValueError("frontend.type: vllm currently supports single-node aggregate jobs only")
+
+            config.pop("host", None)
+            config.pop("port", None)
+            config.pop("connector", None)
+            config.setdefault("served-model-name", served_model_name)
+
+            cmd.extend(
+                [
+                    "vllm",
+                    "serve",
+                    model_arg,
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    str(runtime.frontend_port),
+                ]
+            )
+            if not self.set_cuda_visible_devices:
+                device_ids = ",".join(str(i) for i in sorted(process.gpu_indices))
+                if device_ids:
+                    cmd.extend(["--device-ids", device_ids])
+            cmd.extend(_config_to_cli_args(config))
+            return cmd
 
         # Base command - use dynamo.vllm module
         cmd.extend(
@@ -813,17 +860,6 @@ class VLLMProtocol:
         if kv_cfg and process.kv_events_port is not None:
             kv_cfg["endpoint"] = f"tcp://*:{process.kv_events_port}"
             cmd.extend(["--kv-events-config", json.dumps(kv_cfg)])
-
-        if profiling is not None and profiling.is_nsys and not profiling.is_nsys_time:
-            phase = profiling._get_phase_config(mode)
-            if phase is not None and phase.start_step is not None and phase.stop_step is not None:
-                config["profiler-config"] = json.dumps(
-                    {
-                        "profiler": "cuda",
-                        "delay_iterations": phase.vllm_nsys_delay_iterations,
-                        "max_iterations": phase.vllm_nsys_max_iterations,
-                    }
-                )
 
         # Add all config flags from vllm_config
         cmd.extend(_config_to_cli_args(config))

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -126,7 +126,11 @@ class SweepOrchestrator(
         deterministically within a job.
         """
         allocator = NodePortAllocator()
-        return self.backend.endpoints_to_processes(self.endpoints, port_allocator=allocator)
+        return self.backend.endpoints_to_processes(
+            self.endpoints,
+            port_allocator=allocator,
+            frontend_type=self.config.frontend.type,
+        )
 
     def start_head_infrastructure(self, registry: ProcessRegistry) -> ManagedProcess:
         """Start NATS and etcd on the infra node.
@@ -664,9 +668,9 @@ class SweepOrchestrator(
 
         try:
             # Stage 1: Head infrastructure (NATS, etcd). Only the dynamo request
-            # plane uses it; trtllm_serve routes via a static ser.yaml, so skip it.
-            if self.config.frontend.type == "trtllm_serve":
-                logger.info("Skipping NATS/etcd infrastructure (frontend.type=trtllm_serve)")
+            # plane uses it; static/direct frontends skip it.
+            if self.config.frontend.type in {"trtllm_serve", "vllm"}:
+                logger.info("Skipping NATS/etcd infrastructure (frontend.type=%s)", self.config.frontend.type)
             else:
                 reporter.report(JobStatus.STARTING, JobStage.HEAD_INFRASTRUCTURE, "Starting head infrastructure")
                 head_proc = self.start_head_infrastructure(registry)

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -422,6 +422,14 @@ class BenchmarkStageMixin:
         metrics endpoints if DYN_KVBM_METRICS_PORT is configured.
         """
         urls: list[str] = []
+        if self.config.frontend.type == "vllm":
+            for process in self.backend_processes:
+                if process.endpoint_mode == "agg" and process.is_leader:
+                    host = get_hostname_ip(process.node, self.runtime.network_interface)
+                    urls.append(f"http://{host}:{FRONTEND_PUBLIC_PORT}/metrics")
+            if urls:
+                return {"AIPERF_SERVER_METRICS_URLS": ",".join(sorted(set(urls)))}
+
         for process in self.backend_processes:
             if process.sys_port > 0:
                 host = get_hostname_ip(process.node, self.runtime.network_interface)

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -115,6 +115,7 @@ class TelemetryStageMixin:
                 frontend_topology=topology,
                 runtime=self.runtime,
                 telemetry=telemetry,
+                frontend_type=self.config.frontend.type,
             )
         )
 

--- a/src/srtctl/core/health.py
+++ b/src/srtctl/core/health.py
@@ -208,6 +208,44 @@ def check_trtllm_serve_health(
     )
 
 
+def check_vllm_health(
+    host: str,
+    port: int,
+    health_url: str,
+) -> WorkerHealthResult:
+    """Check direct vLLM OpenAI server readiness.
+
+    vLLM's /health returns HTTP 200 when the server is up; /v1/models verifies
+    that the OpenAI serving stack has exposed at least one model.
+    """
+    models_url = f"http://{host}:{port}/v1/models"
+    try:
+        models_response = requests.get(models_url, timeout=5.0)
+        if models_response.status_code != 200:
+            return WorkerHealthResult(
+                ready=False,
+                message=f"vLLM /health is up but /v1/models returned {models_response.status_code}",
+            )
+        data = models_response.json()
+        models = data.get("data", [])
+        if models:
+            return WorkerHealthResult(
+                ready=True,
+                message=f"vLLM OpenAI server ready at {health_url}; {len(models)} model(s) available",
+                decode_ready=1,
+                decode_expected=1,
+            )
+        return WorkerHealthResult(
+            ready=False,
+            message="vLLM /health is up but /v1/models has no models",
+        )
+    except Exception as e:
+        return WorkerHealthResult(
+            ready=False,
+            message=f"vLLM /health is up but /v1/models check failed: {e}",
+        )
+
+
 def wait_for_port(
     host: str,
     port: int,
@@ -433,6 +471,16 @@ def wait_for_model(
                 if frontend_type == "trtllm_serve":
                     logger.info("trtllm-serve frontend healthy at %s", health_url)
                     return True
+                if frontend_type == "vllm":
+                    result = check_vllm_health(host, port, health_url)
+                    if result.ready:
+                        logger.info(result.message)
+                        return True
+                    if time.time() - last_report_time >= report_every:
+                        logger.info(result.message)
+                        last_report_time = time.time()
+                    time.sleep(poll_interval)
+                    continue
 
                 response_json = response.json()
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1399,7 +1399,7 @@ class FrontendConfig:
     """Frontend/router configuration.
 
     Attributes:
-        type: Frontend type - "dynamo" (default) or "sglang"
+        type: Frontend type - "dynamo" (default), "sglang", "trtllm_serve", or "vllm"
         enable_multiple_frontends: Scale with nginx + multiple routers.
             When ``True`` (default), srtctl stands up nginx and fans out
             to ``num_additional_frontends + 1`` router replicas. When
@@ -1542,6 +1542,7 @@ class SrtConfig:
         self._validate_mooncake_kv_store()
         self._validate_het_jobs()
         self._validate_trtllm_serve()
+        self._validate_vllm_frontend()
 
     def _validate_trtllm_serve(self):
         """Catch trtllm_serve misconfigurations at load time (dry-run) instead of
@@ -1566,6 +1567,28 @@ class SrtConfig:
                 "frontend.type: trtllm_serve requires a disaggregated layout "
                 "(set resources.prefill_nodes/prefill_workers and decode_nodes/decode_workers)"
             )
+
+    def _validate_vllm_frontend(self):
+        """Catch direct-vLLM frontend misconfigurations at load time.
+
+        Direct vLLM means the aggregate `vllm serve` worker owns the OpenAI port
+        itself. It is not a disaggregated router and does not support the nginx
+        multi-frontend path.
+        """
+        if self.frontend.type != "vllm":
+            return
+        if self.backend_type != "vllm":
+            raise ValidationError(f"frontend.type: vllm requires backend.type: vllm; got {self.backend_type!r}")
+        if self.frontend.enable_multiple_frontends:
+            raise ValidationError(
+                "frontend.type: vllm binds vllm serve directly; set frontend.enable_multiple_frontends: false"
+            )
+        if self.resources.is_disaggregated:
+            raise ValidationError("frontend.type: vllm supports aggregate jobs only, not disaggregated layouts")
+        if self.resources.num_agg < 1:
+            raise ValidationError("frontend.type: vllm requires resources.agg_workers >= 1")
+        if (self.resources.agg_nodes or 1) != 1:
+            raise ValidationError("frontend.type: vllm currently supports single-node aggregate jobs only")
 
     def _validate_het_jobs(self):
         """When ``resources.het_jobs`` is set to True, enforce supported shape.

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from srtctl.core.slurm import get_hostname_ip
+from srtctl.ports import FRONTEND_PUBLIC_PORT
 
 if TYPE_CHECKING:
     from srtctl.cli.mixins.frontend_stage import FrontendTopology
@@ -36,6 +37,7 @@ def generate_telemetry_config(
     frontend_topology: FrontendTopology,
     runtime: RuntimeContext,
     telemetry: TelemetryConfig,
+    frontend_type: str = "dynamo",
 ) -> str:
     """Generate telemetry TOML from backend and frontend topology."""
     dcgm_exporter = telemetry.dcgm_exporter
@@ -84,6 +86,7 @@ def generate_telemetry_config(
 
     for process in sorted(processes, key=lambda p: (p.endpoint_mode, p.endpoint_index, p.node_rank, p.node)):
         node_ip = get_hostname_ip(process.node, runtime.network_interface)
+        port = FRONTEND_PUBLIC_PORT if frontend_type == "vllm" and process.endpoint_mode == "agg" else process.sys_port
         node_metadata = {
             "hostname": process.node,
             "worker_index": str(process.endpoint_index),
@@ -94,7 +97,7 @@ def generate_telemetry_config(
         endpoints.append(
             TelemetryEndpoint(
                 name=f"backend_{process.endpoint_mode}{process.endpoint_index}_rank{process.node_rank}",
-                url=f"http://{node_ip}:{process.sys_port}/metrics",
+                url=f"http://{node_ip}:{port}/metrics",
                 frequency=telemetry.default_frequency,
                 filter="backend",
                 node_metadata=node_metadata,

--- a/src/srtctl/frontends/__init__.py
+++ b/src/srtctl/frontends/__init__.py
@@ -7,6 +7,7 @@ Frontend implementations for routing requests to backend workers.
 Supported frontend types:
 - dynamo: Dynamo frontend with NATS/etcd communication
 - sglang: SGLang native router with direct worker connections
+- vllm: Direct vLLM OpenAI server for aggregate jobs
 """
 
 from srtctl.frontends.base import (
@@ -17,6 +18,7 @@ from srtctl.frontends.base import (
 from srtctl.frontends.dynamo import DynamoFrontend
 from srtctl.frontends.sglang import SGLangFrontend
 from srtctl.frontends.trtllm_serve import TRTLLMServeFrontend
+from srtctl.frontends.vllm import VLLMFrontend
 
 __all__ = [
     "FrontendProtocol",
@@ -25,4 +27,5 @@ __all__ = [
     "DynamoFrontend",
     "SGLangFrontend",
     "TRTLLMServeFrontend",
+    "VLLMFrontend",
 ]

--- a/src/srtctl/frontends/base.py
+++ b/src/srtctl/frontends/base.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from srtctl.core.topology import Process
 
 # Supported frontend types - extensible by adding new literals
-FrontendType = Literal["dynamo", "sglang", "trtllm_serve"]
+FrontendType = Literal["dynamo", "sglang", "trtllm_serve", "vllm"]
 
 
 class FrontendProtocol(Protocol):
@@ -97,6 +97,7 @@ def get_frontend(frontend_type: str) -> FrontendProtocol:
     from srtctl.frontends.dynamo import DynamoFrontend
     from srtctl.frontends.sglang import SGLangFrontend
     from srtctl.frontends.trtllm_serve import TRTLLMServeFrontend
+    from srtctl.frontends.vllm import VLLMFrontend
 
     if frontend_type == "dynamo":
         return DynamoFrontend()
@@ -104,5 +105,7 @@ def get_frontend(frontend_type: str) -> FrontendProtocol:
         return SGLangFrontend()
     elif frontend_type == "trtllm_serve":
         return TRTLLMServeFrontend()
+    elif frontend_type == "vllm":
+        return VLLMFrontend()
     else:
-        raise ValueError(f"Unknown frontend type: {frontend_type!r}. Supported: dynamo, sglang, trtllm_serve")
+        raise ValueError(f"Unknown frontend type: {frontend_type!r}. Supported: dynamo, sglang, trtllm_serve, vllm")

--- a/src/srtctl/frontends/vllm.py
+++ b/src/srtctl/frontends/vllm.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Direct vLLM frontend implementation.
+
+For aggregate vLLM jobs the OpenAI-compatible HTTP server is the worker
+process itself (`vllm serve`). There is no separate router/frontend process.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING, Any
+
+from srtctl.core.health import WorkerHealthResult
+
+if TYPE_CHECKING:
+    from srtctl.core.processes import ManagedProcess
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.topology import Process
+
+logger = logging.getLogger(__name__)
+
+
+class VLLMFrontend:
+    """Direct vLLM OpenAI server frontend.
+
+    This frontend is intentionally narrow: aggregate vLLM jobs only, with the
+    backend worker binding the public OpenAI port directly. Disaggregated vLLM
+    still needs a real router/orchestrator such as Dynamo.
+    """
+
+    @property
+    def type(self) -> str:
+        return "vllm"
+
+    @property
+    def health_endpoint(self) -> str:
+        return "/health"
+
+    def parse_health(
+        self,
+        response_json: dict,
+        expected_prefill: int,
+        expected_decode: int,
+    ) -> WorkerHealthResult:
+        return WorkerHealthResult(
+            ready=True,
+            message="vLLM OpenAI server healthy",
+            prefill_ready=expected_prefill,
+            prefill_expected=expected_prefill,
+            decode_ready=expected_decode,
+            decode_expected=expected_decode,
+        )
+
+    def get_frontend_args_list(self, args: dict[str, Any] | None) -> list[str]:
+        if not args:
+            return []
+        result = []
+        for key, value in args.items():
+            if value is True:
+                result.append(f"--{key}")
+            elif value is not False and value is not None:
+                result.extend([f"--{key}", str(value)])
+        return result
+
+    def start_frontends(
+        self,
+        topology: Any,
+        runtime: RuntimeContext,
+        config: Any,
+        backend: Any,
+        backend_processes: list[Process],
+        stop_event: threading.Event | None = None,
+    ) -> list[ManagedProcess]:
+        if config.backend.type != "vllm":
+            raise ValueError(f"frontend.type: vllm requires backend.type: vllm (got {config.backend.type!r})")
+        if topology.uses_nginx or len(topology.frontend_nodes) != 1:
+            raise ValueError(
+                "frontend.type: vllm binds vllm serve directly to the public port; "
+                "set frontend.enable_multiple_frontends: false"
+            )
+        if config.resources.is_disaggregated or config.resources.num_agg < 1:
+            raise ValueError("frontend.type: vllm supports aggregate vLLM jobs only")
+
+        logger.info("frontend.type=vllm: no separate frontend process; vllm serve owns port %d", topology.public_port)
+        return []

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -2015,6 +2015,118 @@ class TestVLLMDataParallelMode:
                 vllm_config=VLLMServerConfig(decode={"data-parallel-size": 8, "headless": True}),
             )
 
+    def test_direct_vllm_dp_mode_keeps_single_process(self):
+        """Direct vllm serve supervises local DP ranks from one process."""
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                aggregated={"data-parallel-size": 8, "enable-expert-parallel": True},
+            )
+        )
+
+        endpoint = Endpoint(
+            mode="agg",
+            index=0,
+            nodes=("node0",),
+            gpu_indices=frozenset(range(8)),
+            gpus_per_node=8,
+        )
+
+        processes = backend.endpoints_to_processes([endpoint], frontend_type="vllm")
+
+        assert len(processes) == 1
+        assert processes[0].node == "node0"
+        assert processes[0].gpu_indices == frozenset(range(8))
+
+    def test_direct_vllm_command_preserves_current_main_device_binding(self):
+        """Direct vllm serve uses the public port and main's --device-ids binding."""
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Process
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                aggregated={
+                    "data-parallel-size": 4,
+                    "enable-expert-parallel": True,
+                }
+            )
+        )
+        process = Process(
+            node="node0",
+            gpu_indices=frozenset(range(4)),
+            sys_port=8081,
+            http_port=0,
+            endpoint_mode="agg",
+            endpoint_index=0,
+            node_rank=0,
+        )
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.frontend_port = 9000
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            cmd = backend.build_worker_command(
+                process=process,
+                endpoint_processes=[process],
+                runtime=runtime,
+                frontend_type="vllm",
+            )
+
+        assert cmd[:3] == ["vllm", "serve", "/model"]
+        assert cmd[cmd.index("--port") + 1] == "9000"
+        assert cmd[cmd.index("--device-ids") + 1] == "0,1,2,3"
+        assert "--request-plane" not in cmd
+        assert "dynamo.vllm" not in cmd
+
+    def test_direct_vllm_command_keeps_iteration_profiler_config(self):
+        """Direct vllm serve retains main's profiling-derived server option."""
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Process
+
+        backend = VLLMProtocol(vllm_config=VLLMServerConfig(aggregated={"tensor-parallel-size": 4}))
+        process = Process(
+            node="node0",
+            gpu_indices=frozenset(range(4)),
+            sys_port=8081,
+            http_port=0,
+            endpoint_mode="agg",
+            endpoint_index=0,
+            node_rank=0,
+        )
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.frontend_port = 8000
+        profiling = MagicMock(is_nsys=True, is_nsys_time=False)
+        profiling._get_phase_config.return_value = SimpleNamespace(
+            start_step=10,
+            stop_step=25,
+            vllm_nsys_delay_iterations=10,
+            vllm_nsys_max_iterations=15,
+        )
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            cmd = backend.build_worker_command(
+                process=process,
+                endpoint_processes=[process],
+                runtime=runtime,
+                frontend_type="vllm",
+                profiling=profiling,
+            )
+
+        profiler_config = json.loads(cmd[cmd.index("--profiler-config") + 1])
+        assert profiler_config == {"profiler": "cuda", "delay_iterations": 10, "max_iterations": 15}
+
     def test_dp_mode_allocates_unique_ports_for_multiple_endpoints_per_node(self):
         """Test DP endpoints sharing a node get non-colliding coordination ports."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for frontend implementations (SGLang and Dynamo)."""
+"""Tests for frontend implementations."""
 
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from srtctl.core.schema import ObservabilityConfig
-from srtctl.frontends import DynamoFrontend, SGLangFrontend, get_frontend
+from srtctl.frontends import DynamoFrontend, SGLangFrontend, VLLMFrontend, get_frontend
 
 # ============================================================================
 # get_frontend() Tests
@@ -33,13 +33,19 @@ class TestGetFrontend:
         assert isinstance(frontend, SGLangFrontend)
         assert frontend.type == "sglang"
 
+    def test_get_vllm_frontend(self):
+        """get_frontend('vllm') returns VLLMFrontend."""
+        frontend = get_frontend("vllm")
+        assert isinstance(frontend, VLLMFrontend)
+        assert frontend.type == "vllm"
+
     def test_get_unknown_frontend_raises(self):
         """get_frontend() with unknown type raises ValueError."""
         with pytest.raises(ValueError, match="Unknown frontend type"):
             get_frontend("unknown")
 
         with pytest.raises(ValueError, match="Unknown frontend type"):
-            get_frontend("vllm")
+            get_frontend("invalid")
 
 
 # ============================================================================
@@ -60,6 +66,11 @@ class TestFrontendProperties:
         frontend = SGLangFrontend()
         assert frontend.type == "sglang"
 
+    def test_vllm_type(self):
+        """VLLMFrontend.type is 'vllm'."""
+        frontend = VLLMFrontend()
+        assert frontend.type == "vllm"
+
     def test_dynamo_health_endpoint(self):
         """DynamoFrontend uses /health endpoint."""
         frontend = DynamoFrontend()
@@ -69,6 +80,11 @@ class TestFrontendProperties:
         """SGLangFrontend uses /workers endpoint."""
         frontend = SGLangFrontend()
         assert frontend.health_endpoint == "/workers"
+
+    def test_vllm_health_endpoint(self):
+        """VLLMFrontend uses /health endpoint."""
+        frontend = VLLMFrontend()
+        assert frontend.health_endpoint == "/health"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- add `frontend.type: vllm` for aggregate jobs that launch `vllm serve` directly, without Dynamo
- validate the supported topology: vLLM backend, aggregate-only, one worker on one node, and one frontend
- wire direct-vLLM health checks, telemetry, AIPerf server metrics, profiling, and public-port ownership
- preserve current `main` per-node DP behavior for Dynamo while keeping direct vLLM in the standard one-process topology

## Motivation

Aggregate vLLM benchmarks do not need Dynamo as an orchestration layer. This provides a native direct-serving path while leaving existing Dynamo aggregate and disaggregated configurations unchanged.

## Validation

- `uv run ruff check` on all changed files
- `uv run pytest -q tests/test_configs.py tests/test_frontends.py` (162 passed)
- `uv run pytest -q` (893 passed, 2 skipped, 6 deselected)