### PR TITLE
Add `sequential_node_start` for TRTLLM backends

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -76,7 +76,7 @@ class TRTLLMProtocol:
     # Controls batched startup of workers that share the same node.
     # 0 = start all workers in parallel (no constraint).
     # 1 = fully sequential: one worker at a time, each must be ready before the next.
-    # N > 1        = start N workers simultaneously per batch, wait for all to be ready, then next batch.
+    # N > 1 = start N workers simultaneously per batch, wait for all to be ready, then next batch.
     # For trtllm_serve: readiness is an HTTP 200 on the worker's http_port.
     # For dynamo.trtllm: readiness is a TCP connection on the worker's sys_port.
     sequential_node_start: int = 0

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -73,12 +73,13 @@ class TRTLLMProtocol:
     # is not needed.
     publish_events_and_metrics: bool = False
 
-    # When True, workers that share the same node are started one at a time.
-    # Each worker must become ready before the next on the same node is launched.
+    # Controls batched startup of workers that share the same node.
+    # 0 (or false) = start all workers in parallel (no constraint).
+    # 1 (or true)  = fully sequential: one worker at a time, each must be ready before the next.
+    # N > 1        = start N workers simultaneously per batch, wait for all to be ready, then next batch.
     # For trtllm_serve: readiness is an HTTP 200 on the worker's http_port.
     # For dynamo.trtllm: readiness is a TCP connection on the worker's sys_port.
-    # Useful when model loading on a single node causes resource contention.
-    sequential_node_start: bool = False
+    sequential_node_start: int = 0
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
 

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -73,6 +73,13 @@ class TRTLLMProtocol:
     # is not needed.
     publish_events_and_metrics: bool = False
 
+    # When True, workers that share the same node are started one at a time.
+    # Each worker must become ready before the next on the same node is launched.
+    # For trtllm_serve: readiness is an HTTP 200 on the worker's http_port.
+    # For dynamo.trtllm: readiness is a TCP connection on the worker's sys_port.
+    # Useful when model loading on a single node causes resource contention.
+    sequential_node_start: bool = False
+
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
     # =========================================================================

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -74,8 +74,8 @@ class TRTLLMProtocol:
     publish_events_and_metrics: bool = False
 
     # Controls batched startup of workers that share the same node.
-    # 0 (or false) = start all workers in parallel (no constraint).
-    # 1 (or true)  = fully sequential: one worker at a time, each must be ready before the next.
+    # 0 = start all workers in parallel (no constraint).
+    # 1 = fully sequential: one worker at a time, each must be ready before the next.
     # N > 1        = start N workers simultaneously per batch, wait for all to be ready, then next batch.
     # For trtllm_serve: readiness is an HTTP 200 on the worker's http_port.
     # For dynamo.trtllm: readiness is a TCP connection on the worker's sys_port.

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from srtctl.core.fingerprint import generate_capture_script
+from srtctl.core.health import wait_for_health
 from srtctl.core.processes import ManagedProcess, NamedProcesses
 from srtctl.core.schema import build_otel_env, installs_dynamo
 from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, get_hostname_ip, start_srun_process
@@ -393,6 +394,35 @@ class WorkerStageMixin:
             critical=True,
         )
 
+    def _wait_for_worker_ready(self, leader: "Process") -> None:
+        """Wait for a single endpoint worker to become ready before starting the next.
+
+        For trtllm_serve: polls the worker's per-process HTTP health endpoint (http_port).
+        For dynamo.trtllm: polls the dynamo system status server on sys_port. The dynamo
+        runtime starts an axum HTTP server on DYN_SYSTEM_PORT (which we set to sys_port)
+        and exposes GET /health → 200 {"status":"ready"} once the model is loaded and the
+        NATS/TCP request endpoint is registered.
+        """
+        health_cfg = self.config.health_check
+        frontend_type = self.config.frontend.type
+
+        # dynamo.trtllm: DYN_SYSTEM_PORT is set to sys_port in start_endpoint_worker,
+        # which enables the per-worker axum HTTP server on that same port.
+        port = leader.http_port if frontend_type == "trtllm_serve" else leader.sys_port
+
+        logger.info(
+            "Sequential node start: waiting for worker %s:%d to be ready",
+            leader.node,
+            port,
+        )
+        if not wait_for_health(
+            leader.node,
+            port,
+            max_attempts=health_cfg.max_attempts,
+            interval=health_cfg.interval_seconds,
+        ):
+            raise RuntimeError(f"Sequential node start: worker on {leader.node}:{port} did not become healthy")
+
     def start_all_workers(self) -> NamedProcesses:
         """Start all backend workers."""
         logger.info("Starting backend workers")
@@ -410,9 +440,34 @@ class WorkerStageMixin:
 
         if launch_per_endpoint:
             # MPI-style: one srun per endpoint (TRTLLM)
-            for endpoint_processes in grouped.values():
-                managed = self.start_endpoint_worker(endpoint_processes)
-                result[managed.name] = managed
+            sequential = getattr(self.backend, "sequential_node_start", False)
+            if sequential:
+                # Group endpoints by leader node; start sequentially within each node
+                # so that model loading on a shared node doesn't cause resource contention.
+                by_node: dict[str, list[list[Process]]] = defaultdict(list)
+                for ep_procs in grouped.values():
+                    by_node[ep_procs[0].node].append(ep_procs)
+
+                for node, node_groups in by_node.items():
+                    if len(node_groups) == 1:
+                        # Only one worker on this node — start immediately, no sequencing needed
+                        managed = self.start_endpoint_worker(node_groups[0])
+                        result[managed.name] = managed
+                    else:
+                        logger.info(
+                            "Sequential node start: %d workers share node %s, starting one by one",
+                            len(node_groups),
+                            node,
+                        )
+                        for i, ep_procs in enumerate(node_groups):
+                            managed = self.start_endpoint_worker(ep_procs)
+                            result[managed.name] = managed
+                            if i < len(node_groups) - 1:
+                                self._wait_for_worker_ready(ep_procs[0])
+            else:
+                for endpoint_processes in grouped.values():
+                    managed = self.start_endpoint_worker(endpoint_processes)
+                    result[managed.name] = managed
         else:
             # Per-process: one srun per node (SGLang)
             for endpoint_processes in grouped.values():

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -10,6 +10,7 @@ Handles starting backend worker processes (prefill/decode/agg).
 import logging
 import shlex
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any
 
 from srtctl.core.fingerprint import generate_capture_script
@@ -444,26 +445,35 @@ class WorkerStageMixin:
             if sequential:
                 # Group endpoints by leader node; start sequentially within each node
                 # so that model loading on a shared node doesn't cause resource contention.
+                # Different nodes start in parallel.
                 by_node: dict[str, list[list[Process]]] = defaultdict(list)
                 for ep_procs in grouped.values():
                     by_node[ep_procs[0].node].append(ep_procs)
 
-                for node, node_groups in by_node.items():
+                def start_node_workers(node: str, node_groups: list) -> list:
                     if len(node_groups) == 1:
-                        # Only one worker on this node — start immediately, no sequencing needed
-                        managed = self.start_endpoint_worker(node_groups[0])
-                        result[managed.name] = managed
-                    else:
-                        logger.info(
-                            "Sequential node start: %d workers share node %s, starting one by one",
-                            len(node_groups),
-                            node,
-                        )
-                        for i, ep_procs in enumerate(node_groups):
-                            managed = self.start_endpoint_worker(ep_procs)
+                        return [self.start_endpoint_worker(node_groups[0])]
+                    logger.info(
+                        "Sequential node start: %d workers share node %s, starting one by one",
+                        len(node_groups),
+                        node,
+                    )
+                    managed_list = []
+                    for i, ep_procs in enumerate(node_groups):
+                        managed = self.start_endpoint_worker(ep_procs)
+                        managed_list.append(managed)
+                        if i < len(node_groups) - 1:
+                            self._wait_for_worker_ready(ep_procs[0])
+                    return managed_list
+
+                with ThreadPoolExecutor(max_workers=len(by_node)) as executor:
+                    futures = {
+                        executor.submit(start_node_workers, node, node_groups): node
+                        for node, node_groups in by_node.items()
+                    }
+                    for future in as_completed(futures):
+                        for managed in future.result():
                             result[managed.name] = managed
-                            if i < len(node_groups) - 1:
-                                self._wait_for_worker_ready(ep_procs[0])
             else:
                 for endpoint_processes in grouped.values():
                     managed = self.start_endpoint_worker(endpoint_processes)

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -441,9 +441,9 @@ class WorkerStageMixin:
 
         if launch_per_endpoint:
             # MPI-style: one srun per endpoint (TRTLLM)
-            sequential = getattr(self.backend, "sequential_node_start", False)
-            if sequential:
-                # Group endpoints by leader node; start sequentially within each node
+            concurrency = int(getattr(self.backend, "sequential_node_start", 0))
+            if concurrency:
+                # Group endpoints by leader node; start in batches within each node
                 # so that model loading on a shared node doesn't cause resource contention.
                 # Different nodes start in parallel.
                 by_node: dict[str, list[list[Process]]] = defaultdict(list)
@@ -454,16 +454,19 @@ class WorkerStageMixin:
                     if len(node_groups) == 1:
                         return [self.start_endpoint_worker(node_groups[0])]
                     logger.info(
-                        "Sequential node start: %d workers share node %s, starting one by one",
+                        "Sequential node start: %d workers share node %s, starting %d at a time",
                         len(node_groups),
                         node,
+                        concurrency,
                     )
                     managed_list = []
-                    for i, ep_procs in enumerate(node_groups):
-                        managed = self.start_endpoint_worker(ep_procs)
-                        managed_list.append(managed)
-                        if i < len(node_groups) - 1:
-                            self._wait_for_worker_ready(ep_procs[0])
+                    for batch_start in range(0, len(node_groups), concurrency):
+                        batch = node_groups[batch_start : batch_start + concurrency]
+                        batch_managed = [self.start_endpoint_worker(ep_procs) for ep_procs in batch]
+                        managed_list.extend(batch_managed)
+                        if batch_start + concurrency < len(node_groups):
+                            for ep_procs in batch:
+                                self._wait_for_worker_ready(ep_procs[0])
                     return managed_list
 
                 with ThreadPoolExecutor(max_workers=len(by_node)) as executor:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3156,3 +3156,345 @@ class TestExtraMountExpansion:
 
             assert extra_root.resolve() in runtime.container_mounts
             assert runtime.container_mounts[extra_root.resolve()] == Path("/extra")
+
+
+class TestSequentialNodeStart:
+    """Tests for TRTLLMProtocol.sequential_node_start feature."""
+
+    def test_sequential_node_start_defaults_to_false(self):
+        from srtctl.backends.trtllm import TRTLLMProtocol
+
+        backend = TRTLLMProtocol()
+        assert backend.sequential_node_start is False
+
+    def test_sequential_node_start_can_be_enabled(self):
+        from srtctl.backends.trtllm import TRTLLMProtocol
+
+        backend = TRTLLMProtocol(sequential_node_start=True)
+        assert backend.sequential_node_start is True
+
+    def test_start_all_workers_sequential_same_node(self, tmp_path):
+        """Workers on the same node are started one-by-one when sequential_node_start=True."""
+        import os
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import MagicMock, call, patch
+
+        from srtctl.backends.trtllm import TRTLLMProtocol
+        from srtctl.cli.mixins.worker_stage import WorkerStageMixin
+        from srtctl.core.processes import ManagedProcess
+        from srtctl.core.runtime import RuntimeContext
+        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
+        from srtctl.core.topology import Process
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        container_path = tmp_path / "container.sqsh"
+        container_path.touch()
+
+        slurm_env = {
+            "SLURM_JOB_ID": "12345",
+            "SLURM_JOBID": "12345",
+            "SLURM_NODELIST": "gpu-01",
+            "SLURM_JOB_NUM_NODES": "1",
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+        }
+
+        def mock_scontrol(cmd, **kwargs):
+            if cmd[0] == "scontrol" and "hostnames" in cmd:
+                result = MagicMock()
+                result.stdout = "gpu-01"
+                result.returncode = 0
+                return result
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with (
+            patch.dict(os.environ, slurm_env),
+            patch("subprocess.run", mock_scontrol),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            config = SrtConfig(
+                name="test",
+                model=ModelConfig(
+                    path=str(model_path),
+                    container=str(container_path),
+                    precision="fp8",
+                ),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    gpus_per_node=8,
+                    decode_nodes=1,
+                    decode_workers=2,
+                ),
+                backend=TRTLLMProtocol(sequential_node_start=True),
+            )
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
+
+            # Two decode workers on the same node (gpu-01), each using 4 GPUs
+            proc_a = Process(
+                node="gpu-01",
+                gpu_indices=frozenset([0, 1, 2, 3]),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="decode",
+                endpoint_index=0,
+                node_rank=0,
+            )
+            proc_b = Process(
+                node="gpu-01",
+                gpu_indices=frozenset([4, 5, 6, 7]),
+                sys_port=8082,
+                http_port=30001,
+                endpoint_mode="decode",
+                endpoint_index=1,
+                node_rank=0,
+            )
+
+            class MockWorkerStage(WorkerStageMixin):
+                def __init__(self, cfg, rt):
+                    self.config = cfg
+                    self.runtime = rt
+
+                @property
+                def backend_processes(self):
+                    return [proc_a, proc_b]
+
+            worker_stage = MockWorkerStage(config, runtime)
+
+            call_order = []
+
+            def fake_start_endpoint(ep_procs):
+                leader = ep_procs[0]
+                call_order.append(("start", leader.endpoint_index))
+                mp = MagicMock(spec=ManagedProcess)
+                mp.name = f"decode_{leader.endpoint_index}_gpu-01"
+                return mp
+
+            def fake_wait_ready(leader):
+                call_order.append(("wait", leader.endpoint_index))
+
+            with (
+                patch.object(worker_stage, "start_endpoint_worker", side_effect=fake_start_endpoint),
+                patch.object(worker_stage, "_wait_for_worker_ready", side_effect=fake_wait_ready),
+            ):
+                worker_stage.start_all_workers()
+
+            # start(0) → wait(0) → start(1)  (no wait after last)
+            assert ("start", 0) in call_order
+            assert ("start", 1) in call_order
+            assert ("wait", 0) in call_order
+            # wait must happen between the two starts
+            assert call_order.index(("wait", 0)) > call_order.index(("start", 0))
+            assert call_order.index(("start", 1)) > call_order.index(("wait", 0))
+            # no wait after the last worker
+            assert ("wait", 1) not in call_order
+
+    def test_start_all_workers_no_wait_when_disabled(self, tmp_path):
+        """Workers are all started without intermediate waits when sequential_node_start=False."""
+        import os
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends.trtllm import TRTLLMProtocol
+        from srtctl.cli.mixins.worker_stage import WorkerStageMixin
+        from srtctl.core.processes import ManagedProcess
+        from srtctl.core.runtime import RuntimeContext
+        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
+        from srtctl.core.topology import Process
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        container_path = tmp_path / "container.sqsh"
+        container_path.touch()
+
+        slurm_env = {
+            "SLURM_JOB_ID": "12345",
+            "SLURM_JOBID": "12345",
+            "SLURM_NODELIST": "gpu-01",
+            "SLURM_JOB_NUM_NODES": "1",
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+        }
+
+        def mock_scontrol(cmd, **kwargs):
+            if cmd[0] == "scontrol" and "hostnames" in cmd:
+                result = MagicMock()
+                result.stdout = "gpu-01"
+                result.returncode = 0
+                return result
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with (
+            patch.dict(os.environ, slurm_env),
+            patch("subprocess.run", mock_scontrol),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            config = SrtConfig(
+                name="test",
+                model=ModelConfig(
+                    path=str(model_path),
+                    container=str(container_path),
+                    precision="fp8",
+                ),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    gpus_per_node=8,
+                    decode_nodes=1,
+                    decode_workers=2,
+                ),
+                backend=TRTLLMProtocol(sequential_node_start=False),
+            )
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
+
+            proc_a = Process(
+                node="gpu-01",
+                gpu_indices=frozenset([0, 1, 2, 3]),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="decode",
+                endpoint_index=0,
+                node_rank=0,
+            )
+            proc_b = Process(
+                node="gpu-01",
+                gpu_indices=frozenset([4, 5, 6, 7]),
+                sys_port=8082,
+                http_port=30001,
+                endpoint_mode="decode",
+                endpoint_index=1,
+                node_rank=0,
+            )
+
+            class MockWorkerStage(WorkerStageMixin):
+                def __init__(self, cfg, rt):
+                    self.config = cfg
+                    self.runtime = rt
+
+                @property
+                def backend_processes(self):
+                    return [proc_a, proc_b]
+
+            worker_stage = MockWorkerStage(config, runtime)
+
+            wait_called = []
+
+            def fake_start_endpoint(ep_procs):
+                mp = MagicMock(spec=ManagedProcess)
+                mp.name = f"decode_{ep_procs[0].endpoint_index}_gpu-01"
+                return mp
+
+            def fake_wait_ready(leader):
+                wait_called.append(leader.endpoint_index)
+
+            with (
+                patch.object(worker_stage, "start_endpoint_worker", side_effect=fake_start_endpoint),
+                patch.object(worker_stage, "_wait_for_worker_ready", side_effect=fake_wait_ready),
+            ):
+                worker_stage.start_all_workers()
+
+            # No readiness waits should have been called
+            assert wait_called == []
+
+    def test_sequential_node_start_no_wait_when_only_one_worker_per_node(self, tmp_path):
+        """When sequential_node_start=True but each node has only one worker, no wait occurs."""
+        import os
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends.trtllm import TRTLLMProtocol
+        from srtctl.cli.mixins.worker_stage import WorkerStageMixin
+        from srtctl.core.processes import ManagedProcess
+        from srtctl.core.runtime import RuntimeContext
+        from srtctl.core.schema import ModelConfig, ResourceConfig, SrtConfig
+        from srtctl.core.topology import Process
+
+        model_path = tmp_path / "model"
+        model_path.mkdir()
+        container_path = tmp_path / "container.sqsh"
+        container_path.touch()
+
+        slurm_env = {
+            "SLURM_JOB_ID": "12345",
+            "SLURM_JOBID": "12345",
+            "SLURM_NODELIST": "gpu-[01-02]",
+            "SLURM_JOB_NUM_NODES": "2",
+            "SRTCTL_SOURCE_DIR": str(Path(__file__).parent.parent),
+        }
+
+        def mock_scontrol(cmd, **kwargs):
+            if cmd[0] == "scontrol" and "hostnames" in cmd:
+                result = MagicMock()
+                result.stdout = "gpu-01\ngpu-02"
+                result.returncode = 0
+                return result
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with (
+            patch.dict(os.environ, slurm_env),
+            patch("subprocess.run", mock_scontrol),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            config = SrtConfig(
+                name="test",
+                model=ModelConfig(
+                    path=str(model_path),
+                    container=str(container_path),
+                    precision="fp8",
+                ),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    gpus_per_node=8,
+                    decode_nodes=2,
+                    decode_workers=2,
+                ),
+                backend=TRTLLMProtocol(sequential_node_start=True),
+            )
+            runtime = RuntimeContext.from_config(config, job_id="12345", log_dir_base=tmp_path)
+
+            # One decode worker per node — different leader nodes
+            proc_a = Process(
+                node="gpu-01",
+                gpu_indices=frozenset(range(8)),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="decode",
+                endpoint_index=0,
+                node_rank=0,
+            )
+            proc_b = Process(
+                node="gpu-02",
+                gpu_indices=frozenset(range(8)),
+                sys_port=8082,
+                http_port=30001,
+                endpoint_mode="decode",
+                endpoint_index=1,
+                node_rank=0,
+            )
+
+            class MockWorkerStage(WorkerStageMixin):
+                def __init__(self, cfg, rt):
+                    self.config = cfg
+                    self.runtime = rt
+
+                @property
+                def backend_processes(self):
+                    return [proc_a, proc_b]
+
+            worker_stage = MockWorkerStage(config, runtime)
+
+            wait_called = []
+
+            def fake_start_endpoint(ep_procs):
+                mp = MagicMock(spec=ManagedProcess)
+                mp.name = f"decode_{ep_procs[0].endpoint_index}_{ep_procs[0].node}"
+                return mp
+
+            with (
+                patch.object(worker_stage, "start_endpoint_worker", side_effect=fake_start_endpoint),
+                patch.object(worker_stage, "_wait_for_worker_ready", side_effect=lambda p: wait_called.append(p)),
+            ):
+                worker_stage.start_all_workers()
+
+            # Each node has only 1 worker — no wait should be triggered
+            assert wait_called == []

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3165,13 +3165,19 @@ class TestSequentialNodeStart:
         from srtctl.backends.trtllm import TRTLLMProtocol
 
         backend = TRTLLMProtocol()
-        assert backend.sequential_node_start is False
+        assert not backend.sequential_node_start
 
     def test_sequential_node_start_can_be_enabled(self):
         from srtctl.backends.trtllm import TRTLLMProtocol
 
         backend = TRTLLMProtocol(sequential_node_start=True)
-        assert backend.sequential_node_start is True
+        assert backend.sequential_node_start
+
+    def test_sequential_node_start_batch_size(self):
+        from srtctl.backends.trtllm import TRTLLMProtocol
+
+        backend = TRTLLMProtocol(sequential_node_start=2)
+        assert backend.sequential_node_start == 2
 
     def test_start_all_workers_sequential_same_node(self, tmp_path):
         """Workers on the same node are started one-by-one when sequential_node_start=True."""


### PR DESCRIPTION
## Add `sequential_node_start` for TRTLLM backends

### Problem

When multiple TRTLLM workers share the same physical node, they all begin loading model weights
simultaneously. This causes GPU memory pressure and resource contention during initialization,
which can slow down or destabilize startup causing OOM — especially on densely packed nodes (4 TP1 workers on one GB300 node).

### Solution

Add a `sequential_node_start` field to `TRTLLMProtocol` that controls how co-located workers
start up:

| Value | Behavior |
|-------|----------|
| `0` (default) | All workers start in parallel (existing behavior) |
| `1` | Fully sequential: one worker at a time, each must be healthy before the next begins |
| `N > 1` | Batched: N workers start simultaneously, wait for all to be ready, then next batch |

Workers on **different** nodes always start in parallel via a `ThreadPoolExecutor` — the
sequencing constraint only applies within a node.

### Implementation

- **`TRTLLMProtocol.sequential_node_start`** — new `int` field on the backend config (accepts
  `bool` coerced to `0`/`1`).
- **`WorkerStageMixin.start_all_workers`** — when `sequential_node_start > 0`, endpoints are
  grouped by their leader node. A `ThreadPoolExecutor` runs one fiber per node; within each
  fiber, workers start in batches of `sequential_node_start` with a health-check barrier between
  batches.
- **`WorkerStageMixin._wait_for_worker_ready`** — polls the appropriate health endpoint before
  releasing the next batch:
  - `trtllm_serve`: HTTP health on `http_port`
  - `dynamo.trtllm`: axum HTTP server on `sys_port` (DYN_SYSTEM_PORT)

### Usage

```yaml
backend:
  type: trtllm
  sequential_node_start: true   # one at a time
  # or:
  sequential_node_start: 2      # two workers per batch as long as they don't OOM