### PR TITLE
fix(topology): don't over-allocate GPUs on multi-node workers

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -559,13 +559,15 @@ class VLLMProtocol:
         )
 
     def _is_dp_mode(self, mode: WorkerMode) -> bool:
-        """Check if this mode uses Data Parallel + Expert Parallel pattern.
+        """Check if this mode uses Data Parallel + Expert Parallel launch.
 
-        DP+EP mode is detected when data-parallel-size is set in the mode's config.
+        ``data-parallel-size: 1`` is still passed to vLLM, but launch is the
+        standard TP/PP ``--nnodes`` / ``--node-rank`` path. A PP stage that
+        spans nodes cannot be one DP rank's local GPU group.
         ``dp_launch_mode`` controls whether a process owns one rank or all local ranks.
         """
-        config = self.get_config_for_mode(mode)
-        return config.get("data-parallel-size") is not None or config.get("data_parallel_size") is not None
+        dp_size = self._get_dp_size(mode)
+        return dp_size is not None and dp_size > 1
 
     def _get_dp_size(self, mode: WorkerMode) -> int | None:
         """Get the data-parallel-size for a mode, or None if not in DP mode."""

--- a/src/srtctl/core/topology.py
+++ b/src/srtctl/core/topology.py
@@ -159,7 +159,10 @@ class Endpoint:
         mode: Worker mode ("prefill", "decode", or "agg")
         index: Zero-based index within the mode (e.g., prefill worker 0, 1, 2)
         nodes: Tuple of node hostnames this endpoint uses
-        gpu_indices: Set of GPU indices used on each node (e.g., {0,1,2,3,4,5,6,7})
+        gpu_indices: GPU indices used on each node. Multi-node workers that do
+            not fill the node (e.g. 6 GPUs on 2×4-GPU nodes) use the same
+            subset on every node ({0,1,2}) so ``--nnodes`` local world sizes
+            match. Leftover GPUs stay idle.
         gpus_per_node: Number of GPUs per node in the cluster
     """
 
@@ -407,16 +410,33 @@ def allocate_endpoints(
 
         for i in range(count):
             if nodes_per_worker >= 1 and gpus_per_worker >= gpus_per_node:
-                # Multi-node or full-node worker
+                # Multi-node or full-node worker. When gpus_per_worker is not a
+                # multiple of gpus_per_node, leave GPUs idle so every node of
+                # this worker sees the same count (required by --nnodes).
+                # 6 GPUs on 4-GPU nodes → 2 nodes × {0,1,2}, not 4+2.
                 worker_nodes = tuple(available_nodes[node_idx + j] for j in range(nodes_per_worker))
                 node_idx += nodes_per_worker
+                per_node, uneven = divmod(gpus_per_worker, nodes_per_worker)
+                if uneven:
+                    raise ValueError(
+                        f"{mode} worker {i} needs {gpus_per_worker} GPUs across "
+                        f"{nodes_per_worker} nodes, which is not an even split "
+                        f"({gpus_per_worker} % {nodes_per_worker} = {uneven}). "
+                        f"--nnodes requires the same GPU count on every node; "
+                        f"use {per_node * nodes_per_worker} or "
+                        f"{(per_node + 1) * nodes_per_worker} GPUs"
+                    )
+                if per_node > gpus_per_node:
+                    raise ValueError(
+                        f"{mode} worker {i} would place {per_node} GPUs on a {gpus_per_node}-GPU node"
+                    )
 
                 result.append(
                     Endpoint(
                         mode=mode,
                         index=i,
                         nodes=worker_nodes,
-                        gpu_indices=frozenset(range(gpus_per_node)),
+                        gpu_indices=frozenset(range(per_node)),
                         gpus_per_node=gpus_per_node,
                     )
                 )

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1902,6 +1902,14 @@ class TestVLLMDataParallelMode:
         assert backend_dp._is_dp_mode("decode") is True
         assert backend_dp._get_dp_size("prefill") == 16
 
+        backend_dp1 = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                prefill={"data-parallel-size": 1, "pipeline-parallel-size": 6},
+            )
+        )
+        assert backend_dp1._get_dp_size("prefill") == 1
+        assert backend_dp1._is_dp_mode("prefill") is False
+
     def test_dp_mode_creates_per_gpu_processes(self):
         """Test that DP mode creates one process per GPU instead of per node."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
@@ -1946,6 +1954,62 @@ class TestVLLMDataParallelMode:
         # dp_rank (stored in node_rank) should go from 0 to 15
         dp_ranks = [p.node_rank for p in processes]
         assert dp_ranks == list(range(16))
+
+    def test_dp_size_one_pp_across_nodes_uses_nnodes_not_dp_ranks(self):
+        """PP6 on 2×3 GPUs is TP/PP launch, not one DP rank owning 6 GPUs."""
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import allocate_endpoints
+
+        backend = VLLMProtocol(
+            vllm_config=VLLMServerConfig(
+                prefill={
+                    "tensor-parallel-size": 1,
+                    "pipeline-parallel-size": 6,
+                    "data-parallel-size": 1,
+                },
+            )
+        )
+        endpoints = allocate_endpoints(
+            num_prefill=1,
+            num_decode=0,
+            num_agg=0,
+            gpus_per_prefill=6,
+            gpus_per_decode=1,
+            gpus_per_agg=0,
+            gpus_per_node=4,
+            available_nodes=("node0", "node1"),
+        )
+        assert endpoints[0].total_gpus == 6
+        assert endpoints[0].gpu_indices == frozenset({0, 1, 2})
+
+        processes = backend.endpoints_to_processes(endpoints)
+        assert len(processes) == 2
+        assert [p.node for p in processes] == ["node0", "node1"]
+        assert all(p.gpu_indices == frozenset({0, 1, 2}) for p in processes)
+        assert [p.node_rank for p in processes] == [0, 1]
+
+        mock_runtime = MagicMock()
+        mock_runtime.model_path = Path("/model")
+        mock_runtime.is_hf_model = False
+        mock_runtime.request_plane = "tcp"
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            follower = backend.build_worker_command(
+                process=processes[1],
+                endpoint_processes=processes,
+                runtime=mock_runtime,
+            )
+
+        assert follower[follower.index("--nnodes") + 1] == "2"
+        assert follower[follower.index("--node-rank") + 1] == "1"
+        assert "--headless" in follower
+        assert "--data-parallel-rank" not in follower
+        assert follower[follower.index("--pipeline-parallel-size") + 1] == "6"
+        assert follower[follower.index("--data-parallel-size") + 1] == "1"
+        assert follower[follower.index("--device-ids") + 1] == "0,1,2"
 
     def test_dp_per_node_mode_creates_per_node_processes(self):
         """Per-node DP owns all local GPUs and reserves rank-sized port blocks."""

--- a/tests/test_endpoint_allocation.py
+++ b/tests/test_endpoint_allocation.py
@@ -99,6 +99,49 @@ class TestAllocateEndpoints:
         for ep in endpoints:
             assert len(ep.nodes) == 2
             assert ep.total_gpus == 8
+            assert ep.gpu_indices == frozenset(range(4))
+
+    def test_multi_node_worker_leaves_gpus_idle_evenly(self):
+        """6 GPUs on 4-GPU nodes use 3+3, not 4+2 (nnodes needs an even split)."""
+        endpoints = allocate_endpoints(
+            num_prefill=2,
+            num_decode=1,
+            num_agg=0,
+            gpus_per_prefill=6,
+            gpus_per_decode=8,
+            gpus_per_agg=0,
+            gpus_per_node=4,
+            available_nodes=("n0", "n1", "n2", "n3", "n4", "n5"),
+        )
+
+        prefill = [e for e in endpoints if e.mode == "prefill"]
+        decode = [e for e in endpoints if e.mode == "decode"]
+
+        assert [ep.nodes for ep in prefill] == [("n0", "n1"), ("n2", "n3")]
+        for ep in prefill:
+            assert ep.gpu_indices == frozenset({0, 1, 2})
+            assert ep.total_gpus == 6
+        assert decode[0].nodes == ("n4", "n5")
+        assert decode[0].gpu_indices == frozenset(range(4))
+        assert decode[0].total_gpus == 8
+
+        processes = endpoints_to_processes(prefill)
+        assert len(processes) == 4
+        assert all(p.gpu_indices == frozenset({0, 1, 2}) for p in processes)
+
+    def test_multi_node_worker_rejects_uneven_gpu_split(self):
+        """A GPU count that cannot split evenly across spanned nodes is rejected."""
+        with pytest.raises(ValueError, match="not an even split"):
+            allocate_endpoints(
+                num_prefill=1,
+                num_decode=0,
+                num_agg=0,
+                gpus_per_prefill=5,
+                gpus_per_decode=1,
+                gpus_per_agg=0,
+                gpus_per_node=4,
+                available_nodes=("n0", "n1"),
+            )
 
     def test_insufficient_gpus(self):
         """Test that we raise an error when there are insufficient GPUs."""


### PR DESCRIPTION
This PR enables serving vllm disaggregated serving of 2 prefill endpoints of PP6 topology each (2xPP6) and 1 decode endpoint of DP2TP4+EP topology (1xDP2TP4+EP) on cluster with 4xGPU nodes. The problematic case here is that PP6 does not fully cover two allocated nodes. Now srt-slurm supports allocation of partial GPU resources on a node.