### PR TITLE
fix(processes): guard the post-kill wait in ManagedProcess.terminate

### DIFF
--- a/src/srtctl/core/processes.py
+++ b/src/srtctl/core/processes.py
@@ -22,6 +22,25 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+def terminate_and_reap(popen: subprocess.Popen, *, terminate_timeout: float = 10.0, kill_timeout: float = 5.0) -> bool:
+    """Terminate, then kill, then report whether the child was reaped."""
+    if popen.poll() is not None:
+        return True
+    popen.terminate()
+    try:
+        popen.wait(timeout=terminate_timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning("Process did not terminate, killing...")
+    popen.kill()
+    try:
+        popen.wait(timeout=kill_timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.error("Process was not reaped after SIGKILL")
+        return False
+
+
 @dataclass
 class ManagedProcess:
     """A process managed by the registry.
@@ -55,13 +74,8 @@ class ManagedProcess:
         if not self.is_running:
             return
 
-        self.popen.terminate()
-        try:
-            self.popen.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            logger.warning("Process %s did not terminate, killing...", self.name)
-            self.popen.kill()
-            self.popen.wait(timeout=5)
+        if not terminate_and_reap(self.popen, terminate_timeout=timeout, kill_timeout=5):
+            logger.error("Process %s was not reaped after SIGKILL", self.name)
 
 
 # Type alias for named process collections

--- a/tests/test_process_registry.py
+++ b/tests/test_process_registry.py
@@ -4,10 +4,10 @@
 """Tests for ProcessRegistry."""
 
 from pathlib import Path
-from subprocess import Popen
+from subprocess import Popen, TimeoutExpired
 from unittest.mock import MagicMock
 
-from srtctl.core.processes import ManagedProcess, ProcessRegistry
+from srtctl.core.processes import ManagedProcess, ProcessRegistry, terminate_and_reap
 
 
 class TestManagedProcess:
@@ -44,6 +44,51 @@ class TestManagedProcess:
 
         # exit_code comes from popen.returncode
         assert mock_popen.returncode == 1
+
+    def test_terminate_does_not_raise_when_kill_wait_times_out(self):
+        """A child that survives SIGKILL must not raise out of terminate()."""
+        mock_popen = MagicMock(spec=Popen)
+        mock_popen.poll.return_value = None
+        mock_popen.wait.side_effect = TimeoutExpired(cmd="worker", timeout=1)
+
+        mp = ManagedProcess(name="stuck", popen=mock_popen)
+
+        mp.terminate(timeout=0.01)
+
+        mock_popen.terminate.assert_called_once()
+        mock_popen.kill.assert_called_once()
+
+
+class TestTerminateAndReap:
+    """Tests for the terminate_and_reap helper."""
+
+    def test_already_exited_child_is_reported_reaped(self):
+        mock_popen = MagicMock(spec=Popen)
+        mock_popen.poll.return_value = 0
+
+        assert terminate_and_reap(mock_popen) is True
+        mock_popen.terminate.assert_not_called()
+
+    def test_graceful_terminate_is_reported_reaped(self):
+        mock_popen = MagicMock(spec=Popen)
+        mock_popen.poll.return_value = None
+        mock_popen.wait.return_value = 0
+
+        assert terminate_and_reap(mock_popen, terminate_timeout=0.01) is True
+        mock_popen.terminate.assert_called_once()
+        mock_popen.kill.assert_not_called()
+
+    def test_unreapable_child_is_reported_not_reaped(self):
+        mock_popen = MagicMock(spec=Popen)
+        mock_popen.poll.return_value = None
+        mock_popen.wait.side_effect = TimeoutExpired(cmd="worker", timeout=1)
+
+        assert (
+            terminate_and_reap(mock_popen, terminate_timeout=0.01, kill_timeout=0.01)
+            is False
+        )
+        mock_popen.terminate.assert_called_once()
+        mock_popen.kill.assert_called_once()
 
 
 class TestProcessRegistry:


### PR DESCRIPTION
## What

`ManagedProcess.terminate()` calls `self.popen.wait(timeout=5)` after SIGKILL with no guard. A child that survives SIGKILL (D-state / NFS hang) raises `subprocess.TimeoutExpired` out of `terminate()`, which escapes `ProcessRegistry.cleanup()` and aborts the remaining teardown mid-loop.

## Change

- Promote the terminate → kill → confirm ladder into a module-level `terminate_and_reap(popen, *, terminate_timeout, kill_timeout) -> bool` in `core/processes.py`.
- `ManagedProcess.terminate()` delegates to it and logs instead of raising when the child cannot be reaped.

Behavior is unchanged on the normal path; the only difference is that an unreapable child is now reported instead of raised.

## Tests

- `terminate()` no longer raises when the post-kill wait times out.
- `terminate_and_reap` truth table: already-exited → True short-circuit, graceful terminate → True, unreapable → False with terminate and kill each called once.

`pytest tests/` passes (same 3 pre-existing environment-dependent failures as `main` on my machine: fingerprint CPU probe, apply_mock CPU allocation, mcp_spec explain-field).
