### PR TITLE
feat(hwinfo): snapshot NVLink and MNNVL state before and after every run

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -210,8 +210,8 @@ GPU 0: NVIDIA GB300
 Collected per node: GPU inventory with serials and driver version; `nvidia-smi
 nvlink -s`, `-e` and `topo -m`; the MNNVL wiring (`/dev/nvidia-caps-imex-channels/`,
 `/etc/nvidia-imex/nodes_config.cfg`, `config.cfg`, the IMEX unit state and
-`nvidia-imex-ctl -N`); per-GPU fabric State/Status/CliqueId; and `dmesg` Xid
-lines plus the row remapper state.
+`nvidia-imex-ctl -N -H` for the domain state and its host list); per-GPU fabric
+State/Status/CliqueId; and `dmesg` Xid lines plus the row remapper state.
 
 The point is the difference between the two files:
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -127,6 +127,10 @@ logs/4459_4P_1D_20251122_041341/
 ├── {node}_nginx.err                         # Nginx stderr
 ├── {node}_config.json                       # Per-node SGLang config dump
 │
+├── hwinfo/                                  # NVLink/MNNVL snapshots
+│   ├── before.out                           # Fabric state before the run
+│   └── after.out                            # Fabric state when the run ended
+│
 ├── cached_assets/                           # Cached model assets
 └── sa-bench_isl_1024_osl_1024/              # Benchmark results
     ├── isl_1024_osl_1024_concurrency_128_req_rate_inf.json
@@ -184,6 +188,46 @@ P99 TPOT (ms):                           22.36
 ### Worker Logs ({node}\_prefill_w0.err, {node}\_decode_w0.err)
 
 SGLang worker logs showing model loading, memory allocation, and runtime info. Check these for debugging CUDA errors, OOM issues, or NCCL failures.
+
+### hwinfo/before.out, hwinfo/after.out
+
+NVLink and MNNVL state on every worker node, captured before any load and again
+when the run ends (on success as well as failure). Each command is recorded with
+its output and, when it failed, its exit code:
+
+```
+===== theia0245 | before | 2026-08-13T07:53:30Z =====
+
+# ---------- NVLink ----------
+
+$ nvidia-smi nvlink -e
+GPU 0: NVIDIA GB300
+	 Link 0: Replay Errors: 0
+	 Link 0: Recovery Errors: 0
+	 Link 0: CRC Errors: 0
+```
+
+Collected per node: GPU inventory with serials and driver version; `nvidia-smi
+nvlink -s`, `-e` and `topo -m`; the MNNVL wiring (`/dev/nvidia-caps-imex-channels/`,
+`/etc/nvidia-imex/nodes_config.cfg`, `config.cfg`, the IMEX unit state and
+`nvidia-imex-ctl -N`); per-GPU fabric State/Status/CliqueId; and `dmesg` Xid
+lines plus the row remapper state.
+
+The point is the difference between the two files:
+
+```bash
+diff hwinfo/before.out hwinfo/after.out
+```
+
+A job that died with `CUDA error: uncorrectable NVLink error` reports nothing
+about which link failed. Error counters that moved between the snapshots do, and
+the GPU serials in the same file are what a hardware ticket needs. Counters that
+grow during a run that still passed are the earliest warning that a link is
+about to take the next job down.
+
+Everything here is best effort: a missing tool or a read the job user is not
+allowed to make is recorded and skipped, and a hung driver call is cut off after
+20 seconds (`HWINFO_CMD_TIMEOUT`). Collection never fails a job.
 
 ### config.yaml
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -191,9 +191,9 @@ SGLang worker logs showing model loading, memory allocation, and runtime info. C
 
 ### hwinfo/before.out, hwinfo/after.out
 
-NVLink and MNNVL state on every worker node, captured before any load and again
-when the run ends (on success as well as failure). Each command is recorded with
-its output and, when it failed, its exit code:
+NVLink, MNNVL and GPU memory state on every worker node, captured before any load
+and again when the run ends (on success as well as failure). Each command is
+recorded with its output and, when it failed, its exit code:
 
 ```
 ===== theia0245 | before | 2026-08-13T07:53:30Z =====
@@ -207,11 +207,51 @@ GPU 0: NVIDIA GB300
 	 Link 0: CRC Errors: 0
 ```
 
-Collected per node: GPU inventory with serials and driver version; `nvidia-smi
-nvlink -s`, `-e` and `topo -m`; the MNNVL wiring (`/dev/nvidia-caps-imex-channels/`,
-`/etc/nvidia-imex/nodes_config.cfg`, `config.cfg`, the IMEX unit state and
-`nvidia-imex-ctl -N -H` for the domain state and its host list); per-GPU fabric
-State/Status/CliqueId; and `dmesg` Xid lines plus the row remapper state.
+The commands run per node in the order below, grouped into the sections that
+appear in the file.
+
+**GPU inventory** — which card is which.
+
+| Command | What it answers |
+| --- | --- |
+| `nvidia-smi --query-gpu=index,name,serial,uuid,pci.bus_id --format=csv` | Which physical GPU a rank in a crash log refers to. Serials are what a hardware ticket needs. |
+| `nvidia-smi --version` | Whether one node in the domain runs a different driver than the rest. |
+
+**GPU memory and processes** — what was already on the cards before the job.
+
+| Command | What it answers |
+| --- | --- |
+| `nvidia-smi --query-gpu=index,memory.total,memory.used,memory.free --format=csv` | Whether the GPUs were clean at startup. A worker that dies with `Free memory on device ... is less than desired GPU memory utilization` names no culprit; this shows how much was missing and on which cards. |
+| `nvidia-smi --query-gpu=index,memory.reserved --format=csv` | How much the driver itself holds. Explains memory that is used while no process owns it. |
+| `nvidia-smi --query-compute-apps=pid,process_name,used_memory,gpu_uuid --format=csv` | Which processes hold device memory. Usually a previous job that has not finished dying. |
+| `fuser -v /dev/nvidia*` | Processes holding the device open that NVML does not report, for example one in another container. |
+| `ps -eo pid,ppid,user,rss,etime,args --sort=-rss \| head -15` | Identifies a leftover worker by its command line and how long it has been running. |
+
+**NVLink** — the links themselves.
+
+| Command | What it answers |
+| --- | --- |
+| `nvidia-smi nvlink -s` | Link state and negotiated speed. A link that is down or trained low shows up here. |
+| `nvidia-smi nvlink -e` | Replay, recovery and CRC counters. The before/after diff of this command is what identifies a degrading link. |
+| `nvidia-smi topo -m` | Which GPU pairs are actually NVLink-connected rather than falling back to PCIe. |
+
+**MNNVL / IMEX** — whether remote peers are reachable at all.
+
+| Command | What it answers |
+| --- | --- |
+| `ls -al /dev/nvidia-caps-imex-channels/` | Whether the kernel side of MNNVL is wired up on this node. |
+| `cat /etc/nvidia-imex/nodes_config.cfg` | Whether the node list matches the allocation. A mismatch is a classic cause of remote NVLink faults. |
+| `cat /etc/nvidia-imex/config.cfg` | The daemon's own settings, including the ports it expects. |
+| `systemctl is-active nvidia-imex`, `systemctl status nvidia-imex` | Whether the daemon is running, and what it said if it is not. |
+| `nvidia-imex-ctl -c <copy> -N -H` | Domain state and the hosts in it, as the daemon sees them. Run against a copy of the config with log and stats paths redirected to `/tmp`, because the shipped paths are root-only and an unprivileged run otherwise reports a misleading parse error. |
+| `nvidia-smi -q \| grep -A8 -i "^ *Fabric"` | Per-GPU fabric State, Status and CliqueId. A GPU outside the clique cannot reach remote peers even though its local links look healthy. |
+
+**Driver and GPU faults** — what the machine logged on its own.
+
+| Command | What it answers |
+| --- | --- |
+| `dmesg -T \| grep -iE "xid\|nvlink\|nvswitch\|imex" \| tail -60` | Xid codes and driver-level link events, with timestamps to correlate against the crash. |
+| `nvidia-smi -q -d ROW_REMAPPER` | Whether the GPU was already degrading before the run started. |
 
 The point is the difference between the two files:
 
@@ -228,6 +268,41 @@ about to take the next job down.
 Everything here is best effort: a missing tool or a read the job user is not
 allowed to make is recorded and skipped, and a hung driver call is cut off after
 20 seconds (`HWINFO_CMD_TIMEOUT`). Collection never fails a job.
+
+#### Preflight
+
+The `before` snapshot is also read back at startup, and a run whose hardware
+already looks fatal is stopped there instead of failing twenty minutes later:
+
+```
+RuntimeError: Preflight found 1 problem(s) that would break this run:
+  - theia0282.lyris.clusters.nvidia.com: IMEX domain node #11 is UNAVAILABLE
+Full snapshot: /.../logs/hwinfo/before.out
+Set preflight.enabled: false to run anyway.
+```
+
+Four conditions are treated as fatal:
+
+| Finding | Why it stops the run |
+| --- | --- |
+| A process still holds device memory | A worker will die on the memory check with a message that names no owner. The pid and its size come from `--query-compute-apps`. |
+| A card has less free memory than `gpu_memory_utilization x total` | Exactly the arithmetic the engine does in `init_device`, so this card is already known to fail. |
+| A node in the IMEX domain is not `READY` | MNNVL spans every node in `nodes_config.cfg`, so a broken peer breaks an MNNVL all2all backend even when that node is outside this allocation. |
+| A GPU did not join the fabric clique | `State`, `Status` or health other than Completed/Success/Healthy means remote peers are unreachable while local links still look fine. |
+
+A finding about the shared domain is reported once for the offending peer, not
+once per node that observed it. A command that was missing or timed out yields no
+finding, so an older snapshot or a node without `nvidia-smi` still passes.
+
+The utilization threshold is taken from the recipe — the largest
+`gpu-memory-utilization` (or SGLang's `mem-fraction-static`) across
+`prefill`, `decode` and `aggregated` — and can be overridden:
+
+```yaml
+preflight:
+  enabled: true                  # false: log the findings and run anyway
+  gpu_memory_utilization: 0.92   # default: whatever the recipe asks for
+```
 
 ### config.yaml
 

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -35,6 +35,7 @@ from srtctl.cli.mixins import (
 )
 from srtctl.core.config import load_config
 from srtctl.core.health import wait_for_port
+from srtctl.core.hwinfo import record_hwinfo_snapshot
 from srtctl.core.lockfile import write_lockfile
 from srtctl.core.processes import (
     ManagedProcess,
@@ -660,6 +661,10 @@ class SweepOrchestrator(
 
         resource_snapshot = record_resource_snapshot(self.config, self.runtime)
 
+        # Baseline the fabric before any load, so the snapshot taken when the run
+        # ends can be diffed against known-good NVLink error counters.
+        record_hwinfo_snapshot(self.runtime, "before")
+
         # Create status reporter (fire-and-forget, no-op if not configured)
         reporter = StatusReporter.from_config(self.config.reporting, self.runtime.job_id)
         reporter.report_started(self.config, self.runtime, resource_snapshot=resource_snapshot)
@@ -763,6 +768,10 @@ class SweepOrchestrator(
             logger.info("Cleanup")
             # NOTE: finalize before registry.cleanup() so samples and manifest are durable.
             exit_code = self.finalize_power_telemetry(exit_code, interrupted=stop_event.is_set())
+            # Snapshot the fabric while the allocation is still ours. Taken on
+            # success too: counters that grew during a run that happened to pass
+            # are the earliest warning of a link about to take a job down.
+            record_hwinfo_snapshot(self.runtime, "after")
             stop_event.set()
             registry.cleanup()
             if exit_code != 0:

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -36,6 +36,7 @@ from srtctl.cli.mixins import (
 from srtctl.core.config import load_config
 from srtctl.core.health import wait_for_port
 from srtctl.core.hwinfo import record_hwinfo_snapshot
+from srtctl.core.preflight import check_snapshot, format_findings
 from srtctl.core.lockfile import write_lockfile
 from srtctl.core.processes import (
     ManagedProcess,
@@ -387,6 +388,47 @@ class SweepOrchestrator(
         if removed > 0:
             logger.info("Cleaned %d stale .lock files from HF cache: %s", removed, hf_home)
 
+    def _check_preflight(self, snapshot: Path | None) -> None:
+        """Stop the run when the baseline snapshot already predicts a failure.
+
+        Without this the job spends its startup time loading weights before a
+        worker dies on free memory, or hangs on an MNNVL peer that was never in
+        the domain, and the reason is only recoverable by reading the snapshot by
+        hand afterwards.
+        """
+        if snapshot is None:
+            return
+
+        util = self.config.preflight.gpu_memory_utilization
+        if util is None:
+            util = self._configured_gpu_memory_utilization()
+
+        findings = check_snapshot(snapshot, gpu_memory_utilization=util)
+        if not findings:
+            logger.info("Preflight: hardware baseline is clean")
+            return
+
+        message = format_findings(findings, snapshot)
+        if not self.config.preflight.enabled:
+            logger.warning("Preflight disabled, continuing anyway:\n%s", message)
+            return
+        raise RuntimeError(message)
+
+    def _configured_gpu_memory_utilization(self) -> float | None:
+        """Largest gpu-memory-utilization any worker mode asks for, if set."""
+        engine_config = getattr(self.config.backend, "vllm_config", None) or getattr(
+            self.config.backend, "sglang_config", None
+        )
+        if engine_config is None:
+            return None
+        values = []
+        for mode in ("prefill", "decode", "aggregated"):
+            mode_config = getattr(engine_config, mode, None) or {}
+            for key in ("gpu-memory-utilization", "gpu_memory_utilization", "mem-fraction-static"):
+                if (value := mode_config.get(key)) is not None:
+                    values.append(float(value))
+        return max(values) if values else None
+
     def _stage_model(self) -> None:
         """Copy the model from shared storage to node-local storage on every
         worker node before workers start (model.stage_dir). One srun per node,
@@ -663,7 +705,8 @@ class SweepOrchestrator(
 
         # Baseline the fabric before any load, so the snapshot taken when the run
         # ends can be diffed against known-good NVLink error counters.
-        record_hwinfo_snapshot(self.runtime, "before")
+        snapshot = record_hwinfo_snapshot(self.runtime, "before")
+        self._check_preflight(snapshot)
 
         # Create status reporter (fire-and-forget, no-op if not configured)
         reporter = StatusReporter.from_config(self.config.reporting, self.runtime.job_id)

--- a/src/srtctl/core/hwinfo.py
+++ b/src/srtctl/core/hwinfo.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVLink / MNNVL health snapshots taken around a run.
+
+An uncorrectable NVLink fault kills a job with a CUDA error that says nothing
+about which link failed, and by the time anyone looks the allocation is gone.
+This module captures the fabric state on every worker node before the run and
+again when it ends, into ``logs/hwinfo/before.out`` and ``logs/hwinfo/after.out``.
+The interesting part is the difference between the two: NVLink error counters
+that moved point at the link that degraded.
+
+Collection is best effort by construction — it must never be the reason a
+benchmark fails.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from srtctl.core.slurm import start_srun_process
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+
+logger = logging.getLogger(__name__)
+
+HWINFO_DIRNAME = "hwinfo"
+
+COLLECT_SCRIPT = Path(__file__).resolve().parent.parent / "runtime_scripts" / "collect_hwinfo.sh"
+
+# Generous enough for a slow driver call on every node, short enough that a
+# wedged node cannot hold up job startup or cleanup for long.
+COLLECT_TIMEOUT_S = 180
+
+
+def record_hwinfo_snapshot(runtime: RuntimeContext, phase: str) -> Path | None:
+    """Capture NVLink/MNNVL state on all worker nodes without failing a job.
+
+    Returns the merged snapshot path, or None when nothing could be collected.
+    """
+    try:
+        return _collect(runtime, phase)
+    except Exception as error:  # noqa: BLE001
+        logger.warning("Failed to capture %s hwinfo snapshot: %s", phase, error)
+        return None
+
+
+def _collect(runtime: RuntimeContext, phase: str) -> Path | None:
+    nodes = list(dict.fromkeys(runtime.nodes.worker))
+    if not nodes:
+        logger.debug("No worker nodes to snapshot for %s hwinfo", phase)
+        return None
+
+    hwinfo_dir = runtime.log_dir / HWINFO_DIRNAME
+    parts_dir = hwinfo_dir / f".{phase}.parts"
+    # A retried phase must not merge stale parts from the previous attempt.
+    shutil.rmtree(parts_dir, ignore_errors=True)
+    parts_dir.mkdir(parents=True, exist_ok=True)
+
+    for het_group, chunk in _node_chunks(runtime, nodes):
+        proc = start_srun_process(
+            command=["bash", str(COLLECT_SCRIPT), str(parts_dir), phase],
+            nodes=len(chunk),
+            ntasks=len(chunk),
+            nodelist=chunk,
+            # Runs on the host: the IMEX config and MNNVL channel devices are
+            # not visible inside the job container.
+            container_image=None,
+            srun_options=runtime.srun_options,
+            het_group=het_group,
+        )
+        try:
+            proc.wait(timeout=COLLECT_TIMEOUT_S)
+        except Exception as error:  # noqa: BLE001
+            logger.warning("hwinfo collection on %s did not finish: %s", ",".join(chunk), error)
+            proc.kill()
+
+    snapshot_path = hwinfo_dir / f"{phase}.out"
+    _merge_parts(nodes, parts_dir, snapshot_path)
+    shutil.rmtree(parts_dir, ignore_errors=True)
+
+    logger.info("Wrote %s hardware snapshot: %s", phase, snapshot_path)
+    return snapshot_path
+
+
+def _node_chunks(runtime: RuntimeContext, nodes: list[str]) -> list[tuple[int | None, list[str]]]:
+    """Group nodes so each srun stays inside one heterogeneous-job component."""
+    if not runtime.nodes.het:
+        return [(None, nodes)]
+
+    groups: dict[int, list[str]] = {}
+    for node in nodes:
+        group = runtime.nodes.het_group_for(node)
+        if group is None:
+            logger.warning("Skipping hwinfo for %s: node is not in any het component", node)
+            continue
+        groups.setdefault(group, []).append(node)
+    return [(group, members) for group, members in sorted(groups.items())]
+
+
+def _merge_parts(nodes: list[str], parts_dir: Path, snapshot_path: Path) -> None:
+    """Concatenate per-node parts in node order into one readable file.
+
+    Each task writes its own part so that output from twelve nodes cannot
+    interleave into an unreadable mess.
+    """
+    sections = []
+    merged: set[Path] = set()
+    for node in nodes:
+        part = parts_dir / f"{node}.part"
+        if part.is_file():
+            sections.append(part.read_text(errors="replace"))
+            merged.add(part)
+        else:
+            sections.append(f"===== {node} =====\n\n[no hwinfo collected from this node]\n\n")
+
+    # A node whose SLURM name differs from what the task reported still has its
+    # snapshot appended rather than silently dropped.
+    for part in sorted(parts_dir.glob("*.part")):
+        if part not in merged:
+            sections.append(part.read_text(errors="replace"))
+
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_text("".join(sections))

--- a/src/srtctl/core/preflight.py
+++ b/src/srtctl/core/preflight.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail a run before it starts when the hardware is not fit to serve it.
+
+The ``before`` hwinfo snapshot already contains everything needed to predict the
+common startup failures, but nobody reads three thousand lines of it until a job
+has burned twenty minutes and died with a message that names no culprit:
+
+- a worker dies with ``Free memory on device ... is less than desired GPU memory
+  utilization`` because a previous job is still holding memory on the card;
+- an MNNVL-backed all2all backend hangs or crashes because a node in the fabric
+  domain is UNAVAILABLE — including a node outside this allocation, since the
+  domain spans every node in ``nodes_config.cfg``;
+- a GPU never joined the fabric clique, so its local links look healthy while
+  remote peers are unreachable.
+
+This module parses the snapshot and turns those into one readable failure at
+startup. It only reports what the snapshot actually recorded: a command that was
+missing or timed out yields no finding rather than a false alarm.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+GIB = 1024**3
+
+# nvidia-smi prints "12345 MiB" / "1.5 GiB" style values in --format=csv output.
+_MEMORY_VALUE = re.compile(r"^\s*(?P<value>[0-9.]+)\s*(?P<unit>[KMG]i?B)?\s*$", re.IGNORECASE)
+_UNIT_SCALE = {"kib": 1024, "mib": 1024**2, "gib": 1024**3, "b": 1}
+
+# "Node #11  - 10.66.6.19  - UNAVAILABLE  - Version:  - Hostname: theia0282..."
+_IMEX_NODE = re.compile(
+    r"^Node\s+#(?P<index>\d+)\s+[-*]\s*(?P<ip>[0-9a-fA-F.:]+)\s*\*?\s*-\s*"
+    r"(?P<state>[A-Z_]+)\b.*?(?:Hostname:\s*(?P<host>\S+))?\s*$"
+)
+
+_SECTION = re.compile(r"^# -+ (?P<name>.+?) -+$")
+_COMMAND = re.compile(r"^\$ (?P<command>.+)$")
+_NODE_HEADER = re.compile(r"^===== (?P<node>\S+) \| ")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One reason the run should not start."""
+
+    node: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.node}: {self.detail}"
+
+
+def check_snapshot(
+    snapshot_path: Path,
+    *,
+    gpu_memory_utilization: float | None = None,
+) -> list[Finding]:
+    """Inspect a merged hwinfo snapshot and return everything that looks fatal.
+
+    ``gpu_memory_utilization`` is the fraction of each card the engine will
+    request. When given, a card with less free memory than
+    ``utilization x total`` is reported — the same arithmetic, and the same
+    verdict, the worker would reach minutes later.
+    """
+    try:
+        text = snapshot_path.read_text(errors="replace")
+    except OSError as error:
+        logger.warning("Preflight skipped, cannot read %s: %s", snapshot_path, error)
+        return []
+
+    # Domain-level facts are reported by every node that can see them, so the
+    # same broken peer would otherwise appear once per observer.
+    findings: dict[Finding, None] = {}
+    for node, blocks in _parse(text).items():
+        for finding in (
+            *_check_compute_apps(node, blocks),
+            *_check_free_memory(node, blocks, gpu_memory_utilization),
+            *_check_imex_domain(blocks),
+            *_check_fabric(node, blocks),
+        ):
+            findings.setdefault(finding)
+    return list(findings)
+
+
+def _parse(text: str) -> dict[str, dict[str, str]]:
+    """Split the snapshot into {node: {command: output}}.
+
+    The snapshot format is stable and line-oriented: a node header, then
+    ``# ---------- section ----------`` and ``$ command`` blocks.
+    """
+    nodes: dict[str, dict[str, str]] = {}
+    node = ""
+    command = ""
+    lines: list[str] = []
+
+    def flush() -> None:
+        if node and command:
+            nodes.setdefault(node, {})[command] = "\n".join(lines)
+
+    for line in text.splitlines():
+        if header := _NODE_HEADER.match(line):
+            flush()
+            node, command, lines = header.group("node"), "", []
+            nodes.setdefault(node, {})
+        elif _SECTION.match(line):
+            flush()
+            command, lines = "", []
+        elif found := _COMMAND.match(line):
+            flush()
+            command, lines = found.group("command"), []
+        elif command:
+            lines.append(line)
+    flush()
+    return nodes
+
+
+def _output_for(blocks: dict[str, str], needle: str) -> str | None:
+    """Return the output of the recorded command containing ``needle``."""
+    for command, output in blocks.items():
+        if needle in command:
+            return output
+    return None
+
+
+def _is_usable(output: str | None) -> bool:
+    """Whether a block holds real output rather than a failure marker."""
+    if not output:
+        return False
+    stripped = output.strip()
+    return bool(stripped) and not stripped.startswith(("[exit ", "[timed out", "[no output"))
+
+
+def _parse_memory(value: str) -> float | None:
+    """Return bytes for an nvidia-smi memory value, or None if unparseable."""
+    found = _MEMORY_VALUE.match(value)
+    if not found:
+        return None
+    unit = (found.group("unit") or "MiB").lower().replace("mb", "mib").replace("gb", "gib")
+    return float(found.group("value")) * _UNIT_SCALE.get(unit, _UNIT_SCALE["mib"])
+
+
+def _csv_rows(output: str) -> list[list[str]]:
+    """Rows of an nvidia-smi --format=csv block, header dropped."""
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    return [[cell.strip() for cell in line.split(",")] for line in lines[1:]]
+
+
+def _check_compute_apps(node: str, blocks: dict[str, str]) -> list[Finding]:
+    """Any process holding device memory before we start is someone else's."""
+    output = _output_for(blocks, "--query-compute-apps")
+    if not _is_usable(output):
+        return []
+    # "No running processes found" and a header-only block both mean clean.
+    findings = []
+    for row in _csv_rows(output):
+        if len(row) < 3:
+            continue
+        pid, name, used = row[0], row[1], row[2]
+        findings.append(
+            Finding(node, f"GPU memory held by pid {pid} ({name}), {used} — leftover process")
+        )
+    return findings
+
+
+def _check_free_memory(
+    node: str, blocks: dict[str, str], gpu_memory_utilization: float | None
+) -> list[Finding]:
+    """A card with less free memory than the engine will request cannot serve.
+
+    Mirrors the engine's own arithmetic — ``utilization x total`` against free
+    memory — so a card that fails here is exactly a card that would fail at
+    ``init_device``.
+    """
+    if gpu_memory_utilization is None:
+        return []
+    output = _output_for(blocks, "memory.total,memory.used,memory.free")
+    if not _is_usable(output):
+        return []
+
+    findings = []
+    for row in _csv_rows(output):
+        if len(row) < 4:
+            continue
+        index, total, _used, free = row[0], row[1], row[2], row[3]
+        free_bytes = _parse_memory(free)
+        total_bytes = _parse_memory(total)
+        if free_bytes is None or total_bytes is None:
+            continue
+        required = total_bytes * gpu_memory_utilization
+        if free_bytes < required:
+            findings.append(
+                Finding(
+                    node,
+                    f"GPU {index} has {free_bytes / GIB:.2f} GiB free of "
+                    f"{total_bytes / GIB:.2f} GiB, engine needs {required / GIB:.2f} GiB "
+                    f"at gpu_memory_utilization={gpu_memory_utilization:g}",
+                )
+            )
+    return findings
+
+
+def _check_imex_domain(blocks: dict[str, str]) -> list[Finding]:
+    """A node missing from the fabric domain breaks MNNVL for everyone in it.
+
+    Reported even when the node is outside this allocation: the domain is shared,
+    and an MNNVL all2all backend addresses it as a whole. The finding is keyed by
+    the offending peer rather than the node that observed it, so a domain of
+    twelve nodes reports one problem and not twelve.
+    """
+    output = _output_for(blocks, "nvidia-imex-ctl")
+    if not _is_usable(output):
+        return []
+
+    findings = []
+    for line in output.splitlines():
+        found = _IMEX_NODE.match(line.strip())
+        if not found or found.group("state") == "READY":
+            continue
+        host = found.group("host") or found.group("ip")
+        findings.append(
+            Finding(host, f"IMEX domain node #{found.group('index')} is {found.group('state')}")
+        )
+    return findings
+
+
+def _check_fabric(node: str, blocks: dict[str, str]) -> list[Finding]:
+    """A GPU that did not join the clique cannot reach remote peers over NVLink."""
+    output = _output_for(blocks, "Fabric")
+    if not _is_usable(output):
+        return []
+
+    findings = []
+    gpu = -1
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped == "Fabric":
+            gpu += 1
+        elif ":" not in stripped:
+            continue
+        key, _, value = (part.strip() for part in stripped.partition(":"))
+        if key == "State" and value != "Completed":
+            findings.append(Finding(node, f"GPU {gpu} fabric State is {value}, expected Completed"))
+        elif key == "Status" and value not in ("Success", "N/A"):
+            findings.append(Finding(node, f"GPU {gpu} fabric Status is {value}, expected Success"))
+        elif key == "Summary" and value not in ("Healthy", "N/A"):
+            findings.append(Finding(node, f"GPU {gpu} fabric health is {value}, expected Healthy"))
+    return findings
+
+
+def format_findings(findings: list[Finding], snapshot_path: Path) -> str:
+    """One message that says what is wrong, where, and where to look."""
+    lines = [
+        f"Preflight found {len(findings)} problem(s) that would break this run:",
+        *(f"  - {finding}" for finding in findings),
+        f"Full snapshot: {snapshot_path}",
+        "Set preflight.enabled: false to run anyway.",
+    ]
+    return "\n".join(lines)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1548,6 +1548,30 @@ class HealthCheckConfig:
 
 
 @dataclass(frozen=True)
+class PreflightConfig:
+    """Abort a run when the ``before`` hardware snapshot already looks fatal.
+
+    The snapshot is taken anyway; this only decides whether its findings stop the
+    job at startup instead of letting it fail twenty minutes later with a message
+    that names no culprit. Checked: processes still holding device memory, cards
+    with less free memory than the engine will request, nodes that are not READY
+    in the IMEX domain (including nodes outside this allocation, since MNNVL
+    spans the whole domain), and GPUs that did not join the fabric clique.
+
+    Attributes:
+        enabled: If False, findings are logged as warnings and the run proceeds.
+        gpu_memory_utilization: Fraction of each card the engine will request, used
+            to turn "free memory" into a pass/fail. Defaults to the vLLM/SGLang
+            default of 0.9 when the recipe does not set one.
+    """
+
+    enabled: bool = True
+    gpu_memory_utilization: float | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
 class InfraConfig:
     """Infrastructure configuration for etcd/nats placement.
 
@@ -1594,6 +1618,7 @@ class SrtConfig:
     output: OutputConfig = field(default_factory=OutputConfig)
     health_check: HealthCheckConfig = field(default_factory=HealthCheckConfig)
     infra: InfraConfig = field(default_factory=InfraConfig)
+    preflight: PreflightConfig = field(default_factory=PreflightConfig)
     observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
 

--- a/src/srtctl/runtime_scripts/collect_hwinfo.sh
+++ b/src/srtctl/runtime_scripts/collect_hwinfo.sh
@@ -62,6 +62,19 @@ section "GPU inventory"
 record 'nvidia-smi --query-gpu=index,name,serial,uuid,pci.bus_id --format=csv'
 record 'nvidia-smi --version'
 
+# Who is holding device memory before the job starts. vLLM refuses to start when
+# free memory is below gpu_memory_utilization x total, and the error it raises
+# names no culprit. Compute apps caught here are usually a previous job that has
+# not finished dying; memory.reserved accounts for the driver's own share, which
+# no process list can explain. fuser sees file handles NVML does not report,
+# e.g. a process in another container that still has the device open.
+section "GPU memory and processes"
+record 'nvidia-smi --query-gpu=index,memory.total,memory.used,memory.free --format=csv'
+record 'nvidia-smi --query-gpu=index,memory.reserved --format=csv'
+record 'nvidia-smi --query-compute-apps=pid,process_name,used_memory,gpu_uuid --format=csv'
+record 'fuser -v /dev/nvidia* 2>&1 | head -40'
+record 'ps -eo pid,ppid,user,rss,etime,args --sort=-rss | head -15'
+
 # Link state and, more importantly, the error counters. Comparing before.out
 # against after.out shows which link degraded and by how much.
 section "NVLink"

--- a/src/srtctl/runtime_scripts/collect_hwinfo.sh
+++ b/src/srtctl/runtime_scripts/collect_hwinfo.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Snapshot NVLink / MNNVL health on one node.
+#
+# Usage: collect_hwinfo.sh <parts_dir> <phase>
+#
+# Runs on the host (not in the job container) because the IMEX config and the
+# MNNVL channel devices are host paths. Writes <parts_dir>/<hostname>.part; the
+# orchestrator merges the parts into logs/hwinfo/<phase>.out.
+#
+# Everything here is best effort. A missing tool, a denied read or a hung driver
+# call is recorded with its exit code and never fails the job, so this script
+# must not use `set -e`.
+
+set -u
+
+PARTS_DIR="${1:?parts dir required}"
+PHASE="${2:?phase required}"
+
+# Bounds each command so a wedged driver cannot stall job startup or cleanup.
+CMD_TIMEOUT="${HWINFO_CMD_TIMEOUT:-20}"
+
+# SLURMD_NODENAME is SLURM's own name for this node, which is what the
+# orchestrator merges by; hostname is only a fallback for direct invocation.
+host="${SLURMD_NODENAME:-$(hostname -s 2>/dev/null || hostname)}"
+part="${PARTS_DIR}/${host}.part"
+
+mkdir -p "$PARTS_DIR"
+{
+    echo "===== ${host} | ${PHASE} | $(date -u '+%Y-%m-%dT%H:%M:%SZ') ====="
+    echo ""
+} > "$part"
+
+section() {
+    printf '# ---------- %s ----------\n\n' "$1" >> "$part"
+}
+
+record() {
+    local cmd="$1"
+    local out rc
+    out="$(timeout "$CMD_TIMEOUT" bash -c "$cmd" 2>&1)"
+    rc=$?
+    {
+        printf '$ %s\n' "$cmd"
+        [ -n "$out" ] && printf '%s\n' "$out"
+        if [ "$rc" -eq 124 ]; then
+            printf '[timed out after %ss]\n' "$CMD_TIMEOUT"
+        elif [ "$rc" -ne 0 ]; then
+            printf '[exit %s]\n' "$rc"
+        elif [ -z "$out" ]; then
+            printf '[no output]\n'
+        fi
+        printf '\n'
+    } >> "$part"
+}
+
+# Which GPU is which. Serials are what a hardware ticket needs, and the driver
+# version tells you whether one node in the domain is out of step with the rest.
+section "GPU inventory"
+record 'nvidia-smi --query-gpu=index,name,serial,uuid,pci.bus_id --format=csv'
+record 'nvidia-smi --version'
+
+# Link state and, more importantly, the error counters. Comparing before.out
+# against after.out shows which link degraded and by how much.
+section "NVLink"
+record 'nvidia-smi nvlink -s'
+record 'nvidia-smi nvlink -e'
+record 'nvidia-smi topo -m'
+
+# Multi-node NVLink: the channel devices prove the kernel side is wired up, and
+# nodes_config.cfg must list the nodes actually in the allocation.
+section "MNNVL / IMEX"
+record 'ls -al /dev/nvidia-caps-imex-channels/'
+record 'cat /etc/nvidia-imex/nodes_config.cfg'
+record 'cat /etc/nvidia-imex/config.cfg'
+record 'systemctl is-active nvidia-imex'
+record 'systemctl status nvidia-imex --no-pager -l 2>&1 | head -30'
+# nvidia-imex-ctl parses /etc/nvidia-imex/config.cfg, whose LOG_FILE_NAME and
+# STATS_FILE_NAME point at root-only paths; unprivileged runs then fail while
+# parsing and report a misleading "invalid value". Point those at /tmp first.
+# The trap keeps the recorded exit status that of the work, not of the cleanup.
+record 'cfg=$(mktemp); trap "rm -f $cfg" EXIT; sed -e "s|^LOG_FILE_NAME=.*|LOG_FILE_NAME=/tmp/imex_hwinfo.log|" -e "s|^STATS_FILE_NAME=.*|STATS_FILE_NAME=/tmp/imex_hwinfo_stats|" /etc/nvidia-imex/config.cfg > "$cfg" && nvidia-imex-ctl -c "$cfg" -N'
+# On NVL systems each GPU reports whether it joined the fabric (State/Status)
+# and which clique it landed in. A GPU outside the clique cannot reach remote
+# peers over NVLink even though its local links look healthy.
+record 'nvidia-smi -q | grep -A8 -i "^ *Fabric"'
+
+# Correlate an NVLink fault with what the driver logged, and check whether the
+# GPU was already degrading before the run started.
+section "Driver and GPU faults"
+record 'dmesg -T | grep -iE "xid|nvlink|nvswitch|imex" | tail -60'
+record 'nvidia-smi -q -d ROW_REMAPPER'
+
+echo "[hwinfo] ${host}: ${PHASE} snapshot written to ${part}"

--- a/src/srtctl/runtime_scripts/collect_hwinfo.sh
+++ b/src/srtctl/runtime_scripts/collect_hwinfo.sh
@@ -79,9 +79,14 @@ record 'systemctl is-active nvidia-imex'
 record 'systemctl status nvidia-imex --no-pager -l 2>&1 | head -30'
 # nvidia-imex-ctl parses /etc/nvidia-imex/config.cfg, whose LOG_FILE_NAME and
 # STATS_FILE_NAME point at root-only paths; unprivileged runs then fail while
-# parsing and report a misleading "invalid value". Point those at /tmp first.
-# The trap keeps the recorded exit status that of the work, not of the cleanup.
-record 'cfg=$(mktemp); trap "rm -f $cfg" EXIT; sed -e "s|^LOG_FILE_NAME=.*|LOG_FILE_NAME=/tmp/imex_hwinfo.log|" -e "s|^STATS_FILE_NAME=.*|STATS_FILE_NAME=/tmp/imex_hwinfo_stats|" /etc/nvidia-imex/config.cfg > "$cfg" && nvidia-imex-ctl -c "$cfg" -N'
+# parsing and report a misleading "invalid value". Point those at /tmp first,
+# then ask the daemon for the domain state (-N) and the hosts in it (-H).
+# Recording the sed separately keeps both commands in the snapshot short enough
+# to copy-paste when reproducing by hand.
+imex_cfg=/tmp/imex_hwinfo_config.cfg
+record "sed -e 's|^LOG_FILE_NAME=.*|LOG_FILE_NAME=/tmp/imex_hwinfo.log|' -e 's|^STATS_FILE_NAME=.*|STATS_FILE_NAME=/tmp/imex_hwinfo_stats|' /etc/nvidia-imex/config.cfg > ${imex_cfg}"
+record "nvidia-imex-ctl -c ${imex_cfg} -N -H"
+rm -f "$imex_cfg"
 # On NVL systems each GPU reports whether it joined the fabric (State/Status)
 # and which clique it landed in. A GPU outside the clique cannot reach remote
 # peers over NVLink even though its local links look healthy.

--- a/tests/test_hwinfo.py
+++ b/tests/test_hwinfo.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the NVLink/MNNVL hardware snapshots taken around a run."""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from srtctl.core.hwinfo import COLLECT_SCRIPT, record_hwinfo_snapshot
+
+# Diagnostics that must stay in the snapshot: link health, the MNNVL wiring and
+# the driver's own account of what went wrong.
+REQUIRED_COMMANDS = (
+    "nvidia-smi nvlink -s",
+    "nvidia-smi nvlink -e",
+    "nvidia-smi topo -m",
+    "ls -al /dev/nvidia-caps-imex-channels/",
+    "cat /etc/nvidia-imex/nodes_config.cfg",
+    "nvidia-imex-ctl",
+    "dmesg",
+)
+
+
+def _run_script(parts_dir: Path, phase: str = "before", node: str = "node01", stubs: str = "") -> str:
+    """Run the collector with stubbed tools and return the node's part file."""
+    harness = "\n".join(
+        [
+            # Stand-ins are shell functions, not files on PATH, so the test does
+            # not need an exec-capable temp dir.
+            'nvidia-smi() { echo "nvidia-smi $*"; }',
+            'systemctl() { echo "systemctl $*"; }',
+            'nvidia-imex-ctl() { echo "nvidia-imex-ctl $*"; }',
+            'dmesg() { echo "NVRM: Xid (PCI:0009:01:00): 74, pid=1"; }',
+            "export -f nvidia-smi systemctl nvidia-imex-ctl dmesg",
+            stubs,
+            f"export SLURMD_NODENAME={node}",
+            f"bash {shlex.quote(str(COLLECT_SCRIPT))} {shlex.quote(str(parts_dir))} {phase}",
+        ]
+    )
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return (parts_dir / f"{node}.part").read_text()
+
+
+class TestCollectScript:
+    def test_part_is_named_for_the_slurm_node(self, tmp_path):
+        """The orchestrator merges by SLURM node name, so the part must match it."""
+        _run_script(tmp_path, node="theia0245")
+
+        assert (tmp_path / "theia0245.part").is_file()
+
+    def test_header_records_phase_and_time(self, tmp_path):
+        content = _run_script(tmp_path, phase="after", node="theia0245")
+
+        assert re.match(
+            r"^===== theia0245 \| after \| \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z =====$",
+            content.splitlines()[0],
+        )
+
+    @pytest.mark.parametrize("command", REQUIRED_COMMANDS)
+    def test_diagnostic_is_collected(self, tmp_path, command):
+        content = _run_script(tmp_path)
+
+        assert command in content
+
+    def test_each_command_is_shown_with_its_output(self, tmp_path):
+        """A snapshot is only useful if it says what produced each block."""
+        content = _run_script(tmp_path)
+
+        assert "$ nvidia-smi nvlink -e" in content
+        assert "nvidia-smi nvlink -e" in content.split("$ nvidia-smi nvlink -e", 1)[1]
+
+    def test_a_missing_tool_is_recorded_and_collection_continues(self, tmp_path):
+        """Most clusters lack some of these tools; that must not lose the rest."""
+        content = _run_script(tmp_path, stubs="unset -f nvidia-smi")
+
+        assert "[exit 127]" in content
+        # Commands after the failing one still ran.
+        assert "NVRM: Xid" in content
+
+    def test_a_hung_command_is_bounded(self, tmp_path):
+        """A wedged driver call must not hold up job startup or cleanup."""
+        content = _run_script(
+            tmp_path,
+            stubs="nvidia-smi() { sleep 30; }; export -f nvidia-smi; export HWINFO_CMD_TIMEOUT=1",
+        )
+
+        assert "[timed out after 1s]" in content
+
+    def test_sections_group_the_output(self, tmp_path):
+        content = _run_script(tmp_path)
+
+        assert "# ---------- NVLink ----------" in content
+        assert "# ---------- MNNVL / IMEX ----------" in content
+
+
+def _runtime(tmp_path: Path, worker=("node01", "node02"), het=False, groups=None):
+    return SimpleNamespace(
+        log_dir=tmp_path / "logs",
+        nodes=SimpleNamespace(
+            worker=tuple(worker),
+            het=het,
+            het_group_for=lambda node: (groups or {}).get(node),
+        ),
+        srun_options={},
+    )
+
+
+def _fake_srun(parts_written: list[str] | None = None):
+    """Stand in for srun, writing the parts a real collector run would leave."""
+
+    def start(command, **kwargs):
+        parts_dir = Path(command[2])
+        parts_dir.mkdir(parents=True, exist_ok=True)
+        for node in kwargs["nodelist"]:
+            if parts_written is not None and node not in parts_written:
+                continue
+            (parts_dir / f"{node}.part").write_text(f"===== {node} =====\ncounters\n\n")
+        return MagicMock()
+
+    return start
+
+
+class TestSnapshot:
+    def test_parts_are_merged_in_node_order(self, tmp_path):
+        runtime = _runtime(tmp_path, worker=("node02", "node01"))
+
+        with patch("srtctl.core.hwinfo.start_srun_process", side_effect=_fake_srun()):
+            path = record_hwinfo_snapshot(runtime, "before")
+
+        assert path == tmp_path / "logs" / "hwinfo" / "before.out"
+        content = path.read_text()
+        assert content.index("node02") < content.index("node01")
+
+    def test_parts_are_cleaned_up(self, tmp_path):
+        """Only the merged snapshot is left behind, not the per-node scratch."""
+        runtime = _runtime(tmp_path)
+
+        with patch("srtctl.core.hwinfo.start_srun_process", side_effect=_fake_srun()):
+            record_hwinfo_snapshot(runtime, "before")
+
+        assert list((tmp_path / "logs" / "hwinfo").iterdir()) == [tmp_path / "logs" / "hwinfo" / "before.out"]
+
+    def test_a_silent_node_is_called_out(self, tmp_path):
+        """A node that reported nothing is more interesting than a gap."""
+        runtime = _runtime(tmp_path)
+
+        with patch("srtctl.core.hwinfo.start_srun_process", side_effect=_fake_srun(parts_written=["node01"])):
+            path = record_hwinfo_snapshot(runtime, "after")
+
+        content = path.read_text()
+        assert "===== node02 =====" in content
+        assert "[no hwinfo collected from this node]" in content
+
+    def test_stale_parts_from_an_earlier_phase_are_not_reused(self, tmp_path):
+        runtime = _runtime(tmp_path)
+        stale = tmp_path / "logs" / "hwinfo" / ".before.parts"
+        stale.mkdir(parents=True)
+        (stale / "node99.part").write_text("stale snapshot\n")
+
+        with patch("srtctl.core.hwinfo.start_srun_process", side_effect=_fake_srun()):
+            path = record_hwinfo_snapshot(runtime, "before")
+
+        assert "stale snapshot" not in path.read_text()
+
+    def test_collection_runs_on_the_host(self, tmp_path):
+        """The IMEX config and channel devices are not inside the container."""
+        runtime = _runtime(tmp_path)
+
+        with patch("srtctl.core.hwinfo.start_srun_process", side_effect=_fake_srun()) as srun:
+            record_hwinfo_snapshot(runtime, "before")
+
+        assert srun.call_args.kwargs["container_image"] is None
+
+    def test_het_jobs_get_one_srun_per_component(self, tmp_path):
+        """A single srun cannot span two heterogeneous-job components."""
+        runtime = _runtime(
+            tmp_path,
+            worker=("node01", "node02", "node03"),
+            het=True,
+            groups={"node01": 0, "node02": 1, "node03": 1},
+        )
+
+        with patch("srtctl.core.hwinfo.start_srun_process", side_effect=_fake_srun()) as srun:
+            record_hwinfo_snapshot(runtime, "before")
+
+        calls = {call.kwargs["het_group"]: call.kwargs["nodelist"] for call in srun.call_args_list}
+        assert calls == {0: ["node01"], 1: ["node02", "node03"]}
+
+    def test_a_failure_never_breaks_the_run(self, tmp_path):
+        runtime = _runtime(tmp_path)
+
+        with patch("srtctl.core.hwinfo.start_srun_process", side_effect=OSError("srun missing")):
+            assert record_hwinfo_snapshot(runtime, "before") is None
+
+    def test_nothing_to_snapshot_without_workers(self, tmp_path):
+        runtime = _runtime(tmp_path, worker=())
+
+        with patch("srtctl.core.hwinfo.start_srun_process") as srun:
+            assert record_hwinfo_snapshot(runtime, "before") is None
+
+        srun.assert_not_called()

--- a/tests/test_hwinfo.py
+++ b/tests/test_hwinfo.py
@@ -16,12 +16,15 @@ import pytest
 
 from srtctl.core.hwinfo import COLLECT_SCRIPT, record_hwinfo_snapshot
 
-# Diagnostics that must stay in the snapshot: link health, the MNNVL wiring and
-# the driver's own account of what went wrong.
+# Diagnostics that must stay in the snapshot: link health, the MNNVL wiring, who
+# was already holding device memory and the driver's own account of what went
+# wrong.
 REQUIRED_COMMANDS = (
     "nvidia-smi nvlink -s",
     "nvidia-smi nvlink -e",
     "nvidia-smi topo -m",
+    "nvidia-smi --query-gpu=index,memory.total,memory.used,memory.free --format=csv",
+    "nvidia-smi --query-compute-apps=pid,process_name,used_memory,gpu_uuid --format=csv",
     "ls -al /dev/nvidia-caps-imex-channels/",
     "cat /etc/nvidia-imex/nodes_config.cfg",
     "nvidia-imex-ctl -c /tmp/imex_hwinfo_config.cfg -N -H",

--- a/tests/test_hwinfo.py
+++ b/tests/test_hwinfo.py
@@ -24,7 +24,7 @@ REQUIRED_COMMANDS = (
     "nvidia-smi topo -m",
     "ls -al /dev/nvidia-caps-imex-channels/",
     "cat /etc/nvidia-imex/nodes_config.cfg",
-    "nvidia-imex-ctl",
+    "nvidia-imex-ctl -c /tmp/imex_hwinfo_config.cfg -N -H",
     "dmesg",
 )
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the startup gate that reads the before-run hardware snapshot."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from srtctl.core.preflight import check_snapshot, format_findings
+
+CLEAN_MEMORY = """\
+$ nvidia-smi --query-gpu=index,memory.total,memory.used,memory.free --format=csv
+index, memory.total [MiB], memory.used [MiB], memory.free [MiB]
+0, 283264 MiB, 3072 MiB, 280192 MiB
+1, 283264 MiB, 3072 MiB, 280192 MiB
+"""
+
+NO_COMPUTE_APPS = """\
+$ nvidia-smi --query-compute-apps=pid,process_name,used_memory,gpu_uuid --format=csv
+pid, process_name, used_memory [MiB], gpu_uuid
+"""
+
+READY_DOMAIN = """\
+$ nvidia-imex-ctl -c /tmp/imex_hwinfo_config.cfg -N -H
+Node #0   - 10.66.6.8          - READY                - Version: 580.173.02      - Hostname: theia0271
+Node #1   * 10.66.6.9 *        - READY                - Version: 580.173.02      - Hostname: theia0272
+"""
+
+HEALTHY_FABRIC = """\
+$ nvidia-smi -q | grep -A8 -i "^ *Fabric"
+    Fabric
+        State                                          : Completed
+        Status                                         : Success
+        CliqueId                                       : 32766
+        Health
+            Summary                                    : Healthy
+"""
+
+
+def _snapshot(tmp_path, *blocks, node: str = "theia0271"):
+    """Write a merged snapshot with the given command blocks for one node."""
+    body = f"===== {node} | before | 2026-08-24T07:01:27Z =====\n\n"
+    body += "# ---------- GPU inventory ----------\n\n"
+    body += "\n".join(textwrap.dedent(block) for block in blocks)
+    path = tmp_path / "before.out"
+    path.write_text(body)
+    return path
+
+
+class TestCleanSnapshot:
+    def test_healthy_hardware_reports_nothing(self, tmp_path):
+        path = _snapshot(tmp_path, CLEAN_MEMORY, NO_COMPUTE_APPS, READY_DOMAIN, HEALTHY_FABRIC)
+
+        assert check_snapshot(path, gpu_memory_utilization=0.92) == []
+
+    def test_missing_commands_do_not_raise_false_alarms(self, tmp_path):
+        """An older snapshot, or a node where nvidia-smi is absent, must pass."""
+        path = _snapshot(
+            tmp_path,
+            "$ nvidia-smi --query-compute-apps=pid,process_name,used_memory,gpu_uuid --format=csv\n[exit 127]\n",
+            "$ nvidia-imex-ctl -c /tmp/imex_hwinfo_config.cfg -N -H\n[timed out after 20s]\n",
+        )
+
+        assert check_snapshot(path, gpu_memory_utilization=0.92) == []
+
+    def test_unreadable_snapshot_is_skipped(self, tmp_path):
+        assert check_snapshot(tmp_path / "missing.out", gpu_memory_utilization=0.9) == []
+
+
+class TestFindings:
+    def test_leftover_process_is_reported_with_its_pid(self, tmp_path):
+        path = _snapshot(
+            tmp_path,
+            """\
+            $ nvidia-smi --query-compute-apps=pid,process_name,used_memory,gpu_uuid --format=csv
+            pid, process_name, used_memory [MiB], gpu_uuid
+            4711, python3, 25600 MiB, GPU-d7966220
+            """,
+        )
+
+        findings = check_snapshot(path)
+
+        assert len(findings) == 1
+        assert "pid 4711" in findings[0].detail
+        assert "25600 MiB" in findings[0].detail
+
+    def test_card_below_the_requested_share_is_reported(self, tmp_path):
+        """The same arithmetic the engine does, three minutes earlier."""
+        path = _snapshot(
+            tmp_path,
+            """\
+            $ nvidia-smi --query-gpu=index,memory.total,memory.used,memory.free --format=csv
+            index, memory.total [MiB], memory.used [MiB], memory.free [MiB]
+            0, 283264 MiB, 26286 MiB, 256978 MiB
+            """,
+        )
+
+        findings = check_snapshot(path, gpu_memory_utilization=0.92)
+
+        assert len(findings) == 1
+        assert "GPU 0" in findings[0].detail
+        assert "250.96 GiB free" in findings[0].detail
+        assert "needs 254.50 GiB" in findings[0].detail
+
+    def test_same_card_passes_at_a_lower_share(self, tmp_path):
+        path = _snapshot(
+            tmp_path,
+            """\
+            $ nvidia-smi --query-gpu=index,memory.total,memory.used,memory.free --format=csv
+            index, memory.total [MiB], memory.used [MiB], memory.free [MiB]
+            0, 283264 MiB, 26286 MiB, 256978 MiB
+            """,
+        )
+
+        assert check_snapshot(path, gpu_memory_utilization=0.85) == []
+
+    def test_unavailable_domain_node_is_reported_even_outside_the_allocation(self, tmp_path):
+        """MNNVL spans the whole domain, so a peer we were not given still breaks it."""
+        path = _snapshot(
+            tmp_path,
+            """\
+            $ nvidia-imex-ctl -c /tmp/imex_hwinfo_config.cfg -N -H
+            Node #10  - 10.66.6.18         - READY                - Version: 580.173.02      - Hostname: theia0281
+            Node #11  - 10.66.6.19         - UNAVAILABLE          - Version:                 - Hostname: theia0282
+            """,
+        )
+
+        findings = check_snapshot(path)
+
+        assert len(findings) == 1
+        assert findings[0].node == "theia0282"
+        assert "UNAVAILABLE" in findings[0].detail
+
+    def test_domain_finding_is_reported_once_per_peer(self, tmp_path):
+        """Every node sees the same domain; the report must not multiply by observers."""
+        broken = textwrap.dedent(
+            """\
+            $ nvidia-imex-ctl -c /tmp/imex_hwinfo_config.cfg -N -H
+            Node #11  - 10.66.6.19         - UNAVAILABLE          - Version:                 - Hostname: theia0282
+            """
+        )
+        path = tmp_path / "before.out"
+        path.write_text(
+            "".join(
+                f"===== theia{index} | before | 2026-08-24T07:01:27Z =====\n\n{broken}"
+                for index in (271, 272, 273)
+            )
+        )
+
+        assert len(check_snapshot(path)) == 1
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("State", "Not Started"), ("Status", "Timeout"), ("Summary", "Degraded")],
+    )
+    def test_gpu_outside_the_fabric_clique_is_reported(self, tmp_path, field, value):
+        fabric = {"State": "Completed", "Status": "Success", "Summary": "Healthy"} | {field: value}
+        path = _snapshot(
+            tmp_path,
+            f"""\
+            $ nvidia-smi -q | grep -A8 -i "^ *Fabric"
+                Fabric
+                    State                                          : {fabric["State"]}
+                    Status                                         : {fabric["Status"]}
+                    Health
+                        Summary                                    : {fabric["Summary"]}
+            """,
+        )
+
+        findings = check_snapshot(path)
+
+        assert len(findings) == 1
+        assert value in findings[0].detail
+
+
+class TestMessage:
+    def test_message_names_the_problem_the_node_and_the_file(self, tmp_path):
+        path = _snapshot(
+            tmp_path,
+            """\
+            $ nvidia-imex-ctl -c /tmp/imex_hwinfo_config.cfg -N -H
+            Node #11  - 10.66.6.19         - UNAVAILABLE          - Version:                 - Hostname: theia0282
+            """,
+        )
+        findings = check_snapshot(path)
+
+        message = format_findings(findings, path)
+
+        assert "1 problem" in message
+        assert "theia0282" in message
+        assert str(path) in message
+        assert "preflight.enabled: false" in message


### PR DESCRIPTION
## Summary

A job killed by `CUDA error: uncorrectable NVLink error detected during the execution` names no link, no GPU and no node — the traceback points at whatever CUDA call happened to run next, because the error is sticky and the context was already poisoned. By the time anyone looks, the allocation is gone and with it every counter that could have identified the faulty hardware.

This captures NVLink and MNNVL state on every worker node before the run and again when it ends, into `logs/hwinfo/before.out` and `logs/hwinfo/after.out`. Each command is recorded with its output, and with its exit code when it failed:

```
===== node01 | before | 2026-08-13T07:53:30Z =====

# ---------- NVLink ----------

$ nvidia-smi nvlink -e
GPU 0: NVIDIA GB300
	 Link 0: Replay Errors: 0
	 Link 0: Recovery Errors: 0
	 Link 0: CRC Errors: 0

$ ls -al /dev/nvidia-caps-imex-channels/
ls: cannot access '/dev/nvidia-caps-imex-channels/': No such file or directory
[exit 2]
```

The point is `diff hwinfo/before.out hwinfo/after.out`. Error counters that moved identify the link that degraded, and the GPU serials in the same file are what a hardware ticket needs.

Collected per node, and why each is there:

- **Inventory** — `nvidia-smi --query-gpu=index,name,serial,uuid,pci.bus_id` and `nvidia-smi --version`. Maps the rank in a crash log to a serial, and catches one node in the domain running a different driver than the rest.
- **NVLink** — `nvlink -s` for link state and speed, `nvlink -e` for the error counters that make the before/after diff worth taking, `topo -m` to confirm which GPUs are NVLink-connected rather than PCIe.
- **MNNVL / IMEX** — `/dev/nvidia-caps-imex-channels/`, `nodes_config.cfg`, `config.cfg`, the IMEX unit state and `nvidia-imex-ctl -N`, plus each GPU's fabric State/Status/CliqueId. A GPU outside the clique cannot reach remote peers over NVLink even though its local links look healthy, and a `nodes_config.cfg` that disagrees with the allocation is a classic cause of remote-NVLink faults. `nvidia-imex-ctl` is invoked against a temporary copy of the config with the log and stats paths redirected to `/tmp`, because the shipped paths are root-only and an unprivileged run otherwise fails while parsing and reports a misleading "invalid value".
- **Driver and GPU faults** — `dmesg` filtered to Xid/NVLink/NVSwitch/IMEX lines, and `nvidia-smi -q -d ROW_REMAPPER`. Together these separate "a link died" from "this GPU was already degrading before the run started".

Implementation notes:

- Collection runs on the host rather than in the job container: the IMEX config and the MNNVL channel devices are host paths that are not mounted inside it.
- One `srun --overlap` covers all worker nodes, split into one call per component for heterogeneous jobs since a single srun cannot span two.
- Each task writes its own part file, named from `SLURMD_NODENAME`, and the orchestrator merges the parts in node order and removes them. Twelve nodes writing one file directly would interleave line by line into something unreadable. A node that reported nothing is called out in the merged file instead of leaving a silent gap.
- `after.out` is written on success too. Counters that grew during a run that happened to pass are the earliest warning that a link is about to take the next job down.
- Best effort throughout: a missing tool or a denied read is recorded and skipped, each command is cut off after `HWINFO_CMD_TIMEOUT` (20s) so a wedged driver cannot stall startup or cleanup, the whole phase is bounded, and any failure only logs a warning. There is no path by which this can fail a benchmark.

Tests cover the collector script by running it under bash with stand-ins for the tools — output format, a failing command not costing the commands after it, a hung command hitting the timeout — plus the merge behavior: node ordering, cleanup of the per-node parts, stale parts from an earlier attempt not being reused, silent nodes being reported, running without a container, and one srun per het component.