### PR TITLE
(feat) Support multi-node aggregate jobs with direct vllm frontend

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,8 +215,9 @@ class SweepOrchestrator(WorkerStageMixin, FrontendStageMixin, BenchmarkStageMixi
     def run(self) -> int:
         """Run the complete benchmark sweep."""
         # Stage 1: Start head infrastructure (NATS, etcd)
+        #   (skipped for frontend.type: vllm or trtllm_serve)
         # Stage 2: Start backend workers
-        # Stage 3: Start frontends
+        # Stage 3: Start frontends (no-op for frontend.type: vllm — worker owns the port)
         # Stage 4: Run benchmark
         # Cleanup
 ```
@@ -356,6 +357,8 @@ src/srtctl/frontends/
 |-- base.py         # FrontendProtocol definition
 |-- dynamo.py       # DynamoFrontend (NATS/etcd)
 |-- sglang.py       # SGLangFrontend (direct router)
+|-- trtllm_serve.py # TRTLLMServeFrontend (disagg TRT-LLM orchestrator)
+|-- vllm.py         # VLLMFrontend (direct aggregate vllm serve)
 ```
 
 #### FrontendProtocol
@@ -444,14 +447,14 @@ src/srtctl/core/
 +------------------------------------------------------------------+
                                 |
                                 v
-+------------------------------------------------------------------+
-|                       FRONTEND LAYER                              |
-+------------------------------------------------------------------+
-| FrontendProtocol                   | DynamoFrontend | SGLangFrontend|
-| - start_frontends()                | - /health      | - /workers    |
-| - parse_health()                   | - NATS/etcd    | - Direct conn |
-| - health_endpoint                  |                |               |
-+------------------------------------------------------------------+
++----------------------------------------------------------------------------------------------+
+|                                       FRONTEND LAYER                                         |
++----------------------------------------------------------------------------------------------+
+| FrontendProtocol          | DynamoFrontend | SGLangFrontend | TRTLLMServe  | VLLMFrontend    |
+| - start_frontends()       | srun process   | srun process   | srun process | (no process)    |
+| - parse_health()          | NATS/etcd      | direct workers | /health      | /health         |
+| - health_endpoint         | /health        | /workers       | /health      | agg leader node |
++----------------------------------------------------------------------------------------------+
                                 |
                                 v
 +------------------------------------------------------------------+
@@ -1070,6 +1073,8 @@ src/srtctl/
 |   |-- base.py              # FrontendProtocol definition
 |   |-- dynamo.py            # DynamoFrontend (NATS/etcd)
 |   |-- sglang.py            # SGLangFrontend (direct router)
+|   |-- trtllm_serve.py      # TRTLLMServeFrontend (disagg orchestrator)
+|   |-- vllm.py              # VLLMFrontend (direct aggregate vllm serve)
 |
 |-- cli/                     # CLI entry points
 |   |-- __init__.py

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -403,9 +403,12 @@ The following keys are owned by srtctl and are stripped at runtime if present in
 - `nnodes`
 - `node-rank` / `node_rank`
 
-Existing recipes that still contain these keys continue to work (values are
-ignored). `srtctl dry-run` emits a **WARNING** for each one so operators can
-clean up recipes over time.
+Existing recipes that still contain these keys generally continue to work
+because the values are ignored. One exception is `headless` combined with
+`dp_launch_mode: per_node` and `data-parallel-size`: backend validation rejects
+that combination before direct-vLLM command construction, so remove `headless`
+from such recipes. `srtctl dry-run` emits a **WARNING** for each accepted key so
+operators can clean up recipes over time.
 
 Health checks, benchmark clients, and `SRT_FRONTEND_HOST` target the **aggregate
 endpoint leader** (the node running the public `vllm serve`), not necessarily the

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -270,7 +270,7 @@ Frontend/router configuration.
 
 ```yaml
 frontend:
-  # Frontend type: "dynamo" (default), "sglang", or "trtllm_serve"
+  # Frontend type: "dynamo" (default), "sglang", "trtllm_serve", or "vllm"
   type: dynamo
 
   # Scaling
@@ -294,7 +294,7 @@ frontend:
 
 | Field                       | Type | Default       | Description                         |
 | --------------------------- | ---- | ------------- | ----------------------------------- |
-| `type`                      | str  | dynamo        | Frontend type: "dynamo", "sglang", or "trtllm_serve" |
+| `type`                      | str  | dynamo        | Frontend type: "dynamo", "sglang", "trtllm_serve", or "vllm" |
 | `enable_multiple_frontends` | bool | true          | Scale with nginx + multiple routers |
 | `num_additional_frontends`  | int  | 9             | Additional routers beyond master    |
 | `nginx_container`           | str  | nginx:1.27.4  | Custom nginx container image        |
@@ -318,6 +318,98 @@ Because the orchestrator is a single process, set
 supported). A recipe can be switched between the two TRT-LLM serving stacks by
 changing only `frontend.type` between `dynamo` and `trtllm_serve`. See the sample
 recipe `recipes/trtllm/b200-fp8/1k1k/stp/ctx1_gen3_tp8_batch1024_eplb0_mtp0_4_trtllm_serve.yaml`.
+
+### vllm frontend
+
+`type: vllm` runs aggregate vLLM jobs **without Dynamo**. The OpenAI-compatible
+HTTP server is the aggregate `vllm serve` worker itself — there is no separate
+router/frontend process, and srtctl skips NATS/etcd startup.
+
+Use this for aggregate throughput benchmarks where Dynamo orchestration is not
+needed. Disaggregated prefill/decode layouts still require a real router such as
+Dynamo (`frontend.type: dynamo`).
+
+**Requirements**
+
+| Constraint | Value |
+| ---------- | ----- |
+| `backend.type` | `vllm` |
+| Job layout | Aggregate only; no prefill/decode workers |
+| `agg_workers` | Exactly `1` — scale across nodes with `agg_nodes`, not with replicas |
+| `enable_multiple_frontends` | `false` (nginx + multi-router path is unsupported) |
+
+Nothing load-balances between aggregate endpoints here, so `agg_workers: 2` is
+rejected at load time: the extra replica would either idle behind the single
+public address or collide on the port. Use `frontend.type: dynamo` when you want
+several aggregate replicas behind one endpoint.
+
+**Single-node example**
+
+```yaml
+frontend:
+  type: vllm
+  enable_multiple_frontends: false
+
+resources:
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_node: 8
+
+backend:
+  type: vllm
+  vllm_config:
+    aggregated:
+      tensor-parallel-size: 8
+```
+
+**Multi-node example (TP/PP across nodes)**
+
+```yaml
+frontend:
+  type: vllm
+  enable_multiple_frontends: false
+
+resources:
+  agg_nodes: 2
+  agg_workers: 1
+  gpus_per_node: 8
+
+backend:
+  type: vllm
+  vllm_config:
+    aggregated:
+      tensor-parallel-size: 8
+      pipeline-parallel-size: 2
+```
+
+srtctl launches one `vllm serve` process per node. The endpoint leader
+(`node_rank=0`) binds the public OpenAI port; follower ranks run headless engine
+workers. Multi-node coordination flags (`--master-addr`, `--nnodes`,
+`--node-rank`, `--headless`) are derived from the allocated topology — **do not
+set them in the recipe**.
+
+**Topology-managed `vllm_config` keys**
+
+The following keys are owned by srtctl and are stripped at runtime if present in
+`vllm_config.{aggregated,prefill,decode}`:
+
+- `headless`
+- `host`, `port`
+- `master-addr` / `master_addr`
+- `master-port` / `master_port`
+- `nnodes`
+- `node-rank` / `node_rank`
+
+Existing recipes that still contain these keys continue to work (values are
+ignored). `srtctl dry-run` emits a **WARNING** for each one so operators can
+clean up recipes over time.
+
+Health checks, benchmark clients, and `SRT_FRONTEND_HOST` target the **aggregate
+endpoint leader** (the node running the public `vllm serve`), not necessarily the
+Slurm head node.
+
+Compare with `frontend.type: dynamo` + `backend.type: vllm`, which keeps Dynamo as
+the request router and uses `python3 -m dynamo.vllm` workers with NATS/etcd.
 
 ---
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -388,6 +388,10 @@ workers. Multi-node coordination flags (`--master-addr`, `--nnodes`,
 `--node-rank`, `--headless`) are derived from the allocated topology — **do not
 set them in the recipe**.
 
+`master-port` / `master_port` remains an optional recipe override and is passed
+to every node rank. Set it when jobs may share a leader node and need distinct
+vLLM rendezvous ports; otherwise vLLM's default is used.
+
 **Topology-managed `vllm_config` keys**
 
 The following keys are owned by srtctl and are stripped at runtime if present in
@@ -396,7 +400,6 @@ The following keys are owned by srtctl and are stripped at runtime if present in
 - `headless`
 - `host`, `port`
 - `master-addr` / `master_addr`
-- `master-port` / `master_port`
 - `nnodes`
 - `node-rank` / `node_rank`
 

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -56,7 +56,6 @@ _VLLM_ORCHESTRATION_FLAGS = frozenset(
         "host",
         "port",
         "master-addr",
-        "master-port",
         "nnodes",
         "node-rank",
     }
@@ -763,7 +762,7 @@ class VLLMProtocol:
         is_multi_node = len(endpoint_nodes) > 1
 
         # Get leader IP for distributed init
-        leader_ip = get_hostname_ip(endpoint_nodes[0])
+        leader_ip = get_hostname_ip(endpoint_nodes[0], runtime.network_interface)
 
         # Determine model path: HF model ID or container mount path
         # For HF models (hf:prefix), model_path contains the HF model ID (e.g., "facebook/opt-125m")

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -47,6 +47,62 @@ DPLaunchMode = Literal["per_gpu", "per_node"]
 
 logger = logging.getLogger(__name__)
 
+# vLLM CLI flags srtslurm derives from topology/runtime. Recipes may still set
+# these for backward compatibility; dry-run warns and runtime command building
+# strips them so user values cannot override allocation.
+_VLLM_ORCHESTRATION_FLAGS = frozenset(
+    {
+        "headless",
+        "host",
+        "port",
+        "master-addr",
+        "master-port",
+        "nnodes",
+        "node-rank",
+    }
+)
+
+
+def normalize_vllm_config_key(key: str) -> str:
+    """Normalize a vllm_config dict key to kebab-case CLI flag form."""
+    return str(key).replace("_", "-")
+
+
+def pop_vllm_orchestration_flags(config: dict[str, Any]) -> list[str]:
+    """Remove topology-managed vLLM flags from a mode config dict.
+
+    Returns normalized flag names that were present.
+    """
+    found: list[str] = []
+    for key in list(config.keys()):
+        normalized = normalize_vllm_config_key(key)
+        if normalized in _VLLM_ORCHESTRATION_FLAGS:
+            config.pop(key)
+            if normalized not in found:
+                found.append(normalized)
+    return found
+
+
+def find_vllm_orchestration_recipe_flags(backend: VLLMProtocol) -> list[tuple[str, str]]:
+    """Return ``(mode, flag)`` pairs set in recipe ``vllm_config``."""
+    if backend.vllm_config is None:
+        return []
+
+    findings: list[tuple[str, str]] = []
+    for mode_name, mode_config in (
+        ("prefill", backend.vllm_config.prefill),
+        ("decode", backend.vllm_config.decode),
+        ("aggregated", backend.vllm_config.aggregated),
+    ):
+        if not mode_config:
+            continue
+        for key in mode_config:
+            normalized = normalize_vllm_config_key(key)
+            if normalized in _VLLM_ORCHESTRATION_FLAGS:
+                findings.append((mode_name, normalized))
+    return findings
+
+
 # Filename for the mooncake-store JSON config srtslurm writes to log_dir at job
 # start. log_dir is mounted into every worker at /logs, so workers read the JSON
 # from MOONCAKE_STORE_CONFIG_CONTAINER_PATH.
@@ -684,6 +740,7 @@ class VLLMProtocol:
 
         mode = process.endpoint_mode
         config = self.get_config_for_mode(mode)
+        pop_vllm_orchestration_flags(config)
 
         # Determine if multi-node
         endpoint_nodes = list(dict.fromkeys(p.node for p in endpoint_processes))
@@ -717,25 +774,29 @@ class VLLMProtocol:
         if frontend_type == "vllm":
             if mode != "agg":
                 raise ValueError("frontend.type: vllm supports aggregate vLLM jobs only")
-            if is_multi_node:
-                raise ValueError("frontend.type: vllm currently supports single-node aggregate jobs only")
 
-            config.pop("host", None)
-            config.pop("port", None)
             config.pop("connector", None)
             config.setdefault("served-model-name", served_model_name)
 
-            cmd.extend(
-                [
-                    "vllm",
-                    "serve",
-                    model_arg,
-                    "--host",
-                    "0.0.0.0",
-                    "--port",
-                    str(runtime.frontend_port),
-                ]
-            )
+            node_rank = endpoint_nodes.index(process.node)
+            cmd.extend(["vllm", "serve", model_arg])
+            if node_rank == 0:
+                cmd.extend(["--host", "0.0.0.0", "--port", str(runtime.frontend_port)])
+            if is_multi_node:
+                # vLLM-native multi-node serve (torchrun-style): the leader owns
+                # the OpenAI server; other node ranks run headless engine workers.
+                cmd.extend(
+                    [
+                        "--master-addr",
+                        leader_ip,
+                        "--nnodes",
+                        str(len(endpoint_nodes)),
+                        "--node-rank",
+                        str(node_rank),
+                    ]
+                )
+                if node_rank > 0:
+                    cmd.append("--headless")
             if not self.set_cuda_visible_devices:
                 device_ids = ",".join(str(i) for i in sorted(process.gpu_indices))
                 if device_ids:

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -47,9 +47,9 @@ DPLaunchMode = Literal["per_gpu", "per_node"]
 
 logger = logging.getLogger(__name__)
 
-# vLLM CLI flags srtslurm derives from topology/runtime. Recipes may still set
-# these for backward compatibility; dry-run warns and runtime command building
-# strips them so user values cannot override allocation.
+# vLLM CLI flags srtslurm derives for the direct vLLM frontend. Recipes may
+# still set these for backward compatibility; dry-run warns and direct-vLLM
+# command building strips them so user values cannot override allocation.
 _VLLM_ORCHESTRATION_FLAGS = frozenset(
     {
         "headless",
@@ -755,14 +755,18 @@ class VLLMProtocol:
 
         mode = process.endpoint_mode
         config = self.get_config_for_mode(mode)
-        pop_vllm_orchestration_flags(config)
 
         # Determine if multi-node
         endpoint_nodes = list(dict.fromkeys(p.node for p in endpoint_processes))
         is_multi_node = len(endpoint_nodes) > 1
 
-        # Get leader IP for distributed init
-        leader_ip = get_hostname_ip(endpoint_nodes[0], runtime.network_interface)
+        # Direct vLLM rendezvous must use the configured interface. Keep the
+        # existing Dynamo resolution path unchanged to avoid affecting jobs
+        # outside the scope of the direct-vLLM frontend.
+        if frontend_type == "vllm":
+            leader_ip = get_hostname_ip(endpoint_nodes[0], runtime.network_interface)
+        else:
+            leader_ip = get_hostname_ip(endpoint_nodes[0])
 
         # Determine model path: HF model ID or container mount path
         # For HF models (hf:prefix), model_path contains the HF model ID (e.g., "facebook/opt-125m")
@@ -790,6 +794,7 @@ class VLLMProtocol:
             if mode != "agg":
                 raise ValueError("frontend.type: vllm supports aggregate vLLM jobs only")
 
+            pop_vllm_orchestration_flags(config)
             config.pop("connector", None)
             config.setdefault("served-model-name", served_model_name)
 

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -73,31 +73,53 @@ def normalize_vllm_config_key(key: str) -> str:
     return str(key).replace("_", "-")
 
 
-def _pop_flags(config: dict[str, Any], flags: frozenset[str]) -> list[str]:
-    found: list[str] = []
+def _pop_flags(config: dict[str, Any], flags: frozenset[str]) -> dict[str, Any]:
+    found: dict[str, Any] = {}
     for key in list(config.keys()):
         normalized = normalize_vllm_config_key(key)
         if normalized in flags:
-            config.pop(key)
-            if normalized not in found:
-                found.append(normalized)
+            found[normalized] = config.pop(key)
     return found
 
 
-def pop_vllm_orchestration_flags(config: dict[str, Any]) -> list[str]:
+def pop_vllm_orchestration_flags(config: dict[str, Any]) -> dict[str, Any]:
     """Remove topology-managed vLLM flags from a mode config dict.
 
-    Returns normalized flag names that were present.
+    Returns the normalized flag names that were present, mapped to the value the
+    recipe asked for, so callers can report what they overrode.
     """
     return _pop_flags(config, _VLLM_ORCHESTRATION_FLAGS)
 
 
-def pop_vllm_api_server_flags(config: dict[str, Any]) -> list[str]:
+def pop_vllm_api_server_flags(config: dict[str, Any]) -> dict[str, Any]:
     """Remove API-server-only vLLM flags from a mode config dict.
 
-    Returns normalized flag names that were present.
+    Returns the normalized flag names that were present, mapped to the recipe value.
     """
     return _pop_flags(config, _VLLM_API_SERVER_ONLY_FLAGS)
+
+
+def _log_overridden_recipe_flags(
+    overridden: dict[str, Any],
+    effective: dict[str, str],
+    node: str,
+) -> None:
+    """Report recipe flags srtslurm took over, alongside the values it used.
+
+    Without this the override is invisible at runtime: the flag simply vanishes
+    from the worker command and the recipe still claims otherwise.
+    """
+    if not overridden:
+        return
+
+    changes = ", ".join(
+        f"--{flag}={value!s} -> {effective.get(flag, 'not passed')}" for flag, value in overridden.items()
+    )
+    logger.warning(
+        "Overriding topology-managed vllm_config flags on %s: %s. srtslurm derives these from the allocation.",
+        node,
+        changes,
+    )
 
 
 def find_vllm_orchestration_recipe_flags(backend: VLLMProtocol) -> list[tuple[str, str]]:
@@ -794,14 +816,19 @@ class VLLMProtocol:
             if mode != "agg":
                 raise ValueError("frontend.type: vllm supports aggregate vLLM jobs only")
 
-            pop_vllm_orchestration_flags(config)
+            overridden = pop_vllm_orchestration_flags(config)
             config.pop("connector", None)
             config.setdefault("served-model-name", served_model_name)
 
             node_rank = endpoint_nodes.index(process.node)
             cmd.extend(["vllm", "serve", model_arg])
+            # Collected as the command is built so the override report below can
+            # name the value srtslurm actually passed for each flag it took over.
+            srtslurm_owned: dict[str, str] = {}
             if node_rank == 0:
                 cmd.extend(["--host", "0.0.0.0", "--port", str(runtime.frontend_port)])
+                srtslurm_owned["host"] = "0.0.0.0"
+                srtslurm_owned["port"] = str(runtime.frontend_port)
             if is_multi_node:
                 # vLLM-native multi-node serve (torchrun-style): the leader owns
                 # the OpenAI server; other node ranks run headless engine workers.
@@ -815,16 +842,21 @@ class VLLMProtocol:
                         str(node_rank),
                     ]
                 )
+                srtslurm_owned["master-addr"] = leader_ip
+                srtslurm_owned["nnodes"] = str(len(endpoint_nodes))
+                srtslurm_owned["node-rank"] = str(node_rank)
                 if node_rank > 0:
                     cmd.append("--headless")
+                    srtslurm_owned["headless"] = "true"
                     dropped = pop_vllm_api_server_flags(config)
                     if dropped:
                         logger.info(
-                            "Dropping %s on headless node rank %d (%s); API-server flags apply to rank 0 only",
-                            ", ".join(f"--{flag}" for flag in dropped),
+                            "Dropping %s on headless node rank %d (%s); headless ranks run no API server",
+                            ", ".join(f"--{flag}={value!s}" for flag, value in dropped.items()),
                             node_rank,
                             process.node,
                         )
+            _log_overridden_recipe_flags(overridden, srtslurm_owned, process.node)
             if not self.set_cuda_visible_devices:
                 device_ids = ",".join(str(i) for i in sorted(process.gpu_indices))
                 if device_ids:

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -279,10 +279,10 @@ class VLLMProtocol:
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
-    def __post_init__(self) -> None:
-        """Validate flags whose behavior is fixed by the per-node launch topology."""
+    def find_dp_modes(self) -> list[tuple[str, dict[str, Any]]]:
+        """Return ``(mode, config)`` pairs whose recipe config sets data-parallel-size."""
         if self.vllm_config is None:
-            return
+            return []
 
         dp_mode_configs: list[tuple[str, dict[str, Any]]] = []
         for mode_name, mode_config in (
@@ -295,17 +295,15 @@ class VLLMProtocol:
                 for key, value in mode_config.items()
             ):
                 dp_mode_configs.append((mode_name, mode_config))
+        return dp_mode_configs
 
-        if not dp_mode_configs:
-            return
+    def __post_init__(self) -> None:
+        """Validate flags whose behavior is fixed by the per-node launch topology."""
+        dp_mode_configs = self.find_dp_modes()
 
-        if self.dp_launch_mode == "per_gpu":
-            modes = ", ".join(mode_name for mode_name, _ in dp_mode_configs)
-            logger.warning(
-                "vLLM DP mode(s) %s use dp_launch_mode=per_gpu. per_node is the recommended topology "
-                "and will become the default in a future release; set backend.dp_launch_mode: per_node now",
-                modes,
-            )
+        # The per_gpu advisory lives in SrtConfig, which can tell whether the
+        # setting applies at all: a direct vLLM frontend ignores it.
+        if not dp_mode_configs or self.dp_launch_mode == "per_gpu":
             return
 
         hybrid_lb_modes: list[str] = []

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -63,9 +63,26 @@ _VLLM_ORCHESTRATION_FLAGS = frozenset(
 )
 
 
+# vLLM CLI flags that only apply where the OpenAI API server runs. Headless node
+# ranks host engine workers only, and vLLM rejects a positive --api-server-count
+# there instead of ignoring it.
+_VLLM_API_SERVER_ONLY_FLAGS = frozenset({"api-server-count"})
+
+
 def normalize_vllm_config_key(key: str) -> str:
     """Normalize a vllm_config dict key to kebab-case CLI flag form."""
     return str(key).replace("_", "-")
+
+
+def _pop_flags(config: dict[str, Any], flags: frozenset[str]) -> list[str]:
+    found: list[str] = []
+    for key in list(config.keys()):
+        normalized = normalize_vllm_config_key(key)
+        if normalized in flags:
+            config.pop(key)
+            if normalized not in found:
+                found.append(normalized)
+    return found
 
 
 def pop_vllm_orchestration_flags(config: dict[str, Any]) -> list[str]:
@@ -73,14 +90,15 @@ def pop_vllm_orchestration_flags(config: dict[str, Any]) -> list[str]:
 
     Returns normalized flag names that were present.
     """
-    found: list[str] = []
-    for key in list(config.keys()):
-        normalized = normalize_vllm_config_key(key)
-        if normalized in _VLLM_ORCHESTRATION_FLAGS:
-            config.pop(key)
-            if normalized not in found:
-                found.append(normalized)
-    return found
+    return _pop_flags(config, _VLLM_ORCHESTRATION_FLAGS)
+
+
+def pop_vllm_api_server_flags(config: dict[str, Any]) -> list[str]:
+    """Remove API-server-only vLLM flags from a mode config dict.
+
+    Returns normalized flag names that were present.
+    """
+    return _pop_flags(config, _VLLM_API_SERVER_ONLY_FLAGS)
 
 
 def find_vllm_orchestration_recipe_flags(backend: VLLMProtocol) -> list[tuple[str, str]]:
@@ -797,6 +815,14 @@ class VLLMProtocol:
                 )
                 if node_rank > 0:
                     cmd.append("--headless")
+                    dropped = pop_vllm_api_server_flags(config)
+                    if dropped:
+                        logger.info(
+                            "Dropping %s on headless node rank %d (%s); API-server flags apply to rank 0 only",
+                            ", ".join(f"--{flag}" for flag in dropped),
+                            node_rank,
+                            process.node,
+                        )
             if not self.set_cuda_visible_devices:
                 device_ids = ",".join(str(i) for i in sorted(process.gpu_indices))
                 if device_ids:

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -308,7 +308,7 @@ class SweepOrchestrator(
         logger.info("=" * 60)
         logger.info("Connection Commands")
         logger.info("=" * 60)
-        logger.info("Frontend URL: http://%s:%d", self.runtime.nodes.head, FRONTEND_PUBLIC_PORT)
+        logger.info("Frontend URL: http://%s:%d", self._public_api_node(), FRONTEND_PUBLIC_PORT)
         logger.info("")
         logger.info("To connect to head node (%s):", self.runtime.nodes.head)
         logger.info(
@@ -548,7 +548,7 @@ class SweepOrchestrator(
             hc = self.config.health_check
             logger.info("EVAL_ONLY: Waiting for server health before eval...")
             if not wait_for_model(
-                host=self.runtime.nodes.head,
+                host=self._public_api_node(),
                 port=FRONTEND_PUBLIC_PORT,
                 n_prefill=n_prefill,
                 n_decode=n_decode,
@@ -561,7 +561,7 @@ class SweepOrchestrator(
                 logger.error("Server did not become healthy for eval")
                 return 1
         else:
-            if not wait_for_port(self.runtime.nodes.head, FRONTEND_PUBLIC_PORT, timeout=30):
+            if not wait_for_port(self._public_api_node(), FRONTEND_PUBLIC_PORT, timeout=30):
                 logger.error("Server health check failed before eval - skipping")
                 return 1
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -163,16 +163,20 @@ class BenchmarkStageMixin:
         multi-node workers. Only rank zero owns the logical worker endpoint,
         so follower ranks must not be advertised to benchmark clients.
 
-        Dynamo exposes worker metrics on each leader's system port. Other
-        frontends expose them on the worker HTTP port, matching the endpoint
-        selection already used by the profiling integration.
+        Dynamo exposes worker metrics on each leader's system port. Direct
+        vLLM exposes aggregate metrics on the public frontend port, while
+        other frontends expose them on the worker HTTP port.
         """
-        use_sys_port = self.config.frontend.type == "dynamo"
         endpoints: list[tuple[str, str, int]] = []
         for process in self.backend_processes:
             if not process.is_leader:
                 continue
-            port = process.sys_port if use_sys_port else process.http_port
+            if self.config.frontend.type == "dynamo":
+                port = process.sys_port
+            elif self.config.frontend.type == "vllm":
+                port = self.runtime.frontend_port
+            else:
+                port = process.http_port
             if port <= 0:
                 continue
             host = get_hostname_ip(process.node, self.runtime.network_interface)

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -134,6 +134,17 @@ class BenchmarkStageMixin:
             self.backend_processes, placement, self.runtime.nodes.head, kind="frontend.orchestrator_placement"
         )
 
+    def _public_api_node(self) -> str:
+        """Node hosting the public OpenAI HTTP endpoint clients should probe."""
+        if self.config.frontend.type == "vllm" and self.config.resources.num_agg > 0:
+            agg_leaders = sorted(
+                (p for p in self.backend_processes if p.endpoint_mode == "agg" and p.is_leader),
+                key=lambda p: p.endpoint_index,
+            )
+            if len(agg_leaders) == 1:
+                return agg_leaders[0].node
+        return self._orchestrator_node()
+
     def _benchmark_node(self) -> str:
         """Node the benchmark client runs on (honors benchmark.client_placement)."""
         placement = getattr(self.config.benchmark, "client_placement", "head")
@@ -194,7 +205,7 @@ class BenchmarkStageMixin:
 
         hc = self.config.health_check
         if not wait_for_model(
-            host=self._orchestrator_node(),
+            host=self._public_api_node(),
             port=FRONTEND_PUBLIC_PORT,
             n_prefill=n_prefill,
             n_decode=n_decode,
@@ -245,7 +256,7 @@ class BenchmarkStageMixin:
 
         if benchmark_type == "manual":
             logger.info("Benchmark type is 'manual' - server is ready for testing")
-            logger.info("Frontend URL: http://%s:%d", self._orchestrator_node(), FRONTEND_PUBLIC_PORT)
+            logger.info("Frontend URL: http://%s:%d", self._public_api_node(), FRONTEND_PUBLIC_PORT)
             logger.info("Press Ctrl+C to stop the job")
 
             while not stop_event.is_set():
@@ -518,7 +529,7 @@ class BenchmarkStageMixin:
         # a different node than the orchestrator (e.g. client_placement=last_decode
         # with orchestrator_placement=first_decode), "localhost" is wrong — the
         # command should target http://$SRT_FRONTEND_HOST:$SRT_FRONTEND_PORT.
-        env["SRT_FRONTEND_HOST"] = get_hostname_ip(self._orchestrator_node(), self.runtime.network_interface)
+        env["SRT_FRONTEND_HOST"] = get_hostname_ip(self._public_api_node(), self.runtime.network_interface)
         env["SRT_FRONTEND_PORT"] = str(self.runtime.frontend_port)
 
         # Propagate top-level recipe environment to the bench step. Workers

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -196,7 +196,7 @@ def show_config_details(config: SrtConfig) -> None:
     environment variables (global and backend per-mode) so users can verify their
     config is correct before submitting.
     """
-    if config.backend_type == "vllm":
+    if config.backend_type == "vllm" and config.frontend.type == "vllm":
         from srtctl.backends.vllm import find_vllm_orchestration_recipe_flags
 
         orchestration_flags = find_vllm_orchestration_recipe_flags(config.backend)

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -196,6 +196,19 @@ def show_config_details(config: SrtConfig) -> None:
     environment variables (global and backend per-mode) so users can verify their
     config is correct before submitting.
     """
+    if config.backend_type == "vllm":
+        from srtctl.backends.vllm import find_vllm_orchestration_recipe_flags
+
+        orchestration_flags = find_vllm_orchestration_recipe_flags(config.backend)
+        if orchestration_flags:
+            for mode_name, flag_name in orchestration_flags:
+                console.print(
+                    "[yellow]WARNING:[/] "
+                    f"vllm_config.{mode_name}.{flag_name} is set in the recipe but srtslurm "
+                    "derives this from the job topology at runtime; remove it from the recipe "
+                    "to avoid confusion (the configured value is ignored)."
+                )
+
     # --- Container Mounts ---
     mounts_table = Table(title="Container Mounts", show_lines=False, pad_edge=False)
     mounts_table.add_column("Source", style="dim", width=14)

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -196,18 +196,19 @@ def show_config_details(config: SrtConfig) -> None:
     environment variables (global and backend per-mode) so users can verify their
     config is correct before submitting.
     """
-    if config.backend_type == "vllm" and config.frontend.type == "vllm":
-        from srtctl.backends.vllm import find_vllm_orchestration_recipe_flags
+    if config.frontend.type == "vllm":
+        from srtctl.backends.vllm import VLLMProtocol, find_vllm_orchestration_recipe_flags
 
-        orchestration_flags = find_vllm_orchestration_recipe_flags(config.backend)
-        if orchestration_flags:
-            for mode_name, flag_name in orchestration_flags:
-                console.print(
-                    "[yellow]WARNING:[/] "
-                    f"vllm_config.{mode_name}.{flag_name} is set in the recipe but srtslurm "
-                    "derives this from the job topology at runtime; remove it from the recipe "
-                    "to avoid confusion (the configured value is ignored)."
-                )
+        if isinstance(config.backend, VLLMProtocol):
+            orchestration_flags = find_vllm_orchestration_recipe_flags(config.backend)
+            if orchestration_flags:
+                for mode_name, flag_name in orchestration_flags:
+                    console.print(
+                        "[yellow]WARNING:[/] "
+                        f"vllm_config.{mode_name}.{flag_name} is set in the recipe but srtslurm "
+                        "derives this from the job topology at runtime; remove it from the recipe "
+                        "to avoid confusion (the configured value is ignored)."
+                    )
 
     # --- Container Mounts ---
     mounts_table = Table(title="Container Mounts", show_lines=False, pad_edge=False)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1588,6 +1588,29 @@ class SrtConfig:
         self._validate_het_jobs()
         self._validate_trtllm_serve()
         self._validate_vllm_frontend()
+        self._warn_dp_launch_mode()
+
+    def _warn_dp_launch_mode(self):
+        """Nudge vLLM DP recipes toward the per-node launch topology.
+
+        Skipped for frontend.type: vllm, where the setting has no effect —
+        `vllm serve` owns the local DP ranks, so the layout is one process per
+        node whatever dp_launch_mode says.
+        """
+        if self.backend_type != "vllm" or self.frontend.type == "vllm":
+            return
+        if getattr(self.backend, "dp_launch_mode", "per_gpu") != "per_gpu":
+            return
+
+        dp_modes = self.backend.find_dp_modes()
+        if not dp_modes:
+            return
+
+        logger.warning(
+            "vLLM DP mode(s) %s use dp_launch_mode=per_gpu. per_node is the recommended topology "
+            "and will become the default in a future release; set backend.dp_launch_mode: per_node now",
+            ", ".join(mode_name for mode_name, _ in dp_modes),
+        )
 
     def _validate_trtllm_serve(self):
         """Catch trtllm_serve misconfigurations at load time (dry-run) instead of

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1597,9 +1597,9 @@ class SrtConfig:
         `vllm serve` owns the local DP ranks, so the layout is one process per
         node whatever dp_launch_mode says.
         """
-        if self.backend_type != "vllm" or self.frontend.type == "vllm":
+        if not isinstance(self.backend, VLLMProtocol) or self.frontend.type == "vllm":
             return
-        if getattr(self.backend, "dp_launch_mode", "per_gpu") != "per_gpu":
+        if self.backend.dp_launch_mode != "per_gpu":
             return
 
         dp_modes = self.backend.find_dp_modes()

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1630,10 +1630,14 @@ class SrtConfig:
             )
         if self.resources.is_disaggregated:
             raise ValidationError("frontend.type: vllm supports aggregate jobs only, not disaggregated layouts")
-        if self.resources.num_agg < 1:
-            raise ValidationError("frontend.type: vllm requires resources.agg_workers >= 1")
-        if (self.resources.agg_nodes or 1) != 1:
-            raise ValidationError("frontend.type: vllm currently supports single-node aggregate jobs only")
+        if self.resources.num_agg != 1:
+            raise ValidationError(
+                f"frontend.type: vllm supports exactly one aggregate worker, got {self.resources.num_agg}. "
+                "vllm serve owns the public port directly and there is no router to load-balance "
+                "replicas, so extra workers would either idle or collide on the port. "
+                "Use frontend.type: dynamo to run multiple aggregate workers, or scale a single "
+                "worker across nodes with resources.agg_nodes."
+            )
 
     def _validate_het_jobs(self):
         """When ``resources.het_jobs`` is set to True, enforce supported shape.

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -85,6 +85,8 @@ def generate_telemetry_config(
         )
 
     for process in sorted(processes, key=lambda p: (p.endpoint_mode, p.endpoint_index, p.node_rank, p.node)):
+        if frontend_type == "vllm" and process.endpoint_mode == "agg" and not process.is_leader:
+            continue
         node_ip = get_hostname_ip(process.node, runtime.network_interface)
         port = FRONTEND_PUBLIC_PORT if frontend_type == "vllm" and process.endpoint_mode == "agg" else process.sys_port
         node_metadata = {

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -106,7 +106,20 @@ def generate_telemetry_config(
             )
         )
 
-    for frontend_index, node in enumerate(frontend_topology.frontend_nodes):
+    frontend_nodes = frontend_topology.frontend_nodes
+    if frontend_type == "vllm":
+        # Direct vLLM has no separate frontend process. Its public endpoint is
+        # the aggregate leader, which may differ from the Slurm/orchestrator
+        # head recorded in FrontendTopology.
+        agg_leader_nodes = [
+            process.node
+            for process in sorted(processes, key=lambda p: (p.endpoint_index, p.node_rank, p.node))
+            if process.endpoint_mode == "agg" and process.is_leader
+        ]
+        if agg_leader_nodes:
+            frontend_nodes = list(dict.fromkeys(agg_leader_nodes))
+
+    for frontend_index, node in enumerate(frontend_nodes):
         node_ip = get_hostname_ip(node, runtime.network_interface)
         node_metadata = {
             "frontend_index": str(frontend_index),

--- a/src/srtctl/frontends/vllm.py
+++ b/src/srtctl/frontends/vllm.py
@@ -27,9 +27,10 @@ logger = logging.getLogger(__name__)
 class VLLMFrontend:
     """Direct vLLM OpenAI server frontend.
 
-    This frontend is intentionally narrow: aggregate vLLM jobs only, with the
-    backend worker binding the public OpenAI port directly. Disaggregated vLLM
-    still needs a real router/orchestrator such as Dynamo.
+    This frontend is intentionally narrow: a single aggregate vLLM worker, with
+    that worker binding the public OpenAI port directly. Disaggregated layouts
+    and multiple aggregate replicas still need a real router/orchestrator such
+    as Dynamo, since nothing here load-balances between endpoints.
     """
 
     @property
@@ -82,8 +83,13 @@ class VLLMFrontend:
                 "frontend.type: vllm binds vllm serve directly to the public port; "
                 "set frontend.enable_multiple_frontends: false"
             )
-        if config.resources.is_disaggregated or config.resources.num_agg < 1:
+        if config.resources.is_disaggregated:
             raise ValueError("frontend.type: vllm supports aggregate vLLM jobs only")
+        if config.resources.num_agg != 1:
+            raise ValueError(
+                f"frontend.type: vllm supports exactly one aggregate worker, got {config.resources.num_agg}; "
+                "use frontend.type: dynamo to route between multiple workers"
+            )
 
         logger.info("frontend.type=vllm: no separate frontend process; vllm serve owns port %d", topology.public_port)
         return []

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -254,6 +254,7 @@ class TestCustomBenchmarkRunner:
             ),
             frontend=SimpleNamespace(type=frontend_type),
             profiling=SimpleNamespace(enabled=False),
+            resources=SimpleNamespace(num_agg=sum(p.endpoint_mode == "agg" and p.is_leader for p in processes)),
         )
         stage.runtime = SimpleNamespace(
             environment={},
@@ -357,6 +358,28 @@ class TestCustomBenchmarkRunner:
         assert "SRT_PREFILL_ENDPOINTS" not in env
         assert "SRT_DECODE_ENDPOINTS" not in env
         assert env["AIPERF_SERVER_METRICS_URLS"] == "http://ip-node-a:6100/metrics"
+
+    def test_direct_vllm_aggregated_worker_endpoint_uses_frontend_port(self):
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.custom import CustomBenchmarkRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "agg", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "agg", 0, node_rank=1),
+        ]
+        stage = self._benchmark_stage("vllm", processes)
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(CustomBenchmarkRunner())
+
+        assert env["SRT_AGG_IPS"] == "ip-node-a"
+        assert env["SRT_AGG_ENDPOINTS"] == "ip-node-a:8000"
+        assert env["AIPERF_SERVER_METRICS_URLS"] == "http://ip-node-a:8000/metrics"
 
     def test_worker_endpoint_order_keeps_colocated_logical_workers_aligned(self):
         from unittest.mock import patch

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3337,3 +3337,71 @@ class TestDirectVllmMultiNode:
         assert "10.9.9.9" not in leader_cmd
         assert "--master-port" not in leader_cmd
         assert "--master-port" not in worker_cmd
+
+    def test_direct_vllm_keeps_api_server_count_on_leader_only(self):
+        """vLLM rejects --api-server-count alongside --headless, so only rank 0 keeps it.
+
+        The flag matters under DP: without it vLLM defaults to one API server per
+        DP rank and then disables throughput/KV-cache stat logging.
+        """
+        leader, worker = self._make_processes(["node0", "node1"])
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                aggregated={
+                    "data-parallel-size": 16,
+                    "tensor-parallel-size": 1,
+                    "api-server-count": 1,
+                }
+            )
+        )
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.frontend_port = 9000
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            leader_cmd = backend.build_worker_command(
+                process=leader,
+                endpoint_processes=[leader, worker],
+                runtime=runtime,
+                frontend_type="vllm",
+            )
+            worker_cmd = backend.build_worker_command(
+                process=worker,
+                endpoint_processes=[leader, worker],
+                runtime=runtime,
+                frontend_type="vllm",
+            )
+
+        assert leader_cmd[leader_cmd.index("--api-server-count") + 1] == "1"
+        assert "--api-server-count" not in worker_cmd
+        assert worker_cmd[worker_cmd.index("--data-parallel-size") + 1] == "16"
+
+    def test_direct_vllm_single_node_keeps_api_server_count(self):
+        """Single-node jobs have no headless rank, so the recipe value is untouched."""
+        (leader,) = self._make_processes(["node0"])
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+
+        backend = VLLMProtocol(vllm_config=VLLMServerConfig(aggregated={"api-server-count": 1}))
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.frontend_port = 9000
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            cmd = backend.build_worker_command(
+                process=leader,
+                endpoint_processes=[leader],
+                runtime=runtime,
+                frontend_type="vllm",
+            )
+
+        assert cmd[cmd.index("--api-server-count") + 1] == "1"

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3342,6 +3342,49 @@ class TestDirectVllmMultiNode:
         assert worker_cmd[worker_cmd.index("--master-port") + 1] == "26300"
         assert mock_get_hostname_ip.call_args_list == [call("node0", "ib0"), call("node0", "ib0")]
 
+    def test_dynamo_keeps_recipe_orchestration_flags_and_default_resolution(self):
+        """Direct-vLLM topology ownership must not change existing Dynamo commands."""
+        leader, worker = self._make_processes(["node0", "node1"])
+        from pathlib import Path
+        from unittest.mock import MagicMock, call, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                aggregated={
+                    "tensor-parallel-size": 8,
+                    "headless": True,
+                    "host": "10.9.9.8",
+                    "port": 9001,
+                    "master-addr": "10.9.9.9",
+                    "nnodes": 99,
+                    "node-rank": 42,
+                }
+            )
+        )
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.network_interface = "ib0"
+        runtime.request_plane = "nats"
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1") as mock_get_hostname_ip:
+            cmd = backend.build_worker_command(
+                process=leader,
+                endpoint_processes=[leader, worker],
+                runtime=runtime,
+                frontend_type="dynamo",
+            )
+
+        assert mock_get_hostname_ip.call_args_list == [call("node0")]
+        assert cmd[cmd.index("--host") + 1] == "10.9.9.8"
+        assert cmd[cmd.index("--port") + 1] == "9001"
+        assert "10.9.9.9" in cmd
+        assert "99" in cmd
+        assert "42" in cmd
+        assert "--headless" in cmd
+
     def test_no_dp_launch_mode_warning_for_direct_vllm(self, caplog):
         """dp_launch_mode does not apply here: vllm serve owns the local DP ranks."""
         import logging

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3342,6 +3342,53 @@ class TestDirectVllmMultiNode:
         assert worker_cmd[worker_cmd.index("--master-port") + 1] == "26300"
         assert mock_get_hostname_ip.call_args_list == [call("node0", "ib0"), call("node0", "ib0")]
 
+    def test_direct_vllm_logs_overridden_recipe_flags(self, caplog):
+        """A flag that silently vanishes is undebuggable, so report recipe -> effective."""
+        import logging
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+
+        leader, worker = self._make_processes(["node0", "node1"])
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                aggregated={"headless": True, "master-addr": "10.9.9.9", "nnodes": 8}
+            )
+        )
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.frontend_port = 9000
+        runtime.network_interface = "ib0"
+
+        with (
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+            caplog.at_level(logging.WARNING, logger="srtctl.backends.vllm"),
+        ):
+            backend.build_worker_command(
+                process=leader,
+                endpoint_processes=[leader, worker],
+                runtime=runtime,
+                frontend_type="vllm",
+            )
+
+        assert "--master-addr=10.9.9.9 -> 10.0.0.1" in caplog.text
+        assert "--nnodes=8 -> 2" in caplog.text
+        # The leader owns the API server, so the recipe's headless maps to nothing.
+        assert "--headless=True -> not passed" in caplog.text
+
+    def test_direct_vllm_override_report_is_quiet_without_recipe_flags(self, caplog):
+        """No report when the recipe leaves the topology flags alone."""
+        import logging
+
+        leader, worker = self._make_processes(["node0", "node1"])
+
+        with caplog.at_level(logging.WARNING, logger="srtctl.backends.vllm"):
+            self._build_command(leader, [leader, worker])
+
+        assert "Overriding topology-managed" not in caplog.text
+
     def test_dynamo_keeps_recipe_orchestration_flags_and_default_resolution(self):
         """Direct-vLLM topology ownership must not change existing Dynamo commands."""
         leader, worker = self._make_processes(["node0", "node1"])

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -2103,6 +2103,7 @@ class TestVLLMDataParallelMode:
         runtime.model_path = Path("/model")
         runtime.is_hf_model = False
         runtime.frontend_port = 9000
+        runtime.network_interface = "eth0"
 
         with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
             cmd = backend.build_worker_command(
@@ -3213,6 +3214,7 @@ class TestDirectVllmMultiNode:
         runtime.model_path = Path("/model")
         runtime.is_hf_model = False
         runtime.frontend_port = 9000
+        runtime.network_interface = "eth0"
 
         with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
             return backend.build_worker_command(
@@ -3293,8 +3295,8 @@ class TestDirectVllmMultiNode:
         assert "--master-addr" not in cmd
         assert "--headless" not in cmd
 
-    def test_direct_vllm_strips_recipe_orchestration_flags(self):
-        """Recipe orchestration flags are ignored; srtslurm owns leader/headless wiring."""
+    def test_direct_vllm_strips_derived_flags_but_keeps_master_port(self):
+        """Topology flags are ignored, while the rendezvous-port override reaches every rank."""
         leader, worker = self._make_processes(["node0", "node1"])
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
 
@@ -3310,14 +3312,15 @@ class TestDirectVllmMultiNode:
             )
         )
         from pathlib import Path
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock, call, patch
 
         runtime = MagicMock()
         runtime.model_path = Path("/model")
         runtime.is_hf_model = False
         runtime.frontend_port = 9000
+        runtime.network_interface = "ib0"
 
-        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1") as mock_get_hostname_ip:
             leader_cmd = backend.build_worker_command(
                 process=leader,
                 endpoint_processes=[leader, worker],
@@ -3335,8 +3338,9 @@ class TestDirectVllmMultiNode:
         assert worker_cmd.count("--headless") == 1
         assert leader_cmd[leader_cmd.index("--master-addr") + 1] == "10.0.0.1"
         assert "10.9.9.9" not in leader_cmd
-        assert "--master-port" not in leader_cmd
-        assert "--master-port" not in worker_cmd
+        assert leader_cmd[leader_cmd.index("--master-port") + 1] == "26300"
+        assert worker_cmd[worker_cmd.index("--master-port") + 1] == "26300"
+        assert mock_get_hostname_ip.call_args_list == [call("node0", "ib0"), call("node0", "ib0")]
 
     def test_no_dp_launch_mode_warning_for_direct_vllm(self, caplog):
         """dp_launch_mode does not apply here: vllm serve owns the local DP ranks."""

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3338,6 +3338,42 @@ class TestDirectVllmMultiNode:
         assert "--master-port" not in leader_cmd
         assert "--master-port" not in worker_cmd
 
+    def test_no_dp_launch_mode_warning_for_direct_vllm(self, caplog):
+        """dp_launch_mode does not apply here: vllm serve owns the local DP ranks."""
+        import logging
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.schema import FrontendConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        with caplog.at_level(logging.WARNING, logger="srtctl.core.schema"):
+            SrtConfig(
+                name="t",
+                model=ModelConfig(path="/m", container="/c.sqsh", precision="fp4"),
+                resources=ResourceConfig(gpu_type="b200", gpus_per_node=8, agg_nodes=2, agg_workers=1),
+                frontend=FrontendConfig(type="vllm", enable_multiple_frontends=False),
+                backend=VLLMProtocol(vllm_config=VLLMServerConfig(aggregated={"data-parallel-size": 16})),
+            )
+
+        assert "dp_launch_mode" not in caplog.text
+
+    def test_dp_launch_mode_warning_still_fires_for_dynamo(self, caplog):
+        """The advisory is still useful where the setting picks the process layout."""
+        import logging
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.schema import FrontendConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        with caplog.at_level(logging.WARNING, logger="srtctl.core.schema"):
+            SrtConfig(
+                name="t",
+                model=ModelConfig(path="/m", container="/c.sqsh", precision="fp4"),
+                resources=ResourceConfig(gpu_type="b200", gpus_per_node=8, agg_nodes=2, agg_workers=1),
+                frontend=FrontendConfig(type="dynamo"),
+                backend=VLLMProtocol(vllm_config=VLLMServerConfig(aggregated={"data-parallel-size": 16})),
+            )
+
+        assert "dp_launch_mode=per_gpu" in caplog.text
+
     def test_direct_vllm_keeps_api_server_count_on_leader_only(self):
         """vLLM rejects --api-server-count alongside --headless, so only rank 0 keeps it.
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3156,3 +3156,184 @@ class TestExtraMountExpansion:
 
             assert extra_root.resolve() in runtime.container_mounts
             assert runtime.container_mounts[extra_root.resolve()] == Path("/extra")
+
+
+class TestDirectVllmMultiNode:
+    """Multi-node aggregate support for the direct vllm frontend."""
+
+    def _make_config(self, **resource_overrides):
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.schema import FrontendConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        resources_kwargs = {
+            "gpu_type": "b200",
+            "gpus_per_node": 8,
+            "agg_nodes": 2,
+            "agg_workers": 1,
+        }
+        resources_kwargs.update(resource_overrides)
+        return SrtConfig(
+            name="t",
+            model=ModelConfig(path="/m", container="/c.sqsh", precision="fp4"),
+            resources=ResourceConfig(**resources_kwargs),
+            frontend=FrontendConfig(type="vllm", enable_multiple_frontends=False),
+            backend=VLLMProtocol(
+                vllm_config=VLLMServerConfig(aggregated={"tensor-parallel-size": 8})
+            ),
+        )
+
+    def _make_processes(self, nodes):
+        from srtctl.core.topology import Process
+
+        return [
+            Process(
+                node=node,
+                gpu_indices=frozenset(range(8)),
+                sys_port=8081,
+                http_port=0,
+                endpoint_mode="agg",
+                endpoint_index=0,
+                node_rank=rank,
+            )
+            for rank, node in enumerate(nodes)
+        ]
+
+    def _build_command(self, process, endpoint_processes):
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                aggregated={"tensor-parallel-size": 8, "pipeline-parallel-size": 2}
+            )
+        )
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.frontend_port = 9000
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            return backend.build_worker_command(
+                process=process,
+                endpoint_processes=endpoint_processes,
+                runtime=runtime,
+                frontend_type="vllm",
+            )
+
+    def test_schema_accepts_multi_node_aggregate(self):
+        """agg_nodes > 1 no longer trips the vllm-frontend load-time validation."""
+        cfg = self._make_config()
+        assert cfg.resources.agg_nodes == 2
+        assert cfg.frontend.type == "vllm"
+
+    def test_schema_still_rejects_disaggregated(self):
+        import pytest
+        from marshmallow import ValidationError
+
+        with pytest.raises(ValidationError, match="aggregate jobs only"):
+            self._make_config(
+                agg_nodes=None,
+                agg_workers=None,
+                prefill_nodes=1,
+                decode_nodes=1,
+                prefill_workers=1,
+                decode_workers=1,
+            )
+
+    def test_schema_rejects_multiple_agg_workers(self):
+        """Extra replicas have no router, so point the user at the dynamo frontend."""
+        import pytest
+        from marshmallow import ValidationError
+
+        with pytest.raises(ValidationError, match="frontend.type: dynamo"):
+            self._make_config(agg_workers=2)
+
+    def test_multi_node_leader_owns_port_and_coordination(self):
+        """Rank 0 keeps the OpenAI port and gets the torchrun-style flags."""
+        leader, worker = self._make_processes(["node0", "node1"])
+
+        cmd = self._build_command(leader, [leader, worker])
+
+        assert cmd[:3] == ["vllm", "serve", "/model"]
+        assert cmd[cmd.index("--host") + 1] == "0.0.0.0"
+        assert cmd[cmd.index("--port") + 1] == "9000"
+        assert cmd[cmd.index("--master-addr") + 1] == "10.0.0.1"
+        assert cmd[cmd.index("--nnodes") + 1] == "2"
+        assert cmd[cmd.index("--node-rank") + 1] == "0"
+        assert "--headless" not in cmd
+        assert "dynamo.vllm" not in cmd
+        assert "--request-plane" not in cmd
+
+    def test_multi_node_nonleader_runs_headless_without_port(self):
+        """Ranks > 0 are headless engine workers and must not bind the API port."""
+        leader, worker = self._make_processes(["node0", "node1"])
+
+        cmd = self._build_command(worker, [leader, worker])
+
+        assert cmd[:3] == ["vllm", "serve", "/model"]
+        assert "--headless" in cmd
+        assert cmd[cmd.index("--node-rank") + 1] == "1"
+        assert cmd[cmd.index("--nnodes") + 1] == "2"
+        assert cmd[cmd.index("--master-addr") + 1] == "10.0.0.1"
+        assert "--host" not in cmd
+        assert "--port" not in cmd
+
+    def test_single_node_command_has_no_multinode_flags(self):
+        """The original single-node command shape is unchanged."""
+        (leader,) = self._make_processes(["node0"])
+
+        cmd = self._build_command(leader, [leader])
+
+        assert cmd[:3] == ["vllm", "serve", "/model"]
+        assert cmd[cmd.index("--port") + 1] == "9000"
+        assert "--nnodes" not in cmd
+        assert "--node-rank" not in cmd
+        assert "--master-addr" not in cmd
+        assert "--headless" not in cmd
+
+    def test_direct_vllm_strips_recipe_orchestration_flags(self):
+        """Recipe orchestration flags are ignored; srtslurm owns leader/headless wiring."""
+        leader, worker = self._make_processes(["node0", "node1"])
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                aggregated={
+                    "tensor-parallel-size": 8,
+                    "pipeline-parallel-size": 2,
+                    "headless": True,
+                    "master-addr": "10.9.9.9",
+                    "master-port": 26300,
+                }
+            )
+        )
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.frontend_port = 9000
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            leader_cmd = backend.build_worker_command(
+                process=leader,
+                endpoint_processes=[leader, worker],
+                runtime=runtime,
+                frontend_type="vllm",
+            )
+            worker_cmd = backend.build_worker_command(
+                process=worker,
+                endpoint_processes=[leader, worker],
+                runtime=runtime,
+                frontend_type="vllm",
+            )
+
+        assert leader_cmd.count("--headless") == 0
+        assert worker_cmd.count("--headless") == 1
+        assert leader_cmd[leader_cmd.index("--master-addr") + 1] == "10.0.0.1"
+        assert "10.9.9.9" not in leader_cmd
+        assert "--master-port" not in leader_cmd
+        assert "--master-port" not in worker_cmd

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -449,3 +449,66 @@ class TestDryRunRemapRoot:
         show_config_details(config)
         output = capsys.readouterr().out
         assert "ENROOT_REMAP_ROOT" not in output
+
+
+class TestDryRunVllmOrchestrationWarnings:
+    """Dry-run warns when recipes set topology-managed vLLM flags."""
+
+    def test_orchestration_flags_emit_warnings(self, capsys):
+        config = _make_config(
+            {
+                "resources": {
+                    "gpu_type": "b200",
+                    "gpus_per_node": 8,
+                    "prefill_nodes": None,
+                    "decode_nodes": None,
+                    "prefill_workers": None,
+                    "decode_workers": None,
+                    "agg_nodes": 2,
+                    "agg_workers": 1,
+                },
+                "frontend": {"type": "vllm", "enable_multiple_frontends": False},
+                "backend": {
+                    "type": "vllm",
+                    "vllm_config": {
+                        "aggregated": {
+                            "tensor-parallel-size": 8,
+                            "headless": True,
+                            "master-addr": "10.9.9.9",
+                            "master-port": 26300,
+                        }
+                    },
+                },
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "WARNING:" in output
+        assert "vllm_config.aggregated.headless" in output
+        assert "vllm_config.aggregated.master-addr" in output
+        assert "vllm_config.aggregated.master-port" in output
+
+    def test_clean_recipe_has_no_orchestration_warnings(self, capsys):
+        config = _make_config(
+            {
+                "resources": {
+                    "gpu_type": "b200",
+                    "gpus_per_node": 8,
+                    "prefill_nodes": None,
+                    "decode_nodes": None,
+                    "prefill_workers": None,
+                    "decode_workers": None,
+                    "agg_nodes": 2,
+                    "agg_workers": 1,
+                },
+                "frontend": {"type": "vllm", "enable_multiple_frontends": False},
+                "backend": {
+                    "type": "vllm",
+                    "vllm_config": {"aggregated": {"tensor-parallel-size": 8}},
+                },
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "vllm_config.aggregated.headless" not in output
+        assert "derives this from the job topology" not in output

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -486,7 +486,7 @@ class TestDryRunVllmOrchestrationWarnings:
         assert "WARNING:" in output
         assert "vllm_config.aggregated.headless" in output
         assert "vllm_config.aggregated.master-addr" in output
-        assert "vllm_config.aggregated.master-port" in output
+        assert "vllm_config.aggregated.master-port" not in output
 
     def test_clean_recipe_has_no_orchestration_warnings(self, capsys):
         config = _make_config(

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -512,3 +512,28 @@ class TestDryRunVllmOrchestrationWarnings:
         output = capsys.readouterr().out
         assert "vllm_config.aggregated.headless" not in output
         assert "derives this from the job topology" not in output
+
+    def test_dynamo_recipe_has_no_direct_vllm_orchestration_warning(self, capsys):
+        config = _make_config(
+            {
+                "resources": {
+                    "gpu_type": "b200",
+                    "gpus_per_node": 8,
+                    "prefill_nodes": None,
+                    "decode_nodes": None,
+                    "prefill_workers": None,
+                    "decode_workers": None,
+                    "agg_nodes": 2,
+                    "agg_workers": 1,
+                },
+                "frontend": {"type": "dynamo"},
+                "backend": {
+                    "type": "vllm",
+                    "vllm_config": {"aggregated": {"master-addr": "10.9.9.9"}},
+                },
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "vllm_config.aggregated.master-addr" not in output
+        assert "configured value is ignored" not in output

--- a/tests/test_node_placement.py
+++ b/tests/test_node_placement.py
@@ -160,3 +160,54 @@ def test_benchmark_env_injects_frontend_host():
         env = orch._get_benchmark_env(runner)
     assert env["SRT_FRONTEND_HOST"] == "ip-g0"
     assert env["SRT_FRONTEND_PORT"] == "8000"
+
+
+def _agg_vllm_config() -> SrtConfig:
+    data = {
+        "name": "test",
+        "model": {"path": "/models/test", "container": "test.sqsh", "precision": "fp4"},
+        "resources": {
+            "gpu_type": "b200",
+            "gpus_per_node": 8,
+            "agg_nodes": 2,
+            "agg_workers": 1,
+        },
+        "backend": {"type": "vllm"},
+        "frontend": {"type": "vllm", "enable_multiple_frontends": False},
+        "benchmark": {"type": "custom", "command": "true"},
+    }
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        yaml.dump(data, f)
+        f.flush()
+        path = f.name
+    return SrtConfig.from_yaml(Path(path))
+
+
+_AGG_PROCS = [
+    Process(
+        node="g0",
+        gpu_indices=frozenset(range(8)),
+        sys_port=8081,
+        http_port=0,
+        endpoint_mode="agg",
+        endpoint_index=0,
+        node_rank=0,
+    ),
+    Process(
+        node="g1",
+        gpu_indices=frozenset(range(8)),
+        sys_port=8082,
+        http_port=0,
+        endpoint_mode="agg",
+        endpoint_index=0,
+        node_rank=1,
+    ),
+]
+
+
+def test_public_api_node_for_direct_vllm_agg_uses_leader_not_head():
+    """Direct vLLM serve binds the public port on the agg endpoint leader."""
+    orch = SweepOrchestrator(config=_agg_vllm_config(), runtime=_runtime(["p0", "g0", "g1"]))
+    with patch.object(type(orch), "backend_processes", new_callable=PropertyMock, return_value=_AGG_PROCS):
+        assert orch._orchestrator_node() == "p0"
+        assert orch._public_api_node() == "g0"

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -418,7 +418,7 @@ class TestVllmNsysProfilerConfig:
         from srtctl.backends.vllm import VLLMProtocol, VLLMServerConfig
         from srtctl.core.topology import Process
 
-        monkeypatch.setattr(slurm_mod, "get_hostname_ip", lambda node: "10.0.0.1")
+        monkeypatch.setattr(slurm_mod, "get_hostname_ip", lambda node, interface=None: "10.0.0.1")
 
         backend = VLLMProtocol(vllm_config=VLLMServerConfig(decode=decode_cfg or {"tensor-parallel-size": 1}))
         process = Process(
@@ -429,7 +429,12 @@ class TestVllmNsysProfilerConfig:
             endpoint_mode="decode",
             endpoint_index=0,
         )
-        runtime = SimpleNamespace(model_path=Path("/model"), is_hf_model=False, request_plane="nats")
+        runtime = SimpleNamespace(
+            model_path=Path("/model"),
+            is_hf_model=False,
+            request_plane="nats",
+            network_interface="eth0",
+        )
         return backend.build_worker_command(
             process=process,
             endpoint_processes=[process],

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -108,8 +108,9 @@ class TestTelemetryConfigGeneration:
         assert 'name = "frontend0"' in config_text
 
     @patch("srtctl.core.telemetry.get_hostname_ip")
-    def test_vllm_frontend_skips_nonleader_agg_metrics(self, mock_get_hostname_ip):
+    def test_vllm_frontend_targets_only_agg_leader_metrics(self, mock_get_hostname_ip):
         mock_get_hostname_ip.side_effect = lambda host, interface=None: {
+            "head": "10.0.0.10",
             "node-a": "10.0.0.1",
             "node-b": "10.0.0.2",
         }[host]
@@ -146,7 +147,7 @@ class TestTelemetryConfigGeneration:
         ]
         topology = FrontendTopology(
             nginx_node=None,
-            frontend_nodes=["node-a"],
+            frontend_nodes=["head"],
             frontend_port=8000,
             public_port=8000,
         )
@@ -161,6 +162,9 @@ class TestTelemetryConfigGeneration:
 
         assert 'name = "backend_agg0_rank0"' in config_text
         assert 'url = "http://10.0.0.1:8000/metrics"' in config_text
+        assert 'name = "frontend0"' in config_text
+        assert config_text.count('url = "http://10.0.0.1:8000/metrics"') == 2
+        assert "10.0.0.10:8000" not in config_text
         assert "backend_agg0_rank1" not in config_text
         assert "10.0.0.2:8000" not in config_text
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -107,6 +107,63 @@ class TestTelemetryConfigGeneration:
         assert '"cluster" = "pdx"' in config_text
         assert 'name = "frontend0"' in config_text
 
+    @patch("srtctl.core.telemetry.get_hostname_ip")
+    def test_vllm_frontend_skips_nonleader_agg_metrics(self, mock_get_hostname_ip):
+        mock_get_hostname_ip.side_effect = lambda host, interface=None: {
+            "node-a": "10.0.0.1",
+            "node-b": "10.0.0.2",
+        }[host]
+
+        telemetry = TelemetryConfig(
+            enabled=True,
+            container_image="telemetry:latest",
+            dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
+            node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
+        )
+        runtime = MagicMock()
+        runtime.job_id = "12345"
+        runtime.run_name = "test_12345"
+        runtime.network_interface = "eth0"
+        processes = [
+            Process(
+                node="node-a",
+                gpu_indices=frozenset(range(8)),
+                sys_port=8081,
+                http_port=0,
+                endpoint_mode="agg",
+                endpoint_index=0,
+                node_rank=0,
+            ),
+            Process(
+                node="node-b",
+                gpu_indices=frozenset(range(8)),
+                sys_port=8082,
+                http_port=0,
+                endpoint_mode="agg",
+                endpoint_index=0,
+                node_rank=1,
+            ),
+        ]
+        topology = FrontendTopology(
+            nginx_node=None,
+            frontend_nodes=["node-a"],
+            frontend_port=8000,
+            public_port=8000,
+        )
+
+        config_text = generate_telemetry_config(
+            processes=processes,
+            frontend_topology=topology,
+            runtime=runtime,
+            telemetry=telemetry,
+            frontend_type="vllm",
+        )
+
+        assert 'name = "backend_agg0_rank0"' in config_text
+        assert 'url = "http://10.0.0.1:8000/metrics"' in config_text
+        assert "backend_agg0_rank1" not in config_text
+        assert "10.0.0.2:8000" not in config_text
+
 
 class TestTelemetryStageMixin:
     """Telemetry stage startup."""


### PR DESCRIPTION
Add vllm frontend support for aggregated multi-node vllm jobs. Initial work on adding support vllm frontend for aggregated **single-node** vllm jobs has been done in https://github.com/NVIDIA/srt-slurm/pull/278. Then in srt-slurm [fork](https://github.com/functionstackx/srt-slurm-nv) @functionstackx added support for multi-node case https://github.com/functionstackx/srt-slurm-nv/pull/1 (which is the base for this PR but it has been extended a lot; also improves docs).

This vllm frontend support is required to make reproducible Kimi-K3 multi-node recipes uploaded to SA here https://github.com/SemiAnalysisAI/InferenceX/pull/2391