### PR TITLE
feat(analysis): median reference line + p99 y-axis clipping for batch plots

### DIFF
--- a/src/srtctl/analysis/batch_plot_matrix.py
+++ b/src/srtctl/analysis/batch_plot_matrix.py
@@ -11,6 +11,7 @@ post-mortem ``plot_batch_metrics.py`` CLI.
 
 from __future__ import annotations
 
+import math
 import os
 import re
 from dataclasses import dataclass
@@ -171,14 +172,110 @@ def _global_origin(prefill: Iterable[_PlotSeries], decode: Iterable[_PlotSeries]
     return first_seen
 
 
+def _resolve_cmap(plt, name: str, lut: int):
+    """Return a discrete colormap across matplotlib versions.
+
+    ``plt.cm.get_cmap`` was removed in matplotlib 3.9; ``matplotlib.colormaps``
+    is the replacement but does not exist before 3.5.
+    """
+    getter = getattr(plt.cm, "get_cmap", None)
+    if getter is not None:
+        return getter(name, lut)
+    import matplotlib
+
+    return matplotlib.colormaps[name].resampled(lut)
+
+
+# Counters with a tiny integer range (e.g. #prealloc-req over 0..3) gain nothing
+# from percentile clipping, and the annotation would just be noise.
+_CLIP_MIN_MAX = 10.0
+# Only clip when the tail actually squashes the plot.
+_CLIP_TRIGGER_RATIO = 1.5
+
+
+def _annotate_axis(
+    ax,
+    pooled: list[float],
+    *,
+    show_median: bool,
+    clip_percentile: float | None,
+) -> None:
+    """Add a median reference line and optionally cap the y-axis at a percentile."""
+    values = [v for v in pooled if v is not None and math.isfinite(v)]
+    if not values:
+        return
+
+    ordered = sorted(values)
+    median = _quantile(ordered, 0.5)
+
+    if clip_percentile is not None:
+        high = _quantile(ordered, clip_percentile / 100.0)
+        low, top = ordered[0], ordered[-1]
+        span = high - low
+        n_over = sum(1 for v in ordered if v > high)
+        if n_over and top > high * _CLIP_TRIGGER_RATIO and top > _CLIP_MIN_MAX:
+            # A flat baseline punctuated by spikes has span == 0, which is exactly
+            # the case worth clipping; fall back to a magnitude-relative pad.
+            pad = span * 0.08 if span > 0 else max(abs(high) * 0.08, 1.0)
+            ax.set_ylim(low - pad, high + pad)
+            ax.annotate(
+                f"▲ {n_over} pt(s) > p{clip_percentile:g} (max {top:,.4g}, axis clipped)",
+                xy=(0.5, 0.03),
+                xycoords="axes fraction",
+                ha="center",
+                va="bottom",
+                fontsize=7,
+                color="darkred",
+                bbox={"boxstyle": "round,pad=0.25", "fc": "mistyrose", "ec": "darkred", "lw": 0.6, "alpha": 0.9},
+            )
+
+    if show_median:
+        ax.axhline(median, color="red", linestyle="--", linewidth=1.1, alpha=0.85, zorder=5)
+        ax.annotate(
+            f"median {median:,.4g}",
+            xy=(1.0, median),
+            xycoords=("axes fraction", "data"),
+            xytext=(-4, 3),
+            textcoords="offset points",
+            ha="right",
+            va="bottom",
+            fontsize=7.5,
+            color="darkred",
+            fontweight="bold",
+            bbox={"boxstyle": "round,pad=0.2", "fc": "white", "ec": "red", "lw": 0.6, "alpha": 0.85},
+            zorder=6,
+        )
+
+
+def _quantile(ordered: list[float], q: float) -> float:
+    """Linear-interpolated quantile over a pre-sorted list (avoids a numpy dep)."""
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = q * (len(ordered) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = pos - lo
+    return ordered[lo] * (1.0 - frac) + ordered[hi] * frac
+
+
 def render_batch_plot_matrix(
     state: LogState,
     output_path: str | Path,
     title: str | None = None,
     downsample: int = 1,
     smooth_input_window: int = 8,
+    show_median: bool = True,
+    clip_percentile: float | None = 99.0,
 ) -> bool:
     """Render per-worker time-series to a PNG.
+
+    Args:
+        show_median: draw a dashed reference line at the pooled median of each
+            subplot and label its value.
+        clip_percentile: cap the y-axis at this percentile so a handful of
+            spikes cannot squash the steady-state signal into a flat line.
+            Out-of-range points are annotated with their count and the true
+            maximum. Pass ``None`` to disable.
 
     Returns ``True`` when a PNG was written and ``False`` when the state
     has no parsed batch rows yet.
@@ -196,7 +293,7 @@ def render_batch_plot_matrix(
         return False
 
     n_rows = len(PLOT_ROWS)
-    cmap = plt.cm.get_cmap("tab20", max(len(pf_files), len(dc_files), 1))
+    cmap = _resolve_cmap(plt, "tab20", max(len(pf_files), len(dc_files), 1))
     colors = [cmap(i) for i in range(cmap.N)]
 
     fig, axes = plt.subplots(n_rows, 2, figsize=(20, 3.0 * n_rows), squeeze=False)
@@ -214,6 +311,7 @@ def render_batch_plot_matrix(
             return
 
         drawn = False
+        pooled: list[float] = []
         for idx, s in enumerate(files):
             vs = _values_for_metric(s, metric, smooth_input_window)
             if not vs:
@@ -225,6 +323,7 @@ def render_batch_plot_matrix(
                 continue
             elapsed = _elapsed_seconds([p[0] for p in pairs], origin)
             values = [p[1] for p in pairs]
+            pooled.extend(values)
             ax.plot(elapsed, values, color=colors[idx % len(colors)], linewidth=0.9, alpha=0.8, label=s.label)
             drawn = True
 
@@ -235,10 +334,14 @@ def render_batch_plot_matrix(
         ax.grid(True, alpha=0.3)
         if not drawn:
             ax.text(0.5, 0.5, "no data", ha="center", va="center", transform=ax.transAxes, color="grey", fontsize=9)
-        elif files:
+            return
+
+        _annotate_axis(ax, pooled, show_median=show_median, clip_percentile=clip_percentile)
+
+        if files:
             ax.legend(
                 fontsize=7,
-                loc="upper right",
+                loc="upper left",
                 ncol=max(1, len(files) // 8 + 1),
                 framealpha=0.35,
                 facecolor="white",

--- a/src/srtctl/benchmarks/scripts/plot_batch_metrics.py
+++ b/src/srtctl/benchmarks/scripts/plot_batch_metrics.py
@@ -42,6 +42,8 @@ def process_single_run(
     downsample_factor: int = 1,
     output_path: str | None = None,
     smooth_input_window: int = 8,
+    show_median: bool = True,
+    clip_percentile: float | None = 99.0,
 ) -> bool:
     """Process a single logs directory. Returns ``True`` when a plot was generated."""
     log_path = Path(log_dir)
@@ -57,6 +59,8 @@ def process_single_run(
         title=default_batch_plot_title(log_path),
         downsample=downsample_factor,
         smooth_input_window=smooth_input_window,
+        show_median=show_median,
+        clip_percentile=clip_percentile,
     )
 
 

--- a/tests/test_batch_plot_metrics.py
+++ b/tests/test_batch_plot_metrics.py
@@ -40,12 +40,13 @@ def test_plot_batch_metrics_cli_uses_shared_live_renderer(monkeypatch, tmp_path)
 
     calls = {}
 
-    def fake_render_batch_plot_matrix(state, output_path, title, downsample, smooth_input_window):
+    def fake_render_batch_plot_matrix(state, output_path, title, downsample, smooth_input_window, **kwargs):
         calls["state"] = state
         calls["output_path"] = Path(output_path)
         calls["title"] = title
         calls["downsample"] = downsample
         calls["smooth_input_window"] = smooth_input_window
+        calls.update(kwargs)
         calls["output_path"].write_text("fake png")
         return True
 
@@ -150,3 +151,82 @@ def test_renderer_splits_agg_logs_by_dp_and_derives_input_throughput(tmp_path):
     derived = {s.label: _values_for_metric(s, "input throughput (token/s)", smooth_input_window=1) for s in plot_series}
     assert derived["bia0003_agg_w0_DP0"] == [None, 200.0]
     assert derived["bia0003_agg_w0_DP1"] == [None, 200.0]
+
+
+def test_quantile_interpolates_like_numpy():
+    """_quantile must match linear interpolation so p99 lines up with expectations."""
+    from srtctl.analysis.batch_plot_matrix import _quantile
+
+    ordered = [float(v) for v in range(101)]  # 0..100
+    assert _quantile(ordered, 0.5) == 50.0
+    assert _quantile(ordered, 0.99) == 99.0
+    assert _quantile(ordered, 0.0) == 0.0
+    assert _quantile(ordered, 1.0) == 100.0
+    assert _quantile([7.0], 0.5) == 7.0
+
+
+class _FakeAxis:
+    """Minimal stand-in recording the calls _annotate_axis makes."""
+
+    def __init__(self):
+        self.ylim = None
+        self.hlines = []
+        self.annotations = []
+
+    def set_ylim(self, low, high):
+        self.ylim = (low, high)
+
+    def axhline(self, y, **_kwargs):
+        self.hlines.append(y)
+
+    def annotate(self, text, **_kwargs):
+        self.annotations.append(text)
+
+
+def test_annotate_axis_draws_median_line():
+    from srtctl.analysis.batch_plot_matrix import _annotate_axis
+
+    ax = _FakeAxis()
+    _annotate_axis(ax, [1.0, 2.0, 3.0], show_median=True, clip_percentile=None)
+
+    assert ax.hlines == [2.0]
+    assert any("median 2" in a for a in ax.annotations)
+    assert ax.ylim is None  # clipping disabled
+
+
+def test_annotate_axis_clips_outliers_and_reports_true_max():
+    """A few huge spikes must not squash the steady-state signal."""
+    from srtctl.analysis.batch_plot_matrix import _annotate_axis
+
+    ax = _FakeAxis()
+    values = [100.0] * 200 + [1_000_000.0]
+    _annotate_axis(ax, values, show_median=True, clip_percentile=99.0)
+
+    assert ax.ylim is not None
+    assert ax.ylim[1] < 1_000.0  # axis capped well below the spike
+    clipped = [a for a in ax.annotations if "axis clipped" in a]
+    assert clipped, ax.annotations
+    assert "1 pt(s)" in clipped[0]
+    assert f"{1_000_000.0:,.4g}" in clipped[0]  # true max is reported, not the clipped bound
+
+
+def test_annotate_axis_skips_clipping_for_small_integer_counters():
+    """Counters like #prealloc-req (0..3) gain nothing from clipping."""
+    from srtctl.analysis.batch_plot_matrix import _annotate_axis
+
+    ax = _FakeAxis()
+    _annotate_axis(ax, [0.0] * 200 + [1.0, 3.0], show_median=True, clip_percentile=99.0)
+
+    assert ax.ylim is None
+    assert not any("axis clipped" in a for a in ax.annotations)
+
+
+def test_annotate_axis_handles_empty_and_nonfinite():
+    from srtctl.analysis.batch_plot_matrix import _annotate_axis
+
+    ax = _FakeAxis()
+    _annotate_axis(ax, [], show_median=True, clip_percentile=99.0)
+    _annotate_axis(ax, [float("nan"), float("inf")], show_median=True, clip_percentile=99.0)
+
+    assert ax.hlines == []
+    assert ax.annotations == []


### PR DESCRIPTION
Two readability problems made `batch_metrics.png` hard to use in practice:

1. **Spikes squash the signal.** On a disagg run the prefill input-throughput panel peaks around `1.8e6` during warmup/teardown while steady state sits at `8.2e4`. The whole steady-state region collapses into a flat line at the bottom of the axis and you cannot read anything off it.
2. **No quick read of the steady-state level.** You had to eyeball it.

<img width="2196" height="1015" alt="image" src="https://github.com/user-attachments/assets/9a5129e0-1929-4cee-b532-9ab5b9c0c06e" />

## What this adds

Two opt-out knobs on `render_batch_plot_matrix` (both plumbed through `plot_batch_metrics.py`):

| arg | default | effect |
|---|---|---|
| `show_median` | `True` | dashed red line at the pooled median of each subplot, labelled with its value |
| `clip_percentile` | `99.0` | cap the y-axis at that percentile; annotate how many points are outside **and the true maximum**. `None` disables. |

Clipping never silently hides outliers — the annotation always reports the real max and the count of out-of-range points.

### Clipping only engages when it helps

- there must be points above the percentile, **and**
- `max > percentile * 1.5` (the tail actually squashes the plot), **and**
- `max > 10`, so small integer counters such as `#prealloc-req` over `0..3` are left alone instead of getting a meaningless "axis clipped" badge.

A flat baseline punctuated by spikes has zero interquantile span, which is exactly the case worth clipping, so the padding falls back to a magnitude-relative value there rather than skipping.

## Drive-by bug fix

`plt.cm.get_cmap` was **removed in matplotlib 3.9**, so `plot_batch_metrics.py` raised `AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'` on any current environment — the script was unusable. `_resolve_cmap` selects whichever API is available.

## Notes

- Legend moved to upper-left so the bottom-centre out-of-range annotation does not collide with it.
- `_quantile` is a small linear-interpolating helper rather than adding a numpy dependency, since this module currently has none.

## Testing

- 5 new unit tests in `tests/test_batch_plot_metrics.py`: quantile interpolation vs numpy semantics, median line, outlier clipping with true-max reporting, the small-integer-counter skip, and empty/non-finite input.
- `uv run pytest tests/test_batch_plot_metrics.py` — 9 passed.
- `make lint` — 0 diagnostics on the two changed source files.
- End-to-end on a real 1P1D disagg run (~460 MB of worker logs) through the `plot_batch_metrics.py` CLI.
- `make check` has 5 pre-existing failures on this machine (`os.sched_getaffinity` missing on macOS; `../lib/profiling.sh` resolution depends on clone location). **Verified identical on a clean `main` via `git stash`** — unrelated to this change.

Marked draft: happy to flip the defaults (e.g. `clip_percentile=None` so existing output stays byte-identical) if you would rather this be opt-in.
