### PR TITLE
(feat): Do not hardcode HF token in recipes

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -117,11 +117,14 @@ The `srtslurm.yaml` file can contain the following fields:
 | `containers`                    | dict   | Container image aliases                               |
 | `default_mounts`                | dict   | Cluster-wide container mounts                         |
 | `default_bash_preamble`         | string | Shell snippet prepended to every container srun       |
+| `environment`                   | dict   | Cluster-wide environment variables                    |
 | `nginx_raise_ulimit`          | bool   | Optional default for `frontend.nginx_raise_ulimit`  |
 
 **output_dir**: When set, job logs are written to `output_dir/{job_id}/logs` instead of `srtctl_root/outputs/{job_id}/logs`. Useful for CI/CD and ephemeral environments.
 
 **default_bash_preamble**: A shell snippet (e.g. `"ulimit -n 1048576 -s unlimited -u 1048576"`) prepended to every container srun launched by srtctl — workers, frontends, telemetry, benchmark, postprocess. Runs before per-call `bash_preamble` and the main command, so cluster-wide ulimits apply to everything downstream. Silently dropped for distroless containers (e.g. `prom/node-exporter`) that bypass the bash wrapper; a WARNING log is emitted in that case.
+
+**environment**: Merged underneath every job's top-level [`environment`](#environment) block, so a recipe can override a single variable without restating the rest. Use it for anything cluster-specific that shouldn't clutter shareable recipes — a shared `HF_HOME`, a cluster-wide `NCCL_SOCKET_IFNAME`, or a `${VAR}` reference to a secret (see [Forwarding host variables](#forwarding-host-variables)).
 
 **nginx_raise_ulimit**: When set to `true` or `false`, this value is applied to jobs that omit `frontend.nginx_raise_ulimit` in the recipe. Use `true` on clusters where raising the nginx container’s open-file limit is allowed; leave unset if each job should rely on the frontend default (`false`). A recipe that sets `frontend.nginx_raise_ulimit` always wins.
 
@@ -1204,6 +1207,27 @@ environment:
 | Key    | Value  | Description                      |
 | ------ | ------ | -------------------------------- |
 | string | string | Environment variable name=value  |
+
+### Forwarding host variables
+
+Jobs start from a clean environment: srtctl submits with `sbatch --export=NONE`, so nothing that happens to be exported in your login shell — host CUDA paths, `LD_LIBRARY_PATH`, leftover module variables — reaches the containers by accident.
+
+To let a specific variable through, reference it with `${VAR}`:
+
+```yaml
+environment:
+  HF_TOKEN: ${HF_TOKEN}
+```
+
+srtctl asks SLURM to forward that variable by name and never reads the value itself, so the secret stays out of the generated sbatch script, the job's config copy, and the sweep logs. This works in any environment block: the global `environment`, `backend.*_environment`, `frontend.env`, `benchmark.env` — and in `srtslurm.yaml`, which is usually the better place, since it keeps recipes shareable.
+
+Three rules follow from forwarding by name rather than by value:
+
+- The reference must be the entire value. `Bearer ${HF_TOKEN}` is rejected.
+- The name cannot change. Write `HF_TOKEN: ${HF_TOKEN}`, not `MY_TOKEN: ${HF_TOKEN}`.
+- The variable must be set in the submitting shell, otherwise submission fails immediately rather than the job failing later with an unrelated-looking authorization error.
+
+A bare `$VAR` without braces is never treated as a reference, so values that merely contain a dollar sign are passed through untouched.
 
 ### Per-Worker Template Variables
 

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -90,6 +90,18 @@ def _assert_preflight_passed(raw_config: dict[str, Any], *, label: str) -> None:
         raise ValueError(_format_preflight_error(label, failed))
 
 
+def sbatch_export_spec(config: SrtConfig) -> str:
+    """Build the ``sbatch --export`` value for a job.
+
+    Jobs start from a clean environment: whatever happens to be exported in the
+    submitting shell (host CUDA paths, LD_LIBRARY_PATH, leftover module vars)
+    must not silently reach the containers. Variables the recipe asked for with
+    ``${VAR}`` are named here so SLURM forwards them, which keeps their values
+    off the command line and out of every file srtctl writes.
+    """
+    return ",".join(config.host_env_passthrough) if config.host_env_passthrough else "NONE"
+
+
 def _install_mock_submit_patches() -> list:
     """Stub the subset of `submit_with_orchestrator` that reaches real infra.
 
@@ -299,6 +311,12 @@ def show_config_details(config: SrtConfig) -> None:
         console.print(Panel(env_table, border_style="yellow"))
     else:
         console.print("[dim]No custom environment variables configured.[/]")
+
+    # Names only — the whole point of ${VAR} is that srtctl never handles the value.
+    if config.host_env_passthrough:
+        forwarded = " ".join(config.host_env_passthrough)
+        console.print(f"[dim]Forwarded from the submitting shell:[/] {forwarded}")
+    console.print("[dim]All other host environment variables are dropped (sbatch --export).[/]")
 
     # --- srun options ---
     if config.srun_options:
@@ -640,7 +658,7 @@ def submit_with_orchestrator(
     keep_script = False
     try:
         result = subprocess.run(
-            ["sbatch", script_path],
+            ["sbatch", f"--export={sbatch_export_spec(config)}", script_path],
             capture_output=True,
             text=True,
             check=True,

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -78,6 +78,90 @@ def load_cluster_config() -> dict[str, Any] | None:
         return None
 
 
+# An environment value of exactly ``${VAR}`` marks that variable for propagation
+# from the submitting shell. Braces are required, and a bare ``$VAR`` is left
+# alone, so values that merely contain a dollar sign are never touched.
+_HOST_ENV_REF = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
+_HOST_ENV_REF_ANYWHERE = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\}")
+
+# Config sections holding environment variables, as (path, key) into the raw
+# config dict, so ``${VAR}`` means the same thing everywhere a user can write
+# an environment variable.
+_ENV_SECTIONS: tuple[tuple[tuple[str, ...], str], ...] = (
+    ((), "environment"),
+    (("backend",), "env"),
+    (("backend",), "prefill_environment"),
+    (("backend",), "decode_environment"),
+    (("backend",), "aggregated_environment"),
+    (("frontend",), "env"),
+    (("benchmark",), "env"),
+)
+
+
+def extract_host_env_passthrough(config: dict[str, Any]) -> list[str]:
+    """Turn ``HF_TOKEN: ${HF_TOKEN}`` entries into a list of names to propagate.
+
+    Lets a recipe (or srtslurm.yaml) use a secret without storing it anywhere:
+
+        environment:
+          HF_TOKEN: ${HF_TOKEN}
+
+    The value is deliberately never read here. srtctl asks SLURM to forward the
+    variable by name, so the secret stays out of the generated sbatch script,
+    the job's config copy and the sweep logs — all of which persist in the job
+    directory. Matching entries are dropped from the config so that nothing
+    later re-exports the literal ``${HF_TOKEN}`` over the forwarded value.
+
+    Returns the sorted variable names. Raises ValueError if a reference cannot
+    be honored by name alone.
+    """
+    names: set[str] = set()
+    errors: list[str] = []
+
+    for path, key in _ENV_SECTIONS:
+        parent: Any = config
+        for part in path:
+            parent = parent.get(part) if isinstance(parent, dict) else None
+            if parent is None:
+                break
+        if not isinstance(parent, dict):
+            continue
+        env = parent.get(key)
+        if not isinstance(env, dict):
+            continue
+
+        section = ".".join([*path, key])
+        kept: dict[str, Any] = {}
+        for name, value in env.items():
+            match = _HOST_ENV_REF.fullmatch(value) if isinstance(value, str) else None
+            if match is None:
+                if isinstance(value, str) and _HOST_ENV_REF_ANYWHERE.search(value):
+                    errors.append(
+                        f"{section}.{name}: '${{VAR}}' forwards a host variable by name, so it must be "
+                        f"the entire value — it cannot be embedded in a larger string."
+                    )
+                kept[name] = value
+                continue
+            var = match.group(1)
+            if var != name:
+                errors.append(
+                    f"{section}.{name}: cannot forward ${{{var}}} under a different name; "
+                    f"write '{var}: ${{{var}}}' instead."
+                )
+                continue
+            if var not in os.environ:
+                errors.append(f"{section}.{name}: ${{{var}}} is not set in the submitting shell.")
+                continue
+            names.add(var)
+
+        parent[key] = kept
+
+    if errors:
+        raise ValueError("Invalid host environment reference(s):\n  " + "\n  ".join(errors))
+
+    return sorted(names)
+
+
 def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: dict[str, Any] | None) -> dict[str, Any]:
     """
     Resolve user config by applying cluster defaults and aliases.
@@ -98,6 +182,7 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
     config = copy.deepcopy(user_config)
 
     if cluster_config is None:
+        config["host_env_passthrough"] = extract_host_env_passthrough(config)
         return config
 
     # Apply SLURM defaults
@@ -161,6 +246,13 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         config["health_check"] = cluster_config["default_health_check"]
         logger.debug("Applied default_health_check: %s", config["health_check"])
 
+    # Merge cluster-level environment underneath the recipe's own, so a recipe
+    # can override any single cluster variable without restating the rest.
+    cluster_environment = cluster_config.get("environment")
+    if isinstance(cluster_environment, dict) and cluster_environment:
+        config["environment"] = {**cluster_environment, **(config.get("environment") or {})}
+        logger.debug("Applied cluster environment keys: %s", sorted(cluster_environment))
+
     # Resolve frontend nginx_container alias
     frontend = config.get("frontend", {})
     nginx_container = frontend.get("nginx_container", "")
@@ -212,6 +304,9 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
                     f"Resolved telemetry.{exporter_key}.container_image alias "
                     f"'{exporter_image}' -> '{resolved_exporter}'"
                 )
+
+    # Runs last so it also covers variables introduced by the cluster defaults above.
+    config["host_env_passthrough"] = extract_host_env_passthrough(config)
 
     return config
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -203,6 +203,11 @@ class ClusterConfig:
     # Cluster-level container mounts (host_path -> container_path)
     # Applied to all jobs on this cluster, useful for cluster-specific paths
     default_mounts: dict[str, str] | None = None
+    # Cluster-level environment variables merged into every job's top-level
+    # ``environment:`` block; the recipe wins on key collision. Values may
+    # reference the submitting shell with ``${VAR}``, which keeps secrets such
+    # as HF_TOKEN out of both this file and the recipe.
+    environment: dict[str, str] | None = None
     # Shell snippet prepended to every container srun (after env exports, before
     # the main command). Useful for cluster-wide ulimits, e.g.
     # ``"ulimit -n 1048576 -s unlimited -u 1048576"``. Silently dropped for
@@ -1559,6 +1564,13 @@ class SrtConfig:
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
 
     environment: dict[str, str] = field(default_factory=dict)
+    # Host variables to forward into the job by name, derived from ``${VAR}``
+    # entries in the environment blocks. Populated during config resolution;
+    # writing it directly in a recipe is possible but not the intended path.
+    host_env_passthrough: tuple[str, ...] = field(
+        default=(),
+        metadata={"marshmallow_field": fields.List(fields.String(), load_default=())},
+    )
     container_mounts: dict[
         Annotated[FormattablePath, FormattablePathField()],
         Annotated[FormattablePath, FormattablePathField()],
@@ -1582,6 +1594,9 @@ class SrtConfig:
 
     def __post_init__(self):
         """Validate configuration after initialization."""
+        # marshmallow hands back a list; keep the frozen dataclass hashable/immutable.
+        if not isinstance(self.host_env_passthrough, tuple):
+            object.__setattr__(self, "host_env_passthrough", tuple(self.host_env_passthrough))
         self._validate_profiling()
         self._validate_telemetry()
         self._validate_mooncake_kv_store()

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -79,6 +79,12 @@
 
 set -e
 
+# sbatch is invoked with --export=NONE (or an explicit allowlist), which SLURM
+# also applies to every srun in this job. The filtering is meant for the
+# submit-side environment only; from here on the job's own environment must
+# reach the workers as usual, so restore the default propagation.
+export SLURM_EXPORT_ENV=ALL
+
 # Setup directories
 SRTCTL_SOURCE="{{ srtctl_source }}"
 OUTPUT_BASE="{{ output_base }}"

--- a/tests/test_host_env.py
+++ b/tests/test_host_env.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for cluster-level environment and ``${VAR}`` host passthrough."""
+
+import pytest
+
+from srtctl.core.config import resolve_config_with_defaults
+
+SECRET = "hf_supersecret_do_not_leak"
+
+BASE_CONFIG = {
+    "name": "test-job",
+    "model": {"path": "/models/test", "container": "test.sqsh", "precision": "fp8"},
+    "resources": {"gpu_type": "h100", "agg_nodes": 1, "agg_workers": 1},
+}
+
+
+def _config(environment=None, **sections):
+    config = {**BASE_CONFIG, **sections}
+    if environment is not None:
+        config["environment"] = environment
+    return config
+
+
+@pytest.fixture
+def host_token(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", SECRET)
+    return SECRET
+
+
+class TestClusterEnvironment:
+    """srtslurm.yaml can carry environment variables for every job on the cluster."""
+
+    def test_cluster_environment_applied(self):
+        resolved = resolve_config_with_defaults(_config(), {"environment": {"HF_HOME": "/cluster/cache"}})
+        assert resolved["environment"] == {"HF_HOME": "/cluster/cache"}
+
+    def test_recipe_wins_per_key(self):
+        """A recipe overrides one cluster variable without restating the others."""
+        resolved = resolve_config_with_defaults(
+            _config({"HF_HOME": "/recipe/cache"}),
+            {"environment": {"HF_HOME": "/cluster/cache", "NCCL_DEBUG": "WARN"}},
+        )
+        assert resolved["environment"] == {"HF_HOME": "/recipe/cache", "NCCL_DEBUG": "WARN"}
+
+    def test_no_cluster_config_leaves_recipe_alone(self):
+        resolved = resolve_config_with_defaults(_config({"NCCL_DEBUG": "INFO"}), None)
+        assert resolved["environment"] == {"NCCL_DEBUG": "INFO"}
+
+
+class TestHostEnvPassthrough:
+    """``VAR: ${VAR}`` forwards a host variable by name, never by value."""
+
+    def test_reference_becomes_passthrough_name(self, host_token):
+        resolved = resolve_config_with_defaults(_config({"HF_TOKEN": "${HF_TOKEN}"}), None)
+
+        assert resolved["host_env_passthrough"] == ["HF_TOKEN"]
+        # The entry is removed so nothing later exports the literal over the forwarded value.
+        assert "HF_TOKEN" not in resolved["environment"]
+
+    def test_secret_value_never_enters_the_config(self, host_token):
+        """The whole point: the value must not reach anything that gets written to disk."""
+        resolved = resolve_config_with_defaults(
+            _config(
+                {"HF_TOKEN": "${HF_TOKEN}"},
+                backend={"type": "vllm", "decode_environment": {"HF_TOKEN": "${HF_TOKEN}"}},
+            ),
+            {"environment": {"HF_TOKEN": "${HF_TOKEN}"}},
+        )
+        assert SECRET not in repr(resolved)
+
+    def test_reference_works_in_every_env_section(self, host_token, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        resolved = resolve_config_with_defaults(
+            _config(
+                {"HF_TOKEN": "${HF_TOKEN}"},
+                backend={"type": "vllm", "decode_environment": {"OPENAI_API_KEY": "${OPENAI_API_KEY}"}},
+                benchmark={"type": "manual", "env": {"HF_TOKEN": "${HF_TOKEN}"}},
+            ),
+            None,
+        )
+        assert resolved["host_env_passthrough"] == ["HF_TOKEN", "OPENAI_API_KEY"]
+        assert resolved["backend"]["decode_environment"] == {}
+        assert resolved["benchmark"]["env"] == {}
+
+    def test_cluster_reference_is_forwarded_too(self, host_token):
+        """The point of putting it in srtslurm.yaml: recipes stay free of secrets."""
+        resolved = resolve_config_with_defaults(_config(), {"environment": {"HF_TOKEN": "${HF_TOKEN}"}})
+        assert resolved["host_env_passthrough"] == ["HF_TOKEN"]
+
+    def test_literal_values_are_untouched(self):
+        resolved = resolve_config_with_defaults(_config({"NCCL_DEBUG": "INFO", "PROMPT": "cost is $5"}), None)
+        assert resolved["environment"] == {"NCCL_DEBUG": "INFO", "PROMPT": "cost is $5"}
+        assert resolved["host_env_passthrough"] == []
+
+    def test_bare_dollar_is_not_a_reference(self):
+        """Only ``${VAR}`` is special, so values containing a plain $ stay literal."""
+        resolved = resolve_config_with_defaults(_config({"PASSWORD": "$ecret$tuff"}), None)
+        assert resolved["environment"] == {"PASSWORD": "$ecret$tuff"}
+        assert resolved["host_env_passthrough"] == []
+
+    def test_unset_variable_fails_at_submit(self, monkeypatch):
+        """Better a clear error now than an unauthorized response an hour into the job."""
+        monkeypatch.delenv("SRTCTL_ABSENT_VAR", raising=False)
+        with pytest.raises(ValueError, match="not set in the submitting shell"):
+            resolve_config_with_defaults(_config({"SRTCTL_ABSENT_VAR": "${SRTCTL_ABSENT_VAR}"}), None)
+
+    def test_renaming_is_rejected(self, host_token):
+        """Forwarding by name cannot rename, so fail instead of silently doing nothing."""
+        with pytest.raises(ValueError, match="under a different name"):
+            resolve_config_with_defaults(_config({"MY_TOKEN": "${HF_TOKEN}"}), None)
+
+    def test_embedded_reference_is_rejected(self, host_token):
+        with pytest.raises(ValueError, match="must be the entire value"):
+            resolve_config_with_defaults(_config({"HF_TOKEN": "Bearer ${HF_TOKEN}"}), None)
+
+
+class TestSbatchExport:
+    """Submission drops the host environment unless a variable was asked for."""
+
+    @staticmethod
+    def _load(environment=None):
+        from srtctl.core.schema import SrtConfig
+
+        return SrtConfig.Schema().load(resolve_config_with_defaults(_config(environment), None))
+
+    def test_clean_environment_by_default(self):
+        from srtctl.cli.submit import sbatch_export_spec
+
+        config = self._load()
+        assert config.host_env_passthrough == ()
+        assert sbatch_export_spec(config) == "NONE"
+
+    def test_requested_variables_are_named(self, host_token, monkeypatch):
+        from srtctl.cli.submit import sbatch_export_spec
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        config = self._load({"HF_TOKEN": "${HF_TOKEN}", "OPENAI_API_KEY": "${OPENAI_API_KEY}"})
+
+        assert config.host_env_passthrough == ("HF_TOKEN", "OPENAI_API_KEY")
+        # Names only: SLURM reads the values from the submitting shell itself.
+        assert sbatch_export_spec(config) == "HF_TOKEN,OPENAI_API_KEY"
+
+    def test_secret_never_reaches_the_command_line(self, host_token):
+        from srtctl.cli.submit import sbatch_export_spec
+
+        assert SECRET not in sbatch_export_spec(self._load({"HF_TOKEN": "${HF_TOKEN}"}))


### PR DESCRIPTION
### Motivation

srtctl submits jobs with a plain `sbatch`, which defaults to `--export=ALL`. Whatever happens to be exported in the shell you submit from therefore ends up in the job, gets propagated by every `srun`, and is handed to the containers by pyxis. Nothing filters it.

This is easy to trigger by accident. A `salloc` shell on the login node has `SLURM_JOB_ID` set, so the compute-node branch of your `.bashrc` fires and exports a host toolchain — `CUDA_HOME`, `NSYS_ROOT`, an overwritten `LD_LIBRARY_PATH`, a `PATH` with a host `nsys` in front. Submit from that shell and all of it silently reaches the container, where it can shadow the container's own CUDA or profiler. Failures of that kind are quiet and very hard to attribute.

It is not hypothetical: the fingerprint of a recent job shows `HF_TOKEN` and `HF_HOME=/home/<user>/.cache/huggingface` captured inside the container, neither of which srtctl sets.

So jobs should start from a clean environment and receive only what the recipe asked for.

That leaves one legitimate case: a value you genuinely need from the host and do not want to write down, typically `HF_TOKEN`. This PR covers it as well.

### What changes

Jobs are now submitted with `sbatch --export=NONE`. Host variables reach a job only when a recipe names them, using a `${VAR}` reference in any environment block:

```yaml
environment:
  HF_TOKEN: ${HF_TOKEN}
```

srtctl asks SLURM to forward that variable **by name** and never reads the value, so the secret stays out of the generated sbatch script, the job's config copy and the sweep logs — all of which persist in the job directory. Forwarding by name also means the reference must be the whole value and cannot be renamed; both are rejected at submit time, as is a variable that is not set in the submitting shell.

The same syntax works in every environment block a recipe can write — the global `environment`, the per-mode backend blocks, `frontend.env` and `benchmark.env`:

```yaml
backend:
  aggregated_environment:
    HF_TOKEN: ${HF_TOKEN}
```

Note that a reference placed in a per-mode block is not scoped to that mode: the variable is forwarded into the job environment, so every container in the job sees it.

`srtslurm.yaml` gains an `environment:` section with the same syntax, merged underneath the recipe's own block so a recipe can override a single variable without restating the rest. This is usually the better place for it: cluster-specific settings and secret references stay in the private cluster config, and recipes remain shareable.

```yaml
# srtslurm.yaml
environment:
  HF_TOKEN: ${HF_TOKEN}
  HF_HOME: /lustre/fsw/<...>/common/cache
```

`srtctl dry-run` lists the forwarded variable names and states that everything else is dropped, without printing any values.
