### PR TITLE
feat(mooncake): support recipe master arguments

### DIFF
--- a/docs/mooncake-kv-store.md
+++ b/docs/mooncake-kv-store.md
@@ -119,6 +119,7 @@ backend:
   type: sglang
   mooncake_kv_store:
     container: nvcr.io/nvidia/mooncake:latest  # optional, default: job container
+    master_extra_args: []                      # optional, appended to mooncake_master
     env:                                        # optional, default: {}
       MOONCAKE_PROTOCOL: rdma
       MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
@@ -137,6 +138,7 @@ backend:
   type: vllm
   mooncake_kv_store:
     container: ...                       # optional, default: job container
+    master_extra_args: []                # optional, appended to mooncake_master
     env:                                 # optional, injected on every vLLM worker (in-process Mooncake C++ knobs)
       MC_ENABLE_DEST_DEVICE_AFFINITY: "1"
       MC_STORE_CLIENT_METRIC: "1"        # default 1 (enabled)
@@ -152,11 +154,24 @@ backend:
 ### Fields
 
 - **`container`** (`str`, optional): Container image used for the `mooncake_master` srun. Defaults to the job container if unset. Useful when mooncake needs a different runtime than your worker container.
+- **`master_extra_args`** (`list[str]`, optional): Extra arguments appended to the standalone `mooncake_master` command. Use this for flags supported only by the Mooncake version in the selected container. Do not use it to override the RPC, HTTP metadata, or metrics ports because srtslurm configures worker endpoints and readiness checks from its own port values.
 - **`env`** (`dict[str, str]`, optional): Pass-through env vars injected on every prefill and decode worker.
   - For **SGLang**, keys map directly to mooncake's environment variable names — see the [SGLang server_args.py](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/environ.py) and [mooncake_store.py](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py) for the full list.
   - For **vLLM**, this is for in-process Mooncake C++ knobs (`MC_*`) read by the transfer engine / store client. vLLM's connector itself reads configuration from `MOONCAKE_CONFIG_PATH` (the JSON rendered from `store_config:`), not from these env vars.
   - Setting `MOONCAKE_MASTER`, `MOONCAKE_TE_META_DATA_SERVER`, or `MOONCAKE_CONFIG_PATH` here is a no-op (srtslurm always wins).
 - **`store_config`** (vLLM only, `dict[str, Any]`): Pass-through dict rendered as JSON into the file pointed to by `MOONCAKE_CONFIG_PATH`. Keys map 1:1 to vLLM's `MooncakeStoreConfig` dataclass — a mix of `str` (e.g. `protocol`), `int` (e.g. `port`), and human-readable size strings (e.g. `"4GB"`). srtslurm does not default these fields — values like `global_segment_size`, `protocol`, and `device_name` are hardware-specific and silently using a srtslurm-picked default is worse than failing loudly, so set them explicitly. `master_server_address` is auto-filled and any user value is ignored.
+
+Mooncake `v0.3.11+` adds NoF SSD-tier eviction flags. Enable them only in recipes using a compatible Mooncake image:
+
+```yaml
+backend:
+  type: vllm
+  mooncake_kv_store:
+    master_extra_args:
+      - --nof_eviction_high_watermark_ratio=0.9
+```
+
+Older Mooncake versions do not recognize this option, so leave it out of those recipes. The existing `--eviction_high_watermark_ratio` controls memory eviction; the `--nof_...` option independently controls the NVMe-over-Fabrics SSD tier.
 
 ## Master Metrics Endpoint
 

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -69,6 +69,7 @@ class MooncakeKVStoreConfig:
 
     container: str | None = None
     env: dict[str, str] = field(default_factory=dict)
+    master_extra_args: list[str] = field(default_factory=list)
 
     Schema: ClassVar[type[Schema]] = Schema
 

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -100,6 +100,7 @@ class VLLMMooncakeKVStoreConfig:
 
     container: str | None = None
     env: dict[str, str] = field(default_factory=dict)
+    master_extra_args: list[str] = field(default_factory=list)
     # ``store_config`` values are JSON-serialized into MOONCAKE_CONFIG_PATH and
     # parsed by vLLM's ``MooncakeStoreConfig`` dataclass — fields are a mix of
     # str (e.g. ``protocol``), int (e.g. ``port``), and human-readable sizes

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -61,6 +61,23 @@ from srtctl.ports import (
 logger = logging.getLogger(__name__)
 
 
+def _build_mooncake_master_command(mooncake_cfg: object) -> list[str]:
+    """Build the master command, including recipe-provided version-specific flags."""
+    command = [
+        "mooncake_master",
+        f"--port={MOONCAKE_MASTER_PORT}",
+        "--enable_http_metadata_server=true",
+        f"--http_metadata_server_port={MOONCAKE_HTTP_METADATA_PORT}",
+        "--eviction_high_watermark_ratio=0.9",
+        "--default_kv_lease_ttl=10000",
+        "--rpc_thread_num=16",
+        "--enable_metric_reporting=true",
+        f"--metrics_port={MOONCAKE_METRICS_PORT}",
+    ]
+    command.extend(getattr(mooncake_cfg, "master_extra_args", []) or [])
+    return command
+
+
 @dataclass
 class SweepOrchestrator(
     WorkerStageMixin,
@@ -239,18 +256,7 @@ class SweepOrchestrator(
         )
 
         proc = start_srun_process(
-            command=[
-                "mooncake_master",
-                f"--port={MOONCAKE_MASTER_PORT}",
-                "--enable_http_metadata_server=true",
-                f"--http_metadata_server_port={MOONCAKE_HTTP_METADATA_PORT}",
-                "--eviction_high_watermark_ratio=0.9",
-                "--nof_eviction_high_watermark_ratio=0.9",
-                "--default_kv_lease_ttl=10000",
-                "--rpc_thread_num=16",
-                "--enable_metric_reporting=true",
-                f"--metrics_port={MOONCAKE_METRICS_PORT}",
-            ],
+            command=_build_mooncake_master_command(mooncake_cfg),
             nodelist=[infra_node],
             output=str(mooncake_log),
             container_image=container,

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -345,6 +345,8 @@ def show_config_details(config: SrtConfig) -> None:
         if mooncake_cfg is not None:
             details.add_row("mooncake", "container", mooncake_cfg.container or "<job container>")
             details.add_row("mooncake", "master_port", f"{MOONCAKE_MASTER_PORT} (auto)")
+            if mooncake_cfg.master_extra_args:
+                details.add_row("mooncake", "master_extra_args", shlex.join(mooncake_cfg.master_extra_args))
             if hasattr(backend, "build_mooncake_store_config"):
                 # vLLM workers need MOONCAKE_CONFIG_PATH pointing at a JSON file
                 # — srtslurm writes this at job start. Show the resolved JSON

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -326,6 +326,7 @@ class TestDryRunExecutionExtensions:
                     "mooncake_kv_store": {
                         "container": "inferactinc/public:mk-int-20260507",
                         "env": {"MOONCAKE_PROTOCOL": "rdma"},
+                        "master_extra_args": ["--nof_eviction_high_watermark_ratio=0.9"],
                     },
                     "vllm_config": {
                         "prefill": {"kv-transfer-config": kv_cfg},
@@ -342,6 +343,8 @@ class TestDryRunExecutionExtensions:
         assert "inferactinc/public:mk-int-202605" in output
         # Shared with the SGLang launch — same port pair.
         assert str(MOONCAKE_MASTER_PORT) in output
+        assert "master_extra_args" in output
+        assert "nof_eviction" in output
 
     def test_vllm_mooncake_store_config_in_dry_run(self, capsys):
         """vLLM store_config + MOONCAKE_CONFIG_PATH appear in the dry-run extensions panel."""

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -636,6 +636,8 @@ backend:
   type: sglang
   mooncake_kv_store:
     container: nvcr.io/nvidia/mooncake:latest
+    master_extra_args:
+      - --nof_eviction_high_watermark_ratio=0.9
     env:
       MOONCAKE_PROTOCOL: rdma
       MOONCAKE_GLOBAL_SEGMENT_SIZE: "4gb"
@@ -643,6 +645,9 @@ backend:
         config = SrtConfig.Schema().load(raw)
         assert config.backend.mooncake_kv_store is not None
         assert config.backend.mooncake_kv_store.container == "nvcr.io/nvidia/mooncake:latest"
+        assert config.backend.mooncake_kv_store.master_extra_args == [
+            "--nof_eviction_high_watermark_ratio=0.9"
+        ]
         assert config.backend.mooncake_kv_store.env["MOONCAKE_PROTOCOL"] == "rdma"
         assert config.backend.mooncake_kv_store.env["MOONCAKE_GLOBAL_SEGMENT_SIZE"] == "4gb"
 
@@ -840,6 +845,8 @@ backend:
   type: vllm
   mooncake_kv_store:
     container: inferactinc/public:mk-int-20260507
+    master_extra_args:
+      - --nof_eviction_high_watermark_ratio=0.9
     env:
       MOONCAKE_PROTOCOL: rdma
   vllm_config:
@@ -851,6 +858,9 @@ backend:
         config = SrtConfig.Schema().load(raw)
         assert config.backend.mooncake_kv_store is not None
         assert config.backend.mooncake_kv_store.container == "inferactinc/public:mk-int-20260507"
+        assert config.backend.mooncake_kv_store.master_extra_args == [
+            "--nof_eviction_high_watermark_ratio=0.9"
+        ]
         assert config.backend.mooncake_kv_store.env["MOONCAKE_PROTOCOL"] == "rdma"
 
     def test_vllm_mooncake_disagg_without_kv_transfer_config_raises(self):
@@ -1064,11 +1074,23 @@ backend:
       kv-transfer-config: '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}'
 """)
         config = SrtConfig.Schema().load(raw)
-        store_cfg = config.backend.mooncake_kv_store.store_config
+        mooncake_cfg = config.backend.mooncake_kv_store
+        store_cfg = mooncake_cfg.store_config
         assert store_cfg is not None
         assert store_cfg["metadata_server"] == "P2PHANDSHAKE"
         assert store_cfg["global_segment_size"] == "100GB"
         assert store_cfg["device_name"] == ""
+
+    def test_mooncake_master_extra_args_are_appended(self):
+        """Version-specific master flags are opt-in and appended after defaults."""
+        from srtctl.backends.vllm import VLLMMooncakeKVStoreConfig
+        from srtctl.cli.do_sweep import _build_mooncake_master_command
+
+        nof_arg = "--nof_eviction_high_watermark_ratio=0.9"
+        command = _build_mooncake_master_command(VLLMMooncakeKVStoreConfig(master_extra_args=[nof_arg]))
+
+        assert "--eviction_high_watermark_ratio=0.9" in command
+        assert command[-1] == nof_arg
 
 
 class TestGB200HetAsymmetric:


### PR DESCRIPTION
## Summary

- add `mooncake_kv_store.master_extra_args` to both SGLang and vLLM recipe schemas
- append version-specific arguments to the standalone `mooncake_master` command and show them in dry-run output
- stop passing `--nof_eviction_high_watermark_ratio=0.9` unconditionally

## Why

`--nof_eviction_high_watermark_ratio` is a valid Mooncake flag for the NVMe-over-Fabrics SSD tier, but it was introduced in Mooncake v0.3.11. Older Mooncake images reject it at startup. Keeping it in the srtslurm default command therefore breaks otherwise valid recipes using older images.

Recipes selecting Mooncake v0.3.11 or newer can now opt in explicitly:

```yaml
backend:
  type: vllm
  mooncake_kv_store:
    master_extra_args:
      - --nof_eviction_high_watermark_ratio=0.9
```

The existing `--eviction_high_watermark_ratio=0.9` memory-tier default is unchanged. NoF configuration remains separate and version-gated by the recipe.

Mooncake references:

- https://github.com/kvcache-ai/Mooncake/pull/2143
- https://github.com/kvcache-ai/Mooncake/blob/main/mooncake-store/src/master.cpp#L132-L141

## Validation

- 30 targeted Mooncake schema, command, and dry-run tests passed
- `ruff check` passed for all changed Python files
- `ruff format --check` passed for changed source files
- `git diff --check` passed
