### PR TITLE
feat(observability): in-job RAW /metrics scraper

### DIFF
--- a/src/srtctl/analysis/metrics_scraper.py
+++ b/src/srtctl/analysis/metrics_scraper.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-job Prometheus scraper -> ``raw_prometheus.jsonl`` (RAW capture).
+
+Why this exists
+---------------
+Worker and frontend ``/metrics`` endpoints are served by the live processes. When
+the SLURM job ends they disappear and the data is gone forever -- there is no
+after-the-fact scrape. Anything that wants a time series of KV-cache occupancy,
+router queue depth or frontend event-loop pressure has to capture it *during*
+the run.
+
+AIPerf already scrapes on its own ``--slice-duration`` cadence, but only for the
+window it is actively benchmarking, and its aggregation is opinionated. This
+scraper is the raw, unopinionated complement: it starts with the benchmark stage
+and appends the response body **verbatim**, so a parser fix never requires
+re-running the job.
+
+Design rule (mirrors ``src/capture/`` in the perf-dashboard repo): *capture emits
+RAW, the processor parses*. One JSON line per ``(sweep, endpoint)``::
+
+    {"timestamp_ns": 1786194627868177662,
+     "endpoint_url": "http://node1:8081/metrics",
+     "role": "prefill",            # frontend | prefill | decode
+     "worker_id": "node1",         # host for workers, null for the frontend
+     "text": "<raw Prometheus exposition text, UNPARSED>"}
+
+``timestamp_ns`` is ``time.time_ns()`` (wall-epoch) so it aligns with AIPerf
+records and Dynamo spans on the same clock.
+
+Best-effort by construction: every failure path is logged and swallowed. A
+scrape that times out costs one missing line, never a failed benchmark.
+
+Stdlib only -- runs on the orchestrator's host python, which reaches every
+worker node over the job's network (same URLs srtctl already hands to AIPerf).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# A slow worker under load can take a while to render its exposition text; keep
+# the timeout well under the sweep interval so one stuck endpoint cannot stall
+# the whole sweep past its next tick.
+_HTTP_TIMEOUT_SECONDS = 5.0
+
+# Log at most one warning per endpoint per this many consecutive failures, so a
+# worker that dies mid-run does not flood the sweep log with identical errors.
+_WARN_EVERY = 20
+
+
+@dataclass(frozen=True)
+class ScrapeTarget:
+    """One endpoint to poll."""
+
+    url: str
+    role: str  # "frontend" | "prefill" | "decode"
+    worker_id: str | None
+
+
+class RawMetricsScraper:
+    """Daemon thread appending RAW ``/metrics`` bodies to a JSONL file."""
+
+    def __init__(
+        self,
+        log_dir: Path,
+        targets: list[ScrapeTarget],
+        interval_seconds: float = 3.0,
+        output_name: str = "raw_prometheus.jsonl",
+    ) -> None:
+        self.output_path = Path(log_dir) / output_name
+        self.targets = list(targets)
+        self.interval_seconds = max(0.5, float(interval_seconds))
+        self._thread: threading.Thread | None = None
+        # Own stop flag *in addition to* the caller's shared stop_event: the
+        # benchmark stage's stop_event is only set on abort, not on normal
+        # completion, so without this the scraper would outlive the client and
+        # keep polling endpoints that are about to be torn down.
+        self._own_stop = threading.Event()
+        self.sweeps = 0
+        self.lines_written = 0
+        self._fail_counts: dict[str, int] = {}
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self, stop_event: threading.Event) -> None:
+        if not self.targets:
+            logger.warning("Raw metrics scraper: no targets, not starting")
+            return
+        self._thread = threading.Thread(
+            target=self._loop,
+            args=(stop_event,),
+            name="RawMetricsScraper",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "Raw metrics scraper started: %d endpoint(s) every %.1fs -> %s",
+            len(self.targets),
+            self.interval_seconds,
+            self.output_path,
+        )
+        for t in self.targets:
+            logger.info("  scrape target %-8s %s", t.role, t.url)
+
+    def stop(self, timeout: float = 15.0) -> None:
+        """Signal the loop and wait for the final flush."""
+        self._own_stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+        logger.info(
+            "Raw metrics scraper stopped: %d sweeps, %d lines -> %s",
+            self.sweeps,
+            self.lines_written,
+            self.output_path,
+        )
+
+    # -- internals ---------------------------------------------------------
+
+    def _fetch(self, target: ScrapeTarget) -> str | None:
+        try:
+            with urllib.request.urlopen(target.url, timeout=_HTTP_TIMEOUT_SECONDS) as resp:
+                if resp.status != 200:
+                    self._note_failure(target, f"HTTP {resp.status}")
+                    return None
+                return resp.read().decode("utf-8", errors="replace")
+        except (urllib.error.URLError, OSError, ValueError) as e:
+            self._note_failure(target, repr(e))
+            return None
+
+    def _note_failure(self, target: ScrapeTarget, reason: str) -> None:
+        n = self._fail_counts.get(target.url, 0) + 1
+        self._fail_counts[target.url] = n
+        if n == 1 or n % _WARN_EVERY == 0:
+            logger.warning(
+                "Raw metrics scraper: %s unreachable (%d consecutive): %s",
+                target.url,
+                n,
+                reason,
+            )
+
+    def _sweep(self, fh) -> None:
+        for target in self.targets:
+            text = self._fetch(target)
+            if text is None:
+                continue
+            self._fail_counts[target.url] = 0
+            record = {
+                "timestamp_ns": time.time_ns(),
+                "endpoint_url": target.url,
+                "role": target.role,
+                "worker_id": target.worker_id,
+                "text": text,
+            }
+            fh.write(json.dumps(record) + "\n")
+            self.lines_written += 1
+        # Flush per sweep, not per line: one fsync-ish cost per interval, and
+        # the file stays readable from another node while the job runs (useful
+        # for live progress checks over lustre).
+        fh.flush()
+
+    def _loop(self, stop_event: threading.Event) -> None:
+        try:
+            self.output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.output_path, "a", encoding="utf-8") as fh:
+                while not stop_event.is_set() and not self._own_stop.is_set():
+                    started = time.monotonic()
+                    try:
+                        self._sweep(fh)
+                        self.sweeps += 1
+                    except Exception as e:  # never kill the thread mid-run  # noqa: BLE001
+                        logger.warning("Raw metrics scraper sweep failed: %s", e)
+                    # Drift-free pacing: wait the remainder of the interval, so a
+                    # slow sweep shortens the gap instead of shifting every
+                    # subsequent tick later. Waiting on the own-stop event (not
+                    # sleeping) makes shutdown immediate rather than up to one
+                    # interval late.
+                    elapsed = time.monotonic() - started
+                    self._own_stop.wait(max(0.0, self.interval_seconds - elapsed))
+        except Exception as e:  # capture is best-effort, never fatal  # noqa: BLE001
+            logger.warning("Raw metrics scraper aborted: %s", e)
+
+
+def try_start_raw_scraper(
+    log_dir: Path,
+    targets: list[ScrapeTarget],
+    observability,
+    stop_event: threading.Event,
+) -> RawMetricsScraper | None:
+    """Start the scraper if ``observability`` opts in, else return ``None``.
+
+    Single entry point for :class:`BenchmarkStageMixin`, so the mixin stays free
+    of analysis-package internals -- same contract as
+    :func:`srtctl.analysis.live_metrics.try_start_snapshotter`. All failures are
+    logged and swallowed: RAW metric capture is best-effort observability, never
+    a hard dependency on the benchmark path.
+    """
+    try:
+        if observability is None or not getattr(observability, "scraper_enabled", False):
+            return None
+        scraper = RawMetricsScraper(
+            log_dir=log_dir,
+            targets=targets,
+            interval_seconds=getattr(observability, "scrape_interval_seconds", 3.0),
+            output_name=getattr(observability, "scrape_output", "raw_prometheus.jsonl"),
+        )
+        scraper.start(stop_event)
+        return scraper
+    except Exception as e:  # capture is best-effort, never fatal  # noqa: BLE001
+        logger.warning("Raw metrics scraper: failed to start (continuing): %s", e)
+        return None

--- a/src/srtctl/analysis/metrics_scraper.py
+++ b/src/srtctl/analysis/metrics_scraper.py
@@ -75,7 +75,7 @@ class RawMetricsScraper:
         self,
         log_dir: Path,
         targets: list[ScrapeTarget],
-        interval_seconds: float = 3.0,
+        interval_seconds: float = 1.0,
         output_name: str = "raw_prometheus.jsonl",
     ) -> None:
         self.output_path = Path(log_dir) / output_name
@@ -211,7 +211,7 @@ def try_start_raw_scraper(
         scraper = RawMetricsScraper(
             log_dir=log_dir,
             targets=targets,
-            interval_seconds=getattr(observability, "scrape_interval_seconds", 3.0),
+            interval_seconds=getattr(observability, "scrape_interval_seconds", 1.0),
             output_name=getattr(observability, "scrape_output", "raw_prometheus.jsonl"),
         )
         scraper.start(stop_event)

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -319,6 +319,7 @@ class BenchmarkStageMixin:
     ) -> int:
         """Run the actual benchmark script."""
         from srtctl.analysis.live_metrics import try_start_snapshotter
+        from srtctl.analysis.metrics_scraper import try_start_raw_scraper
 
         cmd = runner.build_command(self.config, self.runtime)
         env_to_set = self._get_benchmark_env(runner)
@@ -333,6 +334,17 @@ class BenchmarkStageMixin:
         # Optional in-flight batch-metrics snapshotter — no-op unless
         # opted in via reporting.live_metrics in the cluster config.
         snapshotter = try_start_snapshotter(self.runtime.log_dir, stop_event)
+
+        # RAW /metrics capture for the benchmark window — no-op unless
+        # observability.enabled. These endpoints die with the job, so this is
+        # the only chance to record them; it runs alongside the client rather
+        # than after it.
+        raw_scraper = try_start_raw_scraper(
+            self.runtime.log_dir,
+            self._analytics_scrape_targets(),
+            getattr(self.config, "observability", None),
+            stop_event,
+        )
 
         bench_node = self._benchmark_node()
         proc = start_srun_process(
@@ -376,6 +388,8 @@ class BenchmarkStageMixin:
                 self.benchmark_child_allows_window_mutation = True
             if snapshotter is not None:
                 snapshotter.stop()
+            if raw_scraper is not None:
+                raw_scraper.stop()
 
     def _get_benchmark_profiling_env(
         self,
@@ -558,6 +572,44 @@ class BenchmarkStageMixin:
         # runners retain their historical sorted physical-process list.
         urls = list(dict.fromkeys(urls)) if logical_workers_only else sorted(set(urls))
         return {"AIPERF_SERVER_METRICS_URLS": ",".join(urls)}
+
+    def _analytics_scrape_targets(self) -> list:
+        """Frontend + every worker leader, as RAW-scrape targets.
+
+        Worker leaders only: ``backend_processes`` holds one entry per physical
+        node for multi-node workers, but only rank zero serves the logical
+        worker's /metrics. Scraping followers would duplicate rows under a
+        misleading worker_id.
+        """
+        from srtctl.analysis.metrics_scraper import ScrapeTarget
+
+        targets: list[ScrapeTarget] = []
+
+        frontend_host = get_hostname_ip(self._orchestrator_node(), self.runtime.network_interface)
+        targets.append(
+            ScrapeTarget(
+                url=f"http://{frontend_host}:{FRONTEND_PUBLIC_PORT}/metrics",
+                role="frontend",
+                worker_id=None,
+            )
+        )
+
+        for process in self.backend_processes:
+            if not process.is_leader or process.sys_port <= 0:
+                continue
+            host = get_hostname_ip(process.node, self.runtime.network_interface)
+            # endpoint_mode is prefill | decode | agg; the RAW contract's role
+            # vocabulary is frontend | prefill | decode, so map agg -> decode
+            # (an agg worker owns the decode side of the KV panels).
+            role = "decode" if process.endpoint_mode == "agg" else process.endpoint_mode
+            targets.append(
+                ScrapeTarget(
+                    url=f"http://{host}:{process.sys_port}/metrics",
+                    role=role,
+                    worker_id=process.node,
+                )
+            )
+        return targets
 
     def _get_benchmark_env(self, runner: "BenchmarkRunner") -> dict[str, str]:
         """Get environment variables for the benchmark script."""

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -594,12 +594,18 @@ class BenchmarkStageMixin:
         node for multi-node workers, but only rank zero serves the logical
         worker's /metrics. Scraping followers would duplicate rows under a
         misleading worker_id.
+
+        The frontend target is ``_public_api_node``, not ``_orchestrator_node``:
+        those diverge for a single-worker direct-vLLM aggregated job, where the
+        agg leader -- not the orchestrator -- is what listens on
+        ``FRONTEND_PUBLIC_PORT``. Every other pairing of that port in this file
+        uses the same helper.
         """
         from srtctl.analysis.metrics_scraper import ScrapeTarget
 
         targets: list[ScrapeTarget] = []
 
-        frontend_host = get_hostname_ip(self._orchestrator_node(), self.runtime.network_interface)
+        frontend_host = get_hostname_ip(self._public_api_node(), self.runtime.network_interface)
         targets.append(
             ScrapeTarget(
                 url=f"http://{frontend_host}:{FRONTEND_PUBLIC_PORT}/metrics",

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -335,16 +335,30 @@ class BenchmarkStageMixin:
         # opted in via reporting.live_metrics in the cluster config.
         snapshotter = try_start_snapshotter(self.runtime.log_dir, stop_event)
 
-        # RAW /metrics capture for the benchmark window — no-op unless
-        # observability.enabled. These endpoints die with the job, so this is
-        # the only chance to record them; it runs alongside the client rather
-        # than after it.
-        raw_scraper = try_start_raw_scraper(
-            self.runtime.log_dir,
-            self._analytics_scrape_targets(),
-            getattr(self.config, "observability", None),
-            stop_event,
-        )
+        # RAW /metrics capture for the benchmark window — no-op unless opted in.
+        # These endpoints die with the job, so this is the only chance to record
+        # them; it runs alongside the client rather than after it.
+        #
+        # The opt-in is re-checked here rather than left to try_start_raw_scraper
+        # alone: Python evaluates arguments before the call, so building the
+        # target list inside the argument list would run regardless of the knob,
+        # and _analytics_scrape_targets() resolves one get_hostname_ip() per
+        # target — an srun round-trip each, inside a Slurm job. An opted-out run
+        # must not pay that, and must not fail on it.
+        #
+        # `is True` is deliberate, not a truthiness check: scraper_enabled is a
+        # bool property, while this mixin is routinely driven with a mocked
+        # config whose every attribute is truthy. Plain truthiness would silently
+        # switch the scraper on for those callers.
+        observability = getattr(self.config, "observability", None)
+        raw_scraper = None
+        if getattr(observability, "scraper_enabled", False) is True:
+            raw_scraper = try_start_raw_scraper(
+                self.runtime.log_dir,
+                self._analytics_scrape_targets(),
+                observability,
+                stop_event,
+            )
 
         bench_node = self._benchmark_node()
         proc = start_srun_process(

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -600,6 +600,20 @@ class BenchmarkStageMixin:
         agg leader -- not the orchestrator -- is what listens on
         ``FRONTEND_PUBLIC_PORT``. Every other pairing of that port in this file
         uses the same helper.
+
+        **Worker capture is Dynamo-scoped, by design.** Worker targets are the
+        leaders' ``DYN_SYSTEM_PORT``, which is where Dynamo publishes the worker
+        ``/metrics`` surface. That matches the rest of the knob rather than
+        narrowing it: ``expand_observability`` sets ``publish_events_and_metrics``
+        and the ``DYN_LOGGING_*`` span env, none of which a non-Dynamo frontend
+        consumes, so a non-Dynamo run has no worker surface for this capture to
+        find in the first place. Other frontends publish worker metrics on the
+        frontend or worker HTTP port instead -- ``_logical_worker_endpoints`` has
+        that mapping if this ever needs to grow one.
+
+        Rather than emit targets known to be wrong, such a run is warned once and
+        gets the frontend endpoint only. Silence would be the worse failure: the
+        run would look instrumented and yield no worker rows.
         """
         from srtctl.analysis.metrics_scraper import ScrapeTarget
 
@@ -613,6 +627,14 @@ class BenchmarkStageMixin:
                 worker_id=None,
             )
         )
+
+        if self.config.frontend.type != "dynamo":
+            logger.warning(
+                "observability scraper: frontend.type=%s does not publish worker /metrics on "
+                "DYN_SYSTEM_PORT; capturing the frontend endpoint only, no per-worker rows",
+                self.config.frontend.type,
+            )
+            return targets
 
         for process in self.backend_processes:
             if not process.is_leader or process.sys_port <= 0:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1053,7 +1053,10 @@ class ObservabilityConfig:
             Required when enable_otel is True.
         scrape_metrics: Run the in-job Prometheus scraper. Defaults to the value
             of ``enabled``; set False to opt out while keeping the rest.
-        scrape_interval_seconds: Seconds between scrape sweeps.
+        scrape_interval_seconds: Seconds between scrape sweeps. Default: 1.0.
+            The floor is 0.5; a sweep slower than the interval simply runs
+            back-to-back rather than queueing (see the drift-free pacing in
+            ``RawMetricsScraper``).
         scrape_output: Filename (under the run's log dir) for the RAW capture.
     """
 
@@ -1062,7 +1065,7 @@ class ObservabilityConfig:
     otel_endpoint: str | None = None
 
     scrape_metrics: bool | None = None
-    scrape_interval_seconds: float = 3.0
+    scrape_interval_seconds: float = 1.0
     scrape_output: str = "raw_prometheus.jsonl"
 
     Schema: ClassVar[type[Schema]] = Schema

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1032,13 +1032,18 @@ class ObservabilityConfig:
     * ``DYN_LOGGING_SPAN_EVENTS`` / ``DYN_LOGGING_JSONL`` / ``DYN_LOG=debug`` on
       prefill, decode and frontend -- per-request ``SPAN_CLOSED`` trace lines.
 
+    and, at benchmark time (see ``BenchmarkStageMixin``):
+
+    * an in-job Prometheus scraper writing ``raw_prometheus.jsonl`` for the whole
+      benchmark window (see ``scrape_*`` below).
+
     Every expansion uses setdefault semantics: an explicit value in the recipe
     always wins, so ``observability.enabled`` is safe to switch on globally.
 
     Scope is deliberately server-side. The knob configures what the workers and
-    frontend *emit*; it does not reach into the benchmark client. Capturing the
-    ``/metrics`` surface it creates is a separate concern, handled by scraping
-    those endpoints directly rather than by asking a client to re-export them.
+    frontend *emit*, and captures that surface by scraping the endpoints
+    directly. It never reaches into the benchmark client to ask it to re-export
+    what the servers already publish.
 
     Attributes:
         enabled: Master analytics knob. Default: False.
@@ -1046,13 +1051,26 @@ class ObservabilityConfig:
             and frontends. Requires otel_endpoint to be set. Default: False.
         otel_endpoint: OTEL collector endpoint (e.g. "http://10.0.0.1:4317").
             Required when enable_otel is True.
+        scrape_metrics: Run the in-job Prometheus scraper. Defaults to the value
+            of ``enabled``; set False to opt out while keeping the rest.
+        scrape_interval_seconds: Seconds between scrape sweeps.
+        scrape_output: Filename (under the run's log dir) for the RAW capture.
     """
 
     enabled: bool = False
     enable_otel: bool = False
     otel_endpoint: str | None = None
 
+    scrape_metrics: bool | None = None
+    scrape_interval_seconds: float = 3.0
+    scrape_output: str = "raw_prometheus.jsonl"
+
     Schema: ClassVar[type[Schema]] = Schema
+
+    @property
+    def scraper_enabled(self) -> bool:
+        """Whether the in-job Prometheus scraper should run."""
+        return self.enabled if self.scrape_metrics is None else self.scrape_metrics
 
 
 @dataclass(frozen=True)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -410,6 +410,34 @@ class TestCustomBenchmarkRunner:
         assert env["SRT_AGG_ENDPOINTS"] == "ip-node-a:8000"
         assert env["AIPERF_SERVER_METRICS_URLS"] == "http://ip-node-a:8000/metrics"
 
+    def test_raw_scrape_frontend_target_follows_the_public_api_node(self):
+        """The frontend /metrics target must be whoever serves the public port.
+
+        For a single-worker direct-vLLM aggregated job that is the agg leader,
+        not the orchestrator -- scraping the orchestrator would poll a node that
+        is not listening on FRONTEND_PUBLIC_PORT and lose the frontend rows.
+        """
+        from unittest.mock import patch
+
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "agg", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "agg", 0, node_rank=1),
+        ]
+        stage = self._benchmark_stage("vllm", processes)
+        assert stage._orchestrator_node() == "head-node"  # the wrong answer, kept distinct on purpose
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            targets = stage._analytics_scrape_targets()
+
+        frontend = [t for t in targets if t.role == "frontend"]
+        assert len(frontend) == 1
+        assert frontend[0].url == "http://ip-node-a:8000/metrics"
+
     def test_worker_endpoint_order_keeps_colocated_logical_workers_aligned(self):
         from unittest.mock import patch
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -438,6 +438,41 @@ class TestCustomBenchmarkRunner:
         assert len(frontend) == 1
         assert frontend[0].url == "http://ip-node-a:8000/metrics"
 
+    def test_raw_scrape_worker_targets_are_dynamo_scoped(self, caplog):
+        """Only Dynamo publishes worker /metrics on DYN_SYSTEM_PORT.
+
+        Other frontends get the frontend endpoint and a warning, rather than a
+        list of ports nothing is serving -- a run that looks instrumented but
+        yields no worker rows is the failure mode this knob exists to prevent.
+        """
+        import logging
+        from unittest.mock import patch
+
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 6101, "decode", 0, node_rank=0),
+        ]
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            dynamo = self._benchmark_stage("dynamo", processes)._analytics_scrape_targets()
+            with caplog.at_level(logging.WARNING):
+                sglang = self._benchmark_stage("sglang", processes)._analytics_scrape_targets()
+
+        assert [t.role for t in dynamo] == ["frontend", "prefill", "decode"]
+        assert [t.url for t in dynamo[1:]] == [
+            "http://ip-node-a:7500/metrics",
+            "http://ip-node-b:7501/metrics",
+        ]
+        assert [t.worker_id for t in dynamo[1:]] == ["node-a", "node-b"]
+
+        assert [t.role for t in sglang] == ["frontend"]
+        assert "does not publish worker /metrics" in caplog.text
+
     def test_worker_endpoint_order_keeps_colocated_logical_workers_aligned(self):
         from unittest.mock import patch
 

--- a/tests/test_metrics_scraper.py
+++ b/tests/test_metrics_scraper.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the in-job RAW /metrics scraper."""
+
+import http.server
+import json
+import socketserver
+import threading
+import time
+
+import pytest
+
+from srtctl.analysis.metrics_scraper import RawMetricsScraper, ScrapeTarget, try_start_raw_scraper
+from srtctl.core.schema import SrtConfig
+
+BASE_CONFIG = {
+    "name": "test-job",
+    "model": {"path": "/models/test-model", "container": "test.sqsh", "precision": "fp8"},
+    "resources": {
+        "gpu_type": "h100",
+        "gpus_per_node": 8,
+        "prefill_nodes": 1,
+        "decode_nodes": 1,
+        "prefill_workers": 1,
+        "decode_workers": 1,
+    },
+}
+
+EXPOSITION = (
+    b"# HELP trtllm_kv_cache_used_blocks Used KV blocks\n"
+    b"# TYPE trtllm_kv_cache_used_blocks gauge\n"
+    b'trtllm_kv_cache_used_blocks{model_name="m"} 512\n'
+)
+
+
+@pytest.fixture
+def metrics_server():
+    """A throwaway HTTP server serving Prometheus exposition text."""
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(EXPOSITION)))
+            self.end_headers()
+            self.wfile.write(EXPOSITION)
+
+        def log_message(self, *args):
+            pass
+
+    srv = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield srv.server_address[1]
+    srv.shutdown()
+
+
+class TestScraperConfig:
+    def test_scraper_follows_enabled(self):
+        cfg = SrtConfig.Schema().load({**BASE_CONFIG, "observability": {"enabled": True}})
+        assert cfg.observability.scraper_enabled is True
+
+    def test_scraper_can_be_opted_out_independently(self):
+        cfg = SrtConfig.Schema().load(
+            {**BASE_CONFIG, "observability": {"enabled": True, "scrape_metrics": False}}
+        )
+        assert cfg.observability.enabled is True
+        assert cfg.observability.scraper_enabled is False
+
+    def test_off_by_default(self):
+        cfg = SrtConfig.Schema().load(BASE_CONFIG)
+        assert cfg.observability.scraper_enabled is False
+
+    def test_interval_round_trips(self):
+        cfg = SrtConfig.Schema().load(
+            {**BASE_CONFIG, "observability": {"enabled": True, "scrape_interval_seconds": 2.5}}
+        )
+        assert cfg.observability.scrape_interval_seconds == 2.5
+
+
+class TestRawMetricsScraper:
+    def test_emits_the_raw_l1_contract(self, metrics_server, tmp_path):
+        target = ScrapeTarget(
+            url=f"http://127.0.0.1:{metrics_server}/metrics", role="decode", worker_id="node9"
+        )
+        scraper = RawMetricsScraper(tmp_path, [target], interval_seconds=0.5)
+        scraper.start(threading.Event())
+        time.sleep(1.6)
+        scraper.stop()
+
+        lines = [
+            json.loads(x)
+            for x in (tmp_path / "raw_prometheus.jsonl").read_text().splitlines()
+            if x.strip()
+        ]
+        assert lines, "scraper produced no output"
+        record = lines[0]
+        assert set(record) == {"timestamp_ns", "endpoint_url", "role", "worker_id", "text"}
+        assert record["role"] == "decode"
+        assert record["worker_id"] == "node9"
+        # Capture is verbatim: parsing happens offline, so a parser fix never
+        # requires re-running the job.
+        assert "trtllm_kv_cache_used_blocks" in record["text"]
+
+    def test_unreachable_endpoint_degrades_without_killing_the_sweep(self, metrics_server, tmp_path):
+        good = ScrapeTarget(
+            url=f"http://127.0.0.1:{metrics_server}/metrics", role="prefill", worker_id="ok"
+        )
+        dead = ScrapeTarget(url="http://127.0.0.1:1/metrics", role="decode", worker_id="dead")
+        scraper = RawMetricsScraper(tmp_path, [good, dead], interval_seconds=0.5)
+        scraper.start(threading.Event())
+        time.sleep(1.6)
+        scraper.stop()
+
+        lines = [
+            json.loads(x)
+            for x in (tmp_path / "raw_prometheus.jsonl").read_text().splitlines()
+            if x.strip()
+        ]
+        assert lines
+        assert all(r["worker_id"] == "ok" for r in lines)
+        assert scraper.sweeps >= 2
+
+    def test_stop_is_independent_of_the_shared_event(self, metrics_server, tmp_path):
+        """The benchmark stage's stop_event only fires on abort, not on normal
+        completion, so the scraper must also stop on its own signal -- otherwise
+        it outlives the client and keeps polling endpoints being torn down."""
+        target = ScrapeTarget(
+            url=f"http://127.0.0.1:{metrics_server}/metrics", role="frontend", worker_id=None
+        )
+        scraper = RawMetricsScraper(tmp_path, [target], interval_seconds=0.5)
+        shared = threading.Event()
+        scraper.start(shared)
+        time.sleep(0.8)
+        scraper.stop()
+
+        assert not shared.is_set()
+        assert scraper._thread is None or not scraper._thread.is_alive()
+
+    def test_no_targets_is_a_noop(self, tmp_path):
+        scraper = RawMetricsScraper(tmp_path, [], interval_seconds=0.5)
+        scraper.start(threading.Event())
+        scraper.stop()
+        assert not (tmp_path / "raw_prometheus.jsonl").exists()
+
+    def test_try_start_returns_none_when_disabled(self, tmp_path):
+        cfg = SrtConfig.Schema().load(BASE_CONFIG)
+        assert try_start_raw_scraper(tmp_path, [], cfg.observability, threading.Event()) is None

--- a/tests/test_metrics_scraper.py
+++ b/tests/test_metrics_scraper.py
@@ -74,6 +74,17 @@ class TestScraperConfig:
         )
         assert cfg.observability.scrape_interval_seconds == 2.5
 
+    def test_interval_defaults_to_one_second(self, tmp_path):
+        """The schema default and the scraper's own fallback must not drift apart.
+
+        try_start_raw_scraper reads the interval off the config with a getattr
+        fallback, so a SimpleNamespace-style config that omits the field has to
+        land on the same cadence as one that went through the schema.
+        """
+        cfg = SrtConfig.Schema().load({**BASE_CONFIG, "observability": {"enabled": True}})
+        assert cfg.observability.scrape_interval_seconds == 1.0
+        assert RawMetricsScraper(tmp_path, []).interval_seconds == 1.0
+
 
 class TestRawMetricsScraper:
     def test_emits_the_raw_l1_contract(self, metrics_server, tmp_path):

--- a/tests/test_metrics_scraper.py
+++ b/tests/test_metrics_scraper.py
@@ -60,9 +60,7 @@ class TestScraperConfig:
         assert cfg.observability.scraper_enabled is True
 
     def test_scraper_can_be_opted_out_independently(self):
-        cfg = SrtConfig.Schema().load(
-            {**BASE_CONFIG, "observability": {"enabled": True, "scrape_metrics": False}}
-        )
+        cfg = SrtConfig.Schema().load({**BASE_CONFIG, "observability": {"enabled": True, "scrape_metrics": False}})
         assert cfg.observability.enabled is True
         assert cfg.observability.scraper_enabled is False
 
@@ -79,19 +77,13 @@ class TestScraperConfig:
 
 class TestRawMetricsScraper:
     def test_emits_the_raw_l1_contract(self, metrics_server, tmp_path):
-        target = ScrapeTarget(
-            url=f"http://127.0.0.1:{metrics_server}/metrics", role="decode", worker_id="node9"
-        )
+        target = ScrapeTarget(url=f"http://127.0.0.1:{metrics_server}/metrics", role="decode", worker_id="node9")
         scraper = RawMetricsScraper(tmp_path, [target], interval_seconds=0.5)
         scraper.start(threading.Event())
         time.sleep(1.6)
         scraper.stop()
 
-        lines = [
-            json.loads(x)
-            for x in (tmp_path / "raw_prometheus.jsonl").read_text().splitlines()
-            if x.strip()
-        ]
+        lines = [json.loads(x) for x in (tmp_path / "raw_prometheus.jsonl").read_text().splitlines() if x.strip()]
         assert lines, "scraper produced no output"
         record = lines[0]
         assert set(record) == {"timestamp_ns", "endpoint_url", "role", "worker_id", "text"}
@@ -102,20 +94,14 @@ class TestRawMetricsScraper:
         assert "trtllm_kv_cache_used_blocks" in record["text"]
 
     def test_unreachable_endpoint_degrades_without_killing_the_sweep(self, metrics_server, tmp_path):
-        good = ScrapeTarget(
-            url=f"http://127.0.0.1:{metrics_server}/metrics", role="prefill", worker_id="ok"
-        )
+        good = ScrapeTarget(url=f"http://127.0.0.1:{metrics_server}/metrics", role="prefill", worker_id="ok")
         dead = ScrapeTarget(url="http://127.0.0.1:1/metrics", role="decode", worker_id="dead")
         scraper = RawMetricsScraper(tmp_path, [good, dead], interval_seconds=0.5)
         scraper.start(threading.Event())
         time.sleep(1.6)
         scraper.stop()
 
-        lines = [
-            json.loads(x)
-            for x in (tmp_path / "raw_prometheus.jsonl").read_text().splitlines()
-            if x.strip()
-        ]
+        lines = [json.loads(x) for x in (tmp_path / "raw_prometheus.jsonl").read_text().splitlines() if x.strip()]
         assert lines
         assert all(r["worker_id"] == "ok" for r in lines)
         assert scraper.sweeps >= 2
@@ -124,9 +110,7 @@ class TestRawMetricsScraper:
         """The benchmark stage's stop_event only fires on abort, not on normal
         completion, so the scraper must also stop on its own signal -- otherwise
         it outlives the client and keeps polling endpoints being torn down."""
-        target = ScrapeTarget(
-            url=f"http://127.0.0.1:{metrics_server}/metrics", role="frontend", worker_id=None
-        )
+        target = ScrapeTarget(url=f"http://127.0.0.1:{metrics_server}/metrics", role="frontend", worker_id=None)
         scraper = RawMetricsScraper(tmp_path, [target], interval_seconds=0.5)
         shared = threading.Event()
         scraper.start(shared)


### PR DESCRIPTION
> **Stacked on #308** — this PR's base is that branch, so the diff below is the scraper delta only
> (4 files). Merge #308 first; GitHub will retarget this to `main` automatically.

## Problem

Worker and frontend `/metrics` endpoints are served by the live processes. **When the SLURM job ends they disappear and the data is gone** — there is no after-the-fact scrape. Anything wanting a time series of KV-cache occupancy, router queue depth or frontend event-loop pressure has to capture it *during* the run.

AIPerf does scrape on its own `--slice-duration` cadence, but only for the window it is actively benchmarking, and its aggregation is opinionated. This is the raw, unopinionated complement.

## What it does

A daemon thread started with the benchmark stage, gated on `observability.scrape_metrics` (defaults to `observability.enabled`). It appends each response body **verbatim**:

```json
{"timestamp_ns": 1786194627868177662,
 "endpoint_url": "http://node1:8081/metrics",
 "role": "prefill", "worker_id": "node1",
 "text": "<raw Prometheus exposition text, UNPARSED>"}
```

**Capture emits RAW, the processor parses.** That split is the point: a parser fix never requires re-running the job. `timestamp_ns` is wall-epoch, so it aligns with client records and spans on the same clock.

Stdlib only — it runs on the orchestrator's host python, which already reaches every worker node over the job's network (the same URLs srtctl hands to AIPerf).

## Design notes for review

- **Best-effort by construction.** Every failure path is logged and swallowed; an unreachable endpoint costs one line and a rate-limited warning, never the benchmark.
- **Stops on its own signal as well as the shared `stop_event`.** The latter only fires on *abort*, not normal completion — relying on it alone would leave the scraper polling endpoints that are being torn down. There's a test for exactly this.
- **Worker leaders only.** `backend_processes` holds one entry per physical node for multi-node workers, but only rank zero serves the logical worker's `/metrics`; scraping followers would duplicate rows under a misleading `worker_id`.
- **Drift-free pacing.** The loop waits the *remainder* of the interval, so a slow sweep shortens the gap rather than shifting every subsequent tick later.
- Modelled deliberately on the existing `LiveMetricsSnapshotter` (same `try_start_*` entry-point contract, same swallow-everything posture), so the benchmark mixin stays free of analysis-package internals.

## Verification

Ran on Lyris jobs **2674508** (30 min) and **2674375** (2 h, DSv4 c3, 7 nodes GB300):

```
raw_prometheus.jsonl        7625 lines
roles                       frontend / prefill / decode  all present
worker_id set               6100/6100 worker rows
trtllm_kv_cache_* in text   6100 lines
scrape window               4572 s
```

The captured file also round-trips through the existing downstream parser to the expected schema, with `dynamo_component` / `worker_id` labels injected as usual.

## Tests

6 new tests in `tests/test_metrics_scraper.py` covering the RAW line contract, verbatim capture, graceful degradation on an unreachable endpoint, the no-targets no-op, `scraper_enabled` precedence, and the independent-stop behaviour. `make check` green: **936 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
