### PR TITLE
Support vLLM DP and TP benchmark runs

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -479,6 +479,11 @@ class VLLMProtocol:
         config = self.get_config_for_mode(mode)
         return config.get("data-parallel-size") or config.get("data_parallel_size")
 
+    def _get_tp_size(self, mode: WorkerMode) -> int:
+        """Get the tensor-parallel-size for a mode."""
+        config = self.get_config_for_mode(mode)
+        return config.get("tensor-parallel-size") or config.get("tensor_parallel_size") or 1
+
     def should_set_cuda_visible_devices(self, process: Process) -> bool:
         """Whether worker_stage should set CUDA_VISIBLE_DEVICES.
 
@@ -624,13 +629,20 @@ class VLLMProtocol:
                 continue
 
             dp_size = self._get_dp_size(endpoint.mode) or endpoint.total_gpus
-            if dp_size != endpoint.total_gpus:
+            tp_size = self._get_tp_size(endpoint.mode)
+            if dp_size * tp_size != endpoint.total_gpus:
                 raise ValueError(
-                    f"{endpoint.mode} data-parallel-size={dp_size} does not match "
-                    f"the endpoint's {endpoint.total_gpus} allocated GPUs"
+                    f"{endpoint.mode} data-parallel-size={dp_size} and tensor-parallel-size={tp_size} "
+                    f"do not match the endpoint's {endpoint.total_gpus} allocated GPUs"
                 )
 
-            local_dp_size = len(endpoint.gpu_indices)
+            if len(endpoint.gpu_indices) % tp_size != 0:
+                raise ValueError(
+                    f"{endpoint.mode} tensor-parallel-size={tp_size} does not fit "
+                    f"the endpoint's {len(endpoint.gpu_indices)} GPUs per node"
+                )
+
+            local_dp_size = len(endpoint.gpu_indices) // tp_size
             dp_rpc_port = port_allocator.next_dp_rpc_port(endpoint.leader_node)
             nixl_base_port = port_allocator.next_nixl_port_block(dp_size)
             dp_start_rank = 0
@@ -782,6 +794,7 @@ class VLLMProtocol:
             rpc_port_snake = config.pop("data_parallel_rpc_port", None)
             config_dp_rpc_port = rpc_port_kebab or rpc_port_snake
             dp_rpc_port = process.dp_rpc_port or config_dp_rpc_port or VLLM_DATA_PARALLEL_RPC_PORT
+            local_dp_size = len(process.gpu_indices) // self._get_tp_size(mode)
 
             # These values are derived from the allocated process topology. Hybrid LB
             # is required so every node-local Dynamo runtime registers with the frontend.
@@ -796,7 +809,7 @@ class VLLMProtocol:
             cmd.extend(
                 [
                     "--data-parallel-size-local",
-                    str(len(process.gpu_indices)),
+                    str(local_dp_size),
                     "--data-parallel-start-rank",
                     str(process.node_rank),
                     "--data-parallel-address",

--- a/src/srtctl/benchmarks/scripts/lib/profiling.sh
+++ b/src/srtctl/benchmarks/scripts/lib/profiling.sh
@@ -76,7 +76,7 @@ profiling__start_profile_on_worker() {
 
     local start_path=""
     case "${SRTCTL_FRONTEND_TYPE}" in
-        dynamo) start_path="/engine/start_profile" ;;
+        dynamo) start_path="/engine/control/start_profile" ;;
         sglang) start_path="/start_profile" ;;
         *)
             echo "Error: unsupported SRTCTL_FRONTEND_TYPE='${SRTCTL_FRONTEND_TYPE}' (expected 'dynamo' or 'sglang')" >&2
@@ -109,7 +109,7 @@ profiling__stop_profile_on_worker() {
 
     local stop_path=""
     case "${SRTCTL_FRONTEND_TYPE}" in
-        dynamo) stop_path="/engine/stop_profile" ;;
+        dynamo) stop_path="/engine/control/stop_profile" ;;
         sglang) stop_path="/stop_profile" ;;
         *)
             echo "Error: unsupported SRTCTL_FRONTEND_TYPE='${SRTCTL_FRONTEND_TYPE}' (expected 'dynamo' or 'sglang')" >&2
@@ -254,5 +254,4 @@ stop_all_profiling() {
     echo ""
     return 0
 }
-
 

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -10,7 +10,7 @@ set -e
 # Ensure benchmark dependencies are available.
 # Creates an isolated venv with --system-site-packages so container packages are
 # reused and only missing deps get installed — without touching system Python.
-SA_BENCH_VENV="/tmp/sa-bench-venv"
+SA_BENCH_VENV="${SA_BENCH_VENV:-/tmp/sa-bench-venv}"
 SA_BENCH_DEPS=(aiohttp numpy pandas datasets Pillow tqdm transformers huggingface_hub)
 
 ensure_sa_bench_deps() {

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -736,6 +736,10 @@ async def benchmark(
 
     print("Starting initial single prompt test run...")
     test_prompt, test_prompt_len, test_output_len, test_mm_content = input_requests[0]
+    test_output_len = min(
+        test_output_len,
+        int(os.environ.get("SA_BENCH_TEST_OUTPUT_LEN", "16")),
+    )
     if backend != "openai-chat" and test_mm_content is not None:
         # multi-modal benchmark is only available on OpenAI Chat backend.
         raise ValueError("Multi-modal content is only supported on 'openai-chat' backend.")

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1980,6 +1980,40 @@ class TestVLLMDataParallelMode:
         assert all(p.http_port > 0 for p in processes)
         assert all(p.bootstrap_port is not None for p in processes)
 
+    def test_dp_per_node_mode_supports_tensor_parallel_groups(self):
+        """Per-node DP ranks may each own a node-local tensor-parallel group."""
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            dp_launch_mode="per_node",
+            vllm_config=VLLMServerConfig(
+                aggregated={
+                    "data-parallel-size": 4,
+                    "tensor-parallel-size": 4,
+                    "enable-expert-parallel": True,
+                },
+            ),
+        )
+        endpoint = Endpoint(
+            mode="agg",
+            index=0,
+            nodes=("node0", "node1", "node2", "node3"),
+            gpu_indices=frozenset(range(4)),
+            gpus_per_node=4,
+        )
+
+        processes = backend.endpoints_to_processes([endpoint])
+
+        assert len(processes) == 4
+        assert [p.node_rank for p in processes] == [0, 1, 2, 3]
+        assert [p.kv_events_port for p in processes] == [
+            KV_EVENTS_PORT_BASE,
+            KV_EVENTS_PORT_BASE + 1,
+            KV_EVENTS_PORT_BASE + 2,
+            KV_EVENTS_PORT_BASE + 3,
+        ]
+
     def test_dp_per_node_mode_allocates_non_overlapping_endpoint_ports(self):
         """Co-located per-node DP endpoints get disjoint coordination ranges."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
@@ -2018,7 +2052,7 @@ class TestVLLMDataParallelMode:
         ]
 
     def test_dp_per_node_mode_rejects_dp_size_mismatch(self):
-        """The configured global DP size must match the allocated GPUs."""
+        """The configured DP and TP product must match the allocated GPUs."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
         from srtctl.core.topology import Endpoint
 
@@ -2339,6 +2373,44 @@ class TestVLLMDataParallelMode:
         assert cmd[cmd.index("--data-parallel-rpc-port") + 1] == str(VLLM_DATA_PARALLEL_RPC_PORT)
         assert "--data-parallel-rank" not in cmd
         assert "--headless" not in cmd
+
+    def test_dp_per_node_hybrid_command_counts_local_tp_groups(self):
+        """The local DP size counts TP groups rather than physical GPUs."""
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Process
+
+        backend = VLLMProtocol(
+            dp_launch_mode="per_node",
+            vllm_config=VLLMServerConfig(
+                aggregated={
+                    "data-parallel-size": 4,
+                    "tensor-parallel-size": 4,
+                    "enable-expert-parallel": True,
+                },
+            ),
+        )
+        process = Process(
+            node="node2",
+            gpu_indices=frozenset(range(4)),
+            sys_port=8083,
+            http_port=6100,
+            endpoint_mode="agg",
+            endpoint_index=0,
+            node_rank=2,
+            dp_rpc_port=VLLM_DATA_PARALLEL_RPC_PORT,
+        )
+        runtime = MagicMock()
+        runtime.model_path = Path("/model")
+        runtime.is_hf_model = False
+        runtime.request_plane = "tcp"
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            cmd = backend.build_worker_command(process, [process], runtime)
+
+        assert cmd[cmd.index("--data-parallel-size-local") + 1] == "1"
+        assert cmd[cmd.index("--data-parallel-start-rank") + 1] == "2"
 
     def test_dp_per_node_forces_hybrid_lb_for_follower(self):
         """Per-node DP keeps every node process registered with Dynamo."""

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -3,6 +3,8 @@
 
 """Tests for profiling configuration, validation, and benchmark runner."""
 
+import subprocess
+
 import pytest
 
 from srtctl.benchmarks import get_runner
@@ -483,6 +485,30 @@ class TestVllmNsysProfilerConfig:
 
 class TestProfilingIntegration:
     """Integration tests for profiling + benchmarks."""
+
+    def test_dynamo_profiling_uses_registered_control_routes(self, tmp_path):
+        profiling_script = SCRIPTS_DIR / "lib" / "profiling.sh"
+        curl_calls = tmp_path / "curl-calls.txt"
+        profile_output = tmp_path / "profiles"
+        shell_script = f"""
+curl() {{ printf '%s\\n' "$*" >> "{curl_calls}"; }}
+export PROFILE_TYPE=nsys
+export PROFILE_OUTPUT_DIR="{profile_output}"
+export PROFILE_AGG_ENDPOINTS=worker.example:7500
+export PROFILE_AGG_START_STEP=10
+export PROFILE_AGG_STOP_STEP=20
+export SRTCTL_FRONTEND_TYPE=dynamo
+source "{profiling_script}"
+profiling_init_from_env
+start_all_profiling
+stop_all_profiling
+"""
+
+        subprocess.run(["bash", "-c", shell_script], check=True, capture_output=True, text=True)
+
+        calls = curl_calls.read_text()
+        assert "http://worker.example:7500/engine/control/start_profile" in calls
+        assert "http://worker.example:7500/engine/control/stop_profile" in calls
 
     def test_no_profiling_benchmark_runner(self):
         """There is no dedicated 'profiling' benchmark runner anymore."""


### PR DESCRIPTION
## Summary

- support node-local tensor-parallel groups when vLLM uses per-node data-parallel launch mode
- validate global DP x TP against the allocated GPU count and derive local DP size/start ranks from TP groups
- allow SA-Bench to reuse a caller-provided virtual environment
- cap the initial connectivity probe to 16 output tokens by default, with an environment-variable override
- use Dynamo's registered `/engine/control/start_profile` and `/engine/control/stop_profile` profiling routes

## Motivation

The per-node vLLM path assumed one data-parallel rank per GPU. A 16-GPU DP4 x TP4 aggregate deployment was therefore rejected because DP did not equal the GPU count, and each four-GPU node would have been launched with local DP size 4 instead of one TP4 group. This change makes the topology accounting use DP x TP while preserving the existing DP-only behavior.

The SA-Bench changes avoid reinstalling dependencies for every Slurm job and prevent a long requested output length from turning the pre-benchmark connectivity probe into a full generation run. Neither change modifies warmup or measured benchmark requests.

The previous profiling URLs returned HTTP 404 because Dynamo registers the control handlers under `/engine/control`. Using the registered routes makes `start_profile` and `stop_profile` reach the vLLM workers and produce a profile.

No open PR matching the DP/TP per-node topology, SA_BENCH_VENV, or profiling-route changes was found before submission.

## Validation

- `uv run pytest tests/test_configs.py::TestVLLMDataParallelMode -v`: 33 passed
- `uv run pytest tests/test_profiling.py -q`: 27 passed
- `uv run pytest tests/ -q`: 916 passed, 2 skipped, 6 deselected
- `uv run ruff check src/srtctl/ tests/test_profiling.py`: passed
- `uv run ruff format src/srtctl/`: no changes
- `ty` reports seven pre-existing diagnostics on upstream main; none are in changed code
- exercised with a four-node, 16-GPU vLLM aggregate deployment using data-parallel-size 4 and tensor-parallel-size 4; all four DP engines registered and served SA-Bench traffic

AI assistance was used to inspect the code, implement changes, and draft tests and documentation. The human submitter reviewed the changes and validation results.
