### PR TITLE
(feat): Introduce new nsys profiling approach nsys-manual

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -906,7 +906,7 @@ profiling:
 | `type`        | string | No       | "none"  | Profiling type: "none", "nsys", "nsys-manual", "nsys-time", "torch"  |
 | `extra_nsys_args` | list[string] | No | null | Extra args for nsys profile (when type is `nsys` or `nsys-time`) |
 | `nsys_path`   | string | No       | `"nsys"` | In-container nsys binary. Ignored when `nsys_dir` is set. |
-| `nsys_dir`    | string | No       | null    | Host Nsight Systems *target* directory. Bind-mounted at `/opt/srtctl-nsys`. |
+| `nsys_dir`    | string | No       | null    | Host Nsight Systems install root (or `target-linux-*`). Bind-mounted at `/opt/srtctl-nsys`; CLI is `bin/nsys`. |
 | `prefill`     | object | Disaggregated | null | Prefill phase config                   |
 | `decode`      | object | Disaggregated | null | Decode phase config                    |
 | `aggregated`  | object | Aggregated | null | Aggregated phase config                  |
@@ -927,11 +927,11 @@ Each phase config has:
 - **nsys-time**: Wall-clock nsys capture (`delay_secs` / `duration_secs`).
 - **torch**: PyTorch profiler. Sets `SGLANG_TORCH_PROFILER_DIR` environment variable.
 
-`nsys_dir` bind-mounts a host Nsight Systems target tree (the directory that
-contains `nsys`, `nsys-launcher`, and the sibling `.so` files) at
-`/opt/srtctl-nsys`. Use this instead of installing nsys in the image. Do not
-overlay a single `nsys` binary onto `/usr/bin/nsys`. Do not set `nsys_path`
-together with `nsys_dir`.
+`nsys_dir` bind-mounts a host Nsight Systems install at `/opt/srtctl-nsys` and
+invokes `/opt/srtctl-nsys/bin/nsys` (the symlink Nsight requires). Point at
+`nsight-systems-<ver>` or its `target-linux-*` tree. Do not invoke the ELF in
+`target-linux-*` directly. Do not overlay a single `nsys` binary onto
+`/usr/bin/nsys`. Do not set `nsys_path` together with `nsys_dir`.
 
 ### Validation Rules
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -903,8 +903,10 @@ profiling:
 
 | Field         | Type   | Required | Default | Description                              |
 | ------------- | ------ | -------- | ------- | ---------------------------------------- |
-| `type`        | string | No       | "none"  | Profiling type: "none", "nsys", "torch"  |
+| `type`        | string | No       | "none"  | Profiling type: "none", "nsys", "nsys-manual", "nsys-time", "torch"  |
 | `extra_nsys_args` | list[string] | No | null | Extra args for nsys profile (when type is `nsys` or `nsys-time`) |
+| `nsys_path`   | string | No       | `"nsys"` | In-container nsys binary. Ignored when `nsys_dir` is set. |
+| `nsys_dir`    | string | No       | null    | Host Nsight Systems *target* directory. Bind-mounted at `/opt/srtctl-nsys`. |
 | `prefill`     | object | Disaggregated | null | Prefill phase config                   |
 | `decode`      | object | Disaggregated | null | Decode phase config                    |
 | `aggregated`  | object | Aggregated | null | Aggregated phase config                  |
@@ -921,7 +923,15 @@ Each phase config has:
 ### Profiling Modes
 
 - **nsys**: NVIDIA Nsight Systems profiling. Wraps worker command with `nsys profile`.
+- **nsys-manual**: On-demand nsys capture via `nsys-manual.sh`. See [profiling.md](profiling.md).
+- **nsys-time**: Wall-clock nsys capture (`delay_secs` / `duration_secs`).
 - **torch**: PyTorch profiler. Sets `SGLANG_TORCH_PROFILER_DIR` environment variable.
+
+`nsys_dir` bind-mounts a host Nsight Systems target tree (the directory that
+contains `nsys`, `nsys-launcher`, and the sibling `.so` files) at
+`/opt/srtctl-nsys`. Use this instead of installing nsys in the image. Do not
+overlay a single `nsys` binary onto `/usr/bin/nsys`. Do not set `nsys_path`
+together with `nsys_dir`.
 
 ### Validation Rules
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -11,6 +11,8 @@ srtctl supports two profiling backends for performance analysis: **Torch Profile
   - [Parameters](#parameters)
 - [Constraints](#constraints)
 - [How It Works](#how-it-works)
+- [On-demand capture (`nsys-manual`)](#on-demand-capture-nsys-manual)
+- [Time-based capture (`nsys-time`)](#time-based-capture-nsys-time)
 - [Example Configurations](#example-configurations)
 - [Output Files](#output-files)
   - [Viewing Results](#viewing-results)
@@ -42,11 +44,17 @@ profiling:
 
 ## Profiling Modes
 
-| Mode    | Description                                                      | Output                                         |
-| ------- | ---------------------------------------------------------------- | ---------------------------------------------- |
-| `none`  | Default. No profiling, uses `dynamo.sglang` for serving          | -                                              |
-| `torch` | PyTorch Profiler. Good for Python-level and CUDA kernel analysis | `/logs/profiles/{mode}/` (Chrome trace format) |
-| `nsys`  | NVIDIA Nsight Systems. Low-overhead GPU profiling                | `/logs/profiles/{mode}/` (`*.nsys-rep`)        |
+| Mode          | Description                                                                 | Output                                         |
+| ------------- | --------------------------------------------------------------------------- | ---------------------------------------------- |
+| `none`        | Default. No profiling, uses `dynamo.sglang` for serving                     | -                                              |
+| `torch`       | PyTorch Profiler. Good for Python-level and CUDA kernel analysis            | `/logs/profiles/{mode}/` (Chrome trace format) |
+| `nsys`        | NVIDIA Nsight Systems, capture bounded by engine steps                      | `/logs/profiles/{mode}/` (`*.nsys-rep`)        |
+| `nsys-manual` | nsys, capture fired by hand mid-run — see [below](#on-demand-capture-nsys-manual) | `/logs/profiles/{mode}/` (`*.nsys-rep`)  |
+| `nsys-time`   | nsys, capture bounded by wall clock — see [below](#time-based-capture-nsys-time)  | `/logs/profiles/{mode}/` (`*.nsys-rep`)  |
+
+Pick the nsys variant by how you want to bound the capture window: by engine
+iteration (`nsys`), by hand while watching the run (`nsys-manual`), or by a
+fixed delay and duration in seconds (`nsys-time`).
 
 ## Configuration Options
 
@@ -54,7 +62,7 @@ profiling:
 
 ```yaml
 profiling:
-  type: "torch" # Required: "none", "torch", or "nsys"
+  type: "torch" # Required: "none", "torch", "nsys", "nsys-manual", or "nsys-time"
 
   # nsys / nsys-time: extra arguments for nsys profile (e.g. ["--stats=true"])
   extra_nsys_args: []  # Optional
@@ -93,6 +101,9 @@ Profiling has specific requirements:
 
 2. **Aggregated mode**: When profiling aggregated workers, `profiling.aggregated` must be set (and `profiling.prefill`/`profiling.decode` must not be set).
 
+Both rules apply to `torch`, `nsys` and `nsys-time`. `nsys-manual` uses
+`phases`/`duration_secs` instead and rejects the per-phase sections entirely.
+
 ## How It Works
 
 ### Normal Mode (`type: none`)
@@ -120,6 +131,100 @@ nsys profile -t cuda,nvtx --cuda-graph-trace=node \
 ```
 
 You can pass extra arguments via `profiling.extra_nsys_args` (e.g. `["--stats=true", "--trace=osrt"]`).
+
+## On-demand capture (`nsys-manual`)
+
+Use this when you cannot express the interesting window in engine steps — for
+example when you want a few seconds of steady-state traffic on a vLLM + dynamo
+disaggregated job, after the load has settled but before the run winds down.
+
+The recipe only picks a phase and a window length; the nsys flags are fixed in
+code (`NSYS_MANUAL_DEFAULT_ARGS`) and are not configurable:
+
+```yaml
+profiling:
+  type: "nsys-manual"
+  phases: prefill      # "prefill" or "decode". Required for disaggregated jobs,
+                       # must be omitted for aggregated ones.
+  duration_secs: 5     # Optional, defaults to 5.
+```
+
+Exactly one process is profiled: **endpoint 0, rank 0** of the chosen phase. Every
+other worker runs completely unwrapped — no nsys, and no vLLM `--profiler-config`
+either — so the rest of the deployment stays a clean baseline and the capture does
+not distort the numbers you are measuring.
+
+At startup srtctl writes a trigger script into the job directory:
+
+```bash
+bash outputs/<job_id>/nsys-manual.sh
+```
+
+It takes no arguments. It POSTs `/engine/start_profile` to the worker, sleeps
+`duration_secs`, then POSTs `/engine/stop_profile`.
+
+### Timing the capture
+
+The window is only useful if it lands on real traffic, so fire the script against
+the stage banners that sa-bench writes into the worker logs:
+
+```bash
+tail -f outputs/<job_id>/logs/*_prefill_w0.out
+```
+
+```text
+======== [17:56:30] cc=1024 warmup begin ========
+======== [17:59:39] cc=1024 warmup end ========
+======== [17:59:39] cc=1024 benchmark begin ========
+```
+
+Fire it after `benchmark begin`, and give yourself room: a run with a small
+`num_prompts_mult` can be over in under 20 seconds, which is easy to miss. The
+`benchmark.out` log also prints the measured window as wall-clock time, which is
+handy afterwards for checking where your capture actually landed:
+
+```text
+Benchmark measurement start (UTC):     2026-08-09T10:24:54.114949+00:00
+```
+
+### Confirming the capture happened
+
+The trigger goes to the Dynamo system server on `DYN_SYSTEM_PORT`, not to the vLLM
+HTTP frontend, and dynamo logs are quiet by default — so a successful capture
+leaves no request log. Look for nsys's own markers in the worker log instead:
+
+```text
+Capture range started in the application.
+Capture range ended in the application.
+Generating '/tmp/nsys-report-987b.qdstrm'
+Generated:
+	/logs/profiles/prefill/<node>_prefill_w0_profile_gpu0.nsys-rep
+```
+
+Note that the report is written when the worker exits, not when the window
+closes, and nsys buffers those messages — so they show up at teardown, below the
+SLURM step-cancellation notice. That ordering is normal and does not mean the
+capture failed.
+
+A full working recipe lives in
+[`examples/nsys-manual-qwen35-disagg.yaml`](../examples/nsys-manual-qwen35-disagg.yaml).
+
+## Time-based capture (`nsys-time`)
+
+Same idea as `nsys-manual`, but the window is fixed in advance relative to worker
+launch instead of being fired by hand. Useful for unattended runs:
+
+```yaml
+profiling:
+  type: "nsys-time"
+  delay_secs: 120             # nsys --delay: wait this long after worker launch
+  duration_secs: 30           # nsys --duration: then capture this long
+  benchmark_duration_secs: 300  # traffic must cover delay + duration
+```
+
+There is no cudaProfilerApi trigger here, so nothing needs to call
+`/start_profile`. Make sure the benchmark is still generating load when the window
+opens — the delay is counted from worker launch, which includes model load time.
 
 ## Example Configurations
 
@@ -218,9 +323,16 @@ logs/{job_id}_{workers}_{timestamp}/
 
 - Disaggregated mode requires both `profiling.prefill` and `profiling.decode` to be set.
 - Aggregated mode requires `profiling.aggregated` to be set (and `profiling.prefill`/`profiling.decode` must not be set).
+- For `nsys-manual`, disaggregated jobs require `profiling.phases`, aggregated jobs must omit it, and the per-phase sections are not allowed at all.
 
 ### Empty profile output
 Ensure the benchmark workload is generating requests during the profiling window.
+
+With `nsys-manual` this is the usual failure: a short benchmark can finish before
+you fire the trigger, leaving a report full of an idle engine. The `.nsys-rep` will
+still be tens of megabytes — nsys writes process and symbol metadata regardless —
+so file size proves nothing. Watch for the `benchmark begin` banner in the worker
+log and enlarge `benchmark.num_prompts_mult` if the run is too short to aim at.
 
 ### Profile too short/long
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -92,6 +92,8 @@ profiling:
 | `decode.stop_step`      | Step number to end decode profiling           | `50`     |
 | `aggregated.start_step` | Step number to begin aggregated profiling     | `0`      |
 | `aggregated.stop_step`  | Step number to end aggregated profiling       | `50`     |
+| `nsys_dir`              | Host Nsight target tree, mounted at `/opt/srtctl-nsys` | unset |
+| `nsys_path`             | In-container nsys binary (ignored if `nsys_dir` is set) | `nsys` |
 
 ## Constraints
 
@@ -147,6 +149,10 @@ profiling:
   phases: prefill      # "prefill" or "decode". Required for disaggregated jobs,
                        # must be omitted for aggregated ones.
   duration_secs: 5     # Optional, defaults to 5.
+  # Optional: bind-mount a host Nsight Systems *target* tree so the image does
+  # not need nsys installed. Point at target-linux-sbsa-armv8 (or
+  # target-linux-x64), not the installer root. Mounted at /opt/srtctl-nsys.
+  # nsys_dir: /path/to/nsight-systems-*/target-linux-sbsa-armv8
 ```
 
 Exactly one process is profiled: **endpoint 0, rank 0** of the chosen phase. Every
@@ -205,6 +211,30 @@ Note that the report is written when the worker exits, not when the window
 closes, and nsys buffers those messages — so they show up at teardown, below the
 SLURM step-cancellation notice. That ordering is normal and does not mean the
 capture failed.
+
+### Using a host nsys instead of the container's
+
+Do not overlay a single `nsys` binary onto `/usr/bin/nsys`. The target package
+is a relocatable tree: `nsys` has `RPATH $ORIGIN` and needs sibling libraries
+(`libcupti*.so`, `libcrypto.so.3`, `nsys-launcher`, `plugins/`, …). Mount the
+whole architecture-specific directory.
+
+The recipe field does that for you:
+
+```yaml
+profiling:
+  type: "nsys-manual"
+  phases: prefill
+  duration_secs: 5
+  nsys_dir: /home/you/nsight-systems-2026.1.3/target-linux-sbsa-armv8
+```
+
+srtctl bind-mounts that host path at `/opt/srtctl-nsys` and wraps workers with
+`/opt/srtctl-nsys/nsys`. The same field works for `nsys` and `nsys-time`.
+
+You can still do the mount yourself (`extra_mount` or `srtslurm.yaml`
+`default_mounts`) and set `profiling.nsys_path: /opt/nsys-host/nsys` instead —
+do not set both `nsys_dir` and `nsys_path`.
 
 A full working recipe lives in
 [`examples/nsys-manual-qwen35-disagg.yaml`](../examples/nsys-manual-qwen35-disagg.yaml).
@@ -324,6 +354,7 @@ logs/{job_id}_{workers}_{timestamp}/
 - Disaggregated mode requires both `profiling.prefill` and `profiling.decode` to be set.
 - Aggregated mode requires `profiling.aggregated` to be set (and `profiling.prefill`/`profiling.decode` must not be set).
 - For `nsys-manual`, disaggregated jobs require `profiling.phases`, aggregated jobs must omit it, and the per-phase sections are not allowed at all.
+- `profiling.nsys_dir` is only valid with `nsys` / `nsys-manual` / `nsys-time`, and cannot be combined with `profiling.nsys_path`.
 
 ### Empty profile output
 Ensure the benchmark workload is generating requests during the profiling window.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -92,7 +92,7 @@ profiling:
 | `decode.stop_step`      | Step number to end decode profiling           | `50`     |
 | `aggregated.start_step` | Step number to begin aggregated profiling     | `0`      |
 | `aggregated.stop_step`  | Step number to end aggregated profiling       | `50`     |
-| `nsys_dir`              | Host Nsight target tree, mounted at `/opt/srtctl-nsys` | unset |
+| `nsys_dir`              | Host Nsight install root (or its `target-linux-*` tree); mounted at `/opt/srtctl-nsys` | unset |
 | `nsys_path`             | In-container nsys binary (ignored if `nsys_dir` is set) | `nsys` |
 
 ## Constraints
@@ -149,10 +149,10 @@ profiling:
   phases: prefill      # "prefill" or "decode". Required for disaggregated jobs,
                        # must be omitted for aggregated ones.
   duration_secs: 5     # Optional, defaults to 5.
-  # Optional: bind-mount a host Nsight Systems *target* tree so the image does
-  # not need nsys installed. Point at target-linux-sbsa-armv8 (or
-  # target-linux-x64), not the installer root. Mounted at /opt/srtctl-nsys.
-  # nsys_dir: /path/to/nsight-systems-*/target-linux-sbsa-armv8
+  # Optional: bind-mount a host Nsight Systems install so the image does
+  # not need nsys installed. Point at nsight-systems-* or its
+  # target-linux-* tree (srtctl walks up to bin/nsys). Mounted at /opt/srtctl-nsys.
+  # nsys_dir: /path/to/nsight-systems-2026.1.3
 ```
 
 Exactly one process is profiled: **endpoint 0, rank 0** of the chosen phase. Every
@@ -214,23 +214,24 @@ capture failed.
 
 ### Using a host nsys instead of the container's
 
-Do not overlay a single `nsys` binary onto `/usr/bin/nsys`. The target package
-is a relocatable tree: `nsys` has `RPATH $ORIGIN` and needs sibling libraries
-(`libcupti*.so`, `libcrypto.so.3`, `nsys-launcher`, `plugins/`, …). Mount the
-whole architecture-specific directory.
-
-The recipe field does that for you:
+Do not overlay a single `nsys` binary onto `/usr/bin/nsys`, and do not invoke
+the ELF in `target-linux-sbsa-armv8/` directly — Nsight exits with
+"Modify the executable in your command to be a symbolic link pointing to
+'target-linux-.../nsys'". The CLI must be the install's `bin/nsys` symlink, and
+the target tree has to come along for `$ORIGIN` libraries (`libcupti*.so`,
+`libcrypto.so.3`, `nsys-launcher`, `plugins/`, …).
 
 ```yaml
 profiling:
   type: "nsys-manual"
   phases: prefill
   duration_secs: 5
-  nsys_dir: /home/you/nsight-systems-2026.1.3/target-linux-sbsa-armv8
+  nsys_dir: /home/you/nsight-systems-2026.1.3
+  # or .../nsight-systems-2026.1.3/target-linux-sbsa-armv8 — srtctl walks up
 ```
 
-srtctl bind-mounts that host path at `/opt/srtctl-nsys` and wraps workers with
-`/opt/srtctl-nsys/nsys`. The same field works for `nsys` and `nsys-time`.
+srtctl bind-mounts the install root at `/opt/srtctl-nsys` and wraps workers with
+`/opt/srtctl-nsys/bin/nsys`. The same field works for `nsys` and `nsys-time`.
 
 You can still do the mount yourself (`extra_mount` or `srtslurm.yaml`
 `default_mounts`) and set `profiling.nsys_path: /opt/nsys-host/nsys` instead —

--- a/examples/nsys-manual-qwen35-disagg.yaml
+++ b/examples/nsys-manual-qwen35-disagg.yaml
@@ -1,0 +1,104 @@
+# On-demand nsys capture: Qwen3.5 NVFP4 disaggregated on GB200 (vLLM + dynamo).
+#
+# Workers launch already wrapped in nsys, waiting on a cudaProfilerApi capture
+# range, so nothing is recorded until you fire the trigger by hand:
+#
+#   bash outputs/<job_id>/nsys-manual.sh
+#
+# Time it against the stage banners sa-bench writes into the worker logs — fire
+# it after "benchmark begin" so the window lands on steady-state traffic rather
+# than on warmup or on an already-idle engine:
+#
+#   tail -f outputs/<job_id>/logs/*_prefill_w0.out
+#   ======== [17:59:39] cc=1024 benchmark begin ========
+#
+# See docs/profiling.md for the full workflow.
+
+name: "nsys-manual-qwen35-disagg"
+
+model:
+  path: "hf:nvidia/Qwen3.5-397B-A17B-NVFP4"
+  container: "vllm/vllm-openai:nightly-d223c900d85224c02f2162ee2c757a769e99f519"
+  precision: "NVFP4"
+
+dynamo:
+  version: "1.2.0.dev20260526"
+  install: true
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+
+  # 4xDEP2 on prefill:
+  # 4 endpoints, each DEP2 topology
+  prefill_nodes: 2
+  prefill_workers: 4
+  gpus_per_prefill: 2
+
+  # 8xDEP2 on decode:
+  # 1 endpoint, DEP8 topology
+  decode_nodes: 2
+  decode_workers: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+profiling:
+  type: "nsys-manual"
+  # Which side to capture: "prefill" or "decode". Only the first worker of that
+  # phase is profiled; the rest of the deployment runs unwrapped.
+  phases: prefill
+  # Length of the window fired by nsys-manual.sh. Defaults to 5.
+  duration_secs: 5
+
+backend:
+  type: vllm
+  connector: null
+
+  prefill_environment:
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  decode_environment:
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}'
+      served-model-name: "Qwen3.5-397B-A17B-NVFP4"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      no-disable-hybrid-kv-cache-manager: true
+      generation-config: "vllm"
+      no-enable-prefix-caching: true
+      async-scheduling: true
+      stream-interval: 100
+      mamba-ssm-cache-dtype: "bfloat16"
+
+benchmark:
+  type: "sa-bench"
+  isl: 128
+  osl: 64
+  concurrencies: "1024"
+  req_rate: "inf"
+  random_range_ratio: 1.0
+  # Keep the measured run long enough to comfortably fit a manual capture.
+  num_prompts_mult: 8
+  num_warmup_mult: 1

--- a/examples/nsys-manual-qwen35-disagg.yaml
+++ b/examples/nsys-manual-qwen35-disagg.yaml
@@ -52,10 +52,9 @@ profiling:
   phases: prefill
   # Length of the window fired by nsys-manual.sh. Defaults to 5.
   duration_secs: 5
-  # Optional: host Nsight Systems *target* tree (contains nsys, nsys-launcher,
-  # and sibling .so files). Bind-mounted at /opt/srtctl-nsys so the container
-  # does not need nsys installed. Do not overlay a single nsys onto /usr/bin.
-  # nsys_dir: /path/to/nsight-systems-*/target-linux-sbsa-armv8
+  # Optional: host Nsight Systems install (bin/nsys + target-linux-* tree).
+  # Bind-mounted at /opt/srtctl-nsys; workers run /opt/srtctl-nsys/bin/nsys.
+  # nsys_dir: /path/to/nsight-systems-2026.1.3
 
 backend:
   type: vllm

--- a/examples/nsys-manual-qwen35-disagg.yaml
+++ b/examples/nsys-manual-qwen35-disagg.yaml
@@ -52,6 +52,10 @@ profiling:
   phases: prefill
   # Length of the window fired by nsys-manual.sh. Defaults to 5.
   duration_secs: 5
+  # Optional: host Nsight Systems *target* tree (contains nsys, nsys-launcher,
+  # and sibling .so files). Bind-mounted at /opt/srtctl-nsys so the container
+  # does not need nsys installed. Do not overlay a single nsys onto /usr/bin.
+  # nsys_dir: /path/to/nsight-systems-*/target-linux-sbsa-armv8
 
 backend:
   type: vllm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,13 @@ dev = [
     "httpx>=0.27.0",  # Required by FastAPI TestClient
     "uvicorn>=0.27.0",  # Required for integration test mock server
     "aiperf",  # Benchmark tool for trace replay integration tests
+    # Runtime deps of src/srtctl/benchmarks/scripts/sa-bench, needed to import
+    # benchmark_serving.py in tests. Jobs get these from the container instead
+    # (bench.sh backfills whatever is missing), so they are dev-only here.
+    "aiohttp",
+    "datasets",
+    "huggingface_hub",
+    "transformers",
 ]
 
 # =============================================================================

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -703,9 +703,20 @@ class VLLMProtocol:
         # Start with nsys prefix if provided
         cmd: list[str] = list(nsys_prefix) if nsys_prefix else []
 
-        if profiling is not None and profiling.is_nsys and not profiling.is_nsys_time:
+        # Only wrapped processes get the engine profiler; the rest stay a clean baseline.
+        if (
+            profiling is not None
+            and profiling.is_nsys
+            and profiling.profiles_mode(mode)
+            and profiling.should_wrap_process_with_nsys(
+                endpoint_index=process.endpoint_index,
+                node_rank=process.node_rank,
+            )
+        ):
             phase = profiling._get_phase_config(mode)
-            if phase is not None and phase.start_step is not None and phase.stop_step is not None:
+            if profiling.is_nsys_manual:
+                config["profiler-config"] = json.dumps({"profiler": "cuda"})
+            elif phase is not None and phase.start_step is not None and phase.stop_step is not None:
                 config["profiler-config"] = json.dumps(
                     {
                         "profiler": "cuda",

--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -159,6 +159,27 @@ profiling_init_from_env
 cleanup() { stop_all_profiling; }
 trap cleanup EXIT
 
+# Visual stage separator written directly into the prefill/decode worker logs
+# (not benchmark.out), so those logs stay readable across warmup vs measured
+# runs and across concurrencies. The job log dir is mounted at /logs, so worker
+# logs are /logs/<node>_<mode>_w<i>.out. srun opens them with --open-mode=append,
+# so our O_APPEND writes interleave atomically with the worker output.
+WORKER_LOG_ROOT="$(dirname "${PROFILE_OUTPUT_DIR:-/logs/profiles}")"
+stage_banner() {
+    local line
+    line="======== [$(date '+%H:%M:%S')] $* ========"
+    local f wrote=0
+    for f in "${WORKER_LOG_ROOT}"/*_prefill_w*.out \
+             "${WORKER_LOG_ROOT}"/*_decode_w*.out \
+             "${WORKER_LOG_ROOT}"/*_agg_w*.out; do
+        [ -e "$f" ] || continue
+        printf '\n%s\n\n' "$line" >> "$f"
+        wrote=1
+    done
+    # Fall back to stdout only if no worker logs were found (e.g. unexpected layout).
+    [ "$wrote" -eq 1 ] || echo "$line"
+}
+
 # Parse concurrency list
 IFS='x' read -r -a CONCURRENCY_LIST <<< "$CONCURRENCIES"
 
@@ -192,6 +213,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
 
     if [ "$NUM_WARMUP_MULT" -gt 0 ]; then
         num_warmup_prompts=$((concurrency * NUM_WARMUP_MULT))
+        stage_banner "cc=${concurrency} warmup begin"
         python3 -u "${WORK_DIR}/benchmark_serving.py" \
             --model "${MODEL_NAME}" --tokenizer "${MODEL_PATH}" \
             --host "$HOST" --port "$PORT" \
@@ -208,6 +230,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
             "${HTTP_CONNECTION_ARGS[@]}" \
             "${CHAT_TEMPLATE_ARGS[@]}" \
             "${CUSTOM_TOKENIZER_ARGS[@]}"
+        stage_banner "cc=${concurrency} warmup end"
     fi
 
     num_prompts=$((concurrency * NUM_PROMPTS_MULT))
@@ -221,6 +244,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
 
     echo "Running benchmark with concurrency: $concurrency"
     echo "$(date '+%Y-%m-%d %H:%M:%S')"
+    stage_banner "cc=${concurrency} benchmark begin"
 
     set -x
     python3 -u "${WORK_DIR}/benchmark_serving.py" \
@@ -244,6 +268,7 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         --save-result --result-dir "$result_dir" --result-filename "$result_filename"
     set +x
 
+    stage_banner "cc=${concurrency} benchmark end"
     echo "$(date '+%Y-%m-%d %H:%M:%S')"
     echo "Completed benchmark with concurrency: $concurrency"
     echo "-----------------------------------------"

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -39,7 +39,7 @@ import time
 import warnings
 from collections.abc import AsyncGenerator, Collection
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import partial
 from multiprocessing import Pool, cpu_count
 from typing import Any
@@ -734,7 +734,7 @@ async def benchmark(
     if backend == "dynamo" and request_session is not None:
         request_func = partial(request_func, session=request_session)
 
-    print("Starting initial single prompt test run...")
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] Starting initial single prompt test run...")
     test_prompt, test_prompt_len, test_output_len, test_mm_content = input_requests[0]
     if backend != "openai-chat" and test_mm_content is not None:
         # multi-modal benchmark is only available on OpenAI Chat backend.
@@ -759,7 +759,7 @@ async def benchmark(
             f"are correctly specified. Error: {test_output.error}"
         )
     else:
-        print("Initial test run completed. Starting main benchmark run...")
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] Initial test run completed. Starting main benchmark run...")
 
     if lora_modules:
         # For each input request, choose a LoRA module at random.
@@ -833,7 +833,14 @@ async def benchmark(
         async with semaphore:
             return await request_func(request_func_input=request_func_input, pbar=pbar)
 
+    # Wall-clock bounds of the measured window, so a worker log or nsys capture can
+    # be lined up against the run without guessing from the log's own timestamps.
+    benchmark_start_wall_time = datetime.now(timezone.utc)
     benchmark_start_time = time.perf_counter()
+    print(
+        f"Benchmark measurement start (UTC):     {benchmark_start_wall_time.isoformat(timespec='microseconds')}",
+        flush=True,
+    )
     tasks: list[asyncio.Task] = []
     try:
         async for request in get_request(input_requests, request_rate, burstiness):
@@ -894,6 +901,7 @@ async def benchmark(
         pbar.close()
 
     benchmark_duration = time.perf_counter() - benchmark_start_time
+    benchmark_end_wall_time = datetime.now(timezone.utc)
     if backend == "dynamo" and request_session is not None and not request_session.closed:
         await request_session.close()
         # Allow asyncio to finish closing pooled transports before CPU-heavy metrics.
@@ -911,6 +919,18 @@ async def benchmark(
 
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
+    print(
+        "{:<40} {:<10}".format(
+            "Benchmark measurement start (UTC):",
+            benchmark_start_wall_time.isoformat(timespec="microseconds"),
+        )
+    )
+    print(
+        "{:<40} {:<10}".format(
+            "Benchmark measurement end (UTC):",
+            benchmark_end_wall_time.isoformat(timespec="microseconds"),
+        )
+    )
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
     print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))
@@ -923,6 +943,10 @@ async def benchmark(
 
     result = {
         "duration": benchmark_duration,
+        "benchmark_start_time_utc": benchmark_start_wall_time.isoformat(timespec="microseconds"),
+        "benchmark_end_time_utc": benchmark_end_wall_time.isoformat(timespec="microseconds"),
+        "benchmark_start_time_unix_s": benchmark_start_wall_time.timestamp(),
+        "benchmark_end_time_unix_s": benchmark_end_wall_time.timestamp(),
         "completed": metrics.completed,
         "total_input_tokens": metrics.total_input,
         "total_output_tokens": metrics.total_output,

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -343,6 +343,12 @@ class BenchmarkStageMixin:
         if not p.enabled:
             return env
 
+        # Manual on-demand mode: workers are already nsys-wrapped at launch and the
+        # user fires the capture by hand (nsys-manual.sh). Export nothing here so the
+        # benchmark script's start_all_profiling/stop_all_profiling stay no-ops.
+        if p.is_nsys_manual:
+            return env
+
         # Inside the container, the host log directory is mounted to /logs. Use the container path so profiling
         # artifacts persist back to the host log directory across nodes.
         profiles_dir_in_container = "/logs/profiles"

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from srtctl.core.fingerprint import generate_capture_script
 from srtctl.core.processes import ManagedProcess, NamedProcesses
-from srtctl.core.schema import build_otel_env, installs_dynamo
+from srtctl.core.schema import DYNAMO_DEFAULT_ENV, build_otel_env, installs_dynamo
 from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, get_hostname_ip, start_srun_process
 from srtctl.ports import ETCD_CLIENT_PORT, KV_EVENTS_PORT_BASE, KVBM_ZMQ_PORT_BASE, NATS_PORT
 
@@ -24,10 +24,6 @@ if TYPE_CHECKING:
     from srtctl.core.topology import Endpoint, Process
 
 logger = logging.getLogger(__name__)
-
-# Dynamo runtime (Rust) log filter for worker containers; YAML prefill_environment /
-# decode_environment / aggregated_environment override via the merge below.
-_DEFAULT_WORKER_DYN_LOG = "info,dynamo_runtime::pipeline::network::ingress::push_handler=warn"
 
 
 class WorkerStageMixin:
@@ -135,13 +131,23 @@ class WorkerStageMixin:
         # Profiling setup
         profiling = self.config.profiling
         nsys_prefix = None
-        if profiling.enabled:
+        if profiling.enabled and profiling.profiles_mode(mode):
             (self.runtime.log_dir / "profiles" / mode).mkdir(parents=True, exist_ok=True)
-        if profiling.is_nsys:
+        if (
+            profiling.is_nsys
+            and profiling.profiles_mode(mode)
+            and profiling.should_wrap_process_with_nsys(
+                endpoint_index=process.endpoint_index,
+                node_rank=process.node_rank,
+            )
+        ):
             gpu_label = process.cuda_visible_devices.replace(",", "-")
             nsys_output = f"/logs/profiles/{mode}/{process.node}_{mode}_w{index}_profile_gpu{gpu_label}"
             nsys_prefix = profiling.get_nsys_prefix(
-                nsys_output, frontend_type=self.config.frontend.type, backend_type=self.config.backend_type
+                nsys_output,
+                mode=mode,
+                frontend_type=self.config.frontend.type,
+                backend_type=self.config.backend_type,
             )
 
         # Build command using backend's method
@@ -157,6 +163,7 @@ class WorkerStageMixin:
 
         # Environment variables
         env_to_set = {
+            **DYNAMO_DEFAULT_ENV,
             "HEAD_NODE_IP": self.runtime.head_node_ip,
             "ETCD_ENDPOINTS": f"http://{self.runtime.nodes.infra}:{ETCD_CLIENT_PORT}",
             "NATS_SERVER": f"nats://{self.runtime.nodes.infra}:{NATS_PORT}",
@@ -169,8 +176,6 @@ class WorkerStageMixin:
 
         # Add OTEL env vars (before mode-specific env so OTEL_SERVICE_NAME can be overridden)
         env_to_set.update(build_otel_env(self.config.observability, mode))
-
-        env_to_set.setdefault("DYN_LOG", _DEFAULT_WORKER_DYN_LOG)
 
         # Add mode-specific environment variables from backend
         # Support simple {node} and {node_id} templating
@@ -289,12 +294,22 @@ class WorkerStageMixin:
         # Profiling setup
         profiling = self.config.profiling
         nsys_prefix = None
-        if profiling.enabled:
+        if profiling.enabled and profiling.profiles_mode(mode):
             (self.runtime.log_dir / "profiles" / mode).mkdir(parents=True, exist_ok=True)
-        if profiling.is_nsys:
+        if (
+            profiling.is_nsys
+            and profiling.profiles_mode(mode)
+            and profiling.should_wrap_process_with_nsys(
+                endpoint_index=leader.endpoint_index,
+                node_rank=leader.node_rank,
+            )
+        ):
             nsys_output = f"/logs/profiles/{mode}/{leader.node}_{mode}_w{index}_profile_rank%q{{SLURM_PROCID}}"
             nsys_prefix = profiling.get_nsys_prefix(
-                nsys_output, frontend_type=self.config.frontend.type, backend_type=self.config.backend_type
+                nsys_output,
+                mode=mode,
+                frontend_type=self.config.frontend.type,
+                backend_type=self.config.backend_type,
             )
 
         # Build command using backend's method
@@ -310,6 +325,7 @@ class WorkerStageMixin:
 
         # Environment variables
         env_to_set = {
+            **DYNAMO_DEFAULT_ENV,
             "HEAD_NODE_IP": self.runtime.head_node_ip,
             "ETCD_ENDPOINTS": f"http://{self.runtime.nodes.infra}:{ETCD_CLIENT_PORT}",
             "NATS_SERVER": f"nats://{self.runtime.nodes.infra}:{NATS_PORT}",
@@ -321,8 +337,6 @@ class WorkerStageMixin:
 
         # Add OTEL env vars (before mode-specific env so OTEL_SERVICE_NAME can be overridden)
         env_to_set.update(build_otel_env(self.config.observability, mode))
-
-        env_to_set.setdefault("DYN_LOG", _DEFAULT_WORKER_DYN_LOG)
 
         # Add mode-specific environment variables from backend
         env_to_set.update(self.backend.get_environment_for_mode(mode))
@@ -393,6 +407,82 @@ class WorkerStageMixin:
             critical=True,
         )
 
+    def _write_nsys_manual_script(self) -> None:
+        """Write an on-demand nsys-manual trigger script into the job output directory."""
+        import stat
+
+        profiling = self.config.profiling
+        job_dir = self.runtime.log_dir.parent
+        frontend_type = self.config.frontend.type
+        if frontend_type == "dynamo":
+            start_path, stop_path = "/engine/start_profile", "/engine/stop_profile"
+            use_sys_port = True
+        else:
+            start_path, stop_path = "/start_profile", "/stop_profile"
+            use_sys_port = False
+
+        endpoints: list[str] = []
+        for process in self.backend_processes:
+            mode = process.endpoint_mode
+            if not profiling.profiles_mode(mode):
+                continue
+            if not profiling.should_wrap_process_with_nsys(
+                endpoint_index=process.endpoint_index,
+                node_rank=process.node_rank,
+            ):
+                continue
+            if not use_sys_port and not process.is_leader:
+                continue
+            host = get_hostname_ip(process.node, self.runtime.network_interface)
+            port = process.sys_port if use_sys_port else process.http_port
+            if not port:
+                continue
+            endpoints.append(f"{host}:{port}")
+            break  # endpoint 0 rank 0 only
+
+        if not endpoints:
+            return
+
+        profiles_dir = self.runtime.log_dir / "profiles"
+        duration = profiling.manual_duration_secs
+        ep_lines = "\n".join(f'  "{ep}"' for ep in endpoints)
+        script = f"""#!/usr/bin/env bash
+# Auto-generated by srtctl (nsys-manual profiling). Run with NO arguments:
+#   bash {job_dir}/nsys-manual.sh
+set -u
+DURATION={duration}
+ENDPOINTS=(
+{ep_lines}
+)
+
+fanout() {{
+  local path="$1" verb="$2" ok="$3"
+  local ep
+  for ep in "${{ENDPOINTS[@]}}"; do
+    (
+      if curl -sS -f -m 30 --noproxy '*' -X POST "http://${{ep}}${{path}}" \\
+        -H 'Content-Type: application/json' -d '{{}}' >/dev/null 2>&1; then
+        echo "  ${{ok}} ${{ep}}"
+      else
+        echo "  WARN: ${{verb}} failed for ${{ep}}"
+      fi
+    ) &
+  done
+  wait
+}}
+
+echo "[nsys-manual] START -> ${{#ENDPOINTS[@]}} worker(s) (parallel), capturing ${{DURATION}}s"
+fanout "{start_path}" start started
+echo "[nsys-manual] capturing for ${{DURATION}}s ..."
+sleep "${{DURATION}}"
+fanout "{stop_path}" stop stopped
+echo "[nsys-manual] done. nsys reports land in: {profiles_dir} (written when workers exit)"
+"""
+        script_path = job_dir / "nsys-manual.sh"
+        script_path.write_text(script)
+        script_path.chmod(stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+        logger.info("nsys-manual profiling: run `%s` to capture a window.", script_path)
+
     def start_all_workers(self) -> NamedProcesses:
         """Start all backend workers."""
         logger.info("Starting backend workers")
@@ -421,4 +511,8 @@ class WorkerStageMixin:
                     result[managed.name] = managed
 
         logger.info("Started %d worker processes", len(result))
+
+        if self.config.profiling.is_nsys_manual:
+            self._write_nsys_manual_script()
+
         return result

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -55,7 +55,7 @@ from srtctl.core.git_state import (
     write_git_state_snapshot,
 )
 from srtctl.core.lockfile import load_lockfile_fingerprints
-from srtctl.core.schema import SrtConfig, installs_dynamo
+from srtctl.core.schema import DYNAMO_DEFAULT_ENV, SrtConfig, installs_dynamo
 from srtctl.core.status import create_job_record
 from srtctl.core.validation import preflight_config_variants
 from srtctl.ports import MOONCAKE_MASTER_PORT
@@ -299,6 +299,14 @@ def show_config_details(config: SrtConfig) -> None:
         console.print(Panel(env_table, border_style="yellow"))
     else:
         console.print("[dim]No custom environment variables configured.[/]")
+
+    # srtctl exports these to every dynamo worker and frontend; any scope above wins.
+    overridden = set(config.environment) | set(config.frontend.env or {})
+    overridden.update(var for _, env in mode_envs for var in env)
+    console.print("[dim]dynamo defaults (workers + frontend):[/]")
+    for var, val in sorted(DYNAMO_DEFAULT_ENV.items()):
+        suffix = " (overridden)" if var in overridden else ""
+        console.print(f"[dim]  {var}={val}{suffix}[/]")
 
     # --- srun options ---
     if config.srun_options:

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -212,7 +212,7 @@ def show_config_details(config: SrtConfig) -> None:
 
     # --- Container Mounts ---
     mounts_table = Table(title="Container Mounts", show_lines=False, pad_edge=False)
-    mounts_table.add_column("Source", style="dim", width=14)
+    mounts_table.add_column("Source", style="dim", width=20)
     mounts_table.add_column("Host Path", style="green")
     mounts_table.add_column("Container Path", style="cyan")
 
@@ -227,6 +227,12 @@ def show_config_details(config: SrtConfig) -> None:
         for host_path, container_path in cluster_mounts.items():
             expanded = os.path.expandvars(host_path)
             mounts_table.add_row("srtslurm.yaml", expanded, container_path)
+
+    # Host nsys tree from profiling.nsys_dir
+    nsys_mount = config.profiling.nsys_container_mount()
+    if nsys_mount is not None:
+        host_nsys_dir, container_nsys_dir = nsys_mount
+        mounts_table.add_row("profiling.nsys_dir", str(host_nsys_dir), str(container_nsys_dir))
 
     # Recipe extra_mount (simple string mounts)
     if config.extra_mount:

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -334,6 +334,20 @@ class RuntimeContext:
                 expanded_host = os.path.expandvars(host_path)
                 container_mounts[Path(expanded_host).expanduser().resolve()] = Path(container_path)
 
+        # Host Nsight Systems target tree (profiling.nsys_dir) -> /opt/srtctl-nsys
+        nsys_mount = config.profiling.nsys_container_mount()
+        if nsys_mount is not None:
+            host_nsys_dir, container_nsys_dir = nsys_mount
+            nsys_bin = host_nsys_dir / "nsys"
+            if not nsys_bin.is_file():
+                raise FileNotFoundError(
+                    "profiling.nsys_dir must be an Nsight Systems target directory "
+                    f"containing an nsys binary (got {host_nsys_dir}). "
+                    "Use the architecture-specific tree, e.g. "
+                    ".../nsight-systems-*/target-linux-sbsa-armv8, not the installer root."
+                )
+            container_mounts[host_nsys_dir] = container_nsys_dir
+
         # Mount InferenceX workspace if available (for lm-eval support).
         # Skip exists() check: the orchestrator runs on the SLURM head node
         # where the GH Actions workspace path may not be directly accessible,

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -334,17 +334,18 @@ class RuntimeContext:
                 expanded_host = os.path.expandvars(host_path)
                 container_mounts[Path(expanded_host).expanduser().resolve()] = Path(container_path)
 
-        # Host Nsight Systems target tree (profiling.nsys_dir) -> /opt/srtctl-nsys
+        # Host Nsight Systems install (profiling.nsys_dir) -> /opt/srtctl-nsys
         nsys_mount = config.profiling.nsys_container_mount()
         if nsys_mount is not None:
             host_nsys_dir, container_nsys_dir = nsys_mount
-            nsys_bin = host_nsys_dir / "nsys"
-            if not nsys_bin.is_file():
+            nsys_cli = config.profiling.nsys_host_cli()
+            if nsys_cli is None:
                 raise FileNotFoundError(
-                    "profiling.nsys_dir must be an Nsight Systems target directory "
-                    f"containing an nsys binary (got {host_nsys_dir}). "
-                    "Use the architecture-specific tree, e.g. "
-                    ".../nsight-systems-*/target-linux-sbsa-armv8, not the installer root."
+                    "profiling.nsys_dir must be an Nsight Systems install containing "
+                    f"bin/nsys (or nsys in the directory itself); got {host_nsys_dir}. "
+                    "Point at nsight-systems-<ver> or its target-linux-* tree. "
+                    "Do not invoke the ELF in target-linux-* directly — nsys must be "
+                    "run via the bin/nsys symlink."
                 )
             container_mounts[host_nsys_dir] = container_nsys_dir
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -291,6 +291,10 @@ NSYS_MANUAL_DEFAULT_ARGS: tuple[str, ...] = (
 # Capture window used by ``nsys-manual.sh`` when a recipe omits ``duration_secs``.
 NSYS_MANUAL_DEFAULT_DURATION_SECS = 5
 
+# Bind-mount destination for a host Nsight Systems *target* tree
+# (``profiling.nsys_dir``). The in-container binary is ``{this}/nsys``.
+NSYS_HOST_CONTAINER_DIR = "/opt/srtctl-nsys"
+
 
 class TelemetryProvider(str, Enum):
     SCRAPER = "scraper"
@@ -878,8 +882,16 @@ class ProfilingConfig:
     duration_secs: int | None = None  # nsys --duration: seconds to capture after delay
     benchmark_duration_secs: int = 300  # total traffic generation duration (must cover delay + duration)
 
-    # Default nsys binary name/path. ``SRTCTL_NSYS_BIN`` env overrides this at runtime.
+    # Default nsys binary name/path inside the container. ``SRTCTL_NSYS_BIN``
+    # overrides this at runtime. Ignored when ``nsys_dir`` is set.
     nsys_path: str = "nsys"
+
+    # Host path to an Nsight Systems *target* directory (the tree that contains
+    # ``nsys``, ``nsys-launcher``, and the sibling ``.so`` files — e.g.
+    # ``.../nsight-systems-*/target-linux-sbsa-armv8``). Bind-mounted at
+    # ``NSYS_HOST_CONTAINER_DIR`` so the image does not need nsys installed.
+    # A path to the ``nsys`` binary itself is also accepted (parent is mounted).
+    nsys_dir: str | None = None
 
     # Restrict nsys wrapping to specific DP ranks (``nsys``/``nsys-time`` only).
     profile_ranks: tuple[int, ...] | None = field(
@@ -997,14 +1009,35 @@ class ProfilingConfig:
 
         return env
 
+    def resolved_nsys_host_dir(self) -> Path | None:
+        """Absolute host directory of the Nsight Systems target tree, or None."""
+        if not self.nsys_dir:
+            return None
+        path = Path(os.path.expandvars(self.nsys_dir)).expanduser()
+        if path.is_file():
+            path = path.parent
+        return path.resolve()
+
+    def nsys_container_mount(self) -> tuple[Path, Path] | None:
+        """Host dir -> ``NSYS_HOST_CONTAINER_DIR``, or None when ``nsys_dir`` is unset."""
+        host = self.resolved_nsys_host_dir()
+        if host is None:
+            return None
+        return host, Path(NSYS_HOST_CONTAINER_DIR)
+
     @property
     def nsys_binary(self) -> str:
-        """nsys executable to invoke.
+        """nsys executable to invoke inside the container.
 
-        Defaults to ``nsys_path``. Override at runtime via ``SRTCTL_NSYS_BIN`` when
-        the container doesn't ship nsys on PATH.
+        Order: ``SRTCTL_NSYS_BIN`` env, then ``{NSYS_HOST_CONTAINER_DIR}/nsys``
+        when ``nsys_dir`` is set, else ``nsys_path`` (default ``nsys`` on PATH).
         """
-        return os.environ.get("SRTCTL_NSYS_BIN", self.nsys_path)
+        override = os.environ.get("SRTCTL_NSYS_BIN")
+        if override:
+            return override
+        if self.nsys_dir:
+            return f"{NSYS_HOST_CONTAINER_DIR}/nsys"
+        return self.nsys_path
 
     def _get_nsys_prefix_trtllm(self, output_file: str) -> list[str]:
         """Get nsys command prefix for TRTLLM workers.
@@ -1951,6 +1984,7 @@ class SrtConfig:
         known_types = tuple(t.value for t in ProfilingType)
         if prof.type not in known_types:
             raise ValidationError(f"Unknown profiling.type {prof.type!r}. Supported types: {', '.join(known_types)}")
+        self._validate_nsys_dir()
         if not prof.enabled:
             return
 
@@ -2017,6 +2051,21 @@ class SrtConfig:
             self._validate_nsys_profiling_steps()
             if backend_type == "vllm":
                 self._validate_vllm_nsys_profiler_config_not_set()
+
+    def _validate_nsys_dir(self) -> None:
+        """``nsys_dir`` is an nsys-only host bind-mount; do not combine with ``nsys_path``."""
+        prof = self.profiling
+        if not prof.nsys_dir:
+            return
+        if not prof.is_nsys:
+            raise ValidationError(
+                "profiling.nsys_dir is only valid when profiling.type is nsys, nsys-manual, or nsys-time"
+            )
+        if prof.nsys_path != "nsys":
+            raise ValidationError(
+                "profiling.nsys_dir already selects the nsys binary at "
+                f"{NSYS_HOST_CONTAINER_DIR}/nsys; do not also set profiling.nsys_path"
+            )
 
     def _validate_nsys_manual(self) -> None:
         """Validate ``nsys-manual`` recipe shape (``phases``, ``duration_secs``)."""

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -291,9 +291,27 @@ NSYS_MANUAL_DEFAULT_ARGS: tuple[str, ...] = (
 # Capture window used by ``nsys-manual.sh`` when a recipe omits ``duration_secs``.
 NSYS_MANUAL_DEFAULT_DURATION_SECS = 5
 
-# Bind-mount destination for a host Nsight Systems *target* tree
-# (``profiling.nsys_dir``). The in-container binary is ``{this}/nsys``.
+# Bind-mount destination for a host Nsight Systems install
+# (``profiling.nsys_dir``). The in-container CLI is ``{this}/bin/nsys`` when
+# the host tree has the usual ``bin/nsys -> ../target-linux-*/nsys`` layout.
 NSYS_HOST_CONTAINER_DIR = "/opt/srtctl-nsys"
+
+
+def _promote_nsys_install_root(path: Path) -> Path:
+    """Prefer the Nsight install root that contains ``bin/nsys``.
+
+    The ELF in ``target-linux-*/nsys`` refuses to run unless invoked through
+    that symlink ("Modify the executable in your command to be a symbolic
+    link pointing to 'target-linux-.../nsys'").
+    """
+    if (path / "bin" / "nsys").exists():
+        return path
+    if path.name == "bin" and (path / "nsys").exists():
+        return path.parent
+    parent = path.parent
+    if path.name.startswith("target-linux-") and (parent / "bin" / "nsys").exists():
+        return parent
+    return path
 
 
 class TelemetryProvider(str, Enum):
@@ -886,11 +904,11 @@ class ProfilingConfig:
     # overrides this at runtime. Ignored when ``nsys_dir`` is set.
     nsys_path: str = "nsys"
 
-    # Host path to an Nsight Systems *target* directory (the tree that contains
-    # ``nsys``, ``nsys-launcher``, and the sibling ``.so`` files — e.g.
-    # ``.../nsight-systems-*/target-linux-sbsa-armv8``). Bind-mounted at
-    # ``NSYS_HOST_CONTAINER_DIR`` so the image does not need nsys installed.
-    # A path to the ``nsys`` binary itself is also accepted (parent is mounted).
+    # Host path to an Nsight Systems install. Either the install root
+    # (``.../nsight-systems-*/``, containing ``bin/nsys``) or the architecture
+    # target tree (``.../target-linux-sbsa-armv8``) — the latter is walked up
+    # to the install root so nsys is invoked via the ``bin/nsys`` symlink.
+    # Bind-mounted at ``NSYS_HOST_CONTAINER_DIR``.
     nsys_dir: str | None = None
 
     # Restrict nsys wrapping to specific DP ranks (``nsys``/``nsys-time`` only).
@@ -1010,13 +1028,30 @@ class ProfilingConfig:
         return env
 
     def resolved_nsys_host_dir(self) -> Path | None:
-        """Absolute host directory of the Nsight Systems target tree, or None."""
+        """Absolute host directory to bind-mount, or None.
+
+        This is the Nsight install root when ``bin/nsys`` exists (possibly after
+        walking up from ``target-linux-*``), otherwise the path as given.
+        """
         if not self.nsys_dir:
             return None
         path = Path(os.path.expandvars(self.nsys_dir)).expanduser()
         if path.is_file():
             path = path.parent
-        return path.resolve()
+        return _promote_nsys_install_root(path.resolve())
+
+    def nsys_host_cli(self) -> Path | None:
+        """Host nsys CLI to expose in the container (``bin/nsys`` preferred)."""
+        host = self.resolved_nsys_host_dir()
+        if host is None:
+            return None
+        cli = host / "bin" / "nsys"
+        if cli.exists():
+            return cli
+        direct = host / "nsys"
+        if direct.is_file():
+            return direct
+        return None
 
     def nsys_container_mount(self) -> tuple[Path, Path] | None:
         """Host dir -> ``NSYS_HOST_CONTAINER_DIR``, or None when ``nsys_dir`` is unset."""
@@ -1029,15 +1064,19 @@ class ProfilingConfig:
     def nsys_binary(self) -> str:
         """nsys executable to invoke inside the container.
 
-        Order: ``SRTCTL_NSYS_BIN`` env, then ``{NSYS_HOST_CONTAINER_DIR}/nsys``
+        Order: ``SRTCTL_NSYS_BIN`` env, then ``{NSYS_HOST_CONTAINER_DIR}/bin/nsys``
+        when the host install has that symlink, else ``{NSYS_HOST_CONTAINER_DIR}/nsys``
         when ``nsys_dir`` is set, else ``nsys_path`` (default ``nsys`` on PATH).
         """
         override = os.environ.get("SRTCTL_NSYS_BIN")
         if override:
             return override
-        if self.nsys_dir:
-            return f"{NSYS_HOST_CONTAINER_DIR}/nsys"
-        return self.nsys_path
+        if not self.nsys_dir:
+            return self.nsys_path
+        host_cli = self.nsys_host_cli()
+        if host_cli is not None and host_cli.parent.name == "bin":
+            return f"{NSYS_HOST_CONTAINER_DIR}/bin/nsys"
+        return f"{NSYS_HOST_CONTAINER_DIR}/nsys"
 
     def _get_nsys_prefix_trtllm(self, output_file: str) -> list[str]:
         """Get nsys command prefix for TRTLLM workers.

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -250,8 +250,28 @@ class BenchmarkType(str, Enum):
 
 class ProfilingType(str, Enum):
     NSYS = "nsys"
+    NSYS_MANUAL = "nsys-manual"
+    NSYS_TIME = "nsys-time"
     TORCH = "torch"
     NONE = "none"
+
+
+# Default nsys profile flags for ``type: nsys-manual``. Recipes set ``phases`` (disagg)
+# or omit it (aggregated); flags are not configurable in v1.
+NSYS_MANUAL_DEFAULT_ARGS: tuple[str, ...] = (
+    "--trace-fork-before-exec=true",
+    "--cuda-graph-trace=node",
+    "--capture-range=cudaProfilerApi",
+    "--trace=cuda,nvtx",
+    "--capture-range-end=stop",
+    "--kill",
+    "none",
+    "--wait",
+    "all",
+)
+
+# Capture window used by ``nsys-manual.sh`` when a recipe omits ``duration_secs``.
+NSYS_MANUAL_DEFAULT_DURATION_SECS = 5
 
 
 class TelemetryProvider(str, Enum):
@@ -355,6 +375,44 @@ class SweepConfigField(fields.Field):
             result: dict[str, Any] = {"mode": value.mode}
             result.update(value.parameters)
             return result
+        return value
+
+
+class ProfilingPhaseField(fields.Field):
+    """Polymorphic deserializer for a profiling phase (prefill/decode/aggregated).
+
+    A phase value may be written as:
+
+    - **a mapping with start_step/stop_step** (``decode: {start_step: 100, ...}``):
+      iteration-based ``type: nsys``.
+    - **an empty mapping** (``decode: {}``): phase filter for ``nsys-time``.
+    - **a list of nsys flags**: legacy syntax, rejected by validation with a pointer
+      to the current ``nsys-manual`` recipe shape.
+    - **absent**: use srt-slurm's default nsys flags for that phase.
+    """
+
+    def _deserialize(self, value: Any, attr: str | None, data: Mapping[str, Any] | None, **kwargs) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, ProfilingPhaseConfig):
+            return value
+        if isinstance(value, list | tuple):
+            return ProfilingPhaseConfig(nsys_args=tuple(str(v) for v in value))
+        if isinstance(value, dict):
+            if not value:
+                return ProfilingPhaseConfig()
+            return ProfilingPhaseConfig.Schema().load(value)
+        raise ValidationError(
+            f"Expected a list of nsys flags or a mapping for profiling phase, got {type(value).__name__}"
+        )
+
+    def _serialize(self, value: Any | None, attr: str | None, obj: Any, **kwargs) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, ProfilingPhaseConfig):
+            if value.nsys_args is not None:
+                return list(value.nsys_args)
+            return ProfilingPhaseConfig.Schema().dump(value)
         return value
 
 
@@ -738,10 +796,24 @@ class BenchmarkConfig:
 
 @dataclass(frozen=True)
 class ProfilingPhaseConfig:
-    """Profiling config for a single phase (prefill/decode/aggregated)."""
+    """Profiling config for a single phase (prefill/decode/aggregated).
+
+    Two orthogonal ways to drive nsys:
+
+    - ``start_step``/``stop_step``: iteration-based capture. vLLM/TRTLLM trigger
+      cudaProfilerStart/Stop at those step boundaries.
+    - ``nsys_args``: legacy per-phase nsys flag list, kept only so recipes written
+      against the old ``nsys-manual`` syntax fail with an actionable error.
+    """
 
     start_step: int | None = None  # Step to start profiling
     stop_step: int | None = None  # Step to stop profiling
+    nsys_args: tuple[str, ...] | None = field(
+        default=None,
+        metadata={"marshmallow_field": fields.List(fields.String(), allow_none=True)},
+    )
+
+    Schema: ClassVar[builtins.type[Schema]] = Schema
 
     @property
     def vllm_nsys_delay_iterations(self) -> int:
@@ -755,44 +827,68 @@ class ProfilingPhaseConfig:
             return 0
         return max(self.stop_step - self.start_step, 0)
 
-    Schema: ClassVar[builtins.type[Schema]] = Schema
-
 
 @dataclass(frozen=True)
 class ProfilingConfig:
     """Profiling configuration.
 
-    Supports two profiling modes:
-    - nsys: NVIDIA Nsight Systems profiling (wraps command with nsys profile)
-    - torch: PyTorch profiler (uses SGLANG_TORCH_PROFILER_DIR)
-
-    Per-phase start_step/stop_step are specified in the prefill/decode/aggregated sections.
+    Profiling modes (``type``):
+    - ``nsys``: iteration-based nsys (``start_step``/``stop_step`` per phase)
+    - ``nsys-manual``: on-demand nsys (``nsys-manual.sh``; ``phases`` + ``duration_secs``)
+    - ``nsys-time``: wall-clock nsys (``delay_secs``/``duration_secs``)
+    - ``torch``: PyTorch profiler (SGLang; ``SGLANG_TORCH_PROFILER_DIR``)
     """
 
-    type: str = "none"  # "none", "nsys", "nsys-time", or "torch"
+    type: str = "none"  # "none", "nsys", "nsys-manual", "nsys-time", or "torch"
 
-    # Extra arguments passed to nsys profile (appended before `-o`; see get_nsys_prefix)
+    # Extra arguments passed to nsys profile (not used in ``nsys-manual``).
     extra_nsys_args: list[str] | None = None
 
-    # Phase-specific profiling step configs (not used for nsys-time)
-    prefill: ProfilingPhaseConfig | None = None
-    decode: ProfilingPhaseConfig | None = None
-    aggregated: ProfilingPhaseConfig | None = None
+    # Phase-specific profiling configs (``nsys``, ``nsys-time``, ``torch``).
+    prefill: Annotated[ProfilingPhaseConfig, ProfilingPhaseField()] | None = None
+    decode: Annotated[ProfilingPhaseConfig, ProfilingPhaseField()] | None = None
+    aggregated: Annotated[ProfilingPhaseConfig, ProfilingPhaseField()] | None = None
 
-    # nsys-time fields: time-based capture window, same on all workers
+    # nsys-manual: which disagg phase to profile (required for disagg, forbidden for agg).
+    phases: str | None = None  # "prefill" or "decode"
+
+    # nsys-time fields: time-based capture window, same on all workers.
+    # ``duration_secs`` is shared with nsys-manual, where it is the length of the
+    # window fired by ``nsys-manual.sh`` (defaults to NSYS_MANUAL_DEFAULT_DURATION_SECS).
     delay_secs: int | None = None  # nsys --delay: seconds from worker launch before capture starts
     duration_secs: int | None = None  # nsys --duration: seconds to capture after delay
     benchmark_duration_secs: int = 300  # total traffic generation duration (must cover delay + duration)
+
+    # Default nsys binary name/path. ``SRTCTL_NSYS_BIN`` env overrides this at runtime.
+    nsys_path: str = "nsys"
+
+    # Restrict nsys wrapping to specific DP ranks (``nsys``/``nsys-time`` only).
+    profile_ranks: tuple[int, ...] | None = field(
+        default=None,
+        metadata={"marshmallow_field": fields.List(fields.Integer(), allow_none=True)},
+    )
 
     @property
     def enabled(self) -> bool:
         """Check if profiling is enabled."""
         return self.type != "none"
 
+    def wraps_rank(self, node_rank: int) -> bool:
+        """Whether the given DP rank's process should be wrapped with nsys."""
+        if self.profile_ranks is None:
+            return True
+        return node_rank in self.profile_ranks
+
+    def should_wrap_process_with_nsys(self, *, endpoint_index: int, node_rank: int) -> bool:
+        """Whether this worker process should run under nsys."""
+        if self.is_nsys_manual:
+            return endpoint_index == 0 and node_rank == 0
+        return self.wraps_rank(node_rank)
+
     @property
     def is_nsys(self) -> bool:
-        """Check if using NVIDIA Nsight Systems profiling (includes nsys-time)."""
-        return self.type in ("nsys", "nsys-time")
+        """Check if using NVIDIA Nsight Systems profiling (any nsys variant)."""
+        return self.type in ("nsys", "nsys-manual", "nsys-time")
 
     @property
     def is_nsys_time(self) -> bool:
@@ -804,6 +900,16 @@ class ProfilingConfig:
         """Check if using PyTorch profiler."""
         return self.type == "torch"
 
+    @property
+    def is_nsys_manual(self) -> bool:
+        """On-demand nsys (``type: nsys-manual``): user fires /start_profile by hand."""
+        return self.type == "nsys-manual"
+
+    @property
+    def manual_duration_secs(self) -> int:
+        """Capture window baked into ``nsys-manual.sh``."""
+        return self.duration_secs if self.duration_secs is not None else NSYS_MANUAL_DEFAULT_DURATION_SECS
+
     def _get_phase_config(self, mode: str) -> ProfilingPhaseConfig | None:
         """Get the phase config for the given mode."""
         if mode == "prefill":
@@ -813,6 +919,25 @@ class ProfilingConfig:
         elif mode in ("agg", "aggregated"):
             return self.aggregated
         return None
+
+    def profiles_mode(self, mode: str) -> bool:
+        """Whether workers of ``mode`` should be wrapped with nsys."""
+        if self.is_nsys_manual:
+            if self.phases is not None:
+                norm = "aggregated" if mode in ("agg", "aggregated") else mode
+                return norm == self.phases
+            return mode in ("agg", "aggregated")
+        if not self.is_nsys_time:
+            return True
+        present = [
+            name
+            for name, cfg in (("prefill", self.prefill), ("decode", self.decode), ("aggregated", self.aggregated))
+            if cfg is not None
+        ]
+        if not present:
+            return True
+        norm = "aggregated" if mode in ("agg", "aggregated") else mode
+        return norm in present
 
     def get_env_vars(self, mode: str, profile_dir: str) -> dict[str, str]:
         """Get profiling-specific environment variables.
@@ -857,12 +982,10 @@ class ProfilingConfig:
     def nsys_binary(self) -> str:
         """nsys executable to invoke.
 
-        Defaults to ``nsys`` (resolved on PATH). Override via the
-        ``SRTCTL_NSYS_BIN`` environment variable when running inside a
-        container that doesn't ship nsys on PATH — e.g. mount the host's
-        Nsight Systems install and point this at the absolute path.
+        Defaults to ``nsys_path``. Override at runtime via ``SRTCTL_NSYS_BIN`` when
+        the container doesn't ship nsys on PATH.
         """
-        return os.environ.get("SRTCTL_NSYS_BIN", "nsys")
+        return os.environ.get("SRTCTL_NSYS_BIN", self.nsys_path)
 
     def _get_nsys_prefix_trtllm(self, output_file: str) -> list[str]:
         """Get nsys command prefix for TRTLLM workers.
@@ -914,12 +1037,19 @@ class ProfilingConfig:
         return cmd
 
     def get_nsys_prefix(
-        self, output_file: str, *, frontend_type: str | None = None, backend_type: str | None = None
+        self,
+        output_file: str,
+        *,
+        mode: str | None = None,
+        frontend_type: str | None = None,
+        backend_type: str | None = None,
     ) -> list[str]:
         """Get nsys profiling command prefix.
 
         Args:
             output_file: Path for nsys output file (without extension)
+            mode: Worker mode (prefill/decode/agg). Required for ``nsys-manual`` so the
+                configured phase can be matched.
             frontend_type: Frontend type (e.g., "dynamo", "sglang"). When set to "dynamo"
                 with a non-trtllm backend, adds --trace-fork-before-exec=true.
             backend_type: Backend type (e.g., "trtllm", "sglang"). When set to "trtllm",
@@ -930,6 +1060,19 @@ class ProfilingConfig:
         """
         if not self.is_nsys:
             return []
+
+        if self.is_nsys_manual:
+            if mode is None or not self.profiles_mode(mode):
+                return []
+            return [
+                self.nsys_binary,
+                "profile",
+                *NSYS_MANUAL_DEFAULT_ARGS,
+                "--force-overwrite",
+                "true",
+                "-o",
+                output_file,
+            ]
 
         if backend_type == "trtllm":
             return self._get_nsys_prefix_trtllm(output_file)
@@ -1070,6 +1213,16 @@ class TelemetryConfig:
     live_metrics: LiveMetricsConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
+
+
+# Dynamo defaults every component (workers and frontends) starts with. Dynamo's own
+# default log level is ``info``, which buries backend output under runtime chatter, and
+# its ANSI escapes make the .out files unreadable in an editor. Recipes override these
+# via the global ``environment:`` block, ``frontend.env``, or ``*_environment``.
+DYNAMO_DEFAULT_ENV: dict[str, str] = {
+    "DYN_LOG": "error",
+    "DYN_SDK_DISABLE_ANSI_LOGGING": "1",
+}
 
 
 def build_otel_env(observability: ObservabilityConfig, component: str) -> dict[str, str]:
@@ -1729,6 +1882,9 @@ class SrtConfig:
     def _validate_profiling(self):
         """Validate profiling configuration matches serving mode."""
         prof = self.profiling
+        known_types = tuple(t.value for t in ProfilingType)
+        if prof.type not in known_types:
+            raise ValidationError(f"Unknown profiling.type {prof.type!r}. Supported types: {', '.join(known_types)}")
         if not prof.enabled:
             return
 
@@ -1750,6 +1906,12 @@ class SrtConfig:
                 raise ValidationError(
                     "profiling.delay_secs and profiling.duration_secs are required for nsys-time mode"
                 )
+            return
+
+        if prof.is_nsys_manual:
+            self._validate_nsys_manual()
+            if backend_type == "vllm":
+                self._validate_vllm_nsys_profiler_config_not_set()
             return
 
         r = self.resources
@@ -1784,10 +1946,55 @@ class SrtConfig:
                 raise ValidationError("Aggregated mode requires agg_workers to be > 0.")
 
         # Iteration-based nsys (type: nsys) drives the vLLM engine profiler via
-        # --profiler-config, derived from the profiling: block. Forbid duplicating
-        # it in vllm_config so the two can't diverge silently.
-        if prof.type == "nsys" and backend_type == "vllm":
-            self._validate_vllm_nsys_profiler_config_not_set()
+        # --profiler-config from the profiling: block. Forbid duplicating it in vllm_config.
+        if prof.type == "nsys":
+            self._validate_nsys_profiling_steps()
+            if backend_type == "vllm":
+                self._validate_vllm_nsys_profiler_config_not_set()
+
+    def _validate_nsys_manual(self) -> None:
+        """Validate ``nsys-manual`` recipe shape (``phases``, ``duration_secs``)."""
+        prof = self.profiling
+        if prof.prefill is not None or prof.decode is not None or prof.aggregated is not None:
+            raise ValidationError(
+                "nsys-manual uses profiling.phases and profiling.duration_secs; "
+                "do not set prefill/decode/aggregated blocks."
+            )
+        if prof.profile_ranks is not None:
+            raise ValidationError("nsys-manual always profiles endpoint 0 rank 0; do not set profile_ranks.")
+        if prof.delay_secs is not None:
+            raise ValidationError("nsys-manual capture starts when you run nsys-manual.sh; do not set delay_secs.")
+        if prof.duration_secs is not None and prof.duration_secs <= 0:
+            raise ValidationError("profiling.duration_secs must be > 0 for nsys-manual.")
+
+        is_disaggregated = self.resources.is_disaggregated
+        if is_disaggregated:
+            if prof.phases not in ("prefill", "decode"):
+                raise ValidationError(
+                    "Disaggregated nsys-manual requires profiling.phases to be 'prefill' or 'decode'."
+                )
+        elif prof.phases is not None:
+            raise ValidationError("Aggregated nsys-manual must not set profiling.phases.")
+
+    def _validate_nsys_profiling_steps(self) -> None:
+        """Iteration-based ``nsys`` requires start_step/stop_step per configured phase."""
+        prof = self.profiling
+        for name, phase in (("prefill", prof.prefill), ("decode", prof.decode), ("aggregated", prof.aggregated)):
+            if phase is None:
+                continue
+            if phase.nsys_args is not None:
+                raise ValidationError(
+                    f"profiling.{name} uses explicit nsys flags, which are no longer configurable. "
+                    "For on-demand capture use profiling.type nsys-manual with phases/duration."
+                )
+            if phase.start_step is None or phase.stop_step is None:
+                raise ValidationError(f"profiling.{name} requires both start_step and stop_step.")
+            if phase.start_step < 0 or phase.stop_step < 0:
+                raise ValidationError(f"profiling.{name}: start_step and stop_step must be >= 0.")
+            if phase.stop_step < phase.start_step:
+                raise ValidationError(
+                    f"profiling.{name}: stop_step ({phase.stop_step}) must be >= start_step ({phase.start_step})."
+                )
 
     def _validate_vllm_nsys_profiler_config_not_set(self):
         """Reject profiler-config.* in vllm_config when nsys profiling is enabled.

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -280,6 +280,12 @@ def start_srun_process(
 
     if output:
         srun_cmd.extend(["--output", output])
+        # Open the log in append mode so srun streams task output with O_APPEND.
+        # This lets other same-FS processes (e.g. bench.sh writing stage banners
+        # into the live worker logs) inject lines via their own O_APPEND writes
+        # without srun clobbering them on its next write. Files are unique per
+        # job, so append is equivalent to truncate for the first open.
+        srun_cmd.extend(["--open-mode", "append"])
 
     # Container options
     if container_image:

--- a/src/srtctl/frontends/dynamo.py
+++ b/src/srtctl/frontends/dynamo.py
@@ -13,7 +13,7 @@ import threading
 from typing import TYPE_CHECKING, Any
 
 from srtctl.core.health import WorkerHealthResult, check_dynamo_health
-from srtctl.core.schema import build_otel_env
+from srtctl.core.schema import DYNAMO_DEFAULT_ENV, build_otel_env
 from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, start_srun_process
 from srtctl.ports import ETCD_CLIENT_PORT, NATS_PORT
 
@@ -83,6 +83,7 @@ class DynamoFrontend:
             cmd.extend(self.get_frontend_args_list(config.frontend.args))
 
             env_to_set = {
+                **DYNAMO_DEFAULT_ENV,
                 "ETCD_ENDPOINTS": f"http://{runtime.nodes.infra}:{ETCD_CLIENT_PORT}",
                 "NATS_SERVER": f"nats://{runtime.nodes.infra}:{NATS_PORT}",
                 "DYN_REQUEST_PLANE": config.dynamo.request_plane,

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -3,6 +3,8 @@
 
 """Tests for benchmark runners."""
 
+import os
+
 import pytest
 
 from srtctl.benchmarks import get_runner, list_benchmarks
@@ -1004,6 +1006,70 @@ source "$script" "$@"
             if line.startswith("BENCHMARK_CALL reuse=")
         ]
         assert calls == expected
+
+    def test_sa_bench_writes_stage_banners_into_worker_logs(self, tmp_path):
+        """Warmup/benchmark boundaries are marked in the live worker logs.
+
+        Worker logs have no notion of which sa-bench phase is running, so without
+        these separators it is impossible to tell warmup traffic from the measured
+        run when reading a worker log (or when timing a manual nsys capture).
+        """
+        import subprocess
+
+        script = SCRIPTS_DIR / "sa-bench" / "bench.sh"
+        prefill_log = tmp_path / "node0_prefill_w0.out"
+        decode_log = tmp_path / "node1_decode_w0.out"
+        prefill_log.touch()
+        decode_log.touch()
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                r"""
+script=$1
+shift
+python3() { return 0; }
+curl() { return 0; }
+mkdir() { return 0; }
+source "$script" "$@"
+""",
+                "_",
+                str(script),
+                "http://localhost:8000",
+                "1",
+                "1",
+                "2",
+                "inf",
+                "/model",
+                "model",
+                "false",
+                "1",
+                "0",
+                "0",
+                "0.8",
+                "1",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": os.environ["PATH"], "PROFILE_OUTPUT_DIR": str(tmp_path / "profiles")},
+        )
+
+        assert result.returncode == 0, result.stderr
+        for log in (prefill_log, decode_log):
+            stages = [
+                line.split("] ", 1)[1].removesuffix(" ========")
+                for line in log.read_text().splitlines()
+                if line.startswith("========")
+            ]
+            assert stages == [
+                "cc=2 warmup begin",
+                "cc=2 warmup end",
+                "cc=2 benchmark begin",
+                "cc=2 benchmark end",
+            ]
 
     def test_mmlu_script_exists(self):
         """MMLU script exists."""

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1223,6 +1223,105 @@ class TestWorkerEnvironmentTemplating:
                     # Mixed case: supported replaced, unsupported kept
                     assert env_vars["MIXED"] == "gpu-01-{unsupported_var}-cache"
 
+    def _start_worker_env(self, tmp_path, backend, environment=None):
+        """Start one prefill worker and return the env srtctl would export to srun."""
+        import os
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.cli.mixins.worker_stage import WorkerStageMixin
+        from srtctl.core.runtime import RuntimeContext
+        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
+        from srtctl.core.topology import Process
+
+        model_path = tmp_path / "model"
+        model_path.mkdir(exist_ok=True)
+        container_path = tmp_path / "container.sqsh"
+        container_path.touch()
+
+        slurm_env = {
+            "SLURM_JOB_ID": "12345",
+            "SLURM_JOBID": "12345",
+            "SLURM_NODELIST": "gpu-[01-03]",
+            "SLURM_JOB_NUM_NODES": "3",
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+        }
+
+        def mock_scontrol(cmd, **kwargs):
+            if cmd[0] == "scontrol" and "hostnames" in cmd:
+                result = MagicMock()
+                result.stdout = "gpu-01\ngpu-02\ngpu-03"
+                result.returncode = 0
+                return result
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with (
+            patch.dict(os.environ, slurm_env),
+            patch("subprocess.run", mock_scontrol),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            config = SrtConfig(
+                name="test",
+                model=ModelConfig(path=str(model_path), container=str(container_path), precision="fp8"),
+                resources=ResourceConfig(gpu_type="h100", gpus_per_node=8, prefill_nodes=1, decode_nodes=1),
+                backend=backend,
+                environment=environment or {},
+            )
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
+
+            class MockWorkerStage(WorkerStageMixin):
+                def __init__(self, config, runtime):
+                    self.config = config
+                    self.runtime = runtime
+
+            worker_stage = MockWorkerStage(config, runtime)
+            process = Process(
+                node="gpu-01",
+                gpu_indices=frozenset(range(8)),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=0,
+            )
+
+            mock_backend = MagicMock()
+            mock_backend.get_environment_for_mode.side_effect = config.backend.get_environment_for_mode
+            mock_backend.build_worker_command.return_value = ["echo", "test"]
+
+            with (
+                patch.object(worker_stage, "config") as mock_config,
+                patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
+            ):
+                mock_config.backend = mock_backend
+                mock_config.profiling = config.profiling
+                mock_srun.return_value = MagicMock()
+                worker_stage.start_worker(process, [process])
+                return mock_srun.call_args.kwargs.get("env_to_set", {})
+
+    def test_worker_gets_quiet_dynamo_defaults(self, tmp_path):
+        """Dynamo's own defaults (info + ANSI colors) make worker logs unreadable."""
+        from srtctl.backends import SGLangProtocol
+
+        env_vars = self._start_worker_env(tmp_path, SGLangProtocol())
+
+        assert env_vars["DYN_LOG"] == "error"
+        assert env_vars["DYN_SDK_DISABLE_ANSI_LOGGING"] == "1"
+
+    def test_recipe_overrides_dynamo_defaults(self, tmp_path):
+        """Both the global environment block and per-mode env win over the defaults."""
+        from srtctl.backends import SGLangProtocol
+
+        env_vars = self._start_worker_env(
+            tmp_path,
+            SGLangProtocol(prefill_environment={"DYN_SDK_DISABLE_ANSI_LOGGING": "0"}),
+            environment={"DYN_LOG": "debug"},
+        )
+
+        assert env_vars["DYN_LOG"] == "debug"
+        assert env_vars["DYN_SDK_DISABLE_ANSI_LOGGING"] == "0"
+
 
 class TestInfraConfig:
     """Tests for InfraConfig dataclass."""
@@ -2141,7 +2240,8 @@ class TestVLLMDataParallelMode:
         runtime.model_path = Path("/model")
         runtime.is_hf_model = False
         runtime.frontend_port = 8000
-        profiling = MagicMock(is_nsys=True, is_nsys_time=False)
+        profiling = MagicMock(is_nsys=True, is_nsys_time=False, is_nsys_manual=False)
+        profiling.profiles_mode.return_value = True
         profiling._get_phase_config.return_value = SimpleNamespace(
             start_step=10,
             stop_step=25,

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -173,6 +173,29 @@ class TestDryRunEnvironment:
         output = capsys.readouterr().out
         assert "No custom environment variables configured" in output
 
+    def test_dynamo_defaults_always_shown(self, capsys):
+        """srtctl-injected dynamo defaults are visible even with no custom env."""
+        config = _make_config()
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "dynamo defaults" in output
+        assert "DYN_LOG=error" in output
+        assert "DYN_SDK_DISABLE_ANSI_LOGGING=1" in output
+        assert "overridden" not in output
+
+    def test_dynamo_defaults_marked_overridden(self, capsys):
+        """A recipe value for a default key is flagged so the effective value is obvious."""
+        config = _make_config(
+            {
+                "environment": {"DYN_LOG": "info"},
+                "backend": {"type": "sglang", "decode_environment": {"DYN_SDK_DISABLE_ANSI_LOGGING": "0"}},
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "DYN_LOG=error (overridden)" in output
+        assert "DYN_SDK_DISABLE_ANSI_LOGGING=1 (overridden)" in output
+
     def test_trtllm_backend_environment(self, capsys):
         config = _make_config(
             {

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -113,6 +113,22 @@ class TestDryRunMounts:
         assert "/model" in output
         assert "recipe" not in output
 
+    def test_nsys_dir_mount_shown(self, capsys):
+        config = _make_config(
+            {
+                "profiling": {
+                    "type": "nsys-manual",
+                    "phases": "prefill",
+                    "nsys_dir": "/host/nsys-tree",
+                }
+            }
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "/host/nsys-tree" in output
+        assert "/opt/srtctl-nsys" in output
+        assert "profiling.nsys_dir" in output
+
 
 class TestDryRunEnvironment:
     """Test that environment variables from all levels appear in dry-run output."""

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -526,7 +526,13 @@ class TestFrontendEnvHandling:
 # ============================================================================
 
 
-def _dynamo_frontend_call(*, dynamo_install: bool, event_plane: str | None = "zmq"):
+def _dynamo_frontend_call(
+    *,
+    dynamo_install: bool,
+    event_plane: str | None = "zmq",
+    environment: dict[str, str] | None = None,
+    frontend_env: dict[str, str] | None = None,
+):
     """Invoke DynamoFrontend.start_frontends with a minimal config; return the mock srun call."""
     frontend = DynamoFrontend()
     topology = SimpleNamespace(frontend_nodes=["node0"], frontend_port=8180)
@@ -535,10 +541,10 @@ def _dynamo_frontend_call(*, dynamo_install: bool, event_plane: str | None = "zm
         nodes=SimpleNamespace(infra="infra-node", het_group_for=lambda node: None),
         container_image=Path("/container.sqsh"),
         container_mounts={},
-        environment={},
+        environment=environment or {},
     )
     config = SimpleNamespace(
-        frontend=SimpleNamespace(args=None, env=None),
+        frontend=SimpleNamespace(args=None, env=frontend_env),
         observability=ObservabilityConfig(),
         dynamo=SimpleNamespace(
             install=dynamo_install,
@@ -564,6 +570,27 @@ class TestDynamoFrontendRemapRoot:
     def test_no_remap_root_when_install_false(self):
         mock_srun = _dynamo_frontend_call(dynamo_install=False)
         assert mock_srun.call_args.kwargs["srun_export_env"] is None
+
+
+class TestDynamoFrontendLogDefaults:
+    """The frontend gets the same quiet dynamo defaults as workers."""
+
+    def test_defaults_applied(self):
+        env = _dynamo_frontend_call(dynamo_install=False).call_args.kwargs["env_to_set"]
+        assert env["DYN_LOG"] == "error"
+        assert env["DYN_SDK_DISABLE_ANSI_LOGGING"] == "1"
+
+    def test_global_environment_overrides(self):
+        env = _dynamo_frontend_call(dynamo_install=False, environment={"DYN_LOG": "debug"}).call_args.kwargs[
+            "env_to_set"
+        ]
+        assert env["DYN_LOG"] == "debug"
+
+    def test_frontend_env_overrides(self):
+        env = _dynamo_frontend_call(dynamo_install=False, frontend_env={"DYN_LOG": "warn"}).call_args.kwargs[
+            "env_to_set"
+        ]
+        assert env["DYN_LOG"] == "warn"
 
 
 class TestDynamoFrontendEventPlane:

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -120,6 +120,295 @@ class TestProfilingConfig:
         # trtllm path
         assert ProfilingConfig(type="nsys").get_nsys_prefix("/out/w0", backend_type="trtllm")[0] == "/opt/nsight/nsys"
 
+    def test_manual_nsys_phase_parsing(self):
+        """phases: decode loads as nsys-manual with built-in nsys flags."""
+        from srtctl.core.schema import NSYS_MANUAL_DEFAULT_ARGS, ProfilingConfig
+
+        prof = ProfilingConfig.Schema().load(
+            {
+                "type": "nsys-manual",
+                "phases": "decode",
+                "duration_secs": 7,
+            }
+        )
+
+        assert prof.is_nsys is True
+        assert prof.is_nsys_manual is True
+        assert prof.phases == "decode"
+        assert prof.manual_duration_secs == 7
+        assert prof.get_nsys_prefix("/out", mode="decode")[2 : 2 + len(NSYS_MANUAL_DEFAULT_ARGS)] == list(
+            NSYS_MANUAL_DEFAULT_ARGS
+        )
+
+    def test_manual_nsys_profiles_mode(self):
+        """profiles_mode: phases selects prefill or decode; agg omits phases."""
+        from srtctl.core.schema import ProfilingConfig
+
+        disagg = ProfilingConfig(type="nsys-manual", phases="decode")
+        assert disagg.profiles_mode("decode") is True
+        assert disagg.profiles_mode("prefill") is False
+        assert disagg.profiles_mode("agg") is False
+
+        agg = ProfilingConfig(type="nsys-manual")
+        assert agg.profiles_mode("agg") is True
+        assert agg.profiles_mode("aggregated") is True
+        assert agg.profiles_mode("decode") is False
+
+    def test_manual_nsys_wraps_endpoint0_rank0(self):
+        """nsys-manual always wraps endpoint 0 rank 0 only."""
+        from srtctl.core.schema import ProfilingConfig
+
+        prof = ProfilingConfig(type="nsys-manual", phases="decode")
+        assert prof.should_wrap_process_with_nsys(endpoint_index=0, node_rank=0) is True
+        assert prof.should_wrap_process_with_nsys(endpoint_index=0, node_rank=1) is False
+        assert prof.should_wrap_process_with_nsys(endpoint_index=1, node_rank=0) is False
+
+    def test_profile_ranks_wraps_rank(self):
+        """profile_ranks limits which DP ranks get nsys wrapping (non-manual modes)."""
+        from srtctl.core.schema import ProfilingConfig
+
+        prof = ProfilingConfig(type="nsys", profile_ranks=(0,))
+        assert prof.wraps_rank(0) is True
+        assert prof.wraps_rank(1) is False
+        assert ProfilingConfig(type="nsys").wraps_rank(3) is True
+
+    def test_manual_nsys_prefix_uses_builtin_defaults(self, monkeypatch):
+        """Manual mode uses NSYS_MANUAL_DEFAULT_ARGS."""
+        from srtctl.core.schema import NSYS_MANUAL_DEFAULT_ARGS, ProfilingConfig
+
+        monkeypatch.delenv("SRTCTL_NSYS_BIN", raising=False)
+        prof = ProfilingConfig(type="nsys-manual", phases="decode")
+
+        prefix = prof.get_nsys_prefix("/logs/p/decode/out", mode="decode")
+        assert prefix == [
+            "nsys",
+            "profile",
+            *NSYS_MANUAL_DEFAULT_ARGS,
+            "--force-overwrite",
+            "true",
+            "-o",
+            "/logs/p/decode/out",
+        ]
+        assert prof.get_nsys_prefix("/logs/p/prefill/out", mode="prefill") == []
+
+    def test_manual_nsys_disagg_passes_validation(self):
+        """Manual nsys with phases needs no start_step/stop_step to validate."""
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        cfg = SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/container", precision="fp8"),
+            resources=ResourceConfig(
+                gpu_type="h100",
+                prefill_nodes=1,
+                decode_nodes=1,
+                prefill_workers=1,
+                decode_workers=1,
+            ),
+            profiling=ProfilingConfig(type="nsys-manual", phases="decode"),
+        )
+        assert cfg.profiling.is_nsys_manual is True
+
+    def test_manual_nsys_disagg_requires_phases(self):
+        """Disaggregated nsys-manual requires profiling.phases."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        with pytest.raises(ValidationError, match="profiling.phases"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(type="nsys-manual"),
+            )
+
+    def test_manual_nsys_agg_rejects_phases(self):
+        """Aggregated nsys-manual must not set profiling.phases."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        with pytest.raises(ValidationError, match="must not set profiling.phases"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(gpu_type="h100", agg_nodes=1, agg_workers=1),
+                profiling=ProfilingConfig(type="nsys-manual", phases="decode"),
+            )
+
+    def test_manual_nsys_rejects_legacy_blocks(self):
+        """nsys-manual rejects prefill/decode/aggregated blocks."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ProfilingPhaseConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        with pytest.raises(ValidationError, match="do not set prefill"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(
+                    type="nsys-manual",
+                    phases="decode",
+                    decode=ProfilingPhaseConfig(),
+                ),
+            )
+
+    def test_manual_nsys_rejects_profile_ranks(self):
+        """nsys-manual always profiles endpoint 0 rank 0; profile_ranks is rejected."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        with pytest.raises(ValidationError, match="profile_ranks"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(type="nsys-manual", phases="decode", profile_ranks=(0,)),
+            )
+
+    def test_manual_nsys_duration_defaults_to_five_seconds(self):
+        """duration_secs is shared with nsys-time and defaults to 5s for manual capture."""
+        from srtctl.core.schema import NSYS_MANUAL_DEFAULT_DURATION_SECS, ProfilingConfig
+
+        assert ProfilingConfig(type="nsys-manual", phases="decode").manual_duration_secs == (
+            NSYS_MANUAL_DEFAULT_DURATION_SECS
+        )
+        assert ProfilingConfig(type="nsys-manual", phases="decode", duration_secs=30).manual_duration_secs == 30
+
+    def test_manual_nsys_rejects_non_positive_duration(self):
+        """duration_secs must be a positive number of seconds."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        with pytest.raises(ValidationError, match="duration_secs must be > 0"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(type="nsys-manual", phases="decode", duration_secs=0),
+            )
+
+    def test_unknown_profiling_type_rejected(self):
+        """A typo in profiling.type fails fast instead of silently doing nothing."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        with pytest.raises(ValidationError, match="Unknown profiling.type 'nsys-manul'"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(type="nsys-manul", phases="decode"),
+            )
+
+    def test_manual_nsys_prefix_without_mode_is_empty(self):
+        """Callers must pass mode; without it manual mode must not fall back to a
+        full-run nsys command."""
+        from srtctl.core.schema import ProfilingConfig
+
+        assert ProfilingConfig(type="nsys-manual", phases="decode").get_nsys_prefix("/out") == []
+
+    def test_nsys_with_flag_list_rejected(self):
+        """Explicit nsys flags are no longer configurable per phase."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import (
+            ModelConfig,
+            ProfilingConfig,
+            ProfilingPhaseConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        with pytest.raises(ValidationError, match="no longer configurable"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(
+                    type="nsys",
+                    prefill=ProfilingPhaseConfig(nsys_args=()),
+                    decode=ProfilingPhaseConfig(nsys_args=("-c", "cudaProfilerApi")),
+                ),
+            )
+
     def test_torch_profiling(self):
         """Test torch profiling configuration."""
         from srtctl.core.schema import ProfilingConfig, ProfilingPhaseConfig
@@ -410,7 +699,7 @@ class TestVllmNsysProfilerConfig:
         # stop before start clamps to 0 instead of going negative.
         assert ProfilingPhaseConfig(start_step=30, stop_step=10).vllm_nsys_max_iterations == 0
 
-    def _build_decode_cmd(self, profiling, monkeypatch, decode_cfg=None):
+    def _build_decode_cmd(self, profiling, monkeypatch, decode_cfg=None, endpoint_index=0, node_rank=0):
         from pathlib import Path
         from types import SimpleNamespace
 
@@ -427,7 +716,8 @@ class TestVllmNsysProfilerConfig:
             sys_port=20000,
             http_port=0,
             endpoint_mode="decode",
-            endpoint_index=0,
+            endpoint_index=endpoint_index,
+            node_rank=node_rank,
         )
         runtime = SimpleNamespace(model_path=Path("/model"), is_hf_model=False, request_plane="nats")
         return backend.build_worker_command(
@@ -472,6 +762,24 @@ class TestVllmNsysProfilerConfig:
         cmd = self._build_decode_cmd(None, monkeypatch)
         assert self._profiler_config(cmd) is None
 
+    def test_nsys_manual_requires_profiler_config(self, monkeypatch):
+        """type: nsys-manual injects cuda profiler-config for on-demand capture."""
+        from srtctl.core.schema import ProfilingConfig
+
+        profiling = ProfilingConfig(type="nsys-manual", phases="decode")
+        cmd = self._build_decode_cmd(profiling, monkeypatch)
+
+        assert self._profiler_config(cmd) == {"profiler": "cuda"}
+
+    def test_unprofiled_process_stays_a_clean_baseline(self, monkeypatch):
+        """Workers that nsys does not wrap must not load vLLM's profiler wrapper."""
+        from srtctl.core.schema import ProfilingConfig
+
+        profiling = ProfilingConfig(type="nsys-manual", phases="decode")
+
+        assert self._profiler_config(self._build_decode_cmd(profiling, monkeypatch, node_rank=1)) is None
+        assert self._profiler_config(self._build_decode_cmd(profiling, monkeypatch, endpoint_index=1)) is None
+
     def test_nsys_without_phase_steps_does_not_inject(self, monkeypatch):
         """type: nsys but no phase config for this mode -> no engine-driven capture."""
         from srtctl.core.schema import ProfilingConfig
@@ -479,6 +787,178 @@ class TestVllmNsysProfilerConfig:
         profiling = ProfilingConfig(type="nsys")  # no decode phase
         cmd = self._build_decode_cmd(profiling, monkeypatch)
         assert self._profiler_config(cmd) is None
+
+
+class TestProfileDirectories:
+    """srtctl pre-creates profiles/<mode> only for phases it actually captures."""
+
+    def test_only_profiled_phase_gets_a_directory(self, tmp_path):
+        import os
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends.vllm import VLLMProtocol
+        from srtctl.cli.mixins.worker_stage import WorkerStageMixin
+        from srtctl.core.runtime import RuntimeContext
+        from srtctl.core.schema import ModelConfig, ProfilingConfig, ResourceConfig, SrtConfig
+        from srtctl.core.topology import Process
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        container_path = tmp_path / "container.sqsh"
+        container_path.touch()
+
+        slurm_env = {
+            "SLURM_JOB_ID": "12345",
+            "SLURM_JOBID": "12345",
+            "SLURM_NODELIST": "gpu-[01-03]",
+            "SLURM_JOB_NUM_NODES": "3",
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+        }
+
+        def mock_scontrol(cmd, **kwargs):
+            if cmd[0] == "scontrol" and "hostnames" in cmd:
+                result = MagicMock()
+                result.stdout = "gpu-01\ngpu-02\ngpu-03"
+                result.returncode = 0
+                return result
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with (
+            patch.dict(os.environ, slurm_env),
+            patch("subprocess.run", mock_scontrol),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            config = SrtConfig(
+                name="test",
+                model=ModelConfig(path=str(model_path), container=str(container_path), precision="fp8"),
+                resources=ResourceConfig(gpu_type="h100", gpus_per_node=8, prefill_nodes=1, decode_nodes=1),
+                backend=VLLMProtocol(),
+                profiling=ProfilingConfig(type="nsys-manual", phases="prefill"),
+            )
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
+
+            class MockWorkerStage(WorkerStageMixin):
+                def __init__(self, config, runtime):
+                    self.config = config
+                    self.runtime = runtime
+
+            worker_stage = MockWorkerStage(config, runtime)
+            mock_backend = MagicMock()
+            mock_backend.get_environment_for_mode.return_value = {}
+            mock_backend.build_worker_command.return_value = ["echo", "test"]
+
+            with (
+                patch.object(worker_stage, "config") as mock_config,
+                patch("srtctl.cli.mixins.worker_stage.start_srun_process") as mock_srun,
+            ):
+                mock_config.backend = mock_backend
+                mock_config.profiling = config.profiling
+                mock_srun.return_value = MagicMock()
+                for mode in ("prefill", "decode"):
+                    process = Process(
+                        node="gpu-01",
+                        gpu_indices=frozenset(range(8)),
+                        sys_port=8081,
+                        http_port=30000,
+                        endpoint_mode=mode,
+                        endpoint_index=0,
+                        node_rank=0,
+                    )
+                    worker_stage.start_worker(process, [process])
+
+            profiles = runtime.log_dir / "profiles"
+            assert (profiles / "prefill").is_dir()
+            assert not (profiles / "decode").exists()
+
+
+class TestNsysManualScript:
+    """Tests for the generated nsys-manual.sh trigger script."""
+
+    @staticmethod
+    def _worker_stage(tmp_path, profiling, processes, frontend_type="dynamo"):
+        from types import SimpleNamespace
+
+        from srtctl.cli.mixins.worker_stage import WorkerStageMixin
+
+        class MockWorkerStage(WorkerStageMixin):
+            def __init__(self):
+                self.config = SimpleNamespace(
+                    profiling=profiling,
+                    frontend=SimpleNamespace(type=frontend_type),
+                )
+                self.runtime = SimpleNamespace(
+                    log_dir=tmp_path / "12345" / "logs",
+                    network_interface="eth0",
+                )
+                self._processes = processes
+
+            @property
+            def backend_processes(self):
+                return self._processes
+
+        stage = MockWorkerStage()
+        stage.runtime.log_dir.mkdir(parents=True, exist_ok=True)
+        return stage
+
+    @staticmethod
+    def _process(node, sys_port, mode, endpoint_index, node_rank):
+        from srtctl.core.topology import Process
+
+        return Process(
+            node=node,
+            gpu_indices=frozenset({0}),
+            sys_port=sys_port,
+            http_port=0,
+            endpoint_mode=mode,
+            endpoint_index=endpoint_index,
+            node_rank=node_rank,
+        )
+
+    def test_script_targets_endpoint0_rank0_with_fixed_duration(self, tmp_path, monkeypatch):
+        """Only endpoint 0 rank 0 of the configured phase is triggered, for duration seconds."""
+        import srtctl.cli.mixins.worker_stage as ws
+        from srtctl.core.schema import ProfilingConfig
+
+        monkeypatch.setattr(ws, "get_hostname_ip", lambda node, _iface=None: f"10.0.0.{node[-1]}")
+
+        processes = [
+            self._process("node1", 8001, "prefill", 0, 0),
+            self._process("node2", 8002, "decode", 0, 0),
+            self._process("node3", 8003, "decode", 0, 1),
+            self._process("node4", 8004, "decode", 1, 0),
+        ]
+        stage = self._worker_stage(
+            tmp_path, ProfilingConfig(type="nsys-manual", phases="decode", duration_secs=7), processes
+        )
+        stage._write_nsys_manual_script()
+
+        script = (tmp_path / "12345" / "nsys-manual.sh").read_text()
+        assert "DURATION=7" in script
+        assert '"${1:-' not in script  # no CLI argument
+        assert '  "10.0.0.2:8002"' in script
+        assert '    local path="$1" verb="$2" ok="$3"' not in script  # 2-space indent, not 4
+        for other in ("8001", "8003", "8004"):
+            assert other not in script
+        assert "/engine/start_profile" in script
+        assert "/engine/stop_profile" in script
+
+    def test_script_not_written_when_phase_has_no_workers(self, tmp_path, monkeypatch):
+        """prefill phase selected but only decode workers exist -> no script."""
+        import srtctl.cli.mixins.worker_stage as ws
+        from srtctl.core.schema import ProfilingConfig
+
+        monkeypatch.setattr(ws, "get_hostname_ip", lambda node, _iface=None: "10.0.0.1")
+
+        stage = self._worker_stage(
+            tmp_path,
+            ProfilingConfig(type="nsys-manual", phases="prefill"),
+            [self._process("node2", 8002, "decode", 0, 0)],
+        )
+        stage._write_nsys_manual_script()
+
+        assert not (tmp_path / "12345" / "nsys-manual.sh").exists()
 
 
 class TestProfilingIntegration:

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -120,6 +120,72 @@ class TestProfilingConfig:
         # trtllm path
         assert ProfilingConfig(type="nsys").get_nsys_prefix("/out/w0", backend_type="trtllm")[0] == "/opt/nsight/nsys"
 
+    def test_nsys_dir_selects_mounted_binary(self, monkeypatch):
+        """profiling.nsys_dir points the wrapper at the bind-mounted host nsys."""
+        from srtctl.core.schema import NSYS_HOST_CONTAINER_DIR, ProfilingConfig
+
+        monkeypatch.delenv("SRTCTL_NSYS_BIN", raising=False)
+        prof = ProfilingConfig(
+            type="nsys-manual",
+            phases="prefill",
+            nsys_dir="/host/nsight/target-linux-sbsa-armv8",
+        )
+        assert prof.nsys_binary == f"{NSYS_HOST_CONTAINER_DIR}/nsys"
+        assert prof.get_nsys_prefix("/out", mode="prefill")[0] == f"{NSYS_HOST_CONTAINER_DIR}/nsys"
+
+    def test_nsys_dir_env_override_still_wins(self, monkeypatch):
+        """SRTCTL_NSYS_BIN still overrides even when nsys_dir is set."""
+        from srtctl.core.schema import ProfilingConfig
+
+        monkeypatch.setenv("SRTCTL_NSYS_BIN", "/custom/nsys")
+        prof = ProfilingConfig(type="nsys", nsys_dir="/host/nsight")
+        assert prof.nsys_binary == "/custom/nsys"
+
+    def test_nsys_dir_rejected_for_non_nsys_types(self):
+        """nsys_dir is meaningless for torch / none."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import ModelConfig, ProfilingConfig, ResourceConfig, SrtConfig
+
+        with pytest.raises(ValidationError, match="nsys_dir is only valid"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(type="torch", nsys_dir="/host/nsight"),
+            )
+
+    def test_nsys_dir_rejects_custom_nsys_path(self):
+        """nsys_dir already chooses the binary; nsys_path would conflict."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import ModelConfig, ProfilingConfig, ResourceConfig, SrtConfig
+
+        with pytest.raises(ValidationError, match="do not also set profiling.nsys_path"):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(
+                    type="nsys-manual",
+                    phases="prefill",
+                    nsys_dir="/host/nsight",
+                    nsys_path="/usr/bin/nsys",
+                ),
+            )
+
     def test_manual_nsys_phase_parsing(self):
         """phases: decode loads as nsys-manual with built-in nsys flags."""
         from srtctl.core.schema import NSYS_MANUAL_DEFAULT_ARGS, ProfilingConfig
@@ -1078,3 +1144,88 @@ class TestProfilingIntegration:
             "1x2",
             "inf",
         ]
+
+
+class TestNsysDirMount:
+    """profiling.nsys_dir bind-mounts a host Nsight target tree into the container."""
+
+    def _runtime_from_config(self, tmp_path, config):
+        import os
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.core.runtime import RuntimeContext
+
+        slurm_env = {
+            "SLURM_JOB_ID": "12345",
+            "SLURM_JOBID": "12345",
+            "SLURM_NODELIST": "gpu-[01-02]",
+            "SLURM_JOB_NUM_NODES": "2",
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+        }
+
+        def mock_scontrol(cmd, **kwargs):
+            if cmd[0] == "scontrol" and "hostnames" in cmd:
+                result = MagicMock()
+                result.stdout = "gpu-01\ngpu-02"
+                result.returncode = 0
+                return result
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with (
+            patch.dict(os.environ, slurm_env),
+            patch("subprocess.run", mock_scontrol),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            return RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
+
+    def _config(self, tmp_path, nsys_dir):
+        from srtctl.core.schema import ModelConfig, ProfilingConfig, ResourceConfig, SrtConfig
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        container_path = tmp_path / "container.sqsh"
+        container_path.touch()
+        return SrtConfig(
+            name="test",
+            model=ModelConfig(path=str(model_path), container=str(container_path), precision="fp8"),
+            resources=ResourceConfig(
+                gpu_type="h100",
+                gpus_per_node=8,
+                prefill_nodes=1,
+                decode_nodes=1,
+                prefill_workers=1,
+                decode_workers=1,
+            ),
+            profiling=ProfilingConfig(type="nsys-manual", phases="prefill", nsys_dir=nsys_dir),
+        )
+
+    def test_mounts_host_tree_at_opt_srtctl_nsys(self, tmp_path):
+        from pathlib import Path
+
+        from srtctl.core.schema import NSYS_HOST_CONTAINER_DIR
+
+        nsys_dir = tmp_path / "target-linux-sbsa-armv8"
+        nsys_dir.mkdir()
+        (nsys_dir / "nsys").write_text("")
+        runtime = self._runtime_from_config(tmp_path, self._config(tmp_path, str(nsys_dir)))
+        assert runtime.container_mounts[nsys_dir.resolve()] == Path(NSYS_HOST_CONTAINER_DIR)
+
+    def test_accepts_path_to_nsys_binary(self, tmp_path):
+        from pathlib import Path
+
+        from srtctl.core.schema import NSYS_HOST_CONTAINER_DIR
+
+        nsys_dir = tmp_path / "target-linux-sbsa-armv8"
+        nsys_dir.mkdir()
+        nsys_bin = nsys_dir / "nsys"
+        nsys_bin.write_text("")
+        runtime = self._runtime_from_config(tmp_path, self._config(tmp_path, str(nsys_bin)))
+        assert runtime.container_mounts[nsys_dir.resolve()] == Path(NSYS_HOST_CONTAINER_DIR)
+
+    def test_missing_nsys_binary_raises(self, tmp_path):
+        empty = tmp_path / "not-an-nsys-tree"
+        empty.mkdir()
+        with pytest.raises(FileNotFoundError, match="containing an nsys binary"):
+            self._runtime_from_config(tmp_path, self._config(tmp_path, str(empty)))

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1227,5 +1227,23 @@ class TestNsysDirMount:
     def test_missing_nsys_binary_raises(self, tmp_path):
         empty = tmp_path / "not-an-nsys-tree"
         empty.mkdir()
-        with pytest.raises(FileNotFoundError, match="containing an nsys binary"):
+        with pytest.raises(FileNotFoundError, match="bin/nsys"):
             self._runtime_from_config(tmp_path, self._config(tmp_path, str(empty)))
+
+    def test_walks_up_target_tree_to_bin_nsys_symlink(self, tmp_path):
+        """Nsight refuses to run the ELF in target-linux-*; use bin/nsys instead."""
+        from pathlib import Path
+
+        from srtctl.core.schema import NSYS_HOST_CONTAINER_DIR
+
+        install = tmp_path / "nsight-systems-2026.1.3"
+        target = install / "target-linux-sbsa-armv8"
+        target.mkdir(parents=True)
+        (target / "nsys").write_text("")
+        (install / "bin").mkdir()
+        (install / "bin" / "nsys").symlink_to("../target-linux-sbsa-armv8/nsys")
+
+        config = self._config(tmp_path, str(target))
+        runtime = self._runtime_from_config(tmp_path, config)
+        assert runtime.container_mounts[install.resolve()] == Path(NSYS_HOST_CONTAINER_DIR)
+        assert config.profiling.nsys_binary == f"{NSYS_HOST_CONTAINER_DIR}/bin/nsys"

--- a/tests/test_sa_bench_http_session.py
+++ b/tests/test_sa_bench_http_session.py
@@ -331,6 +331,65 @@ def test_session_is_closed_before_metrics(monkeypatch):
     assert request_sessions == [sessions[0], sessions[0], sessions[0]]
 
 
+def test_measured_window_is_reported_as_wall_clock(monkeypatch, capsys):
+    """Worker logs and nsys captures are lined up against the run by wall clock, so
+    the measured window must be printed and recorded, not just its duration."""
+    from datetime import datetime, timezone
+
+    _import_sa_bench_module("backend_request_func")
+    module = _import_sa_bench_module("benchmark_serving")
+
+    async def fake_request(request_func_input, pbar=None, **kwargs):
+        return module.RequestFuncOutput(
+            success=True,
+            output_tokens=1,
+            prompt_len=request_func_input.prompt_len,
+            start_time=1.0,
+            ttft=0.01,
+            latency=0.02,
+        )
+
+    monkeypatch.setitem(module.ASYNC_REQUEST_FUNCS, "dynamo", fake_request)
+
+    before = datetime.now(timezone.utc)
+    result = asyncio.run(
+        module.benchmark(
+            backend="dynamo",
+            api_url="http://localhost:8000/v1/completions",
+            base_url="http://localhost:8000",
+            model_id="model",
+            model_name="model",
+            tokenizer=object(),
+            input_requests=[("prompt", 1, 1, None)],
+            logprobs=None,
+            best_of=1,
+            request_rate=float("inf"),
+            burstiness=1.0,
+            disable_tqdm=True,
+            profile=False,
+            selected_percentile_metrics=[],
+            selected_percentiles=[50.0],
+            ignore_eos=True,
+            goodput_config_dict={},
+            max_concurrency=1,
+            lora_modules=None,
+        )
+    )
+    after = datetime.now(timezone.utc)
+
+    start = datetime.fromisoformat(result["benchmark_start_time_utc"])
+    end = datetime.fromisoformat(result["benchmark_end_time_utc"])
+    assert before <= start <= end <= after
+    assert result["benchmark_start_time_unix_s"] == start.timestamp()
+    assert result["benchmark_end_time_unix_s"] == end.timestamp()
+
+    out = capsys.readouterr().out
+    # Printed once up front so the window is visible before the run finishes,
+    # then again in the summary table next to the duration.
+    assert out.count(result["benchmark_start_time_utc"]) == 2
+    assert f"Benchmark measurement end (UTC):         {result['benchmark_end_time_utc']}" in out
+
+
 @pytest.mark.parametrize("failure", [RuntimeError("probe failed"), asyncio.CancelledError()])
 def test_benchmark_wrapper_closes_session_on_failure(monkeypatch, failure):
     _import_sa_bench_module("backend_request_func")

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -116,6 +116,32 @@ def test_srun_options_use_equals_separator() -> None:
     assert "--exclusive" in srun_cmd
 
 
+def test_srun_output_uses_append_open_mode() -> None:
+    """Worker logs must be O_APPEND so bench.sh stage banners are not clobbered."""
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(["python3", "-m", "server"], output="/logs/node0_decode_w0.out")
+
+    srun_cmd = mock_popen.call_args.args[0]
+    assert srun_cmd[srun_cmd.index("--open-mode") + 1] == "append"
+
+
+def test_srun_without_output_has_no_open_mode() -> None:
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        start_srun_process(["python3", "-m", "server"])
+
+    assert "--open-mode" not in mock_popen.call_args.args[0]
+
+
 def test_srun_export_env_renders_export_with_all_prefix() -> None:
     with (
         patch("srtctl.core.slurm.get_slurm_job_id", return_value="12345"),


### PR DESCRIPTION
### Motivation

This PR adds a new profiling type, `nsys-manual`. The reasoning below comes from concrete experience measuring disaggregated serving performance of Qwen3.5 on vLLM, where both existing nsys-based schemes — `nsys` and `nsys-time` — turned out to be unusable in practice.

#### Problem 1: DP/DEP topologies produce N profiles that don't line up

When dynamo launches the engines, the existing nsys schemes wrap every engine process. A DP8 topology (`-dp 8`) therefore produces eight separate `.nsys-rep` files with no common timeline, which makes joint analysis practically impossible.

This gets worse with DEP8 (`-dp 8 --enable-expert-parallel`), which is what I used while optimizing Qwen3.5: there the eight engines must communicate with each other to exchange local expert results in the MoE block.

In my experience with nsys, the first few seconds after a capture starts always include profiler initialization that noticeably slows the profiled application down, so I normally discard that opening window and only analyze what comes after. With eight concurrent captures, however, every engine takes that slowdown — and not at the same moment, because the captures do not start synchronously. The profiles I collected consequently showed enormous MoE communication waits for a long stretch at the beginning: with profiling enabled at slightly different times across ranks, there is a long wave before the processes settle.

That picture was unexpected enough that it cost me several days to track down. What finally worked was capturing a single engine: it was sufficient for analyzing disaggregated performance, and it carried far less overhead.

#### Problem 2: neither scheme lets you aim the capture window

Taking a profile is easy. Taking a **useful** one is not — it is very easy to capture the wrong moment, or to capture far too much, at which point the report balloons to hundreds of megabytes and becomes painful to work with. Past a certain size, simply opening it in the GUI stops being an option. Precisely positioning the start and the end of the window, so that it covers exactly the part you want to investigate, is the whole game.

The `nsys` scheme requires an exact `start_step` and `stop_step`, so you have to map the moment you care about onto an engine iteration number. Two things make that hard:

- sa-bench runs a warmup pass before the measured benchmark, so the step numbering you are reasoning about has to account for both. You need to keep that in mind every time, and anyone else who picks up your recipe needs to know it too.
- Each engine process counts *its own* steps. After the run you can easily end up with `.nsys-rep` files that do not overlap on the time axis at all, which makes them useless for joint analysis.

Neither of these is hypothetical; I hit both on Qwen3.5 and spent **days!** working out what was going on.

`nsys-time` has the same fundamental problem in a different form. It requires you to set a delay and a duration up front, and picking the delay is arguably harder than picking a step: you need to know *exactly* how long the vLLM server will take to come up, which depends on things outside your control such as checkpoint read throughput from storage.

Between the two, neither scheme let me capture a usable profile of the decode side of Qwen3.5.

### Proposed approach

The approach below is what ultimately let me profile disaggregated serving with minimal effort. It does require some manual interaction, but that is reduced to watching the engine log and running one shell script.

Two parts:

- **Only one engine is profiled.** This removes the cross-rank slowdown wave described above, and the resulting report is small enough to actually open.
- **srt-slurm generates a trigger script.** At job start, `nsys-manual.sh` is written into the job directory. Running it starts the capture immediately and ends it after a configurable number of seconds.

The intended workflow: you watch the server log and decide when you want the capture — for instance when you see an unexplained throughput dip you want to dig into, or when KV cache utilization crosses 90%, or on any other event you care about, since you can always add a log line for it in vLLM itself. Once you have found that moment, you run `nsys-manual.sh` from the job directory in another terminal. That's it — the profile is waiting for you when the job finishes.

### Links

Detailed description of a new `nsys-manual` profiling scheme is available in [docs/profiling.md](https://github.com/NVIDIA/srt-slurm/pull/298/changes#diff-4ff14dc92e1cb31f57ac5a5d323ff0b05f398cd5d85bd2798d16dd0f09277b10).
See nsys-manual profiling recipe example for Qwen3.5 in [examples/nsys-manual-qwen35-disagg.yaml](https://github.com/NVIDIA/srt-slurm/pull/298/changes#diff-e1644e21bada5ed7f626b2bf07422ac320919e16fb040d6a97b97a561c09aa88).

### How to use

```yaml
profiling:
  type: "nsys-manual"
  phases: prefill
  duration_secs: 5
  nsys_dir: /home/aperevedents/storage/cuda/cuda133_arm/nsight-systems-2026.1.3/target-linux-sbsa-armv8
```