### PR TITLE
feat(observability): fan out to the frontend request-trace leg

### DIFF
--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -593,7 +593,11 @@ def expand_observability(cfg: dict) -> dict:
 
     No-op unless ``observability.enabled`` is truthy.
     """
-    from srtctl.core.schema import ANALYTICS_ENGINE_CONFIG, ANALYTICS_SPAN_ENV
+    from srtctl.core.schema import (
+        ANALYTICS_ENGINE_CONFIG,
+        ANALYTICS_REQUEST_TRACE_ENV,
+        ANALYTICS_SPAN_ENV,
+    )
 
     observability = cfg.get("observability")
     if not isinstance(observability, dict) or not observability.get("enabled"):
@@ -613,6 +617,13 @@ def expand_observability(cfg: dict) -> dict:
         frontend = {}
         cfg["frontend"] = frontend
     _setdefault_nested(frontend, "env", ANALYTICS_SPAN_ENV)
+
+    # --- request-trace leg: per-request phase timings, frontend only ---------
+    # Complements the span leg rather than duplicating it. Spans decompose the
+    # router but stop at one opaque handle_payload per worker; these records
+    # carry prefill_wait / prefill / kv_transfer_estimated for the same request,
+    # keyed by x_request_id so all three legs join on one id.
+    _setdefault_nested(frontend, "env", ANALYTICS_REQUEST_TRACE_ENV)
 
     # --- metrics leg: the /metrics surface and what appears on it ------------
     # publish_events_and_metrics is what creates the endpoint; without it the

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -45,6 +45,9 @@ from srtctl.core.formatting import (
     FormattablePathField,
 )
 
+# Leaf module (stdlib-only imports), so this cannot cycle back into schema.
+from srtctl.core.power.contract import CONTAINER_LOG_DIR
+
 logger = logging.getLogger(__name__)
 
 # Local copies of srtctl.core.power.contract values so that loading a config
@@ -1180,6 +1183,35 @@ ANALYTICS_SPAN_ENV: dict[str, str] = {
     "DYN_LOGGING_SPAN_EVENTS": "true",
     "DYN_LOGGING_JSONL": "true",
     "DYN_LOG": "debug",
+}
+
+# Env that makes the Dynamo *frontend* write one ``dynamo.request.trace.v1``
+# ``request_end`` record per request to a JSONL file. This is a different signal
+# from the span leg above: spans decompose the router in detail but treat each
+# worker as one opaque ``handle_payload``, whereas these records carry the
+# frontend's own phase timings -- ``prefill_wait_time_ms`` (receive to dispatch),
+# ``prefill_time_ms`` (dispatch to first token) and, on disagg,
+# ``kv_transfer_estimated_latency_ms`` -- plus ``x_request_id``, so they join to
+# the client and span legs on the key those already use.
+#
+# Frontend-only: the timings come from the router's RequestTracker
+# (``lib/llm/src/protocols/common/timing.rs``) and are emitted from the
+# preprocessor. Workers have no tracker and would write empty files.
+#
+# All three vars are required together:
+#   * DYN_REQUEST_TRACE selects which record kinds exist. Without it the record
+#     list is empty, which makes the whole policy disabled -- and ``load_sinks``
+#     then returns no sinks at all, so DYN_REQUEST_TRACE_SINKS alone writes
+#     nothing.
+#   * DYN_REQUEST_TRACE_SINKS picks the file sink and the uncompressed format
+#     (the built-in default is jsonl_gz).
+#   * DYN_REQUEST_TRACE_FILE_PATH must be overridden. The built-in default is
+#     /tmp/dynamo-request-trace, and container /tmp does not survive the job --
+#     the capture would be written and then thrown away with the node.
+ANALYTICS_REQUEST_TRACE_ENV: dict[str, str] = {
+    "DYN_REQUEST_TRACE": "1",
+    "DYN_REQUEST_TRACE_SINKS": "jsonl",
+    "DYN_REQUEST_TRACE_FILE_PATH": f"{CONTAINER_LOG_DIR}/dynamo-request-trace",
 }
 
 # Engine-config keys that surface per-request and per-iteration statistics on

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -57,6 +57,24 @@ class TestExpandObservability:
             # SPAN_CLOSED is emitted at DEBUG; anything higher yields no traces.
             assert env["DYN_LOG"] == "debug"
 
+    def test_enabled_expands_request_trace_env_on_the_frontend_only(self):
+        """The request-trace leg is frontend-only and needs all three vars.
+
+        DYN_REQUEST_TRACE_SINKS on its own writes nothing: with no record kinds
+        selected the policy is disabled and load_sinks returns an empty sink
+        list. And the built-in file path is /tmp, which dies with the job, so
+        the override is what makes the capture survivable.
+        """
+        cfg = expand_observability(_trtllm_config(enabled=True))
+        fe = cfg["frontend"]["env"]
+        assert fe["DYN_REQUEST_TRACE"] == "1"
+        assert fe["DYN_REQUEST_TRACE_SINKS"] == "jsonl"
+        assert fe["DYN_REQUEST_TRACE_FILE_PATH"].startswith("/logs/")
+
+        # Workers have no RequestTracker; tracing them would write empty files.
+        for mode in ("prefill", "decode"):
+            assert "DYN_REQUEST_TRACE" not in cfg["backend"][f"{mode}_environment"]
+
     def test_enabled_turns_on_metrics_surface_and_iteration_stats(self):
         cfg = expand_observability(_trtllm_config(enabled=True))
         assert cfg["backend"]["publish_events_and_metrics"] is True


### PR DESCRIPTION
## Problem

`observability.enabled` already turns on two per-request signals — `SPAN_CLOSED` spans and the `/metrics` surface. Both stop in the same place. The spans decompose the router in fine detail (`kv_router.compute_block_hashes`, `find_matches`, `schedule`, `select_worker`, …) and then treat each worker as a single opaque `handle_payload`. Measured on a GB300 c3 disagg run, that one span is **950 ms wall with 1.0 ms busy and 949 ms idle** — so ~99% of a request's TTFT lands inside a block the trace cannot subdivide.

Meanwhile the frontend is *already computing* a phase breakdown that nothing currently exports.

## What this adds

Dynamo's router keeps a `RequestTracker` (`lib/llm/src/protocols/common/timing.rs`) with `request_received` / `prefill_start` / `prefill_complete` / `first_token` / `decode_first_token`. It exposes them as `dynamo.request.trace.v1` `request_end` records — one JSONL line per request:

| field | meaning |
|---|---|
| `prefill_wait_time_ms` | receive → dispatch (HTTP parse + tokenize + all router stages + admission queue) |
| `prefill_time_ms` | dispatch → first token |
| `kv_transfer_estimated_latency_ms` | `decode_first_token − prefill_complete` (disagg; upper bound) |
| `ttft_ms`, `total_time_ms`, `avg_itl_ms` | end-to-end timings |
| `kv_hit_rate`, `queue_depth`, `cached_tokens` | router state at routing time |
| `worker{prefill,decode}_{worker_id,dp_rank}` | placement |
| **`x_request_id`** | the key the client and span legs already join on |

This is a **third leg of the existing bundle**, not a parallel system — it lands in the run's log dir next to `raw_prometheus.jsonl` and joins to the other legs on `x_request_id`.

## Why all three env vars

Not obvious from the names, and getting it wrong fails silently:

- **`DYN_REQUEST_TRACE=1`** selects which record kinds exist. Without it `load_records` returns empty → the policy is disabled → **`load_sinks` returns an empty sink list**. `DYN_REQUEST_TRACE_SINKS` alone writes nothing, with no error.
- **`DYN_REQUEST_TRACE_SINKS=jsonl`** picks the file sink and the uncompressed format (built-in default is `jsonl_gz`).
- **`DYN_REQUEST_TRACE_FILE_PATH`** must be overridden. The built-in default is `/tmp/dynamo-request-trace`, and container `/tmp` does not survive the job — the capture would be written and then thrown away with the node.

## Frontend-only, deliberately

The timings come from the router's `RequestTracker` and are emitted from `preprocessor.rs`. Workers have no tracker and would write empty files. The test asserts all three land on `frontend.env` and that none leak onto `prefill_environment` / `decode_environment`.

## Verification

Exercised end-to-end on Lyris job **2739690** (GB300, DSv4-Pro, 1 prefill DEP4 + 3 decode TEP8, conc 3):

- `dynamo-request-trace` written to the run's log dir, 9.6 MB, **133 `request_end` records**
- every phase field populated: `prefill_wait_time_ms`, `prefill_time_ms`, `ttft_ms`, `x_request_id` **133/133**; `kv_transfer_estimated_latency_ms`, `avg_itl_ms` 132/133
- the identity `prefill_wait + prefill_time = ttft` holds to **0.000000 ms** across all 133 records

First breakdown off this data (ms):

| segment | p50 | p95 |
|---|---|---|
| `prefill_wait` (frontend pre-dispatch) | **3.7** | 12.3 |
| `kv_transfer_est` (decode-side lump) | 132.7 | 7231.8 |
| `prefill_time` | 681.8 | 11744.2 |
| `ttft` | 684.1 | 11748.7 |

The immediate finding: **the frontend contributes under 1% of TTFT** (3.7 ms p50 against 684 ms), so tokenization and routing are not where the time goes on this workload — which is exactly the kind of question this leg is meant to answer cheaply.

## Notes for review

- `kv_transfer_estimated_latency_ms` is an **upper bound**, not transfer time — it spans the second routing decision, dispatch, the actual KV pull, decode queueing and decode's first forward. The field name and the upstream doc comment both say "estimated"; worth not reading it as a transfer measurement.
- No behaviour change when `observability.enabled` is false — the whole expansion is a no-op, as before.
- Volume is modest relative to the other legs: 9.6 MB per 133 requests here, versus 275 MB for `raw_prometheus.jsonl` on the same run.

## Tests

`1214 passed, 2 skipped`; `ruff check` / `ruff format --check` / `ty` clean.
