### PR TITLE
feat(analysis): improve prefill batch metric plots

### DIFF
--- a/src/srtctl/analysis/batch_log_parser.py
+++ b/src/srtctl/analysis/batch_log_parser.py
@@ -74,6 +74,7 @@ _PATTERN_CACHE: dict[str, re.Pattern[str]] = {}
 _TS_ANSI = re.compile(r"\[2m(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}\.\d+)")
 _TS_BRACKET = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?)")
 _DP_RANK = re.compile(r"\bDP(\d+)\b")
+_PP_RANK = re.compile(r"\bPP(\d+)\b")
 
 
 def _pattern(raw: str) -> re.Pattern[str]:
@@ -112,6 +113,16 @@ def _parse_dp_rank(line: str) -> int | None:
         return None
 
 
+def _parse_pp_rank(line: str) -> int | None:
+    m = _PP_RANK.search(line)
+    if m is None:
+        return None
+    try:
+        return int(m.group(1))
+    except ValueError:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Per-file series
 # ---------------------------------------------------------------------------
@@ -129,6 +140,7 @@ class FileSeries:
     path: Path
     timestamps: list[datetime] = field(default_factory=list)
     dp_ranks: list[int | None] = field(default_factory=list)
+    pp_ranks: list[int | None] = field(default_factory=list)
     metrics: dict[str, list[float | None]] = field(default_factory=dict)
     byte_offset: int = 0
 
@@ -183,6 +195,7 @@ def parse_file_incremental(series: FileSeries, keyword: str, metrics_def: dict[s
                 if ts is None:
                     continue
                 dp_rank = _parse_dp_rank(line)
+                pp_rank = _parse_pp_rank(line)
 
                 values: dict[str, float | None] = {}
                 any_value = False
@@ -202,6 +215,7 @@ def parse_file_incremental(series: FileSeries, keyword: str, metrics_def: dict[s
 
                 series.timestamps.append(ts)
                 series.dp_ranks.append(dp_rank)
+                series.pp_ranks.append(pp_rank)
                 for name in metrics_def:
                     series.metrics[name].append(values[name])
                 new_rows += 1

--- a/src/srtctl/analysis/batch_plot_matrix.py
+++ b/src/srtctl/analysis/batch_plot_matrix.py
@@ -5,7 +5,7 @@
 
 The parser lives in :mod:`.batch_log_parser`; this module only turns a
 populated :class:`~srtctl.analysis.batch_log_parser.LogState` into the
-per-worker 7x2 PNG view used by both the live snapshotter and the
+per-worker PNG matrix used by both the live snapshotter and the
 post-mortem ``plot_batch_metrics.py`` CLI.
 """
 
@@ -30,10 +30,10 @@ if TYPE_CHECKING:
 # all parsed metrics remain available in LogState for other consumers.
 PLOT_ROWS: list[tuple[str | None, str | None]] = [
     ("input throughput (token/s)", "gen throughput (token/s)"),
-    ("#new-seq", "#running-req"),
+    ("total input throughput (token/s)", "#running-req"),
+    ("cache hit (%)", "full token usage"),
     ("#new-token", "#full token"),
-    ("#cached-token", "full token usage"),
-    ("#prealloc-req", "#prealloc-req"),
+    ("#new-seq", "#prealloc-req"),
     ("#queue-req", "#queue-req"),
     ("#inflight-req", "#transfer-req"),
 ]
@@ -73,35 +73,52 @@ def _dp_label(series: FileSeries, dp_rank: int) -> str:
     return f"{stem}_DP{dp_rank}"
 
 
-def _plot_series_for_files(files: Iterable[FileSeries]) -> list[_PlotSeries]:
-    """Split aggregated worker logs into one plot series per DP rank."""
+def _plot_series_for_files(
+    files: Iterable[FileSeries],
+    *,
+    prefill_stage_zero_only: bool = False,
+) -> list[_PlotSeries]:
+    """Prepare worker plot series, splitting aggregate logs by DP rank.
+
+    Pipeline-parallel prefill workers log the same logical batch once per PP
+    stage. For prefill plots, keep PP0 so token counts and derived throughput
+    are not duplicated. Logs without PP metadata retain their old behavior.
+    """
     out: list[_PlotSeries] = []
     for series in files:
         if series.empty:
             continue
 
-        dp_ranks = list(series.dp_ranks)
-        if len(dp_ranks) < len(series.timestamps):
-            dp_ranks.extend([None] * (len(series.timestamps) - len(dp_ranks)))
-        else:
-            dp_ranks = dp_ranks[: len(series.timestamps)]
+        row_count = len(series.timestamps)
+        dp_ranks = [series.dp_ranks[i] if i < len(series.dp_ranks) else None for i in range(row_count)]
+        pp_ranks = [series.pp_ranks[i] if i < len(series.pp_ranks) else None for i in range(row_count)]
+        idxs = list(range(row_count))
+        known_pps = {pp for pp in pp_ranks if pp is not None}
+        if prefill_stage_zero_only and 0 in known_pps and len(known_pps) > 1:
+            idxs = [i for i, pp in enumerate(pp_ranks) if pp == 0]
+
+        timestamps = [series.timestamps[i] for i in idxs]
+        dp_ranks = [dp_ranks[i] for i in idxs]
+        metrics = {
+            name: [values[i] if i < len(values) else None for i in idxs] for name, values in series.metrics.items()
+        }
 
         known_dps = sorted({dp for dp in dp_ranks if dp is not None})
         should_split = bool(known_dps) and (len(known_dps) > 1 or "_agg_" in series.path.name)
         if not should_split:
-            out.append(_PlotSeries(label=series.label, timestamps=series.timestamps, metrics=series.metrics))
+            out.append(_PlotSeries(label=series.label, timestamps=timestamps, metrics=metrics))
             continue
 
         for dp_rank in known_dps:
-            idxs = [i for i, dp in enumerate(dp_ranks) if dp == dp_rank]
-            metrics = {
-                name: [values[i] if i < len(values) else None for i in idxs] for name, values in series.metrics.items()
+            dp_idxs = [i for i, dp in enumerate(dp_ranks) if dp == dp_rank]
+            dp_metrics = {
+                name: [values[i] if i < len(values) else None for i in dp_idxs] for name, values in metrics.items()
             }
             out.append(
                 _PlotSeries(
                     label=_dp_label(series, dp_rank),
-                    timestamps=[series.timestamps[i] for i in idxs],
-                    metrics=metrics,
+                    timestamps=[timestamps[i] for i in dp_idxs],
+                    metrics=dp_metrics,
                 )
             )
 
@@ -143,8 +160,77 @@ def _derived_input_throughput(series: _PlotSeries, smooth_window: int) -> list[f
     return derived
 
 
+def _derived_total_input_throughput(series: _PlotSeries, smooth_window: int) -> list[float | None]:
+    """Derive logical prompt throughput, including cached and newly computed tokens.
+
+    SGLang's explicit input-throughput metric measures newly computed tokens.
+    Scaling it by ``(new + cached) / new`` preserves SGLang's precise internal
+    timing even when text-log timestamps have only one-second resolution. The
+    timestamp delta is retained as a fallback for logs without the explicit
+    throughput field.
+    """
+    new_tokens = series.metrics.get("#new-token")
+    cached_tokens = series.metrics.get("#cached-token")
+    explicit_input = series.metrics.get("input throughput (token/s)", [])
+    if not new_tokens or not cached_tokens:
+        return []
+
+    derived: list[float | None] = [None] * len(series.timestamps)
+    for i in range(len(series.timestamps)):
+        new = new_tokens[i] if i < len(new_tokens) else None
+        cached = cached_tokens[i] if i < len(cached_tokens) else None
+        if new is None or cached is None:
+            continue
+
+        explicit = explicit_input[i] if i < len(explicit_input) else None
+        if explicit is not None and new > 0:
+            derived[i] = explicit * (new + cached) / new
+            continue
+
+        if i == 0:
+            continue
+        dt = (series.timestamps[i] - series.timestamps[i - 1]).total_seconds()
+        if dt > 0:
+            derived[i] = (new + cached) / dt
+
+    if smooth_window > 1:
+        derived = _moving_average(derived, smooth_window)
+    return derived
+
+
+def _rolling_cache_hit(series: _PlotSeries, smooth_window: int) -> list[float | None]:
+    """Return token-weighted cache-hit percentage over a centered row window."""
+    new_tokens = series.metrics.get("#new-token")
+    cached_tokens = series.metrics.get("#cached-token")
+    if not new_tokens or not cached_tokens:
+        return []
+
+    window = max(1, smooth_window)
+    half = window // 2
+    out: list[float | None] = []
+    for i in range(len(series.timestamps)):
+        lo = max(0, i - half)
+        hi = min(len(series.timestamps), i + half + 1)
+        new_sum = 0.0
+        cached_sum = 0.0
+        for j in range(lo, hi):
+            new = new_tokens[j] if j < len(new_tokens) else None
+            cached = cached_tokens[j] if j < len(cached_tokens) else None
+            if new is None or cached is None:
+                continue
+            new_sum += new
+            cached_sum += cached
+        total = new_sum + cached_sum
+        out.append(100.0 * cached_sum / total if total > 0 else None)
+    return out
+
+
 def _values_for_metric(series: _PlotSeries, metric: str, smooth_input_window: int) -> list[float | None]:
     values = list(series.metrics.get(metric, []))
+    if metric == "total input throughput (token/s)":
+        return _derived_total_input_throughput(series, smooth_input_window)
+    if metric == "cache hit (%)":
+        return _rolling_cache_hit(series, smooth_input_window)
     if metric != "input throughput (token/s)":
         return values
 
@@ -285,7 +371,7 @@ def render_batch_plot_matrix(
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
-    pf_files = _plot_series_for_files(state.prefill_files.values())
+    pf_files = _plot_series_for_files(state.prefill_files.values(), prefill_stage_zero_only=True)
     dc_files = _plot_series_for_files(state.decode_files.values())
 
     origin = _global_origin(pf_files, dc_files)
@@ -337,6 +423,8 @@ def render_batch_plot_matrix(
             return
 
         _annotate_axis(ax, pooled, show_median=show_median, clip_percentile=clip_percentile)
+        if metric == "cache hit (%)":
+            ax.set_ylim(0.0, 100.0)
 
         if files:
             ax.legend(

--- a/src/srtctl/benchmarks/scripts/plot_batch_metrics.py
+++ b/src/srtctl/benchmarks/scripts/plot_batch_metrics.py
@@ -5,7 +5,7 @@
 """
 Plot prefill/decode batch metrics over time from SGLang worker logs.
 
-This CLI uses the same parser and 7x2 per-worker renderer as the live
+This CLI uses the same parser and per-worker renderer as the live
 batch-metrics snapshotter, so post-mortem plots match the in-flight
 ``batch_metrics.png`` view.
 
@@ -128,7 +128,10 @@ def main() -> None:
         "--smooth",
         type=int,
         default=8,
-        help="Centered moving-average window for derived prefill input throughput (default: 8; 1 disables)",
+        help=(
+            "Centered smoothing window for token-derived prefill metrics, including total input throughput "
+            "and cache hit (default: 8; 1 disables)"
+        ),
     )
     args = parser.parse_args()
 

--- a/tests/test_batch_plot_metrics.py
+++ b/tests/test_batch_plot_metrics.py
@@ -7,7 +7,7 @@ import importlib.util
 from pathlib import Path
 
 from srtctl.analysis.batch_log_parser import LogState
-from srtctl.analysis.batch_plot_matrix import _plot_series_for_files, _values_for_metric
+from srtctl.analysis.batch_plot_matrix import PLOT_ROWS, _plot_series_for_files, _values_for_metric
 
 
 def _load_plot_batch_metrics_module():
@@ -88,6 +88,7 @@ def test_batch_log_parser_keeps_millisecond_timestamps_and_dp_ranks(tmp_path):
 
     series = next(iter(state.prefill_files.values()))
     assert series.dp_ranks == [1, 0]
+    assert series.pp_ranks == [None, None]
     assert series.timestamps[0].microsecond == 896000
     assert series.timestamps[1].microsecond == 901000
 
@@ -151,6 +152,76 @@ def test_renderer_splits_agg_logs_by_dp_and_derives_input_throughput(tmp_path):
     derived = {s.label: _values_for_metric(s, "input throughput (token/s)", smooth_input_window=1) for s in plot_series}
     assert derived["bia0003_agg_w0_DP0"] == [None, 200.0]
     assert derived["bia0003_agg_w0_DP1"] == [None, 200.0]
+
+
+def test_renderer_deduplicates_pipeline_prefill_and_derives_total_input_metrics(tmp_path):
+    """PP0/PP1 report the same batch; logical totals must count it only once."""
+    logs_dir = tmp_path / "461675" / "logs"
+    logs_dir.mkdir(parents=True)
+    (logs_dir / "nvl72d068-T01_prefill_w0.out").write_text(
+        "\n".join(
+            [
+                f"[2026-05-19 00:32:50 PP{pp}] Prefill batch, #new-seq: 1, #new-token: 100, "
+                "#cached-token: 900, full token usage: 0.10, #running-req: 0, #queue-req: 0, "
+                "input throughput (token/s): 100.0"
+                for pp in (0, 1)
+            ]
+            + [
+                f"[2026-05-19 00:32:51 PP{pp}] Prefill batch, #new-seq: 1, #new-token: 200, "
+                "#cached-token: 800, full token usage: 0.10, #running-req: 0, #queue-req: 0, "
+                "input throughput (token/s): 200.0"
+                for pp in (0, 1)
+            ]
+        )
+    )
+
+    state = LogState(log_dir=logs_dir)
+    assert state.refresh() == (4, 0)
+    parsed = next(iter(state.prefill_files.values()))
+    assert parsed.pp_ranks == [0, 1, 0, 1]
+
+    plot_series = _plot_series_for_files(state.prefill_files.values(), prefill_stage_zero_only=True)
+    assert len(plot_series) == 1
+    assert len(plot_series[0].timestamps) == 2
+    assert _values_for_metric(plot_series[0], "input throughput (token/s)", smooth_input_window=1) == [100.0, 200.0]
+    assert _values_for_metric(plot_series[0], "total input throughput (token/s)", smooth_input_window=1) == [
+        1000.0,
+        1000.0,
+    ]
+    assert _values_for_metric(plot_series[0], "cache hit (%)", smooth_input_window=1) == [90.0, 80.0]
+
+
+def test_cache_hit_smoothing_is_token_weighted(tmp_path):
+    """Rolling cache hit must divide token sums, not average row percentages."""
+    logs_dir = tmp_path / "461676" / "logs"
+    logs_dir.mkdir(parents=True)
+    rows = [(100, 900), (200, 800), (400, 0)]
+    (logs_dir / "nvl72d068-T01_prefill_w0.out").write_text(
+        "\n".join(
+            f"[2026-05-19 00:32:5{i} PP0] Prefill batch, #new-seq: 1, #new-token: {new}, "
+            f"#cached-token: {cached}, full token usage: 0.10, #running-req: 0, #queue-req: 0"
+            for i, (new, cached) in enumerate(rows)
+        )
+    )
+
+    state = LogState(log_dir=logs_dir)
+    assert state.refresh() == (3, 0)
+    series = _plot_series_for_files(state.prefill_files.values(), prefill_stage_zero_only=True)[0]
+    cache_hit = _values_for_metric(series, "cache hit (%)", smooth_input_window=3)
+    assert cache_hit == [85.0, 100.0 * 1700.0 / 2400.0, 100.0 * 800.0 / 1400.0]
+
+
+def test_plot_layout_keeps_compact_prefill_metrics_without_dropping_decode_prealloc():
+    """Cache hit supersedes cached-token, and prefill never reports prealloc."""
+    prefill_metrics = [prefill for prefill, _decode in PLOT_ROWS]
+    decode_metrics = [decode for _prefill, decode in PLOT_ROWS]
+
+    assert len(PLOT_ROWS) == 7
+    assert "total input throughput (token/s)" in prefill_metrics
+    assert "cache hit (%)" in prefill_metrics
+    assert "#cached-token" not in prefill_metrics
+    assert "#prealloc-req" not in prefill_metrics
+    assert "#prealloc-req" in decode_metrics
 
 
 def test_quantile_interpolates_like_numpy():


### PR DESCRIPTION
## Summary

- add logical total-input throughput and token-weighted rolling cache-hit time series to the shared batch-metrics renderer
- parse pipeline-parallel rank metadata and retain PP0 for prefill plots so PP0/PP1 copies of the same logical batch are not double-counted
- compact the matrix from nine rows to seven by removing redundant prefill cached-token and empty prefill prealloc panels while preserving decode metrics
- extend the post-mortem CLI help and add parser, derivation, deduplication, smoothing, and layout regression coverage

## Implementation notes
<img width="1402" height="785" alt="image" src="https://github.com/user-attachments/assets/37507f28-641f-416e-8b7e-559d3181481a" />

Logical total-input throughput is derived from SGLang new-token throughput as `new_tps * (new + cached) / new`, preserving the scheduler's precise timing. Timestamp deltas are used only when the explicit throughput value is unavailable.

Cache hit is computed as a token-weighted centered window: `sum(cached) / sum(new + cached)`.

## Validation

- `PYTHONPATH=src python -m pytest tests/test_batch_plot_metrics.py -q` (12 passed)
- targeted Ruff checks on the three implementation files and test file
- `git diff --check`
