### PR TITLE
Add recipes for disagg vllm serving of Qwen3.5 on GB200 8k1k

### DIFF
--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/4xdep2-1xdep8-acc.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/4xdep2-1xdep8-acc.yaml
@@ -1,0 +1,78 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-4xdep2-1xdep8-acc"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "gsm8k"
+  repeat: 5

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/4xdep2-1xdep8-cc4096.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/4xdep2-1xdep8-cc4096.yaml
@@ -1,0 +1,85 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-4xdep2-1xdep8-cc4096"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 640
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "4096"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/4xdep2-1xdep8-cc5120.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/4xdep2-1xdep8-cc5120.yaml
@@ -1,0 +1,85 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-4xdep2-1xdep8-cc5120"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 768
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "5120"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/4xdep2-1xdep8.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/4xdep2-1xdep8.yaml
@@ -1,0 +1,84 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-4xdep2-1xdep8"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "64x128x256x512x1024x2048x3072"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/5xdep2-1xdep8-acc.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/5xdep2-1xdep8-acc.yaml
@@ -1,0 +1,79 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-5xdep2-1xdep8-acc"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 3
+  prefill_workers: 5
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "gsm8k"
+  repeat: 5
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/5xdep2-1xdep8-cc4096.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/5xdep2-1xdep8-cc4096.yaml
@@ -1,0 +1,86 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-5xdep2-1xdep8-cc4096"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 3
+  prefill_workers: 5
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 640
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "4096"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/5xdep2-1xdep8-cc5120.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/5xdep2-1xdep8-cc5120.yaml
@@ -1,0 +1,86 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-5xdep2-1xdep8-cc5120"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 3
+  prefill_workers: 5
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 768
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "5120"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/5xdep2-1xdep8.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/5xdep2-1xdep8.yaml
@@ -1,0 +1,85 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-5xdep2-1xdep8"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 3
+  prefill_workers: 5
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "64x128x256x512x1024x2048x3072"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/6xdep2-1xdep8-acc.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/6xdep2-1xdep8-acc.yaml
@@ -1,0 +1,79 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-6xdep2-1xdep8-acc"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 3
+  prefill_workers: 6
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "gsm8k"
+  repeat: 5
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/6xdep2-1xdep8-cc4096.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/6xdep2-1xdep8-cc4096.yaml
@@ -1,0 +1,86 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-6xdep2-1xdep8-cc4096"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 3
+  prefill_workers: 6
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 640
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "4096"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/6xdep2-1xdep8-cc5120.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/6xdep2-1xdep8-cc5120.yaml
@@ -1,0 +1,86 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-6xdep2-1xdep8-cc5120"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 3
+  prefill_workers: 6
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 768
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "5120"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/6xdep2-1xdep8.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/6xdep2-1xdep8.yaml
@@ -1,0 +1,85 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-6xdep2-1xdep8"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 3
+  prefill_workers: 6
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "64x128x256x512x1024x2048x3072"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/7xdep2-1xdep8-acc.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/7xdep2-1xdep8-acc.yaml
@@ -1,0 +1,79 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-7xdep2-1xdep8-acc"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 4
+  prefill_workers: 7
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "gsm8k"
+  repeat: 5
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/7xdep2-1xdep8-cc4096.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/7xdep2-1xdep8-cc4096.yaml
@@ -1,0 +1,86 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-7xdep2-1xdep8-cc4096"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 4
+  prefill_workers: 7
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 640
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "4096"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/7xdep2-1xdep8-cc5120.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/7xdep2-1xdep8-cc5120.yaml
@@ -1,0 +1,86 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-7xdep2-1xdep8-cc5120"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 4
+  prefill_workers: 7
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 768
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "5120"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/7xdep2-1xdep8.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/7xdep2-1xdep8.yaml
@@ -1,0 +1,85 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-7xdep2-1xdep8"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 4
+  prefill_workers: 7
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "64x128x256x512x1024x2048x3072"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/8xdep2-1xdep8-acc.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/8xdep2-1xdep8-acc.yaml
@@ -1,0 +1,79 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-8xdep2-1xdep8-acc"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 4
+  prefill_workers: 8
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "gsm8k"
+  repeat: 5
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/8xdep2-1xdep8-cc4096.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/8xdep2-1xdep8-cc4096.yaml
@@ -1,0 +1,86 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-8xdep2-1xdep8-cc4096"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 4
+  prefill_workers: 8
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 640
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "4096"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/8xdep2-1xdep8-cc5120.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/8xdep2-1xdep8-cc5120.yaml
@@ -1,0 +1,86 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-8xdep2-1xdep8-cc5120"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 4
+  prefill_workers: 8
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-cudagraph-capture-size: 768
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "5120"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+

--- a/recipes/vllm/qwen3.5/GB200/8k1k/disagg/8xdep2-1xdep8.yaml
+++ b/recipes/vllm/qwen3.5/GB200/8k1k/disagg/8xdep2-1xdep8.yaml
@@ -1,0 +1,85 @@
+name: "qwen35-397b-nvfp4-gb200-disagg-8xdep2-1xdep8"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  prefill_nodes: 4
+  prefill_workers: 8
+  gpus_per_prefill: 2
+
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    DYN_LOG: "error"
+    DYN_SDK_DISABLE_ANSI_LOGGING: "1"
+    VLLM_LOGGING_COLOR: "0"
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+      max-num-batched-tokens: 16384
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+      language-model-only: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "64x128x256x512x1024x2048x3072"
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 8
+  num_warmup_mult: 1
+


### PR DESCRIPTION
Add recipes for Qwen3.5 disaggregated serving using vLLM on GB200 ISL/OSL = 8k/1k. Uses topologies NxDEP2+1xDEP8, where N is number of prefill endpoints in range 4 to 8. random range ratio set 0.8 as SA submissions require.
These recipes were also mirrored in srt-slurm-recipes https://github.com/NVIDIA/srt-slurm-recipes/pull/3