### PR TITLE
feat(trtllm): support direct aggregate serve frontend

### DIFF
--- a/examples/trtllm-rc23-qwen3.5-moe-aggregate.yaml
+++ b/examples/trtllm-rc23-qwen3.5-moe-aggregate.yaml
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+#
+# TensorRT-LLM 1.3.0rc23 aggregate smoke for the Qwen3.5-397B-A17B NVFP4
+# MoE checkpoint. Replace only model.path before running preflight. The
+# container, topology, engine settings, and benchmark contract reproduce the
+# validated raw aggregate TEP8 baseline.
+#
+# This is a functional 128/32 smoke, not an 8K/1K performance recipe.
+
+name: "qwen3.5-397b-moe-nvfp4-trtllm-rc23-aggregate-tep8-smoke"
+
+model:
+  # Must be an absolute shared-filesystem path visible on every compute node.
+  path: "/shared/models/Qwen3.5-397B-A17B-NVFP4"
+  container: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23"
+  precision: "fp4"
+
+identity:
+  container:
+    image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23"
+
+resources:
+  # The example assumes GB300 nodes with four GPUs each.
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 2
+  agg_workers: 1
+  gpus_per_agg: 8
+
+srun_options:
+  mem: "0"
+  container-remap-root: ""
+  cpu-bind: "none"
+
+frontend:
+  # The single aggregate worker owns the public port directly. This path does
+  # not launch Dynamo, NATS, etcd, nginx, or a separate router.
+  type: "trtllm_serve"
+  enable_multiple_frontends: false
+
+backend:
+  type: "trtllm"
+
+  aggregated_environment:
+    PYTHONUNBUFFERED: "1"
+    NCCL_DEBUG: "WARN"
+    NCCL_GRAPH_MIXING_SUPPORT: "0"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    OMPI_MCA_coll_ucc_enable: "0"
+    TLLM_ALL_RANK_LOG: "1"
+    TLLM_LOG_LEVEL: "INFO"
+    TRTLLM_ENABLE_PDL: "1"
+    TRTLLM_SERVER_DISABLE_GC: "1"
+    TRTLLM_WORKER_DISABLE_GC: "1"
+
+  trtllm_config:
+    aggregated:
+      # TEP8: attention tensor parallel and MoE expert parallel both span the
+      # same eight-rank TensorRT-LLM worker. EP does not multiply world size.
+      tensor_parallel_size: 8
+      moe_expert_parallel_size: 8
+      pipeline_parallel_size: 1
+      enable_attention_dp: false
+
+      max_batch_size: 8
+      max_num_tokens: 2048
+      max_seq_len: 512
+      trust_remote_code: true
+      enable_chunked_prefill: true
+      allreduce_strategy: AUTO
+      print_iter_log: true
+      num_postprocess_workers: 4
+      cuda_graph_config:
+        enable_padding: true
+        max_batch_size: 8
+      moe_config:
+        backend: CUTEDSL
+      kv_cache_config:
+        dtype: fp8
+        free_gpu_memory_fraction: 0.8
+        enable_block_reuse: false
+
+health_check:
+  max_attempts: 180
+  interval_seconds: 10
+
+benchmark:
+  type: "sa-bench"
+  dataset_name: "random"
+  isl: 128
+  osl: 32
+  concurrencies: [1]
+  req_rate: "inf"
+  random_range_ratio: 0.8
+  num_prompts_mult: 5
+  num_warmup_mult: 1
+  use_chat_template: false
+  reuse_http_connections: false

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -199,18 +199,21 @@ class TRTLLMProtocol:
         )
         base_prefix = list(nsys_prefix or []) + numactl_prefix + ["trtllm-llmapi-launch"]
 
-        # trtllm-serve path: launch an OpenAI-compatible trtllm-serve worker. The
-        # trtllm_serve frontend fronts these via a static ser.yaml (context/generation
-        # server URLs), so there is no dynamo request plane and no --disaggregation-mode:
-        # a worker is prefill or decode purely by which list it appears in in ser.yaml.
+        # trtllm-serve path: launch an OpenAI-compatible trtllm-serve worker. In
+        # disaggregated mode the trtllm_serve frontend fronts these via a static
+        # ser.yaml (context/generation server URLs). In aggregated mode the one
+        # worker is also the public frontend, so it binds runtime.frontend_port.
+        # There is no Dynamo request plane and no --disaggregation-mode: a disagg
+        # worker is prefill or decode purely by which list it appears in in ser.yaml.
         if frontend_type == "trtllm_serve":
+            http_port = runtime.frontend_port if mode == "agg" else process.http_port
             cmd = base_prefix + [
                 "trtllm-serve",
                 model_arg,
                 "--host",
                 "0.0.0.0",
                 "--port",
-                str(process.http_port),
+                str(http_port),
             ]
             # Parallelism also lives in the engine yaml, but pass it explicitly to match
             # the trtllm-serve CLI contract (srun --ntasks == TP*PP is set by the worker stage).

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1593,8 +1593,8 @@ class SrtConfig:
         """Catch trtllm_serve misconfigurations at load time (dry-run) instead of
         failing mid-job at the frontend stage.
 
-        The trtllm_serve frontend runs a single ``trtllm-serve disaggregated``
-        orchestrator, so it needs the trtllm backend, a disaggregated layout, and the
+        The trtllm_serve frontend supports either one direct aggregate worker or a
+        single ``trtllm-serve disaggregated`` orchestrator. Both use the
         single-frontend path (no nginx/multi-frontend).
         """
         if self.frontend.type != "trtllm_serve":
@@ -1605,12 +1605,12 @@ class SrtConfig:
             )
         if self.frontend.enable_multiple_frontends:
             raise ValidationError(
-                "frontend.type: trtllm_serve runs a single orchestrator; set frontend.enable_multiple_frontends: false"
+                "frontend.type: trtllm_serve uses one public endpoint; set frontend.enable_multiple_frontends: false"
             )
-        if not self.resources.is_disaggregated:
+        if not self.resources.is_disaggregated and self.resources.num_agg != 1:
             raise ValidationError(
-                "frontend.type: trtllm_serve requires a disaggregated layout "
-                "(set resources.prefill_nodes/prefill_workers and decode_nodes/decode_workers)"
+                "frontend.type: trtllm_serve aggregate mode requires exactly one "
+                "aggregate worker (set resources.agg_workers: 1)"
             )
 
     def _validate_vllm_frontend(self):

--- a/src/srtctl/frontends/trtllm_serve.py
+++ b/src/srtctl/frontends/trtllm_serve.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-trtllm-serve disaggregated frontend implementation.
+Direct and disaggregated trtllm-serve frontend implementation.
 
-Runs `trtllm-serve disaggregated` as the router. Unlike dynamo (which discovers
-workers via etcd/NATS), trtllm-serve needs a static config (ser.yaml) listing the
-context (prefill) and generation (decode) server URLs. We build that from the
-backend worker leaders, then launch the orchestrator on the head frontend node.
+For aggregate jobs, the one backend worker owns the public OpenAI port and no
+separate frontend process is needed. For disaggregated jobs, this runs
+`trtllm-serve disaggregated` as the router. Unlike Dynamo (which discovers workers
+via etcd/NATS), the disaggregated server needs a static config (ser.yaml) listing
+the context (prefill) and generation (decode) server URLs.
 """
 
 import logging
@@ -29,11 +30,11 @@ logger = logging.getLogger(__name__)
 
 
 class TRTLLMServeFrontend:
-    """trtllm-serve disaggregated frontend.
+    """Direct aggregate or disaggregated trtllm-serve frontend.
 
-    Launches `trtllm-serve disaggregated --config ser.yaml` on the head node,
-    where ser.yaml lists prefill (context_servers) and decode (generation_servers)
-    worker URLs collected from the backend processes. Health via /health.
+    Aggregate mode launches no extra process because the worker itself binds the
+    public port. Disaggregated mode launches `trtllm-serve disaggregated --config
+    ser.yaml` on the head node. Health is exposed at /health in both modes.
     """
 
     @property
@@ -66,20 +67,22 @@ class TRTLLMServeFrontend:
         return result
 
     @staticmethod
-    def _build_ser(config: Any, prefill_urls: list[str], decode_urls: list[str], port: int) -> dict:
+    def _build_ser(config: Any, prefill_urls: list[str], decode_urls: list[str], port: int) -> dict[str, Any]:
         """Build the trtllm-serve disaggregated ser.yaml, merging the optional
         orchestrator-side router / server_config_extra from frontend config."""
-        ser: dict = {
-            "context_servers": {"num_instances": len(prefill_urls), "urls": prefill_urls},
-            "generation_servers": {"num_instances": len(decode_urls), "urls": decode_urls},
+        context_servers: dict[str, Any] = {"num_instances": len(prefill_urls), "urls": prefill_urls}
+        generation_servers: dict[str, Any] = {"num_instances": len(decode_urls), "urls": decode_urls}
+        ser: dict[str, Any] = {
+            "context_servers": context_servers,
+            "generation_servers": generation_servers,
             "hostname": "0.0.0.0",
             "port": port,
         }
         fe = config.frontend
         if getattr(fe, "ctx_router", None):
-            ser["context_servers"]["router"] = dict(fe.ctx_router)
+            context_servers["router"] = dict(fe.ctx_router)
         if getattr(fe, "gen_router", None):
-            ser["generation_servers"]["router"] = dict(fe.gen_router)
+            generation_servers["router"] = dict(fe.gen_router)
         if getattr(fe, "server_config_extra", None):
             ser.update(dict(fe.server_config_extra))
         return ser
@@ -93,22 +96,38 @@ class TRTLLMServeFrontend:
         backend_processes: list["Process"],
         stop_event: "threading.Event | None" = None,
     ) -> list["ManagedProcess"]:
-        """Write ser.yaml from worker leaders and launch the disaggregated orchestrator."""
+        """Use the aggregate worker directly or launch the disaggregated orchestrator."""
         from srtctl.core.processes import ManagedProcess
 
         # trtllm-serve disaggregated fronts trtllm workers; it can't route to other backends.
         if config.backend.type != "trtllm":
             raise ValueError(f"frontend.type: trtllm_serve requires backend.type: trtllm (got {config.backend.type!r})")
 
-        # trtllm-serve disaggregated is a single orchestrator process; the nginx +
-        # multi-frontend path is not supported. uses_nginx also catches the 2-node case
-        # where the topology is nginx + a single frontend node (frontend_nodes len == 1).
+        # trtllm-serve exposes one public endpoint: either the aggregate worker or
+        # a disaggregated orchestrator. The nginx + multi-frontend path is not
+        # supported. uses_nginx also catches the two-node case where the topology
+        # is nginx + one frontend node (frontend_nodes len == 1).
         if topology.uses_nginx or len(topology.frontend_nodes) != 1:
             raise ValueError(
-                "trtllm_serve frontend runs a single disaggregated orchestrator and does "
-                "not support the nginx/multi-frontend path; set "
+                "trtllm_serve uses one public endpoint and does not support "
+                "the nginx/multi-frontend path; set "
                 "frontend.enable_multiple_frontends: false"
             )
+
+        if not config.resources.is_disaggregated:
+            agg_leaders = [
+                process for process in backend_processes if process.endpoint_mode == "agg" and process.is_leader
+            ]
+            if len(agg_leaders) != 1:
+                raise ValueError(
+                    f"trtllm_serve aggregate mode requires exactly one aggregate worker (got {len(agg_leaders)})"
+                )
+            logger.info(
+                "frontend.type=trtllm_serve: no separate frontend process; aggregate trtllm-serve owns port %d",
+                topology.public_port,
+            )
+            return []
+
         frontend_node = topology.frontend_nodes[0]
 
         # Collect prefill/decode worker URLs from endpoint leaders.

--- a/tests/test_mock_sweep.py
+++ b/tests/test_mock_sweep.py
@@ -34,6 +34,47 @@ MINIMAL_CONFIG = {
     "benchmark": {"type": "custom", "command": "echo fake-benchmark"},
 }
 
+TRTLLM_AGGREGATE_CONFIG = {
+    "name": "mock-trtllm-aggregate-sa-bench",
+    "model": {
+        "path": "hf:fake/mock-model",
+        "container": "nvcr.io/fake:latest",
+        "precision": "fp8",
+    },
+    "resources": {
+        "gpu_type": "gb300",
+        "gpus_per_node": 4,
+        "agg_nodes": 2,
+        "agg_workers": 1,
+        "gpus_per_agg": 8,
+    },
+    "frontend": {
+        "type": "trtllm_serve",
+        "enable_multiple_frontends": False,
+    },
+    "backend": {
+        "type": "trtllm",
+        "trtllm_config": {
+            "aggregated": {
+                "tensor_parallel_size": 8,
+                "moe_expert_parallel_size": 8,
+                "pipeline_parallel_size": 1,
+            }
+        },
+    },
+    "benchmark": {
+        "type": "sa-bench",
+        "dataset_name": "random",
+        "isl": 128,
+        "osl": 32,
+        "concurrencies": [1],
+        "req_rate": "inf",
+        "random_range_ratio": 0.8,
+        "num_prompts_mult": 5,
+        "num_warmup_mult": 1,
+    },
+}
+
 
 def _write_config(tmp_path: Path) -> Path:
     cfg = tmp_path / "cfg.yaml"
@@ -115,3 +156,29 @@ def test_run_mock_sweep_result_json_is_parseable_with_fake_metrics(tmp_path: Pat
     assert isinstance(result["score"], float)
     assert 0.0 < result["score"] < 1.0
     assert isinstance(result["param_count"], int)
+
+
+def test_trtllm_aggregate_runs_complete_sa_bench_lifecycle_without_router(tmp_path: Path) -> None:
+    config_path = tmp_path / "trtllm-aggregate.yaml"
+    config_path.write_text(yaml.safe_dump(TRTLLM_AGGREGATE_CONFIG))
+    output_dir = tmp_path / "outputs" / "42045"
+
+    exit_code = run_mock_sweep(
+        config_path=config_path,
+        output_dir=output_dir,
+        job_id="42045",
+        options=MockOptions(
+            child_duration_s=0.05,
+            phase_pause_s=0.01,
+            nodelist=("mock-node-01", "mock-node-02"),
+        ),
+    )
+
+    assert exit_code == 0
+    result = json.loads((output_dir / "result.json").read_text())
+    assert result["status"] == "completed"
+    assert any((output_dir / "logs").glob("*_agg_w0.out"))
+    assert (output_dir / "logs" / "benchmark.out").is_file()
+    assert not (output_dir / "logs" / "infra.out").exists()
+    assert not (output_dir / "logs" / "ser.yaml").exists()
+    assert not any((output_dir / "logs").glob("*_frontend_*.out"))

--- a/tests/test_model_staging.py
+++ b/tests/test_model_staging.py
@@ -4,6 +4,7 @@
 """Tests for lustre->node-local model staging (model.stage_dir)."""
 
 import tempfile
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -102,16 +103,36 @@ class TestWorkerCommandUsesStagedPath:
     def test_trtllm_serve_worker_uses_staged_path(self, tmp_path):
         backend = TRTLLMProtocol(trtllm_config=TRTLLMServerConfig(decode={"tensor_parallel_size": 4}))
         cmd = backend.build_worker_command(
-            self._proc(), [self._proc()], self._runtime_mock(tmp_path, "/raid/scratch/models/DeepSeek-V4-Pro"),
+            self._proc(),
+            [self._proc()],
+            self._runtime_mock(tmp_path, "/raid/scratch/models/DeepSeek-V4-Pro"),
             frontend_type="trtllm_serve",
         )
         assert "/raid/scratch/models/DeepSeek-V4-Pro" in cmd
         assert "/model" not in cmd
 
+    def test_trtllm_serve_aggregate_worker_binds_public_port(self, tmp_path):
+        process = self._proc()
+        process = replace(process, endpoint_mode="agg")
+        runtime = self._runtime_mock(tmp_path, "/model")
+        runtime.frontend_port = 8000
+        backend = TRTLLMProtocol(trtllm_config=TRTLLMServerConfig(aggregated={"tensor_parallel_size": 8}))
+
+        cmd = backend.build_worker_command(
+            process,
+            [process],
+            runtime,
+            frontend_type="trtllm_serve",
+        )
+
+        assert cmd[cmd.index("--port") + 1] == "8000"
+
     def test_dynamo_worker_uses_staged_path(self, tmp_path):
         backend = TRTLLMProtocol(trtllm_config=TRTLLMServerConfig(decode={"tensor_parallel_size": 4}))
         cmd = backend.build_worker_command(
-            self._proc(), [self._proc()], self._runtime_mock(tmp_path, "/raid/scratch/models/DeepSeek-V4-Pro"),
+            self._proc(),
+            [self._proc()],
+            self._runtime_mock(tmp_path, "/raid/scratch/models/DeepSeek-V4-Pro"),
             frontend_type="dynamo",
         )
         # dynamo path passes it as --model-path
@@ -120,7 +141,9 @@ class TestWorkerCommandUsesStagedPath:
     def test_dynamo_worker_does_not_publish_events_by_default(self, tmp_path):
         backend = TRTLLMProtocol(trtllm_config=TRTLLMServerConfig(decode={"tensor_parallel_size": 4}))
         cmd = backend.build_worker_command(
-            self._proc(), [self._proc()], self._runtime_mock(tmp_path, "/raid/scratch/models/DeepSeek-V4-Pro"),
+            self._proc(),
+            [self._proc()],
+            self._runtime_mock(tmp_path, "/raid/scratch/models/DeepSeek-V4-Pro"),
             frontend_type="dynamo",
         )
         assert "--publish-events-and-metrics" not in cmd
@@ -131,7 +154,9 @@ class TestWorkerCommandUsesStagedPath:
             publish_events_and_metrics=True,
         )
         cmd = backend.build_worker_command(
-            self._proc(), [self._proc()], self._runtime_mock(tmp_path, "/raid/scratch/models/DeepSeek-V4-Pro"),
+            self._proc(),
+            [self._proc()],
+            self._runtime_mock(tmp_path, "/raid/scratch/models/DeepSeek-V4-Pro"),
             frontend_type="dynamo",
         )
         assert "--publish-events-and-metrics" in cmd

--- a/tests/test_trtllm_serve_ser.py
+++ b/tests/test_trtllm_serve_ser.py
@@ -3,8 +3,15 @@
 
 """Tests for the trtllm_serve ser.yaml builder (router + server_config_extra)."""
 
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+import pytest
+import yaml
+from marshmallow import ValidationError
+
+from srtctl.core.schema import SrtConfig
 from srtctl.frontends import TRTLLMServeFrontend
 
 
@@ -17,7 +24,7 @@ def _cfg(**frontend_fields):
 
 def test_ser_minimal_no_router():
     ser = TRTLLMServeFrontend._build_ser(_cfg(), ["c0:8000"], ["g0:8001", "g1:8002"], 8000)
-    assert ser["backend"] if "backend" in ser else True  # tolerate absent backend key
+    assert ser.get("backend", True)  # tolerate absent backend key
     assert ser["hostname"] == "0.0.0.0"
     assert ser["port"] == 8000
     assert ser["context_servers"] == {"num_instances": 1, "urls": ["c0:8000"]}
@@ -43,22 +50,13 @@ def test_ser_conversation_router_and_extra():
 
 
 def test_ser_gen_router():
-    ser = TRTLLMServeFrontend._build_ser(
-        _cfg(gen_router={"type": "default"}), ["c0:8000"], ["g0:8001"], 8000
-    )
+    ser = TRTLLMServeFrontend._build_ser(_cfg(gen_router={"type": "default"}), ["c0:8000"], ["g0:8001"], 8000)
     assert ser["generation_servers"]["router"] == {"type": "default"}
     assert "router" not in ser["context_servers"]
 
 
-def test_frontend_config_accepts_router_fields():
+def test_frontend_config_accepts_router_fields(tmp_path: Path):
     # The FrontendConfig schema must round-trip the new fields.
-    import tempfile
-    from pathlib import Path
-
-    import yaml
-
-    from srtctl.core.schema import SrtConfig
-
     data = {
         "name": "r",
         "model": {"path": "/lustre/m", "container": "trtllm", "precision": "fp4"},
@@ -78,9 +76,53 @@ def test_frontend_config_accepts_router_fields():
             "server_config_extra": {"gen_strip_message_history": True, "gen_tokids_ctxbytes": True},
         },
     }
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        yaml.dump(data, f)
-        f.flush()
-        config = SrtConfig.from_yaml(Path(f.name))
+    config_path = tmp_path / "disaggregated.yaml"
+    config_path.write_text(yaml.safe_dump(data))
+    config = SrtConfig.from_yaml(config_path)
     assert config.frontend.ctx_router == {"type": "conversation"}
     assert config.frontend.server_config_extra["gen_strip_message_history"] is True
+
+
+def _aggregate_config(agg_workers: int) -> dict:
+    return {
+        "name": "trtllm-raw",
+        "model": {"path": "/model", "container": "trtllm", "precision": "fp4"},
+        "resources": {
+            "gpu_type": "gb300",
+            "gpus_per_node": 4,
+            "agg_nodes": 2,
+            "agg_workers": agg_workers,
+            "gpus_per_agg": 8,
+        },
+        "backend": {"type": "trtllm"},
+        "frontend": {"type": "trtllm_serve", "enable_multiple_frontends": False},
+    }
+
+
+def test_frontend_config_accepts_single_aggregate_worker(tmp_path: Path):
+    config_path = tmp_path / "aggregate.yaml"
+    config_path.write_text(yaml.safe_dump(_aggregate_config(agg_workers=1)))
+    config = SrtConfig.from_yaml(config_path)
+
+    assert config.resources.num_agg == 1
+
+
+@pytest.mark.parametrize("agg_workers", [0, 2])
+def test_frontend_config_rejects_non_single_aggregate_worker(tmp_path: Path, agg_workers: int):
+    config_path = tmp_path / f"aggregate-{agg_workers}.yaml"
+    config_path.write_text(yaml.safe_dump(_aggregate_config(agg_workers=agg_workers)))
+
+    with pytest.raises(ValidationError, match="requires exactly one aggregate worker"):
+        SrtConfig.from_yaml(config_path)
+
+
+def test_aggregate_frontend_uses_worker_directly():
+    frontend = TRTLLMServeFrontend()
+    topology = SimpleNamespace(uses_nginx=False, frontend_nodes=["node0"], public_port=8000)
+    config = SimpleNamespace(
+        backend=SimpleNamespace(type="trtllm"),
+        resources=SimpleNamespace(is_disaggregated=False),
+    )
+    worker = SimpleNamespace(endpoint_mode="agg", is_leader=True)
+
+    assert frontend.start_frontends(topology, MagicMock(), config, MagicMock(), [worker]) == []


### PR DESCRIPTION
Add a runnable TensorRT-LLM 1.3.0rc23 Qwen3.5 MoE aggregate smoke example with the pinned SA-Bench measurement contract.