### PR TITLE
Fail setup when dependency downloads fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,11 @@ setup:
 		echo "⬇️  Downloading NATS ($(NATS_VERSION)) for $$ARCH_SHORT..."; \
 		NATS_DEB="nats-server-$(NATS_VERSION)-$$ARCH_SHORT.deb"; \
 		NATS_URL="https://github.com/nats-io/nats-server/releases/download/$(NATS_VERSION)/$$NATS_DEB"; \
-		wget -q --show-progress --tries=3 --waitretry=5 "$$NATS_URL" -O "configs/$$NATS_DEB"; \
+		if ! wget -q --show-progress --tries=3 --waitretry=5 "$$NATS_URL" -O "configs/$$NATS_DEB"; then \
+			rm -f "configs/$$NATS_DEB"; \
+			echo "❌ Failed to download NATS from $$NATS_URL"; \
+			exit 1; \
+		fi; \
 		echo "📁 Extracting NATS binary..."; \
 		TMP_DIR=$$(mktemp -d); \
 		dpkg-deb -x "configs/$$NATS_DEB" "$$TMP_DIR"; \
@@ -82,7 +86,11 @@ setup:
 		echo "⬇️  Downloading ETCD ($(ETCD_VERSION)) for $$ARCH_SHORT..."; \
 		ETCD_TAR="etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT.tar.gz"; \
 		ETCD_URL="https://github.com/etcd-io/etcd/releases/download/$(ETCD_VERSION)/$$ETCD_TAR"; \
-		wget -q --show-progress --tries=3 --waitretry=5 "$$ETCD_URL" -O "configs/$$ETCD_TAR"; \
+		if ! wget -q --show-progress --tries=3 --waitretry=5 "$$ETCD_URL" -O "configs/$$ETCD_TAR"; then \
+			rm -f "configs/$$ETCD_TAR"; \
+			echo "❌ Failed to download ETCD from $$ETCD_URL"; \
+			exit 1; \
+		fi; \
 		echo "📁 Extracting ETCD binaries..."; \
 		tar -xzf "configs/$$ETCD_TAR" --strip-components=1 -C configs etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT/etcd etcd-$(ETCD_VERSION)-linux-$$ARCH_SHORT/etcdctl; \
 		chmod +x configs/etcd configs/etcdctl; \


### PR DESCRIPTION
## Summary

- stop `make setup` immediately when the NATS or ETCD `wget` command fails
- remove the partial download and report the exact failed asset URL

## Root cause

The setup target executes multiple commands in one continued shell recipe. A failed `wget` did not stop that recipe, so the following `echo` replaced its nonzero status and setup attempted to extract an incomplete archive. This surfaced downstream as misleading `dpkg-deb` or `gzip` extraction errors.

Observed examples:

- GB300 NATS truncation: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31633154542/job/94237961667
- GB200 invalid NATS archive: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31634694882/job/94249635055
- GB200 truncated ETCD archive: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31634694882/job/94249635591

## Validation

- `git diff --check`
