### PR TITLE
Size per-node data-parallel ranks by tensor-parallel-size

### DIFF
--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -572,6 +572,11 @@ class VLLMProtocol:
         config = self.get_config_for_mode(mode)
         return config.get("data-parallel-size") or config.get("data_parallel_size")
 
+    def _get_tp_size(self, mode: WorkerMode) -> int:
+        """Get the tensor-parallel-size for a mode, defaulting to 1."""
+        config = self.get_config_for_mode(mode)
+        return config.get("tensor-parallel-size") or config.get("tensor_parallel_size") or 1
+
     def should_set_cuda_visible_devices(self, process: Process) -> bool:
         """Whether worker_stage should set CUDA_VISIBLE_DEVICES.
 
@@ -716,14 +721,16 @@ class VLLMProtocol:
                 current_sys_port += len(non_dp)
                 continue
 
-            dp_size = self._get_dp_size(endpoint.mode) or endpoint.total_gpus
-            if dp_size != endpoint.total_gpus:
+            tp_size = self._get_tp_size(endpoint.mode)
+            dp_size = self._get_dp_size(endpoint.mode) or endpoint.total_gpus // tp_size
+            if dp_size * tp_size != endpoint.total_gpus:
                 raise ValueError(
-                    f"{endpoint.mode} data-parallel-size={dp_size} does not match "
+                    f"{endpoint.mode} data-parallel-size={dp_size} x "
+                    f"tensor-parallel-size={tp_size} does not match "
                     f"the endpoint's {endpoint.total_gpus} allocated GPUs"
                 )
 
-            local_dp_size = len(endpoint.gpu_indices)
+            local_dp_size = len(endpoint.gpu_indices) // tp_size
             dp_rpc_port = port_allocator.next_dp_rpc_port(endpoint.leader_node)
             nixl_base_port = port_allocator.next_nixl_port_block(dp_size)
             dp_start_rank = 0

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -2037,6 +2037,53 @@ class TestVLLMDataParallelMode:
         with pytest.raises(ValueError, match="data-parallel-size=7"):
             backend.endpoints_to_processes([endpoint])
 
+    def test_dp_per_node_mode_allows_tensor_parallel_ranks(self):
+        """A DP rank may span several GPUs; size ranks by tensor-parallel-size."""
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            dp_launch_mode="per_node",
+            vllm_config=VLLMServerConfig(
+                prefill={"data-parallel-size": 2, "tensor-parallel-size": 8}
+            ),
+        )
+        endpoint = Endpoint(
+            mode="prefill",
+            index=0,
+            nodes=("node0", "node1"),
+            gpu_indices=frozenset(range(8)),
+            gpus_per_node=8,
+        )
+
+        processes = backend.endpoints_to_processes([endpoint])
+
+        # One process per node, each owning a single TP8 data-parallel rank.
+        assert len(processes) == 2
+        assert [p.node_rank for p in processes] == [0, 1]
+
+    def test_dp_per_node_mode_rejects_tensor_parallel_mismatch(self):
+        """dp_size x tp_size must still account for every allocated GPU."""
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            dp_launch_mode="per_node",
+            vllm_config=VLLMServerConfig(
+                prefill={"data-parallel-size": 3, "tensor-parallel-size": 8}
+            ),
+        )
+        endpoint = Endpoint(
+            mode="prefill",
+            index=0,
+            nodes=("node0", "node1"),
+            gpu_indices=frozenset(range(8)),
+            gpus_per_node=8,
+        )
+
+        with pytest.raises(ValueError, match="tensor-parallel-size=8"):
+            backend.endpoints_to_processes([endpoint])
+
     def test_dp_per_node_mode_rejects_headless(self):
         """Headless node processes cannot satisfy per-node Dynamo health expectations."""
         from marshmallow import ValidationError


### PR DESCRIPTION
`dp_launch_mode: per_node` assumes one GPU per data-parallel rank, so it rejects any endpoint where a rank spans a tensor-parallel group:

```
ValueError: agg data-parallel-size=2 does not match the endpoint's 16 allocated GPUs
```

That is a valid vLLM topology — 2 nodes x TP8, one DP rank per node, EP across all 16 GPUs. vLLM supports it through the hybrid data-parallel load balancer, which this code path already passes (`--data-parallel-hybrid-lb`, `--data-parallel-size-local`, `--data-parallel-start-rank`).

This sizes ranks by `tensor-parallel-size` instead of assuming 1:

- the check becomes `dp_size * tp_size != endpoint.total_gpus`
- `local_dp_size` divides the node's GPUs by `tp_size`

`tp_size` defaults to 1, so existing DP-per-GPU recipes are unchanged.

Tests: added one case for TP8 x DP2 over two nodes (one process per node, ranks 0 and 1) and one for a mismatched product. Existing `per_node` tests pass unchanged.