### PR TITLE
feat(benchmark-manifest): portable manifest schema + validator

### DIFF
--- a/examples/benchmark-manifest/dsv4-pro-8k1k-b300/manifest.yaml
+++ b/examples/benchmark-manifest/dsv4-pro-8k1k-b300/manifest.yaml
@@ -1,0 +1,107 @@
+# Reference benchmark manifest — DeepSeek-V4-Pro, 8k/1k, B300 (disaggregated).
+#
+# This is a WORKED EXAMPLE for the schema + validator skeleton. It is structured
+# to pass `srtctl-validate-manifest`. Digests, commits, and SBOM hashes below are
+# illustrative placeholders in the correct format (sha256:<64 hex>, 40-hex sha);
+# a generator will emit the real values from a completed run. See docs.
+manifest_version: "0.1"
+
+metadata:
+  name: dsv4-pro-8k1k-b300
+  description: DeepSeek-V4-Pro disaggregated throughput frontier, 8192/1024, on B300.
+  owners:
+    trtllm: TODO-trtllm-owner
+    dynamo: tanmayv
+
+artifacts:
+  base_image:
+    ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23
+    digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  wheels:
+    - name: ai-dynamo
+      version: "1.3.0.dev2026071601"
+      sha256: "2222222222222222222222222222222222222222222222222222222222222222"
+  sbom:
+    srt_slurm_relpath: examples/benchmark-manifest/dsv4-pro-8k1k-b300/sbom/pip-freeze.txt
+    sha256: "3333333333333333333333333333333333333333333333333333333333333333"
+
+source:
+  repo: https://github.com/NVIDIA/srt-slurm
+  branch: main
+  commit: "abcabcabcabcabcabcabcabcabcabcabcabcabca"
+  bundle:
+    - srt_slurm_relpath: recipes/deepseek-v4/8k1k/b300/disagg-b300-8k-2p1d-dep4-dep8-b32-mtp0.yaml
+      sha256: "4444444444444444444444444444444444444444444444444444444444444444"
+  launcher_patches:
+    - "sed ENROOT_REMAP_ROOT=yes -> no in launcher (required for PMIx)."
+
+model:
+  served: deepseek-ai/DeepSeek-V4-Pro
+  requested: deepseek-ai/DeepSeek-V4-Pro
+  checkpoint:
+    hf_id: deepseek-ai/DeepSeek-V4-Pro
+    hf_revision: "0000000000000000000000000000000000000000"
+
+topology:
+  prefill:
+    num_workers: 2
+    tp: 4
+    ep: 4
+    dp_attn: 4
+    nodes: 1
+  decode:
+    num_workers: 1
+    tp: 8
+    ep: 8
+    dp_attn: 8
+    nodes: 1
+
+runtime:
+  effective_config:
+    srt_slurm_relpath: examples/benchmark-manifest/dsv4-pro-8k1k-b300/effective-config/trtllm_config_decode.yaml
+    sha256: "5555555555555555555555555555555555555555555555555555555555555555"
+  backends:
+    moe:
+      requested: TRTLLM
+      effective: TRTLLM
+    comm:
+      requested: NIXL
+      effective: NIXL
+  cluster_requirements:
+    numa:
+      gpu_nic_affinity: required
+    preserve_engine_comm:
+      - nixl
+      - ucx
+
+conversion:
+  inputs:
+    trtllm_image_digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    trtllm_source_commit: "def0def0def0def0def0def0def0def0def0def0"
+    dynamo_wheel:
+      name: ai-dynamo
+      version: "1.3.0.dev2026071601"
+      sha256: "2222222222222222222222222222222222222222222222222222222222222222"
+    compat_min_commit: "def0def0def0def0def0def0def0def0def0def0"
+    compat_max_commit: "HEAD@2026-07-16"
+  outputs:
+    preserved_comm:
+      - nixl
+      - ucx
+
+results:
+  baseline:
+    - point_id: 2p1d-b32-conc282
+      metrics:
+        concurrency: 282
+        ttft_ms: 950.0
+        tpot_ms: 25.0
+        output_tput_tok_s: 22090.0
+
+capabilities:
+  worker_without_frontend:
+    available: false
+    notes: TODO confirm with the Dynamo team and record the invocation.
+  prefill_only_discovery:
+    available: false
+    notes: TODO confirm with the Dynamo team and record the invocation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ srtctl-i = "srtctl.cli.interactive:main"
 srtctl-sweep = "srtctl.cli.do_sweep:main"
 srtctl-setup-head = "srtctl.cli.setup_head:main"
 srtctl-mcp = "srtctl.mcp.server:main"
+srtctl-validate-manifest = "srtctl.benchmark_manifest.validate:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/srtctl"]

--- a/src/srtctl/benchmark_manifest/README.md
+++ b/src/srtctl/benchmark_manifest/README.md
@@ -1,0 +1,79 @@
+# Portable benchmark manifest
+
+A single, machine-readable file that fully describes a benchmark run, so a
+different team can reproduce the native baseline and build a matched image with
+**no private paths, out-of-band files, or tribal knowledge**.
+
+This directory is the **schema + validator** skeleton. It defines the target a
+handoff must hit; the generator that emits a manifest from a completed run is a
+separate, not-yet-built piece.
+
+## Layout
+
+| File | What it is |
+|------|------------|
+| `models.py` | The manifest schema, as Pydantic v2 models. Source of truth. |
+| `validate.py` | The validator: schema conformance + semantic consistency checks, with a `--online` stub. |
+| `errors.py` | Structured issue types + stable `IssueCode`s the validator emits. |
+| `export_schema.py` | Emits `schema/benchmark-manifest.schema.json` from the models. |
+| `schema/benchmark-manifest.schema.json` | Generated JSON Schema, for non-Python consumers. Do not edit by hand. |
+
+The reference example lives at
+`examples/benchmark-manifest/dsv4-pro-8k1k-b300/manifest.yaml`, and tests are in
+`tests/test_benchmark_manifest.py`.
+
+## Use
+
+```bash
+# validate a manifest
+srtctl-validate-manifest path/to/manifest.yaml
+# or, without installing:
+uv run python -m srtctl.benchmark_manifest.validate path/to/manifest.yaml
+
+# regenerate the JSON Schema after changing the models
+uv run python -m srtctl.benchmark_manifest.export_schema \
+    -o src/srtctl/benchmark_manifest/schema/benchmark-manifest.schema.json
+```
+
+Exit code is non-zero if there is any **error**-severity issue. Warnings (e.g. a
+missing SBOM) do not fail the run.
+
+## What the validator checks today (static, no network)
+
+| Failure mode | `IssueCode` |
+|---|---|
+| Image (or OCI checkpoint) pinned by a tag, not a digest | `FLOATING_TAG` |
+| Malformed `sha256:` digest, or a bad bare 64-hex sha256 (wheel / bundle file / effective_config / SBOM) | `BAD_DIGEST_FORMAT` |
+| Wheel with only a version string (no sha/commit) | `UNPINNED_WHEEL` |
+| Commit not a full 40-hex sha — `source.commit`, wheel `git_commit`, conversion source/compat commits | `BAD_COMMIT` / `MISSING_COMMIT` |
+| `manifest_version` major this validator cannot read | `UNSUPPORTED_MANIFEST_VERSION` |
+| Served model name != requested | `MODEL_NAME_MISMATCH` |
+| Checkpoint given as a local path (absolute or mount-relative) | `PRIVATE_PATH` |
+| Checkpoint with neither HF id+revision nor OCI digest | `CHECKPOINT_UNDERSPECIFIED` |
+| `backend.effective` != `backend.requested` (silent fallback) | `SILENT_BACKEND_FALLBACK` |
+| Dynamo wheel not baked (floating runtime install) | `RUNTIME_INSTALL_WHEEL` |
+| Result point with no / duplicate `point_id` | `DANGLING_CONFIG_TO_PERF` |
+| Capability declared available but no invocation | `INCOMPLETE_CAPABILITY` |
+| No SBOM recorded (warning, non-blocking) | `MISSING_SBOM` |
+| Any structural/type error against the models | `SCHEMA_ERROR` |
+
+Hashes are checked for *format* only (offline). Whether a `sha256:`/commit actually
+resolves, and whether `trtllm_source_commit` falls inside the compatibility window,
+is left to the `--online` layer (not yet implemented).
+
+## Known gaps (deliberately visible, not hidden)
+
+- **Generator** — not built. The manifest is meant to be machine-emitted from a
+  run's own artifacts (`agg_*.json`, `trtllm_config_*.yaml`, batch script, image
+  SBOM). Until it exists, manifests are hand-written and the strong
+  silent-fallback / model-name guarantees depend on that generator capturing the
+  *effective* values from the run logs — the static checker can only confirm the
+  recorded effective matches the requested one.
+- **`--online`** — not implemented. Registry/HF/git reachability checks emit a
+  single `ONLINE_NOT_IMPLEMENTED` warning so the gap is visible.
+- **Dynamo capabilities** — `worker_without_frontend` and
+  `prefill_only_discovery` are declared in the schema but must be confirmed with
+  the Dynamo team before they can be marked `available: true` with a real
+  invocation.
+- **Conversion execution** — the schema pins the conversion *contract* (inputs →
+  outputs); actually running the conversion is a separate ticket.

--- a/src/srtctl/benchmark_manifest/__init__.py
+++ b/src/srtctl/benchmark_manifest/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Portable benchmark manifest.
+
+A single, machine-readable file that fully describes a benchmark run so a
+different team can reproduce the native baseline and build a matched image
+with no private paths, out-of-band files, or tribal knowledge.
+
+This package provides:
+  - models.py    : the manifest schema, as Pydantic v2 models (source of truth).
+  - validate.py  : a validator that layers cross-field consistency checks on top
+                   of schema conformance and reports structured issues.
+  - errors.py    : the issue/severity/code types the validator emits.
+
+A generator (emit a manifest from a completed run's artifacts) is a separate,
+not-yet-built piece; see docs. The schema and validator here define the target
+it must produce.
+"""
+
+from srtctl.benchmark_manifest.errors import Issue, IssueCode, Report, Severity
+from srtctl.benchmark_manifest.models import BenchmarkManifest
+
+__all__ = [
+    "BenchmarkManifest",
+    "Issue",
+    "IssueCode",
+    "Report",
+    "Severity",
+]

--- a/src/srtctl/benchmark_manifest/errors.py
+++ b/src/srtctl/benchmark_manifest/errors.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structured issue types the manifest validator emits.
+
+Each failure mode has a stable ``IssueCode`` so tests (and CI) can assert on a
+specific failure rather than matching free text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Severity(str, Enum):
+    ERROR = "error"  # blocks the handoff
+    WARNING = "warning"  # allowed, but the manifest is weaker for it
+
+
+class IssueCode(str, Enum):
+    # structural
+    SCHEMA_ERROR = "schema_error"  # failed to parse against the models
+    UNSUPPORTED_MANIFEST_VERSION = "unsupported_manifest_version"  # major version this validator can't read
+
+    # artifact pinning
+    FLOATING_TAG = "floating_tag"  # a tag where a digest is required
+    BAD_DIGEST_FORMAT = "bad_digest_format"  # not 'sha256:<64 hex>' (or a bad bare 64-hex sha256)
+    UNPINNED_WHEEL = "unpinned_wheel"  # neither sha256 nor git_commit
+    MISSING_SBOM = "missing_sbom"  # no SBOM recorded (warning)
+
+    # source
+    BAD_COMMIT = "bad_commit"  # not a 40-hex sha
+    MISSING_COMMIT = "missing_commit"  # empty where required
+
+    # model / checkpoint
+    MODEL_NAME_MISMATCH = "model_name_mismatch"  # served != requested
+    PRIVATE_PATH = "private_path"  # a local filesystem path where a shareable ref is required
+    CHECKPOINT_UNDERSPECIFIED = "checkpoint_underspecified"  # neither HF id+rev nor OCI digest
+
+    # runtime
+    SILENT_BACKEND_FALLBACK = "silent_backend_fallback"  # backend.effective != backend.requested
+
+    # results
+    DANGLING_CONFIG_TO_PERF = "dangling_config_to_perf"  # a result point is not traceable / duplicate id
+
+    # conversion
+    RUNTIME_INSTALL_WHEEL = "runtime_install_wheel"  # wheel not baked (floating install)
+
+    # capabilities
+    INCOMPLETE_CAPABILITY = "incomplete_capability"  # declared available but no invocation, or section missing
+
+    # online checks (not yet implemented)
+    ONLINE_NOT_IMPLEMENTED = "online_not_implemented"
+
+
+@dataclass
+class Issue:
+    code: IssueCode
+    severity: Severity
+    path: str  # dotted location within the manifest, e.g. "artifacts.base_image.digest"
+    message: str
+
+    def __str__(self) -> str:
+        return f"[{self.severity.value}] {self.code.value} at {self.path}: {self.message}"
+
+
+@dataclass
+class Report:
+    """Result of validating one manifest."""
+
+    issues: list[Issue] = field(default_factory=list)
+
+    def add(self, code: IssueCode, severity: Severity, path: str, message: str) -> None:
+        self.issues.append(Issue(code=code, severity=severity, path=path, message=message))
+
+    @property
+    def errors(self) -> list[Issue]:
+        return [i for i in self.issues if i.severity is Severity.ERROR]
+
+    @property
+    def warnings(self) -> list[Issue]:
+        return [i for i in self.issues if i.severity is Severity.WARNING]
+
+    @property
+    def ok(self) -> bool:
+        """True when there are no error-severity issues (warnings are allowed)."""
+        return not self.errors
+
+    def codes(self) -> set[IssueCode]:
+        return {i.code for i in self.issues}

--- a/src/srtctl/benchmark_manifest/export_schema.py
+++ b/src/srtctl/benchmark_manifest/export_schema.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Emit the JSON Schema for the benchmark manifest from the Pydantic models.
+
+The Pydantic models in ``models.py`` are the source of truth; this writes their
+JSON Schema so non-Python consumers can validate against the same contract.
+
+    python -m srtctl.benchmark_manifest.export_schema        # prints to stdout
+    python -m srtctl.benchmark_manifest.export_schema -o schema/benchmark-manifest.schema.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from srtctl.benchmark_manifest.models import BenchmarkManifest
+
+
+def build_schema() -> dict:
+    schema = BenchmarkManifest.model_json_schema()
+    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    schema["title"] = "Portable Benchmark Manifest"
+    return schema
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--out", type=Path, help="Write to this path instead of stdout.")
+    args = parser.parse_args(argv)
+
+    text = json.dumps(build_schema(), indent=2, sort_keys=False)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n")
+        print(f"wrote {args.out}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/srtctl/benchmark_manifest/models.py
+++ b/src/srtctl/benchmark_manifest/models.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Benchmark manifest schema (Pydantic v2 models).
+
+These models ARE the schema. They validate structure and types, and they emit
+JSON Schema via ``BenchmarkManifest.model_json_schema()`` for external consumers
+(see ``export_schema.py``).
+
+Design notes
+------------
+* Required core vs recommended. Fields that BLOCK reproduction are required.
+  Fields that are strongly recommended but not blocking are ``Optional`` with a
+  ``None`` default. Keeping the required set small is deliberate — it is what
+  keeps authors (and the generator) from being overwhelmed.
+
+* Policy lives in the validator, not here. The models stay structural: digests
+  and commits are plain strings here so the validator can emit precise,
+  human-readable failures ("floating tag, not a digest") instead of an opaque
+  regex mismatch. See ``validate.py``.
+
+* Generated vs authored. Most fields are meant to be machine-emitted from a
+  completed run (results file, engine config, batch script, image SBOM). Only a
+  small set is authored by a human: owners, capability invocations, and the
+  conversion compatibility window. Field docstrings note which is which.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+MANIFEST_VERSION = "0.1"
+
+
+class _Model(BaseModel):
+    """Base for all manifest models: reject unknown keys so drift is caught."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# metadata
+# ---------------------------------------------------------------------------
+
+
+class Owners(_Model):
+    """Named owners on both sides of the handoff (authored)."""
+
+    trtllm: str = Field(..., description="Owner on the TRT-LLM (native) side.")
+    dynamo: str = Field(..., description="Owner on the Dynamo (replicating) side.")
+
+
+class Metadata(_Model):
+    name: str = Field(..., description="Short benchmark name, e.g. 'dsv4-pro-8k1k-b300'.")
+    description: str | None = Field(None, description="One-line human description.")
+    owners: Owners
+
+
+# ---------------------------------------------------------------------------
+# artifacts
+# ---------------------------------------------------------------------------
+
+
+class ImageRef(_Model):
+    """A container image, pinned by content digest (generated)."""
+
+    ref: str = Field(..., description="Human-readable image reference, e.g. 'nvcr.io/.../release:1.3.0rc23'.")
+    digest: str = Field(..., description="Content digest, 'sha256:<64 hex>'. The validator rejects a bare tag.")
+
+
+class WheelRef(_Model):
+    """A Python wheel, pinned by SHA or git commit (generated)."""
+
+    name: str = Field(..., description="Distribution name, e.g. 'ai-dynamo'.")
+    version: str | None = Field(None, description="Version string, if any (informational, NOT the pin).")
+    sha256: str | None = Field(None, description="Artifact sha256. Provide this OR git_commit.")
+    git_commit: str | None = Field(None, description="Source commit the wheel was built from. Provide this OR sha256.")
+
+
+class FileRef(_Model):
+    """A file inside the srt-slurm tree, referenced by path + hash (generated)."""
+
+    srt_slurm_relpath: str = Field(..., description="Path relative to the srt-slurm repo root.")
+    sha256: str = Field(..., description="sha256 of the file at the recorded commit.")
+
+
+class SbomRef(FileRef):
+    """Software bill of materials for the built image (recommended, generated).
+
+    A dependency lock (e.g. ``pip freeze`` captured inside the built image). This
+    is what catches the incompatible-nested-dependency failure class.
+    """
+
+
+class ConversionInputs(_Model):
+    """Inputs that pin how the Dynamo image is produced (authored + generated)."""
+
+    trtllm_image_digest: str = Field(..., description="Base TRT-LLM image digest to convert from.")
+    trtllm_source_commit: str = Field(..., description="TRT-LLM source commit the base image was built at.")
+    dynamo_wheel: WheelRef = Field(..., description="Dynamo wheel to bake in (pinned, not runtime-installed).")
+    compat_min_commit: str = Field(..., description="Low end of the TRT-LLM source-commit range the wheel supports.")
+    compat_max_commit: str = Field(..., description="High end of that range ('HEAD@<date>' allowed).")
+
+
+class ConversionOutputs(_Model):
+    """Outputs of the conversion (generated once the image is built; optional)."""
+
+    dynamo_image_digest: str | None = Field(None, description="Digest of the built Dynamo image, once baked.")
+    build_command: str | None = Field(None, description="Exact command that produced it.")
+    preserved_comm: list[str] = Field(
+        default_factory=list,
+        description="Engine-provided comm libs that MUST survive conversion, e.g. ['nixl', 'ucx', 'libfabric'].",
+    )
+
+
+class Conversion(_Model):
+    """The image-conversion I/O contract for this run.
+
+    This fixes what the conversion must satisfy. Actually running the conversion
+    is a separate ticket; only the contract is pinned here.
+    """
+
+    inputs: ConversionInputs
+    outputs: ConversionOutputs = Field(default_factory=ConversionOutputs)
+
+
+class Artifacts(_Model):
+    base_image: ImageRef = Field(..., description="TRT-LLM base image, by digest.")
+    wheels: list[WheelRef] = Field(default_factory=list, description="Wheels installed on top, pinned.")
+    sbom: SbomRef | None = Field(None, description="Built-image dependency lock (recommended).")
+
+
+# ---------------------------------------------------------------------------
+# source
+# ---------------------------------------------------------------------------
+
+
+class Source(_Model):
+    """Where the recipe/client/sweep scripts come from (generated)."""
+
+    repo: str = Field(..., description="srt-slurm repository URL.")
+    branch: str = Field(..., description="Branch name.")
+    commit: str = Field(..., description="40-hex commit SHA. The validator rejects short or non-hex values.")
+    bundle: list[FileRef] = Field(
+        default_factory=list,
+        description="Recipe/client/sweep files by relpath + sha256 at that commit (SHA-reference, not a copy).",
+    )
+    launcher_patches: list[str] = Field(
+        default_factory=list,
+        description="Out-of-band edits applied at launch, declared explicitly (e.g. an ENROOT_REMAP_ROOT sed).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# model
+# ---------------------------------------------------------------------------
+
+
+class Checkpoint(_Model):
+    """Checkpoint by a shareable reference — never a private local path (generated).
+
+    Provide EITHER (hf_id + hf_revision) OR oci_digest. The validator enforces
+    the one-of and rejects anything that looks like a bare filesystem path.
+    """
+
+    hf_id: str | None = Field(None, description="Hugging Face model id, e.g. 'deepseek-ai/DeepSeek-V4-Pro'.")
+    hf_revision: str | None = Field(None, description="Hugging Face revision (commit/tag) pinning the weights.")
+    oci_digest: str | None = Field(None, description="OCI/registry digest, if the checkpoint is stored that way.")
+
+
+class Model(_Model):
+    served: str = Field(..., description="Model name the server actually served (from the engine/worker logs).")
+    requested: str = Field(..., description="Model name the client requested. Validator flags served != requested.")
+    checkpoint: Checkpoint
+
+
+# ---------------------------------------------------------------------------
+# topology + runtime
+# ---------------------------------------------------------------------------
+
+
+class WorkerGroup(_Model):
+    """One side of a disaggregated deployment (generated)."""
+
+    num_workers: int = Field(..., ge=1)
+    tp: int = Field(..., ge=1, description="Tensor-parallel size.")
+    ep: int | None = Field(None, ge=1, description="Expert-parallel size, if applicable.")
+    dp_attn: int | None = Field(None, ge=1, description="Data-parallel attention size, if applicable.")
+    nodes: int | None = Field(None, ge=0, description="Nodes allocated to this group.")
+
+
+class Topology(_Model):
+    prefill: WorkerGroup
+    decode: WorkerGroup
+
+
+class BackendSelection(_Model):
+    """Requested vs effective backend — the silent-fallback guard (generated).
+
+    ``requested`` is what the recipe asked for; ``effective`` is what the engine
+    actually ran, read from its logs. The validator fails if they differ.
+    """
+
+    requested: str
+    effective: str
+
+
+class Backends(_Model):
+    moe: BackendSelection = Field(..., description="MoE kernel backend, e.g. TRTLLM vs MEGAMOE_DEEPGEMM.")
+    comm: BackendSelection = Field(..., description="KV/comm transfer backend, e.g. NIXL vs UCX.")
+
+
+class ClusterRequirements(_Model):
+    """Cluster-specific settings that a naive replay would miss (recommended)."""
+
+    ucx: dict = Field(default_factory=dict, description="UCX env/settings that must be reproduced.")
+    numa: dict = Field(default_factory=dict, description="GPU/NIC/CPU affinity requirements.")
+    mounts: list[str] = Field(default_factory=list)
+    preserve_engine_comm: list[str] = Field(
+        default_factory=list, description="Comm libs from the engine image that must not be overwritten."
+    )
+
+
+class Runtime(_Model):
+    effective_config: FileRef = Field(
+        ..., description="Reference + hash to the engine's resolved config (trtllm_config_*.yaml), not recipe deltas."
+    )
+    backends: Backends
+    environment: dict | None = Field(None, description="Effective environment (recommended).")
+    cluster_requirements: ClusterRequirements | None = Field(None, description="Recommended.")
+
+
+# ---------------------------------------------------------------------------
+# results
+# ---------------------------------------------------------------------------
+
+
+class Metrics(_Model):
+    """Per-point measured metrics. Absolute latencies are the portable ones."""
+
+    concurrency: int = Field(..., ge=1)
+    ttft_ms: float | None = Field(None, description="Mean time-to-first-token, ms.")
+    tpot_ms: float | None = Field(None, description="Mean time-per-output-token, ms.")
+    output_tput_tok_s: float | None = Field(None, description="Output tokens/sec.")
+    total_tput_tok_s: float | None = Field(None, description="Total (in+out) tokens/sec, if reported.")
+
+
+class ResultPoint(_Model):
+    """One reported number within this run's single, fully-pinned configuration.
+
+    A manifest describes one configuration (topology + backends + effective_config),
+    so ``point_id`` is the stable label identifying a point within that run (e.g. a
+    concurrency sweep step). The validator enforces it is present and unique; it does
+    not resolve it against a separate config table.
+    """
+
+    point_id: str = Field(..., description="Stable, unique label for this point, e.g. '2p1d-b32-conc282'.")
+    metrics: Metrics
+
+
+class Results(_Model):
+    baseline: list[ResultPoint] = Field(
+        default_factory=list, description="Native baseline points, each with a unique point_id within this run."
+    )
+
+
+# ---------------------------------------------------------------------------
+# capabilities (Dynamo-side; authored + gated on the Dynamo team)
+# ---------------------------------------------------------------------------
+
+
+class CapabilityDecl(_Model):
+    available: bool = Field(..., description="Whether this capability exists today. If false, it is a declared gap.")
+    invocation: str | None = Field(None, description="How to invoke it (required when available is true).")
+    notes: str | None = None
+
+
+class Capabilities(_Model):
+    worker_without_frontend: CapabilityDecl = Field(
+        ..., description="A Dynamo worker that answers requests without the Dynamo frontend/router."
+    )
+    prefill_only_discovery: CapabilityDecl = Field(..., description="Dynamo-frontend prefill-only topology discovery.")
+
+
+# ---------------------------------------------------------------------------
+# top-level manifest
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkManifest(_Model):
+    """A complete, portable description of one benchmark run."""
+
+    manifest_version: str = Field(
+        ...,
+        description=f"Schema version, e.g. '{MANIFEST_VERSION}'. Required; the validator rejects a major it cannot read.",
+    )
+    metadata: Metadata
+    artifacts: Artifacts
+    source: Source
+    model: Model
+    topology: Topology
+    runtime: Runtime
+    conversion: Conversion
+    results: Results = Field(default_factory=Results)
+    capabilities: Capabilities | None = Field(None, description="Dynamo capability declarations (recommended).")

--- a/src/srtctl/benchmark_manifest/schema/benchmark-manifest.schema.json
+++ b/src/srtctl/benchmark_manifest/schema/benchmark-manifest.schema.json
@@ -1,0 +1,847 @@
+{
+  "$defs": {
+    "Artifacts": {
+      "additionalProperties": false,
+      "properties": {
+        "base_image": {
+          "$ref": "#/$defs/ImageRef",
+          "description": "TRT-LLM base image, by digest."
+        },
+        "wheels": {
+          "description": "Wheels installed on top, pinned.",
+          "items": {
+            "$ref": "#/$defs/WheelRef"
+          },
+          "title": "Wheels",
+          "type": "array"
+        },
+        "sbom": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SbomRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Built-image dependency lock (recommended)."
+        }
+      },
+      "required": [
+        "base_image"
+      ],
+      "title": "Artifacts",
+      "type": "object"
+    },
+    "BackendSelection": {
+      "additionalProperties": false,
+      "description": "Requested vs effective backend \u2014 the silent-fallback guard (generated).\n\n``requested`` is what the recipe asked for; ``effective`` is what the engine\nactually ran, read from its logs. The validator fails if they differ.",
+      "properties": {
+        "requested": {
+          "title": "Requested",
+          "type": "string"
+        },
+        "effective": {
+          "title": "Effective",
+          "type": "string"
+        }
+      },
+      "required": [
+        "requested",
+        "effective"
+      ],
+      "title": "BackendSelection",
+      "type": "object"
+    },
+    "Backends": {
+      "additionalProperties": false,
+      "properties": {
+        "moe": {
+          "$ref": "#/$defs/BackendSelection",
+          "description": "MoE kernel backend, e.g. TRTLLM vs MEGAMOE_DEEPGEMM."
+        },
+        "comm": {
+          "$ref": "#/$defs/BackendSelection",
+          "description": "KV/comm transfer backend, e.g. NIXL vs UCX."
+        }
+      },
+      "required": [
+        "moe",
+        "comm"
+      ],
+      "title": "Backends",
+      "type": "object"
+    },
+    "Capabilities": {
+      "additionalProperties": false,
+      "properties": {
+        "worker_without_frontend": {
+          "$ref": "#/$defs/CapabilityDecl",
+          "description": "A Dynamo worker that answers requests without the Dynamo frontend/router."
+        },
+        "prefill_only_discovery": {
+          "$ref": "#/$defs/CapabilityDecl",
+          "description": "Dynamo-frontend prefill-only topology discovery."
+        }
+      },
+      "required": [
+        "worker_without_frontend",
+        "prefill_only_discovery"
+      ],
+      "title": "Capabilities",
+      "type": "object"
+    },
+    "CapabilityDecl": {
+      "additionalProperties": false,
+      "properties": {
+        "available": {
+          "description": "Whether this capability exists today. If false, it is a declared gap.",
+          "title": "Available",
+          "type": "boolean"
+        },
+        "invocation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "How to invoke it (required when available is true).",
+          "title": "Invocation"
+        },
+        "notes": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Notes"
+        }
+      },
+      "required": [
+        "available"
+      ],
+      "title": "CapabilityDecl",
+      "type": "object"
+    },
+    "Checkpoint": {
+      "additionalProperties": false,
+      "description": "Checkpoint by a shareable reference \u2014 never a private local path (generated).\n\nProvide EITHER (hf_id + hf_revision) OR oci_digest. The validator enforces\nthe one-of and rejects anything that looks like a bare filesystem path.",
+      "properties": {
+        "hf_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Hugging Face model id, e.g. 'deepseek-ai/DeepSeek-V4-Pro'.",
+          "title": "Hf Id"
+        },
+        "hf_revision": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Hugging Face revision (commit/tag) pinning the weights.",
+          "title": "Hf Revision"
+        },
+        "oci_digest": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "OCI/registry digest, if the checkpoint is stored that way.",
+          "title": "Oci Digest"
+        }
+      },
+      "title": "Checkpoint",
+      "type": "object"
+    },
+    "ClusterRequirements": {
+      "additionalProperties": false,
+      "description": "Cluster-specific settings that a naive replay would miss (recommended).",
+      "properties": {
+        "ucx": {
+          "additionalProperties": true,
+          "description": "UCX env/settings that must be reproduced.",
+          "title": "Ucx",
+          "type": "object"
+        },
+        "numa": {
+          "additionalProperties": true,
+          "description": "GPU/NIC/CPU affinity requirements.",
+          "title": "Numa",
+          "type": "object"
+        },
+        "mounts": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Mounts",
+          "type": "array"
+        },
+        "preserve_engine_comm": {
+          "description": "Comm libs from the engine image that must not be overwritten.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Preserve Engine Comm",
+          "type": "array"
+        }
+      },
+      "title": "ClusterRequirements",
+      "type": "object"
+    },
+    "Conversion": {
+      "additionalProperties": false,
+      "description": "The image-conversion I/O contract for this run.\n\nThis fixes what the conversion must satisfy. Actually running the conversion\nis a separate ticket; only the contract is pinned here.",
+      "properties": {
+        "inputs": {
+          "$ref": "#/$defs/ConversionInputs"
+        },
+        "outputs": {
+          "$ref": "#/$defs/ConversionOutputs"
+        }
+      },
+      "required": [
+        "inputs"
+      ],
+      "title": "Conversion",
+      "type": "object"
+    },
+    "ConversionInputs": {
+      "additionalProperties": false,
+      "description": "Inputs that pin how the Dynamo image is produced (authored + generated).",
+      "properties": {
+        "trtllm_image_digest": {
+          "description": "Base TRT-LLM image digest to convert from.",
+          "title": "Trtllm Image Digest",
+          "type": "string"
+        },
+        "trtllm_source_commit": {
+          "description": "TRT-LLM source commit the base image was built at.",
+          "title": "Trtllm Source Commit",
+          "type": "string"
+        },
+        "dynamo_wheel": {
+          "$ref": "#/$defs/WheelRef",
+          "description": "Dynamo wheel to bake in (pinned, not runtime-installed)."
+        },
+        "compat_min_commit": {
+          "description": "Low end of the TRT-LLM source-commit range the wheel supports.",
+          "title": "Compat Min Commit",
+          "type": "string"
+        },
+        "compat_max_commit": {
+          "description": "High end of that range ('HEAD@<date>' allowed).",
+          "title": "Compat Max Commit",
+          "type": "string"
+        }
+      },
+      "required": [
+        "trtllm_image_digest",
+        "trtllm_source_commit",
+        "dynamo_wheel",
+        "compat_min_commit",
+        "compat_max_commit"
+      ],
+      "title": "ConversionInputs",
+      "type": "object"
+    },
+    "ConversionOutputs": {
+      "additionalProperties": false,
+      "description": "Outputs of the conversion (generated once the image is built; optional).",
+      "properties": {
+        "dynamo_image_digest": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Digest of the built Dynamo image, once baked.",
+          "title": "Dynamo Image Digest"
+        },
+        "build_command": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Exact command that produced it.",
+          "title": "Build Command"
+        },
+        "preserved_comm": {
+          "description": "Engine-provided comm libs that MUST survive conversion, e.g. ['nixl', 'ucx', 'libfabric'].",
+          "items": {
+            "type": "string"
+          },
+          "title": "Preserved Comm",
+          "type": "array"
+        }
+      },
+      "title": "ConversionOutputs",
+      "type": "object"
+    },
+    "FileRef": {
+      "additionalProperties": false,
+      "description": "A file inside the srt-slurm tree, referenced by path + hash (generated).",
+      "properties": {
+        "srt_slurm_relpath": {
+          "description": "Path relative to the srt-slurm repo root.",
+          "title": "Srt Slurm Relpath",
+          "type": "string"
+        },
+        "sha256": {
+          "description": "sha256 of the file at the recorded commit.",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "srt_slurm_relpath",
+        "sha256"
+      ],
+      "title": "FileRef",
+      "type": "object"
+    },
+    "ImageRef": {
+      "additionalProperties": false,
+      "description": "A container image, pinned by content digest (generated).",
+      "properties": {
+        "ref": {
+          "description": "Human-readable image reference, e.g. 'nvcr.io/.../release:1.3.0rc23'.",
+          "title": "Ref",
+          "type": "string"
+        },
+        "digest": {
+          "description": "Content digest, 'sha256:<64 hex>'. The validator rejects a bare tag.",
+          "title": "Digest",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ref",
+        "digest"
+      ],
+      "title": "ImageRef",
+      "type": "object"
+    },
+    "Metadata": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Short benchmark name, e.g. 'dsv4-pro-8k1k-b300'.",
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "One-line human description.",
+          "title": "Description"
+        },
+        "owners": {
+          "$ref": "#/$defs/Owners"
+        }
+      },
+      "required": [
+        "name",
+        "owners"
+      ],
+      "title": "Metadata",
+      "type": "object"
+    },
+    "Metrics": {
+      "additionalProperties": false,
+      "description": "Per-point measured metrics. Absolute latencies are the portable ones.",
+      "properties": {
+        "concurrency": {
+          "minimum": 1,
+          "title": "Concurrency",
+          "type": "integer"
+        },
+        "ttft_ms": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Mean time-to-first-token, ms.",
+          "title": "Ttft Ms"
+        },
+        "tpot_ms": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Mean time-per-output-token, ms.",
+          "title": "Tpot Ms"
+        },
+        "output_tput_tok_s": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Output tokens/sec.",
+          "title": "Output Tput Tok S"
+        },
+        "total_tput_tok_s": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Total (in+out) tokens/sec, if reported.",
+          "title": "Total Tput Tok S"
+        }
+      },
+      "required": [
+        "concurrency"
+      ],
+      "title": "Metrics",
+      "type": "object"
+    },
+    "Model": {
+      "additionalProperties": false,
+      "properties": {
+        "served": {
+          "description": "Model name the server actually served (from the engine/worker logs).",
+          "title": "Served",
+          "type": "string"
+        },
+        "requested": {
+          "description": "Model name the client requested. Validator flags served != requested.",
+          "title": "Requested",
+          "type": "string"
+        },
+        "checkpoint": {
+          "$ref": "#/$defs/Checkpoint"
+        }
+      },
+      "required": [
+        "served",
+        "requested",
+        "checkpoint"
+      ],
+      "title": "Model",
+      "type": "object"
+    },
+    "Owners": {
+      "additionalProperties": false,
+      "description": "Named owners on both sides of the handoff (authored).",
+      "properties": {
+        "trtllm": {
+          "description": "Owner on the TRT-LLM (native) side.",
+          "title": "Trtllm",
+          "type": "string"
+        },
+        "dynamo": {
+          "description": "Owner on the Dynamo (replicating) side.",
+          "title": "Dynamo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "trtllm",
+        "dynamo"
+      ],
+      "title": "Owners",
+      "type": "object"
+    },
+    "ResultPoint": {
+      "additionalProperties": false,
+      "description": "One reported number within this run's single, fully-pinned configuration.\n\nA manifest describes one configuration (topology + backends + effective_config),\nso ``point_id`` is the stable label identifying a point within that run (e.g. a\nconcurrency sweep step). The validator enforces it is present and unique; it does\nnot resolve it against a separate config table.",
+      "properties": {
+        "point_id": {
+          "description": "Stable, unique label for this point, e.g. '2p1d-b32-conc282'.",
+          "title": "Point Id",
+          "type": "string"
+        },
+        "metrics": {
+          "$ref": "#/$defs/Metrics"
+        }
+      },
+      "required": [
+        "point_id",
+        "metrics"
+      ],
+      "title": "ResultPoint",
+      "type": "object"
+    },
+    "Results": {
+      "additionalProperties": false,
+      "properties": {
+        "baseline": {
+          "description": "Native baseline points, each with a unique point_id within this run.",
+          "items": {
+            "$ref": "#/$defs/ResultPoint"
+          },
+          "title": "Baseline",
+          "type": "array"
+        }
+      },
+      "title": "Results",
+      "type": "object"
+    },
+    "Runtime": {
+      "additionalProperties": false,
+      "properties": {
+        "effective_config": {
+          "$ref": "#/$defs/FileRef",
+          "description": "Reference + hash to the engine's resolved config (trtllm_config_*.yaml), not recipe deltas."
+        },
+        "backends": {
+          "$ref": "#/$defs/Backends"
+        },
+        "environment": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Effective environment (recommended).",
+          "title": "Environment"
+        },
+        "cluster_requirements": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ClusterRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Recommended."
+        }
+      },
+      "required": [
+        "effective_config",
+        "backends"
+      ],
+      "title": "Runtime",
+      "type": "object"
+    },
+    "SbomRef": {
+      "additionalProperties": false,
+      "description": "Software bill of materials for the built image (recommended, generated).\n\nA dependency lock (e.g. ``pip freeze`` captured inside the built image). This\nis what catches the incompatible-nested-dependency failure class.",
+      "properties": {
+        "srt_slurm_relpath": {
+          "description": "Path relative to the srt-slurm repo root.",
+          "title": "Srt Slurm Relpath",
+          "type": "string"
+        },
+        "sha256": {
+          "description": "sha256 of the file at the recorded commit.",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "srt_slurm_relpath",
+        "sha256"
+      ],
+      "title": "SbomRef",
+      "type": "object"
+    },
+    "Source": {
+      "additionalProperties": false,
+      "description": "Where the recipe/client/sweep scripts come from (generated).",
+      "properties": {
+        "repo": {
+          "description": "srt-slurm repository URL.",
+          "title": "Repo",
+          "type": "string"
+        },
+        "branch": {
+          "description": "Branch name.",
+          "title": "Branch",
+          "type": "string"
+        },
+        "commit": {
+          "description": "40-hex commit SHA. The validator rejects short or non-hex values.",
+          "title": "Commit",
+          "type": "string"
+        },
+        "bundle": {
+          "description": "Recipe/client/sweep files by relpath + sha256 at that commit (SHA-reference, not a copy).",
+          "items": {
+            "$ref": "#/$defs/FileRef"
+          },
+          "title": "Bundle",
+          "type": "array"
+        },
+        "launcher_patches": {
+          "description": "Out-of-band edits applied at launch, declared explicitly (e.g. an ENROOT_REMAP_ROOT sed).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Launcher Patches",
+          "type": "array"
+        }
+      },
+      "required": [
+        "repo",
+        "branch",
+        "commit"
+      ],
+      "title": "Source",
+      "type": "object"
+    },
+    "Topology": {
+      "additionalProperties": false,
+      "properties": {
+        "prefill": {
+          "$ref": "#/$defs/WorkerGroup"
+        },
+        "decode": {
+          "$ref": "#/$defs/WorkerGroup"
+        }
+      },
+      "required": [
+        "prefill",
+        "decode"
+      ],
+      "title": "Topology",
+      "type": "object"
+    },
+    "WheelRef": {
+      "additionalProperties": false,
+      "description": "A Python wheel, pinned by SHA or git commit (generated).",
+      "properties": {
+        "name": {
+          "description": "Distribution name, e.g. 'ai-dynamo'.",
+          "title": "Name",
+          "type": "string"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Version string, if any (informational, NOT the pin).",
+          "title": "Version"
+        },
+        "sha256": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Artifact sha256. Provide this OR git_commit.",
+          "title": "Sha256"
+        },
+        "git_commit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Source commit the wheel was built from. Provide this OR sha256.",
+          "title": "Git Commit"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "WheelRef",
+      "type": "object"
+    },
+    "WorkerGroup": {
+      "additionalProperties": false,
+      "description": "One side of a disaggregated deployment (generated).",
+      "properties": {
+        "num_workers": {
+          "minimum": 1,
+          "title": "Num Workers",
+          "type": "integer"
+        },
+        "tp": {
+          "description": "Tensor-parallel size.",
+          "minimum": 1,
+          "title": "Tp",
+          "type": "integer"
+        },
+        "ep": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expert-parallel size, if applicable.",
+          "title": "Ep"
+        },
+        "dp_attn": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Data-parallel attention size, if applicable.",
+          "title": "Dp Attn"
+        },
+        "nodes": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Nodes allocated to this group.",
+          "title": "Nodes"
+        }
+      },
+      "required": [
+        "num_workers",
+        "tp"
+      ],
+      "title": "WorkerGroup",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "A complete, portable description of one benchmark run.",
+  "properties": {
+    "manifest_version": {
+      "description": "Schema version, e.g. '0.1'. Required; the validator rejects a major it cannot read.",
+      "title": "Manifest Version",
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/Metadata"
+    },
+    "artifacts": {
+      "$ref": "#/$defs/Artifacts"
+    },
+    "source": {
+      "$ref": "#/$defs/Source"
+    },
+    "model": {
+      "$ref": "#/$defs/Model"
+    },
+    "topology": {
+      "$ref": "#/$defs/Topology"
+    },
+    "runtime": {
+      "$ref": "#/$defs/Runtime"
+    },
+    "conversion": {
+      "$ref": "#/$defs/Conversion"
+    },
+    "results": {
+      "$ref": "#/$defs/Results"
+    },
+    "capabilities": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Capabilities"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Dynamo capability declarations (recommended)."
+    }
+  },
+  "required": [
+    "manifest_version",
+    "metadata",
+    "artifacts",
+    "source",
+    "model",
+    "topology",
+    "runtime",
+    "conversion"
+  ],
+  "title": "Portable Benchmark Manifest",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/src/srtctl/benchmark_manifest/validate.py
+++ b/src/srtctl/benchmark_manifest/validate.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Benchmark manifest validator.
+
+Two layers:
+
+1. Schema conformance (``load_manifest``): parse YAML into the Pydantic models.
+   Any structural/type error becomes a single SCHEMA_ERROR issue with the
+   pydantic detail attached.
+
+2. Semantic consistency (``check_consistency``): the policy checks that make a
+   handoff portable — every artifact pinned by digest, served == requested,
+   backend.effective == requested, no private paths, config -> perf traceable.
+   These are where the plain-English "the validator rejects a non-portable
+   handoff" failures come from.
+
+An ``--online`` mode (resolve a digest / HF revision / git commit against the
+network) is declared but NOT implemented yet — it emits a single
+ONLINE_NOT_IMPLEMENTED warning so the gap is visible rather than silently
+skipped.
+
+Run:
+    python -m srtctl.benchmark_manifest.validate path/to/manifest.yaml
+    srtctl-validate-manifest path/to/manifest.yaml        # once installed
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from srtctl.benchmark_manifest.errors import IssueCode, Report, Severity
+from srtctl.benchmark_manifest.models import MANIFEST_VERSION, BenchmarkManifest
+
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")  # a bare sha256, no 'sha256:' prefix
+_SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
+# A Hugging Face repo id is 'namespace/name' — exactly one slash, no path syntax.
+_HF_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+# Escape hatch for a moving upper bound on the compatibility window.
+_HEAD_REF_RE = re.compile(r"^HEAD@")
+# Heuristic for "this is a local filesystem path, not a shareable reference".
+_PATH_LIKE_RE = re.compile(r"^(/|\./|\.\./|~)")
+
+
+# ---------------------------------------------------------------------------
+# layer 1: schema conformance
+# ---------------------------------------------------------------------------
+
+
+def load_manifest(path: Path, report: Report) -> BenchmarkManifest | None:
+    """Load + parse a manifest. Returns None (and records SCHEMA_ERROR) on failure."""
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except (yaml.YAMLError, OSError) as exc:
+        # OSError covers a directory, an unreadable file, etc. — record it rather
+        # than let it crash the CLI and abort the rest of a multi-file batch.
+        report.add(IssueCode.SCHEMA_ERROR, Severity.ERROR, "<file>", f"could not read manifest: {exc}")
+        return None
+    if not isinstance(raw, dict):
+        report.add(IssueCode.SCHEMA_ERROR, Severity.ERROR, "<file>", "Top-level manifest must be a mapping.")
+        return None
+    try:
+        return BenchmarkManifest.model_validate(raw)
+    except ValidationError as exc:
+        for err in exc.errors():
+            loc = ".".join(str(p) for p in err["loc"])
+            report.add(IssueCode.SCHEMA_ERROR, Severity.ERROR, loc or "<root>", err["msg"])
+        return None
+
+
+# ---------------------------------------------------------------------------
+# layer 2: semantic consistency
+# ---------------------------------------------------------------------------
+
+
+def _check_digest(ref_desc: str, path: str, digest: str, report: Report) -> None:
+    if _DIGEST_RE.match(digest):
+        return
+    # A value that starts with 'sha256:' was meant to be a digest but is malformed;
+    # anything else isn't a digest at all — most likely a floating tag.
+    if digest.startswith("sha256:"):
+        report.add(
+            IssueCode.BAD_DIGEST_FORMAT,
+            Severity.ERROR,
+            path,
+            f"{ref_desc} digest '{digest}' is not 'sha256:<64 hex>'.",
+        )
+    else:
+        report.add(
+            IssueCode.FLOATING_TAG,
+            Severity.ERROR,
+            path,
+            f"{ref_desc} is pinned by a tag ('{digest}'); pin it by an immutable sha256 digest.",
+        )
+
+
+def _check_commit(path: str, commit: str, report: Report) -> None:
+    if not commit:
+        report.add(IssueCode.MISSING_COMMIT, Severity.ERROR, path, "commit is empty.")
+    elif not _SHA1_RE.match(commit):
+        report.add(
+            IssueCode.BAD_COMMIT,
+            Severity.ERROR,
+            path,
+            f"commit '{commit}' is not a full 40-hex sha.",
+        )
+
+
+def _check_sha256(ref_desc: str, path: str, value: str, report: Report) -> None:
+    """A bare sha256 hash (no 'sha256:' prefix) — used for wheels, files, and the SBOM."""
+    if not _SHA256_RE.match(value):
+        report.add(
+            IssueCode.BAD_DIGEST_FORMAT,
+            Severity.ERROR,
+            path,
+            f"{ref_desc} sha256 '{value}' is not 64 lowercase hex chars.",
+        )
+
+
+def _check_pin_formats(path: str, sha256: str | None, git_commit: str | None, report: Report) -> None:
+    """Format-check whichever pin a wheel provides (presence is checked separately)."""
+    if sha256:
+        _check_sha256("wheel", f"{path}.sha256", sha256, report)
+    if git_commit and not _SHA1_RE.match(git_commit):
+        report.add(
+            IssueCode.BAD_COMMIT,
+            Severity.ERROR,
+            f"{path}.git_commit",
+            f"git_commit '{git_commit}' is not a full 40-hex sha.",
+        )
+
+
+def _check_oci_digest(path: str, value: str, report: Report) -> None:
+    """An OCI reference must be pinned by digest: 'sha256:<64 hex>' or 'repo@sha256:<64 hex>'."""
+    digest_part = value.rsplit("@", 1)[-1]
+    if _DIGEST_RE.match(digest_part):
+        return
+    if digest_part.startswith("sha256:"):
+        report.add(IssueCode.BAD_DIGEST_FORMAT, Severity.ERROR, path, f"OCI digest '{value}' is not 'sha256:<64 hex>'.")
+    else:
+        report.add(
+            IssueCode.FLOATING_TAG,
+            Severity.ERROR,
+            path,
+            f"'{value}' is not pinned by a digest; use a 'sha256:<64 hex>' (or 'repo@sha256:...') reference.",
+        )
+
+
+def check_consistency(m: BenchmarkManifest, report: Report) -> None:
+    """Run the portability policy checks against a parsed manifest."""
+
+    # --- version: this validator only understands its own major version ---
+    _check_version(m, report)
+
+    # --- artifacts: everything pinned by digest ---
+    _check_digest("base image", "artifacts.base_image.digest", m.artifacts.base_image.digest, report)
+    for i, wheel in enumerate(m.artifacts.wheels):
+        if not (wheel.sha256 or wheel.git_commit):
+            report.add(
+                IssueCode.UNPINNED_WHEEL,
+                Severity.ERROR,
+                f"artifacts.wheels[{i}]",
+                f"wheel '{wheel.name}' has neither sha256 nor git_commit; a version string is not a pin.",
+            )
+        _check_pin_formats(f"artifacts.wheels[{i}]", wheel.sha256, wheel.git_commit, report)
+    if m.artifacts.sbom is None:
+        report.add(
+            IssueCode.MISSING_SBOM,
+            Severity.WARNING,
+            "artifacts.sbom",
+            "No SBOM recorded; nested-dependency mismatches will not be catchable.",
+        )
+    else:
+        _check_sha256("SBOM", "artifacts.sbom.sha256", m.artifacts.sbom.sha256, report)
+
+    # --- source ---
+    _check_commit("source.commit", m.source.commit, report)
+    for i, f in enumerate(m.source.bundle):
+        _check_sha256("bundle file", f"source.bundle[{i}].sha256", f.sha256, report)
+
+    # --- runtime: the effective-config reference must be a real hash ---
+    _check_sha256("effective config", "runtime.effective_config.sha256", m.runtime.effective_config.sha256, report)
+
+    # --- conversion inputs ---
+    _check_digest(
+        "conversion base image",
+        "conversion.inputs.trtllm_image_digest",
+        m.conversion.inputs.trtllm_image_digest,
+        report,
+    )
+    _check_commit("conversion.inputs.trtllm_source_commit", m.conversion.inputs.trtllm_source_commit, report)
+    _check_commit("conversion.inputs.compat_min_commit", m.conversion.inputs.compat_min_commit, report)
+    _check_compat_max("conversion.inputs.compat_max_commit", m.conversion.inputs.compat_max_commit, report)
+    dw = m.conversion.inputs.dynamo_wheel
+    if not (dw.sha256 or dw.git_commit):
+        report.add(
+            IssueCode.RUNTIME_INSTALL_WHEEL,
+            Severity.ERROR,
+            "conversion.inputs.dynamo_wheel",
+            "Dynamo wheel is not pinned (no sha256/git_commit); bake a pinned wheel at build time "
+            "instead of a floating runtime install.",
+        )
+    _check_pin_formats("conversion.inputs.dynamo_wheel", dw.sha256, dw.git_commit, report)
+
+    # --- model / checkpoint ---
+    if m.model.served != m.model.requested:
+        report.add(
+            IssueCode.MODEL_NAME_MISMATCH,
+            Severity.ERROR,
+            "model",
+            f"served ('{m.model.served}') != requested ('{m.model.requested}').",
+        )
+    _check_checkpoint(m, report)
+
+    # --- runtime: silent backend fallback ---
+    for name, sel in (("moe", m.runtime.backends.moe), ("comm", m.runtime.backends.comm)):
+        if sel.effective != sel.requested:
+            report.add(
+                IssueCode.SILENT_BACKEND_FALLBACK,
+                Severity.ERROR,
+                f"runtime.backends.{name}",
+                f"effective backend ('{sel.effective}') != requested ('{sel.requested}'); "
+                "the run did not use the configured backend.",
+            )
+
+    # --- results: every point carries a stable, unique label within this run ---
+    # A manifest describes one fully-pinned configuration, so point_id is the label
+    # that identifies a point within that run (e.g. a concurrency). We enforce that
+    # it is present and unique; we do not resolve it against a separate config table.
+    seen: set[str] = set()
+    for i, pt in enumerate(m.results.baseline):
+        if not pt.point_id:
+            report.add(
+                IssueCode.DANGLING_CONFIG_TO_PERF,
+                Severity.ERROR,
+                f"results.baseline[{i}]",
+                "result point has no point_id, so it cannot be identified.",
+            )
+        elif pt.point_id in seen:
+            report.add(
+                IssueCode.DANGLING_CONFIG_TO_PERF,
+                Severity.ERROR,
+                f"results.baseline[{i}].point_id",
+                f"duplicate point_id '{pt.point_id}'.",
+            )
+        seen.add(pt.point_id)
+
+    # --- capabilities: declared-but-incomplete ---
+    _check_capabilities(m, report)
+
+
+def _check_checkpoint(m: BenchmarkManifest, report: Report) -> None:
+    ckpt = m.model.checkpoint
+    has_hf = bool(ckpt.hf_id and ckpt.hf_revision)
+    has_oci = bool(ckpt.oci_digest)
+    # An hf_id must be a shareable 'namespace/name' id, not a filesystem path.
+    # This also catches mount-relative paths ('lustre/ckpts/...') that a leading-
+    # slash heuristic would miss, since a real HF id has exactly one slash.
+    if ckpt.hf_id and not _HF_ID_RE.match(ckpt.hf_id):
+        report.add(
+            IssueCode.PRIVATE_PATH,
+            Severity.ERROR,
+            "model.checkpoint.hf_id",
+            f"'{ckpt.hf_id}' is not a Hugging Face 'namespace/name' id; it looks like a local path.",
+        )
+    if ckpt.oci_digest:
+        if _PATH_LIKE_RE.match(ckpt.oci_digest):
+            report.add(
+                IssueCode.PRIVATE_PATH,
+                Severity.ERROR,
+                "model.checkpoint.oci_digest",
+                f"'{ckpt.oci_digest}' looks like a local path; use an OCI 'sha256:<64 hex>' reference.",
+            )
+        else:
+            _check_oci_digest("model.checkpoint.oci_digest", ckpt.oci_digest, report)
+    if not (has_hf or has_oci):
+        report.add(
+            IssueCode.CHECKPOINT_UNDERSPECIFIED,
+            Severity.ERROR,
+            "model.checkpoint",
+            "checkpoint needs either (hf_id + hf_revision) or oci_digest.",
+        )
+
+
+def _check_version(m: BenchmarkManifest, report: Report) -> None:
+    supported_major = MANIFEST_VERSION.split(".")[0]
+    major = m.manifest_version.split(".")[0]
+    if major != supported_major:
+        report.add(
+            IssueCode.UNSUPPORTED_MANIFEST_VERSION,
+            Severity.ERROR,
+            "manifest_version",
+            f"manifest_version '{m.manifest_version}' is not supported; this validator understands "
+            f"{supported_major}.x (current schema {MANIFEST_VERSION}).",
+        )
+
+
+def _check_compat_max(path: str, value: str, report: Report) -> None:
+    """The window's upper bound is a 40-hex commit or the 'HEAD@<date>' escape hatch."""
+    if not value:
+        report.add(IssueCode.MISSING_COMMIT, Severity.ERROR, path, "compat_max_commit is empty.")
+    elif not (_HEAD_REF_RE.match(value) or _SHA1_RE.match(value)):
+        report.add(
+            IssueCode.BAD_COMMIT,
+            Severity.ERROR,
+            path,
+            f"'{value}' is not a 40-hex sha or a 'HEAD@<date>' reference.",
+        )
+
+
+def _check_capabilities(m: BenchmarkManifest, report: Report) -> None:
+    if m.capabilities is None:
+        report.add(
+            IssueCode.INCOMPLETE_CAPABILITY,
+            Severity.WARNING,
+            "capabilities",
+            "No Dynamo capability declarations; worker-without-frontend / prefill-only-discovery are unstated.",
+        )
+        return
+    for name in ("worker_without_frontend", "prefill_only_discovery"):
+        decl = getattr(m.capabilities, name)
+        if decl.available and not decl.invocation:
+            report.add(
+                IssueCode.INCOMPLETE_CAPABILITY,
+                Severity.ERROR,
+                f"capabilities.{name}",
+                "declared available but no invocation is documented.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# layer 3: online checks (NOT implemented)
+# ---------------------------------------------------------------------------
+
+
+def check_online(m: BenchmarkManifest, report: Report) -> None:
+    """Resolve digests / HF revisions / commits against the network.
+
+    TODO: not implemented. When built, this must:
+      - resolve artifacts.base_image.digest against the registry (pull-ability),
+      - resolve model.checkpoint HF id+revision (or OCI digest),
+      - resolve source.commit in the srt-slurm repo,
+      - verify trtllm_source_commit falls within [compat_min_commit, compat_max_commit]
+        (needs the git DAG, so it cannot be decided statically).
+    Until then, emit a visible warning rather than silently passing.
+    """
+    report.add(
+        IssueCode.ONLINE_NOT_IMPLEMENTED,
+        Severity.WARNING,
+        "<online>",
+        "--online checks (registry/HF/git reachability) are not implemented yet.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# entry points
+# ---------------------------------------------------------------------------
+
+
+def validate_file(path: Path, online: bool = False) -> Report:
+    report = Report()
+    manifest = load_manifest(path, report)
+    if manifest is None:
+        return report  # structural failure; consistency checks would be noise
+    check_consistency(manifest, report)
+    if online:
+        check_online(manifest, report)
+    return report
+
+
+def _format_report(path: Path, report: Report) -> str:
+    lines = [f"manifest: {path}"]
+    if not report.issues:
+        lines.append("  OK — no issues.")
+    for issue in report.issues:
+        lines.append(f"  {issue}")
+    n_err, n_warn = len(report.errors), len(report.warnings)
+    lines.append(f"  => {n_err} error(s), {n_warn} warning(s)")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a portable benchmark manifest.")
+    parser.add_argument("manifest", type=Path, nargs="+", help="Manifest YAML file(s) to validate.")
+    parser.add_argument("--online", action="store_true", help="Also run network reachability checks (not implemented).")
+    args = parser.parse_args(argv)
+
+    exit_code = 0
+    for path in args.manifest:
+        if not path.exists():
+            print(f"manifest: {path}\n  [error] file not found", file=sys.stderr)
+            exit_code = 1
+            continue
+        report = validate_file(path, online=args.online)
+        print(_format_report(path, report))
+        if not report.ok:
+            exit_code = 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_manifest.py
+++ b/tests/test_benchmark_manifest.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the portable benchmark manifest validator.
+
+The shipped reference example is the positive fixture. Negative cases are built
+by loading that example and mutating exactly one field, so each test isolates a
+single failure mode and asserts its specific IssueCode.
+"""
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from srtctl.benchmark_manifest.errors import IssueCode, Report, Severity
+from srtctl.benchmark_manifest.export_schema import build_schema
+from srtctl.benchmark_manifest.models import BenchmarkManifest
+from srtctl.benchmark_manifest.validate import check_consistency, load_manifest, validate_file
+
+REPO_ROOT = Path(__file__).parent.parent
+EXAMPLE = REPO_ROOT / "examples/benchmark-manifest/dsv4-pro-8k1k-b300/manifest.yaml"
+COMMITTED_SCHEMA = REPO_ROOT / "src/srtctl/benchmark_manifest/schema/benchmark-manifest.schema.json"
+
+HEX64 = "a" * 64  # a well-formed bare sha256
+HEX40 = "b" * 40  # a well-formed commit sha
+
+
+@pytest.fixture
+def example_dict() -> dict:
+    return yaml.safe_load(EXAMPLE.read_text())
+
+
+def _report_for(manifest_dict: dict) -> Report:
+    report = Report()
+    manifest = BenchmarkManifest.model_validate(manifest_dict)
+    check_consistency(manifest, report)
+    return report
+
+
+def _consistency_codes(manifest_dict: dict) -> set[IssueCode]:
+    """Parse a manifest dict and run only the consistency checks; return all codes."""
+    return _report_for(manifest_dict).codes()
+
+
+def _error_codes(manifest_dict: dict) -> set[IssueCode]:
+    """The exact set of ERROR-severity codes — used to assert a mutation is isolated."""
+    return {i.code for i in _report_for(manifest_dict).errors}
+
+
+# ---------------------------------------------------------------------------
+# positive
+# ---------------------------------------------------------------------------
+
+
+def test_reference_example_passes():
+    report = validate_file(EXAMPLE)
+    assert report.ok, f"reference example should validate cleanly, got: {[str(i) for i in report.issues]}"
+    assert not report.errors
+
+
+def test_reference_example_parses_into_models(example_dict):
+    manifest = BenchmarkManifest.model_validate(example_dict)
+    assert manifest.metadata.name == "dsv4-pro-8k1k-b300"
+
+
+# ---------------------------------------------------------------------------
+# negative — one failure mode per test
+# ---------------------------------------------------------------------------
+
+
+def test_floating_tag_rejected(example_dict):
+    example_dict["artifacts"]["base_image"]["digest"] = "1.3.0rc23"  # a tag, not a digest
+    assert IssueCode.FLOATING_TAG in _consistency_codes(example_dict)
+
+
+def test_bad_digest_format_rejected(example_dict):
+    example_dict["artifacts"]["base_image"]["digest"] = "sha256:deadbeef"  # too short
+    assert IssueCode.BAD_DIGEST_FORMAT in _consistency_codes(example_dict)
+
+
+def test_unpinned_wheel_rejected(example_dict):
+    example_dict["artifacts"]["wheels"][0].pop("sha256")  # only a version string left
+    assert IssueCode.UNPINNED_WHEEL in _consistency_codes(example_dict)
+
+
+def test_bad_commit_rejected(example_dict):
+    example_dict["source"]["commit"] = "main"  # not a 40-hex sha
+    assert IssueCode.BAD_COMMIT in _consistency_codes(example_dict)
+
+
+def test_model_name_mismatch_rejected(example_dict):
+    example_dict["model"]["served"] = "some-other-name"
+    assert IssueCode.MODEL_NAME_MISMATCH in _consistency_codes(example_dict)
+
+
+def test_private_checkpoint_path_rejected(example_dict):
+    example_dict["model"]["checkpoint"] = {"hf_id": "/lustre/local/ckpt/dsv4-mxfp4", "hf_revision": "x"}
+    assert IssueCode.PRIVATE_PATH in _consistency_codes(example_dict)
+
+
+def test_checkpoint_underspecified_rejected(example_dict):
+    example_dict["model"]["checkpoint"] = {}  # neither HF id+rev nor OCI digest
+    assert IssueCode.CHECKPOINT_UNDERSPECIFIED in _consistency_codes(example_dict)
+
+
+def test_silent_backend_fallback_rejected(example_dict):
+    example_dict["runtime"]["backends"]["moe"]["effective"] = "TRTLLM"
+    example_dict["runtime"]["backends"]["moe"]["requested"] = "MEGAMOE_DEEPGEMM"
+    assert IssueCode.SILENT_BACKEND_FALLBACK in _consistency_codes(example_dict)
+
+
+def test_runtime_install_wheel_rejected(example_dict):
+    example_dict["conversion"]["inputs"]["dynamo_wheel"] = {"name": "ai-dynamo", "version": "1.3.0.dev0"}
+    assert IssueCode.RUNTIME_INSTALL_WHEEL in _consistency_codes(example_dict)
+
+
+def test_duplicate_point_id_rejected(example_dict):
+    pt = copy.deepcopy(example_dict["results"]["baseline"][0])
+    example_dict["results"]["baseline"].append(pt)  # same point_id twice
+    assert IssueCode.DANGLING_CONFIG_TO_PERF in _consistency_codes(example_dict)
+
+
+def test_incomplete_capability_rejected(example_dict):
+    # Declared available but no invocation documented.
+    example_dict["capabilities"]["worker_without_frontend"] = {"available": True}
+    assert IssueCode.INCOMPLETE_CAPABILITY in _consistency_codes(example_dict)
+
+
+# ---------------------------------------------------------------------------
+# structural (schema layer)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_key_is_schema_error(example_dict, tmp_path):
+    example_dict["unexpected_field"] = 1
+    p = tmp_path / "bad.yaml"
+    p.write_text(yaml.safe_dump(example_dict))
+    report = validate_file(p)
+    assert IssueCode.SCHEMA_ERROR in report.codes()
+    assert not report.ok
+
+
+def test_missing_required_section_is_schema_error(example_dict, tmp_path):
+    del example_dict["runtime"]
+    p = tmp_path / "bad.yaml"
+    p.write_text(yaml.safe_dump(example_dict))
+    report = Report()
+    assert load_manifest(p, report) is None
+    assert IssueCode.SCHEMA_ERROR in report.codes()
+
+
+# ---------------------------------------------------------------------------
+# online stub
+# ---------------------------------------------------------------------------
+
+
+def test_online_checks_flag_not_implemented():
+    report = validate_file(EXAMPLE, online=True)
+    assert IssueCode.ONLINE_NOT_IMPLEMENTED in report.codes()
+    # It's a warning, not an error — the manifest still passes.
+    assert report.ok
+    assert any(i.severity is Severity.WARNING for i in report.issues)
+
+
+# ---------------------------------------------------------------------------
+# accept-alternative pin branches (guard against false-rejection regressions)
+# ---------------------------------------------------------------------------
+
+
+def test_wheel_pinned_by_git_commit_only_accepted(example_dict):
+    example_dict["artifacts"]["wheels"][0] = {"name": "ai-dynamo", "git_commit": HEX40}
+    assert IssueCode.UNPINNED_WHEEL not in _consistency_codes(example_dict)
+
+
+def test_checkpoint_pinned_by_oci_digest_only_accepted(example_dict):
+    example_dict["model"]["checkpoint"] = {"oci_digest": f"sha256:{HEX64}"}
+    codes = _consistency_codes(example_dict)
+    assert IssueCode.CHECKPOINT_UNDERSPECIFIED not in codes
+    assert IssueCode.PRIVATE_PATH not in codes
+    assert IssueCode.FLOATING_TAG not in codes
+
+
+def test_checkpoint_oci_digest_with_repo_prefix_accepted(example_dict):
+    example_dict["model"]["checkpoint"] = {"oci_digest": f"nvcr.io/nvidia/dsv4@sha256:{HEX64}"}
+    assert not _error_codes(example_dict)
+
+
+# ---------------------------------------------------------------------------
+# pin/hash format enforcement (finding: inconsistent enforcement)
+# ---------------------------------------------------------------------------
+
+
+def test_wheel_garbage_sha256_rejected(example_dict):
+    example_dict["artifacts"]["wheels"][0]["sha256"] = "deadbeef"  # present but not 64-hex
+    assert IssueCode.BAD_DIGEST_FORMAT in _consistency_codes(example_dict)
+
+
+def test_wheel_garbage_git_commit_rejected(example_dict):
+    example_dict["artifacts"]["wheels"][0] = {"name": "ai-dynamo", "git_commit": "main"}
+    assert IssueCode.BAD_COMMIT in _consistency_codes(example_dict)
+
+
+def test_effective_config_garbage_sha256_rejected(example_dict):
+    example_dict["runtime"]["effective_config"]["sha256"] = "TODO"
+    assert IssueCode.BAD_DIGEST_FORMAT in _consistency_codes(example_dict)
+
+
+def test_bundle_empty_sha256_rejected(example_dict):
+    example_dict["source"]["bundle"][0]["sha256"] = ""
+    assert IssueCode.BAD_DIGEST_FORMAT in _consistency_codes(example_dict)
+
+
+def test_sbom_garbage_sha256_rejected(example_dict):
+    example_dict["artifacts"]["sbom"]["sha256"] = "not-a-hash"
+    assert IssueCode.BAD_DIGEST_FORMAT in _consistency_codes(example_dict)
+
+
+def test_checkpoint_oci_floating_tag_rejected(example_dict):
+    example_dict["model"]["checkpoint"] = {"oci_digest": "myreg.io/dsv4:latest"}
+    assert IssueCode.FLOATING_TAG in _consistency_codes(example_dict)
+
+
+def test_dynamo_wheel_garbage_sha256_rejected(example_dict):
+    example_dict["conversion"]["inputs"]["dynamo_wheel"]["sha256"] = "deadbeef"
+    assert IssueCode.BAD_DIGEST_FORMAT in _consistency_codes(example_dict)
+
+
+# ---------------------------------------------------------------------------
+# commit checks: conversion image + compat window + missing commit
+# ---------------------------------------------------------------------------
+
+
+def test_conversion_image_floating_tag_rejected(example_dict):
+    example_dict["conversion"]["inputs"]["trtllm_image_digest"] = "release:1.3.0rc23"
+    assert IssueCode.FLOATING_TAG in _consistency_codes(example_dict)
+
+
+def test_missing_commit_rejected(example_dict):
+    example_dict["source"]["commit"] = ""
+    assert IssueCode.MISSING_COMMIT in _consistency_codes(example_dict)
+
+
+def test_compat_min_commit_bad_rejected(example_dict):
+    example_dict["conversion"]["inputs"]["compat_min_commit"] = "main"
+    assert IssueCode.BAD_COMMIT in _consistency_codes(example_dict)
+
+
+def test_compat_max_commit_bad_rejected(example_dict):
+    example_dict["conversion"]["inputs"]["compat_max_commit"] = "whenever"
+    assert IssueCode.BAD_COMMIT in _consistency_codes(example_dict)
+
+
+def test_compat_max_commit_head_ref_accepted(example_dict):
+    example_dict["conversion"]["inputs"]["compat_max_commit"] = "HEAD@2026-01-01"
+    assert IssueCode.BAD_COMMIT not in _consistency_codes(example_dict)
+
+
+# ---------------------------------------------------------------------------
+# manifest version
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_manifest_version_rejected(example_dict):
+    example_dict["manifest_version"] = "2.0"
+    assert IssueCode.UNSUPPORTED_MANIFEST_VERSION in _error_codes(example_dict)
+
+
+def test_missing_manifest_version_is_schema_error(example_dict, tmp_path):
+    del example_dict["manifest_version"]  # now required
+    p = tmp_path / "bad.yaml"
+    p.write_text(yaml.safe_dump(example_dict))
+    report = validate_file(p)
+    assert IssueCode.SCHEMA_ERROR in report.codes()
+    assert not report.ok
+
+
+# ---------------------------------------------------------------------------
+# private-path heuristic: mount-relative form
+# ---------------------------------------------------------------------------
+
+
+def test_relative_private_checkpoint_path_rejected(example_dict):
+    example_dict["model"]["checkpoint"] = {"hf_id": "lustre/local/ckpt/dsv4-mxfp4", "hf_revision": "x"}
+    assert IssueCode.PRIVATE_PATH in _consistency_codes(example_dict)
+
+
+# ---------------------------------------------------------------------------
+# empty point_id branch
+# ---------------------------------------------------------------------------
+
+
+def test_empty_point_id_rejected(example_dict):
+    example_dict["results"]["baseline"][0]["point_id"] = ""
+    assert IssueCode.DANGLING_CONFIG_TO_PERF in _consistency_codes(example_dict)
+
+
+# ---------------------------------------------------------------------------
+# warning-severity branches (non-blocking)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_sbom_warns_but_passes(example_dict):
+    example_dict["artifacts"].pop("sbom")
+    report = _report_for(example_dict)
+    assert IssueCode.MISSING_SBOM in report.codes()
+    assert report.ok  # warning only
+    assert not any(i.severity is Severity.ERROR and i.code is IssueCode.MISSING_SBOM for i in report.issues)
+
+
+def test_missing_capabilities_warns_but_passes(example_dict):
+    example_dict.pop("capabilities")
+    report = _report_for(example_dict)
+    incomplete = [i for i in report.issues if i.code is IssueCode.INCOMPLETE_CAPABILITY]
+    assert incomplete and all(i.severity is Severity.WARNING for i in incomplete)
+    assert report.ok
+
+
+# ---------------------------------------------------------------------------
+# isolation: a single mutation yields exactly its own error (no spurious extras)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mutate, expected",
+    [
+        (lambda d: d["model"].__setitem__("served", "other"), IssueCode.MODEL_NAME_MISMATCH),
+        (
+            lambda d: d["runtime"]["backends"]["moe"].update({"requested": "A", "effective": "B"}),
+            IssueCode.SILENT_BACKEND_FALLBACK,
+        ),
+        (lambda d: d["source"].__setitem__("commit", "main"), IssueCode.BAD_COMMIT),
+    ],
+)
+def test_single_mutation_is_isolated(example_dict, mutate, expected):
+    mutate(example_dict)
+    assert _error_codes(example_dict) == {expected}
+
+
+# ---------------------------------------------------------------------------
+# schema-drift guard: the committed JSON schema matches the models
+# ---------------------------------------------------------------------------
+
+
+def test_committed_schema_matches_models():
+    committed = json.loads(COMMITTED_SCHEMA.read_text())
+    assert build_schema() == committed, (
+        "Committed JSON schema is stale. Regenerate:\n"
+        "  uv run python -m srtctl.benchmark_manifest.export_schema "
+        "-o src/srtctl/benchmark_manifest/schema/benchmark-manifest.schema.json"
+    )


### PR DESCRIPTION
## What this is

A **schema + validator skeleton** for a portable *benchmark manifest*: one
machine-readable file that fully describes a benchmark run, so a different team
can reproduce the native baseline and build a matched image with **no private
paths, out-of-band files, or tribal knowledge**.

This is the first slice of a larger effort to make TRT-LLM → Dynamo benchmark
handoffs reproducible. It defines the target a handoff must hit; the generator
that emits a manifest from a completed run is a separate, not-yet-built piece
(see "Known gaps").

Draft — opening for early review of the schema shape and the validation policy.

## What it adds (`src/srtctl/benchmark_manifest/`)

| File | Role |
|------|------|
| `models.py` | The manifest schema as Pydantic v2 models (source of truth; also emits JSON Schema). Matches the existing `src/srtctl/contract/` idiom. |
| `validate.py` | Schema conformance + cross-field consistency checks, with a stubbed `--online` layer. |
| `errors.py` | Structured issues with stable `IssueCode`s so CI/tests assert on a code, not free text. |
| `export_schema.py` + `schema/benchmark-manifest.schema.json` | Emit + commit the JSON Schema for non-Python consumers. |
| `README.md` | Layout, usage, the check table, and the known gaps stated openly. |

Plus a reference example (`examples/benchmark-manifest/dsv4-pro-8k1k-b300/manifest.yaml`),
tests (`tests/test_benchmark_manifest.py`), and a `srtctl-validate-manifest`
console entry.

```bash
srtctl-validate-manifest examples/benchmark-manifest/dsv4-pro-8k1k-b300/manifest.yaml
```

## What the validator enforces (static, offline)

Every artifact pinned by digest/SHA (image digest, bare sha256 for wheels /
bundle files / effective-config / SBOM, OCI checkpoint digest), full-length
commits, served == requested model, **silent backend fallback**
(`effective != requested`), no private checkpoint paths (absolute or
mount-relative), baked (not runtime-installed) Dynamo wheel, unique result
`point_id`s, capability declarations, and `manifest_version` compatibility.
Hashes are format-checked only; reachability is left to `--online`.

## Known gaps (deliberately visible, not hidden)

- **Generator** — not built. The manifest is meant to be machine-emitted from a
  run's own artifacts; until then the strong silent-fallback / model-name
  guarantees depend on that generator capturing *effective* values from run
  logs. The static checker only confirms recorded-effective == requested.
- **`--online`** — registry/HF/git reachability + compat-window range check emit
  a single visible `ONLINE_NOT_IMPLEMENTED` warning.
- **Dynamo capabilities** (`worker_without_frontend`, `prefill_only_discovery`)
  are in the schema but default to `available: false` until confirmed.
- **Conversion execution** — the schema pins the conversion *contract*; running
  the conversion is a separate ticket.

## Scope

Owns the portable manifest **schema, validator, reference example, and the
image-conversion I/O contract**. Does **not** own the benchmark-tuned defaults,
the comparison-matrix execution / CI conversion job, or the human submission
playbook — those are tracked separately and use the manifest as their interface.

## Testing

- 41 tests: reference example passes; one negative per failure mode (incl. the
  accept-alternative pin branches, warning branches, exact-error-set isolation,
  and a schema-drift guard asserting the committed JSON matches the models).
- `ruff check`, `ruff format --check`, and `pytest` all green.

The schema shape and the validator's severity/enforcement decisions here already
went through an adversarial code-review pass; happy to walk through the
trade-offs.
