### PR TITLE
Keep nginx connections alive across agentic replay idle gaps

### DIFF
--- a/src/srtctl/cli/mixins/frontend_stage.py
+++ b/src/srtctl/cli/mixins/frontend_stage.py
@@ -195,6 +195,7 @@ class FrontendStageMixin:
             nginx_raise_ulimit=self.config.frontend.nginx_raise_ulimit,
             nginx_session_affinity=self.config.frontend.nginx_session_affinity,
             nginx_session_affinity_header=self.config.frontend.nginx_session_affinity_header,
+            nginx_keepalive_timeout=self.config.frontend.nginx_keepalive_timeout,
         )
 
     def start_frontend(

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1456,6 +1456,12 @@ class FrontendConfig:
             Override per job or set ``nginx_raise_ulimit`` in srtslurm.yaml for the cluster.
         nginx_session_affinity: Consistently hash ``nginx_session_affinity_header`` to a
             frontend. Requests without that header use a generated request ID and stay distributed.
+        nginx_keepalive_timeout: Idle timeout for client and upstream keepalive
+            connections in the generated nginx.conf (default "600s"). nginx's own
+            default is 75s, which closes a session's connection during the long
+            recorded think-time of an agentic replay; the client's next write on
+            that pooled socket then fails with "broken pipe" / "server
+            disconnected" and nothing is logged server-side.
         nginx_session_affinity_header: Header hashed when affinity is on (default
             ``X-Dynamo-Session-ID``). Set ``X-Correlation-ID`` for clients (e.g. aiperf) that
             carry the session id in that header instead.
@@ -1470,6 +1476,7 @@ class FrontendConfig:
     nginx_raise_ulimit: bool = False
     nginx_session_affinity: bool = False
     nginx_session_affinity_header: str = "X-Dynamo-Session-ID"
+    nginx_keepalive_timeout: str = "600s"
     args: dict[str, Any] | None = None
     env: dict[str, str] | None = None
     # trtllm_serve orchestrator (ser.yaml) options; ignored by other frontends.

--- a/src/srtctl/templates/nginx.conf.j2
+++ b/src/srtctl/templates/nginx.conf.j2
@@ -25,6 +25,13 @@ http {
     }
 {% endif %}
 
+    # Agentic replay reproduces recorded think-time, so a session's connection can
+    # sit idle for minutes between turns. nginx's default keepalive_timeout of 75s
+    # closes it underneath a pooled client connection, and the client's next write
+    # on that socket surfaces as "broken pipe" / "server disconnected" with nothing
+    # logged server-side.
+    keepalive_timeout {{ nginx_keepalive_timeout }};
+
     upstream backend_servers {
 {% if nginx_session_affinity %}
         hash $frontend_hash_key consistent;
@@ -32,6 +39,9 @@ http {
         {% for frontend_host in frontend_hosts %}
         server {{ frontend_host }}:{{ backend_port }};
         {% endfor %}
+        # Reuse upstream connections instead of a fresh TCP handshake per request.
+        keepalive 512;
+        keepalive_timeout {{ nginx_keepalive_timeout }};
     }
 
     # The main server block that listens for incoming traffic.
@@ -45,6 +55,11 @@ http {
             proxy_buffering off;
             proxy_read_timeout 24h;
             proxy_send_timeout 24h;
+
+            # Required for the upstream keepalive pool above: without these nginx
+            # talks HTTP/1.0 to the backend and opens a new connection per request.
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
         }
     }
 }


### PR DESCRIPTION
## Problem

The generated `nginx.conf` sets no keepalive directives, so two defaults apply:

- the client-facing `keepalive_timeout` falls back to nginx's default of **75s**
- the upstream is spoken to over **HTTP/1.0**, i.e. a fresh TCP connection per request

Agentic replay reproduces recorded think-time, so a session's connection routinely sits idle for minutes between turns. nginx closes it at 75s while the benchmark client still holds it pooled, and the client's next write on that socket surfaces as `ClientOSError(32, 'Broken pipe')` or `ServerDisconnectedError`. Nothing is logged server-side — closing an idle keepalive connection is not an error from nginx's point of view, which makes this hard to attribute.

The consequence is disproportionate for long replays: a single such error on a warmup request aborts the entire run, discarding hours of warmup on large topologies.

## Fix

- render `keepalive_timeout` for both the client-facing `server` and the `upstream` block, from a new `frontend.nginx_keepalive_timeout` (default `600s`)
- enable an upstream connection pool with `keepalive 512`
- add the `proxy_http_version 1.1` / empty `Connection` header pair the pool requires — without them nginx keeps using HTTP/1.0 and the pool is a no-op

Set `nginx_keepalive_timeout: "75s"` to restore the previous behaviour.

## Validation

DeepSeek-V4-Pro FP4 agentic replay, 12 prefill x 4 decode (64 GPU), concurrency 2048, 22673 warmup requests:

| template | outcome |
|---|---|
| current | 3 runs aborted mid-warmup on a single broken-pipe / server-disconnected error at 85-93% completion, zero prior errors |
| this PR (validated at `3600s`) | completed warmup and the full profiling window with **zero** transport errors |

The completed run also matches the one pre-fix run that survived, so the change
removes the transport errors without perturbing the measurement: 61581 vs 61033
tokens/s/GPU (0.9%), TTFT 37.3s vs 37.9s.


Pre-existing `make lint` (127) and `make test` (5) failures on `main` are unchanged by this PR.
