### PR TITLE
fix: preserve scalar types in sweep placeholders

### DIFF
--- a/src/srtctl/core/sweep.py
+++ b/src/srtctl/core/sweep.py
@@ -32,17 +32,15 @@ def expand_template(template: Any, values: dict[str, Any]) -> Any:
         result = template
         for key, value in values.items():
             placeholder = f"{{{key}}}"
-            # Handle list values specially - convert to comma-separated string or keep as list
-            if isinstance(value, list):
-                # For YAML lists, we want to keep them as lists, not convert to string
-                if placeholder in result and result == placeholder:
-                    # If the entire string is just the placeholder, replace with the list
-                    return value
-                else:
-                    # If it's embedded in a string, convert to comma-separated
-                    result = result.replace(placeholder, ",".join(str(v) for v in value))
-            else:
-                result = result.replace(placeholder, str(value))
+            if template == placeholder:
+                # An exact placeholder represents the value itself, so preserve its
+                # YAML type instead of coercing numbers and booleans to strings.
+                return copy.deepcopy(value)
+
+            # Embedded placeholders are necessarily part of a string. Keep the
+            # existing comma-separated representation for list values.
+            replacement = ",".join(str(v) for v in value) if isinstance(value, list) else str(value)
+            result = result.replace(placeholder, replacement)
         return result
     else:
         return template

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -27,14 +27,29 @@ class TestExpandTemplate:
         assert result == "x-y"
 
     def test_numeric_value(self):
-        """Test that numeric values are converted to strings."""
+        """Test that exact numeric placeholders preserve their type."""
         result = expand_template("{num}", {"num": 42})
-        assert result == "42"
+        assert result == 42
 
     def test_float_value(self):
-        """Test float value conversion."""
+        """Test that exact float placeholders preserve their type."""
         result = expand_template("{val}", {"val": 0.85})
-        assert result == "0.85"
+        assert result == 0.85
+
+    def test_boolean_value(self):
+        """Test that exact boolean placeholders preserve their type."""
+        result = expand_template("{enabled}", {"enabled": False})
+        assert result is False
+
+    def test_numeric_value_embedded_in_string(self):
+        """Test that embedded numeric placeholders remain strings."""
+        result = expand_template("rank-{rank}", {"rank": 4})
+        assert result == "rank-4"
+
+    def test_numeric_value_stays_string_when_other_embedded_value_is_empty(self):
+        """Test that an originally embedded numeric placeholder remains text."""
+        result = expand_template("{prefix}{rank}", {"prefix": "", "rank": 4})
+        assert result == "4"
 
     def test_nested_dict(self):
         """Test placeholder replacement in nested dicts."""
@@ -278,12 +293,12 @@ class TestGenerateSweepConfigs:
         }
         results = generate_sweep_configs(config)
 
-        # Check that values are substituted (note: they become strings)
+        # Check that exact placeholders retain the sweep values' YAML types.
         config1 = results[0][0]
         config2 = results[1][0]
 
         prefill1 = config1["backend"]["sglang_config"]["prefill"]
         prefill2 = config2["backend"]["sglang_config"]["prefill"]
 
-        assert prefill1["mem-fraction-static"] == "0.85"
-        assert prefill2["mem-fraction-static"] == "0.9"
+        assert prefill1["mem-fraction-static"] == 0.85
+        assert prefill2["mem-fraction-static"] == 0.9


### PR DESCRIPTION
## What changed

- preserve the native YAML value when a template is exactly one sweep placeholder
- keep string rendering for placeholders embedded in larger strings
- add regression coverage for integer, float, boolean, list, and embedded substitutions

## Why

Sweep expansion previously converted exact numeric and boolean placeholders to strings. Backend configuration dictionaries retain those values without schema coercion, so numeric fields such as vLLM `data-parallel-size` could reach runtime arithmetic as strings and fail before workers launched.

## Impact

Generated sweep configurations now retain the types declared in the `sweep` values while names and other interpolated text continue to render as strings.

## Validation

- `uv run pytest tests/test_sweep.py -q` — 23 passed
- `uv run ruff check src/srtctl/core/sweep.py tests/test_sweep.py`
- `uv run ruff format --check src/srtctl/core/sweep.py tests/test_sweep.py`
- broader Windows run excluding the Linux-only `test_dynamo_wheels.py`: 838 passed; 61 unrelated platform-specific failures

The complete suite cannot collect unchanged Linux-only `fcntl` coverage on Windows.
