### PR TITLE
feat(dynamo): add cargo_patches to override crate sources in source builds

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -12,6 +12,7 @@ Backend configs are defined in srtctl.backends.configs/ for modularity.
 """
 
 import builtins
+import hashlib
 import itertools
 import logging
 import os
@@ -1098,20 +1099,51 @@ def build_otel_env(observability: ObservabilityConfig, component: str) -> dict[s
 _DYNAMO_CACHE_ROOT = "/configs/dynamo-wheels"
 
 
-def _hash_cached_source_install(dynamo_hash: str) -> str:
+def _hash_cached_source_install(dynamo_hash: str, cargo_patches: list[str] | None = None) -> str:
     """Bash for hash-pinned source install with a /configs/dynamo-wheels cache.
 
-    Cache layout: ``{root}/<hash>/`` contains the maturin wheel
+    Cache layout: ``{root}/<key>/`` contains the maturin wheel
     (``ai_dynamo_runtime-*.whl``), a tarball of the dynamo source tree
     (``dynamo-src.tar.gz``), and a ``.complete`` sentinel that's only touched
-    on a successful build. flock on the per-hash lock file serializes the
+    on a successful build. flock on the per-key lock file serializes the
     cold-cache build across multiple frontends starting in parallel.
+
+    ``cargo_patches`` (optional) are dependency-declaration overrides — each a full
+    ``<crate> = <spec>`` line that replaces that crate's declaration across every
+    ``Cargo.toml`` in the tree before ``maturin build`` (typically retargeting a crate
+    like ``dynamo-tokenizers`` at a git branch). When set, the cache key is suffixed with
+    a digest of the overrides so patched and unpatched builds of the same hash never collide.
 
     Uses FD 201 (not 200) so it nests cleanly inside the node-local
     ``flock -x 200`` from ``_serialize_node_install``.
     """
-    cache = f"{_DYNAMO_CACHE_ROOT}/{dynamo_hash}"
-    lock = f"{_DYNAMO_CACHE_ROOT}/.{dynamo_hash}.lock"
+    cache_key = dynamo_hash
+    override_cmd = ""
+    if cargo_patches:
+        # The marker prefix versions the override build-recipe so a recipe fix busts the
+        # cache even when the override strings are unchanged.
+        digest = hashlib.sha1(("dep-override-v3\n" + "\n".join(cargo_patches)).encode()).hexdigest()[:8]
+        cache_key = f"{dynamo_hash}-patch-{digest}"
+        # Replace each crate's dependency DECLARATION (a full `<crate> = <spec>` line) across
+        # every Cargo.toml in the tree — retargeting the workspace dependency (and any direct
+        # decls, incl. `{ workspace = true }` members) at, typically, a git branch.
+        # Why source-replacement and not [patch.crates-io]: a patch is silently dropped when
+        # the branch version doesn't satisfy dynamo's exact pin (e.g. dynamo pins "=1.5.0" but
+        # the branch is 1.5.3 -> "patch ... was not used in the crate graph"), and relaxing the
+        # pin alone loses to the committed Cargo.lock. Changing the dependency SOURCE needs no
+        # version match and forces Cargo to re-resolve, so the branch is actually built.
+        seds = []
+        for entry in cargo_patches:
+            crate = entry.split("=", 1)[0].strip()
+            if not crate:
+                continue
+            repl = entry.replace("&", r"\&")  # '&' is the sed replacement metachar
+            script = f"s|^{crate}[[:space:]]*=.*|{repl}|"
+            seds.append(f"find . -name Cargo.toml -exec sed -i -E {shlex.quote(script)} {{}} +")
+        if seds:
+            override_cmd = " && ".join(seds) + " && "
+    cache = f"{_DYNAMO_CACHE_ROOT}/{cache_key}"
+    lock = f"{_DYNAMO_CACHE_ROOT}/.{cache_key}.lock"
     return (
         f"echo 'Installing dynamo from source ({dynamo_hash}, /configs cache)...' && "
         f"mkdir -p {_DYNAMO_CACHE_ROOT} && "
@@ -1133,6 +1165,7 @@ def _hash_cached_source_install(dynamo_hash: str) -> str:
         f"DYN_BUILD_DIR=$(mktemp -d) && cd $DYN_BUILD_DIR && "
         f"git clone https://github.com/ai-dynamo/dynamo.git && "
         f"cd dynamo && git checkout {dynamo_hash} && "
+        f"{override_cmd}"
         f"cd lib/bindings/python/ && "
         f'export RUSTFLAGS="${{RUSTFLAGS:-}} -C target-cpu=native --cfg tokio_unstable" && '
         f"rm -f /tmp/ai_dynamo_runtime*.whl && "
@@ -1282,6 +1315,12 @@ class DynamoConfig:
     wheel: str | None = None
     request_plane: str = "tcp"
     event_plane: str | None = None
+    # Optional dependency-declaration overrides applied to the dynamo Cargo.toml tree before a
+    # source build (requires `hash`). Each entry is a full `<crate> = <spec>` TOML line, e.g.
+    #   'dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates", branch = "..." }'
+    # The crate's existing declaration is replaced tree-wide, letting a source build pull a crate
+    # from an unmerged branch without waiting for a crates.io release.
+    cargo_patches: list[str] | None = None
 
     def __post_init__(self) -> None:
         install_sources = [
@@ -1304,6 +1343,9 @@ class DynamoConfig:
                 raise ValueError("dynamo.wheel must be a non-empty package version")
             if Path(self.wheel).name.endswith(".whl") or "/" in self.wheel:
                 raise ValueError("dynamo.wheel must be a package version like '1.2.0.dev20260426', not a filename")
+
+        if self.cargo_patches and self.hash is None:
+            raise ValueError("dynamo.cargo_patches requires a source build — set dynamo.hash to a commit")
 
         if self.request_plane not in self._VALID_REQUEST_PLANES:
             raise ValueError(
@@ -1387,7 +1429,7 @@ class DynamoConfig:
         # to ~10 sec lustre access for repeat hashes. top_of_tree skips the
         # cache (no stable key) and always live-builds.
         if self.hash is not None:
-            return _hash_cached_source_install(self.hash)
+            return _hash_cached_source_install(self.hash, self.cargo_patches)
 
         return _live_source_install_for_top_of_tree()
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -264,6 +264,40 @@ class TestDynamoConfig:
         assert "tar -xzf /configs/dynamo-wheels/abc123/dynamo-src.tar.gz" in cmd
         assert "pip install --break-system-packages -e /tmp/dynamo-src/dynamo" in cmd
 
+    def test_hash_with_cargo_patches(self):
+        """cargo_patches replace a crate's dependency declaration tree-wide + namespace cache.
+
+        Used to build a crate (e.g. dynamo-tokenizers) from an unmerged branch: the
+        crate's `<crate> = ...` line is replaced across every Cargo.toml with the given
+        git-source spec after checkout, before maturin build. Source-replacement (not
+        [patch.crates-io]) so it works despite exact version pins + a committed Cargo.lock.
+        The cache key is suffixed with a digest so an overridden build never reuses/poisons
+        the plain build of the same hash.
+        """
+        from srtctl.core.schema import DynamoConfig
+
+        patch = 'dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates", branch = "feat" }'
+        config = DynamoConfig(hash="abc123", cargo_patches=[patch])
+        assert config.needs_source_install
+        cmd = config.get_install_commands()
+
+        # Cache is namespaced so overridden != plain build of the same hash.
+        assert "/configs/dynamo-wheels/abc123-patch-" in cmd
+        assert "/configs/dynamo-wheels/abc123/.complete" not in cmd
+
+        # The crate declaration is replaced tree-wide via sed after checkout, before build.
+        assert "find . -name Cargo.toml -exec sed -i -E" in cmd
+        assert "s|^dynamo-tokenizers[[:space:]]*=.*|" in cmd
+        assert patch in cmd
+        assert cmd.index("git checkout abc123") < cmd.index("s|^dynamo-tokenizers") < cmd.index("maturin build")
+
+    def test_cargo_patches_require_hash(self):
+        """cargo_patches without a source build (hash) is rejected."""
+        from srtctl.core.schema import DynamoConfig
+
+        with pytest.raises(ValueError, match="cargo_patches requires a source build"):
+            DynamoConfig(wheel="1.2.0.dev20260426", cargo_patches=["x = 1"])
+
     def test_top_of_tree_install_command(self):
         """Top-of-tree config generates source install without checkout."""
         from srtctl.core.schema import DynamoConfig


### PR DESCRIPTION
## Summary

Adds an optional `DynamoConfig.cargo_patches: list[str]` that, on a **source build** (`dynamo.hash`), replaces a crate's dependency declaration across every `Cargo.toml` in the dynamo tree before the maturin build. Each entry is a full `<crate> = <spec>` TOML line:

```yaml
dynamo:
  hash: <commit>
  install: true
  cargo_patches:
    - 'dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates", branch = "..." }'
```

This lets a source build compile a crate from an **unmerged branch** (or any git ref) without waiting for a crates.io release — useful for validating in-flight fixes on the fly.

## Motivation

While validating an unmerged `dynamo-tokenizers` fix (frontend-crates#134) we needed to build dynamo against a crate branch. `dynamo.hash` already source-builds dynamo, but the crate is pinned via crates.io, so there was no way to swap it in.

## Why source-replacement (not `[patch.crates-io]`)

A `[patch.crates-io]` is silently dropped when the branch version doesn't satisfy dynamo's exact pin (e.g. dynamo pins `"=1.5.0"` but the branch is `1.5.3` -> *"patch ... was not used in the crate graph"*), and relaxing the pin alone loses to the committed `Cargo.lock`. Replacing the dependency **source** needs no version match and forces Cargo to re-resolve, so the branch is actually built. (Also handles dynamo's split workspaces — the maturin crate under `lib/bindings/python/` is its own workspace.)

## Notes
- No behavior change when `cargo_patches` is unset.
- Requires `dynamo.hash` (validated); the build cache key is suffixed with a digest of the overrides so patched and plain builds of the same hash never collide.
- Covered by unit tests (`tests/test_configs.py`).