### PR TITLE
Unify observability configuration

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1028,45 +1028,74 @@ infra:
 
 ---
 
-## telemetry
+## observability
 
-The `scraper` provider records Prometheus metrics from workers, frontends, DCGM exporter, and node exporter. `make setup` downloads the Tachometer scraper binary for the compute-node architecture.
+`observability.enabled` turns on the server metrics and trace surfaces and captures raw Prometheus responses during the benchmark window:
 
 ```yaml
-telemetry:
+observability:
   enabled: true
-  provider: scraper
-  default_frequency: 5
-  sync_interval_secs: 120
-  compaction_threads: 4
-  storage_subdir: telemetry
-  extra_metadata:
-    cluster: production
-  dcgm_exporter:
-    container_image: /containers/dcgm-exporter.sqsh
-    port: 9400
-  node_exporter:
-    container_image: /containers/node-exporter.sqsh
-    port: 9100
 ```
+
+The default Python scraper writes `<log_dir>/raw_prometheus.jsonl`. To additionally collect parsed Parquet with the native Tachometer scraper:
+
+```yaml
+observability:
+  enabled: true
+  tachometer:
+    enabled: true
+```
+
+Set `scrape_metrics: false` beside `enabled` to use Tachometer without also writing the raw JSONL capture.
 
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
-| `enabled` | bool | `false` | Enable telemetry collection |
-| `provider` | string | `scraper` | Telemetry provider |
+| `enabled` | bool | `false` | Enable server-side metrics/traces and the raw Python scraper |
+| `scrape_metrics` | bool/null | `null` | Override raw capture; `null` follows `enabled` |
+| `scrape_interval_seconds` | float | `1.0` | Interval between raw Prometheus scrape sweeps |
+| `scrape_output` | string | `raw_prometheus.jsonl` | Raw capture filename below the run log directory |
+| `enable_otel` | bool | `false` | Inject OTEL tracing environment variables |
+| `otel_endpoint` | string/null | `null` | OTEL collector endpoint |
+| `tachometer` | object/null | `null` | Optional native Tachometer collection settings |
+
+Tachometer always collects worker and frontend metrics. DCGM and node exporters are optional additions:
+
+```yaml
+observability:
+  enabled: true
+  tachometer:
+    enabled: true
+    default_frequency: 5
+    sync_interval_secs: 120
+    compaction_threads: 4
+    storage_subdir: telemetry
+    extra_metadata:
+      cluster: production
+    dcgm_exporter:
+      container_image: /containers/dcgm-exporter.sqsh
+      port: 9400
+    node_exporter:
+      container_image: /containers/node-exporter.sqsh
+      port: 9100
+```
+
+| Tachometer field | Type | Default | Description |
+| ---------------- | ---- | ------- | ----------- |
+| `enabled` | bool | `false` | Enable native Tachometer collection |
 | `binary_path` | string | `tachometer-scraper` | Scraper command or path on the compute nodes |
-| `container_image` | string/null | `null` | Legacy scraper image field; the native Slurm scraper ignores it |
 | `default_frequency` | float | `5.0` | Scrape frequency in Hz |
 | `sync_interval_secs` | int | `120` | Interval for intermediate Parquet compaction; `0` disables it |
 | `compaction_threads` | int | `4` | Value passed as `POLARS_MAX_THREADS` |
 | `storage_subdir` | string | `telemetry` | Output directory below the run log directory |
 | `extra_metadata` | dict | `{}` | Static string metadata added to every endpoint |
-| `dcgm_exporter` | object | required | DCGM exporter image, port, and optional command |
-| `node_exporter` | object | required | Node exporter image, port, and optional command |
+| `dcgm_exporter` | object/null | `null` | Optional DCGM exporter image, port, and command |
+| `node_exporter` | object/null | `null` | Optional node exporter image, port, and command |
 
-The scraper runs as a native `srun` process on the head node. The exporter processes remain containerized on each worker node. Run `make tachometer-scraper` to build the pinned source locally instead of downloading the release asset.
+`make setup ARCH=<compute_arch>` downloads and checksum-verifies the matching Tachometer binary from the latest srt-slurm release. The scraper runs as a native `srun` process on the head node; configured exporters remain containerized on worker nodes. Run `make tachometer-scraper` to build from source instead.
 
-The output is `<log_dir>/<storage_subdir>/final.parquet`. Intermediate files remain in `<log_dir>/<storage_subdir>/local` until shutdown compaction completes.
+Tachometer writes `<log_dir>/<storage_subdir>/final.parquet`. Intermediate files remain in `<log_dir>/<storage_subdir>/local` until shutdown compaction completes.
+
+The legacy top-level `telemetry:` block remains accepted for existing recipes. New recipes should configure Tachometer under `observability:`; do not set both `observability.tachometer` and top-level `telemetry`.
 
 ---
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1046,7 +1046,7 @@ observability:
     enabled: true
 ```
 
-Set `scrape_metrics: false` beside `enabled` to use Tachometer without also writing the raw JSONL capture.
+Set `scrape_metrics: false` beside `enabled` to use Tachometer without also writing the raw JSONL capture. Otherwise the Python RAW scraper and Tachometer run together.
 
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
@@ -1056,7 +1056,7 @@ Set `scrape_metrics: false` beside `enabled` to use Tachometer without also writ
 | `scrape_output` | string | `raw_prometheus.jsonl` | Raw capture filename below the run log directory |
 | `enable_otel` | bool | `false` | Inject OTEL tracing environment variables |
 | `otel_endpoint` | string/null | `null` | OTEL collector endpoint |
-| `tachometer` | object/null | `null` | Optional native Tachometer collection settings |
+| `tachometer` | object | `enabled: false` | Native Tachometer collection settings |
 
 Tachometer always collects worker and frontend metrics. DCGM and node exporters are optional additions:
 
@@ -1068,7 +1068,7 @@ observability:
     default_frequency: 5
     sync_interval_secs: 120
     compaction_threads: 4
-    storage_subdir: telemetry
+    storage_subdir: tachometer
     extra_metadata:
       cluster: production
     dcgm_exporter:
@@ -1086,7 +1086,7 @@ observability:
 | `default_frequency` | float | `5.0` | Scrape frequency in Hz |
 | `sync_interval_secs` | int | `120` | Interval for intermediate Parquet compaction; `0` disables it |
 | `compaction_threads` | int | `4` | Value passed as `POLARS_MAX_THREADS` |
-| `storage_subdir` | string | `telemetry` | Output directory below the run log directory |
+| `storage_subdir` | string | `tachometer` | Output directory below the run log directory |
 | `extra_metadata` | dict | `{}` | Static string metadata added to every endpoint |
 | `dcgm_exporter` | object/null | `null` | Optional DCGM exporter image, port, and command |
 | `node_exporter` | object/null | `null` | Optional node exporter image, port, and command |
@@ -1095,7 +1095,35 @@ observability:
 
 Tachometer writes `<log_dir>/<storage_subdir>/final.parquet`. Intermediate files remain in `<log_dir>/<storage_subdir>/local` until shutdown compaction completes.
 
-The legacy top-level `telemetry:` block remains accepted for existing recipes. New recipes should configure Tachometer under `observability:`; do not set both `observability.tachometer` and top-level `telemetry`.
+---
+
+## telemetry
+
+`telemetry` is reserved for DCGM power measurement. It can run alongside `observability.tachometer`; it does not start Tachometer itself.
+
+When both are enabled, `telemetry.dcgm_exporter` is shared with Tachometer. Do not also configure `observability.tachometer.dcgm_exporter`; Tachometer can still launch an optional node exporter from its own block.
+
+```yaml
+telemetry:
+  enabled: true
+  default_frequency: 1.0
+  storage_subdir: power
+  required: true
+  dcgm_exporter:
+    container_image: /containers/dcgm-exporter.sqsh
+    port: 9400
+```
+
+| Field | Type | Default | Description |
+| ----- | ---- | ------- | ----------- |
+| `enabled` | bool | `false` | Enable DCGM power collection |
+| `dcgm_exporter` | object/null | `null` | DCGM exporter image, port, and optional command; required when enabled |
+| `default_frequency` | float | `1.0` | Power sample interval in seconds; must be at most `3.0` |
+| `storage_subdir` | string | `power` | Output directory below the run log directory |
+| `required` | bool | `false` | Fail the benchmark when publishable power artifacts cannot be produced |
+| `startup_timeout_seconds` | float | `30.0` | Exporter readiness timeout |
+| `request_timeout_seconds` | float | `2.0` | Per-request exporter timeout |
+| `collector_join_timeout_seconds` | float/null | `null` | Shutdown join timeout; defaults from `request_timeout_seconds` |
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,9 +27,9 @@
 ## Clone and Install
 
 ```bash
-git clone https://github.com/ishandhanani/srt-slurm.git
+git clone https://github.com/NVIDIA/srt-slurm.git
 cd srt-slurm
-pip install -e .
+uv pip install -e .
 ```
 
 ## Gather your cluster user and target partition
@@ -63,7 +63,16 @@ The setup will:
 4. Create `srtslurm.yaml` with your settings
 5. Auto-detect and set `srtctl_root` path
 
-The scraper binaries are attached to srt-slurm GitHub releases for `x86_64` and `aarch64`. Run `make tachometer-scraper` to build the vendored source instead.
+The scraper binaries are attached to srt-slurm GitHub releases for `x86_64` and `aarch64`. `make setup` downloads the matching asset from the latest release and verifies its SHA-256 checksum. Run `make tachometer-scraper` to build the vendored source instead.
+
+After setup, the existing Python observability capture needs only:
+
+```yaml
+observability:
+  enabled: true
+```
+
+Add `tachometer: {enabled: true}` under `observability` when parsed Parquet output is also needed. See [Observability](config-reference.md#observability) for optional DCGM and node exporter collection.
 
 ## Configure srtslurm.yaml
 

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -44,7 +44,7 @@ from srtctl.core.processes import (
 )
 from srtctl.core.resource_snapshot import record_resource_snapshot
 from srtctl.core.runtime import RuntimeContext
-from srtctl.core.schema import SrtConfig, TelemetryProvider
+from srtctl.core.schema import SrtConfig
 from srtctl.core.slurm import get_slurm_job_id, start_srun_process
 from srtctl.core.status import JobStage, JobStatus, StatusReporter
 from srtctl.core.topology import Endpoint, NodePortAllocator, Process, allocate_endpoints_het
@@ -712,8 +712,7 @@ class SweepOrchestrator(
             for proc in frontend_procs:
                 registry.add_process(proc)
 
-            telemetry_config = self.config.telemetry
-            if telemetry_config.enabled and telemetry_config.provider == TelemetryProvider.DCGM_POWER:
+            if self.config.telemetry.enabled:
                 if os.environ.get("EVAL_ONLY", "false").lower() == "true":
                     # Eval-only runs skip the benchmark stage, so every expected
                     # measurement window would be missing and required telemetry
@@ -721,10 +720,10 @@ class SweepOrchestrator(
                     logger.info("EVAL_ONLY=true: skipping dcgm-power telemetry (no benchmark to measure)")
                 else:
                     self.start_power_telemetry(registry)
-            else:
-                telemetry_procs = self.start_telemetry()
-                for proc in telemetry_procs:
-                    registry.add_process(proc)
+
+            tachometer_procs = self.start_tachometer()
+            for proc in tachometer_procs:
+                registry.add_process(proc)
 
             self._print_connection_info()
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -23,7 +23,6 @@ from srtctl.core.power.contract import (
     WINDOWS_DIRNAME,
 )
 from srtctl.core.processes import terminate_and_reap
-from srtctl.core.schema import TelemetryProvider
 from srtctl.core.slurm import get_hostname_ip, start_srun_process
 from srtctl.core.status import JobStage, JobStatus, StatusReporter
 from srtctl.ports import FRONTEND_PUBLIC_PORT, SGLANG_HTTP_PORT_BASE
@@ -534,7 +533,7 @@ class BenchmarkStageMixin:
         path and the host path the collector reads are the same directory.
         """
         telemetry = self.config.telemetry
-        if not telemetry.enabled or telemetry.provider != TelemetryProvider.DCGM_POWER:
+        if not telemetry.enabled:
             return {}
         return {MEASUREMENT_WINDOW_DIR_ENV: f"{CONTAINER_LOG_DIR}/{telemetry.storage_subdir}/{WINDOWS_DIRNAME}"}
 

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -270,8 +270,6 @@ class TelemetryStageMixin:
         if not telemetry.enabled:
             logger.info("Telemetry disabled")
             return []
-        if telemetry.dcgm_exporter is None or telemetry.node_exporter is None:
-            raise ValueError("Telemetry is enabled but required provider configuration is missing")
 
         logger.info("Starting telemetry provider: %s", telemetry.provider.value)
 
@@ -294,27 +292,29 @@ class TelemetryStageMixin:
 
         worker_nodes = sorted({process.node for process in self.backend_processes})
         processes: list[ManagedProcess] = []
-        processes.extend(
-            self._start_exporter_container(
-                exporter_config=telemetry.dcgm_exporter,
-                name="telemetry_dcgm_exporter",
-                nodelist=worker_nodes,
-                log_file=self.runtime.log_dir / "telemetry_dcgm_exporter.out",
-                default_command_template=DCGM_EXPORTER_COMMAND_TEMPLATE,
+        if telemetry.dcgm_exporter is not None:
+            processes.extend(
+                self._start_exporter_container(
+                    exporter_config=telemetry.dcgm_exporter,
+                    name="telemetry_dcgm_exporter",
+                    nodelist=worker_nodes,
+                    log_file=self.runtime.log_dir / "telemetry_dcgm_exporter.out",
+                    default_command_template=DCGM_EXPORTER_COMMAND_TEMPLATE,
+                )
             )
-        )
-        processes.extend(
-            self._start_exporter_container(
-                exporter_config=telemetry.node_exporter,
-                name="telemetry_node_exporter",
-                nodelist=worker_nodes,
-                log_file=self.runtime.log_dir / "telemetry_node_exporter.out",
-                default_command_template=(
-                    "/bin/node_exporter --web.listen-address=:{port} "
-                    "--collector.disable-defaults --collector.cpu --collector.infiniband --collector.meminfo"
-                ),
+        if telemetry.node_exporter is not None:
+            processes.extend(
+                self._start_exporter_container(
+                    exporter_config=telemetry.node_exporter,
+                    name="telemetry_node_exporter",
+                    nodelist=worker_nodes,
+                    log_file=self.runtime.log_dir / "telemetry_node_exporter.out",
+                    default_command_template=(
+                        "/bin/node_exporter --web.listen-address=:{port} "
+                        "--collector.disable-defaults --collector.cpu --collector.infiniband --collector.meminfo"
+                    ),
+                )
             )
-        )
 
         cmd = [
             telemetry.binary_path,

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -17,9 +17,9 @@ from srtctl.core.power.manifest import ExpectedWindow
 from srtctl.core.power.session import PowerSessionSettings, PowerTelemetrySession
 from srtctl.core.power.topology import build_expected_devices
 from srtctl.core.processes import ManagedProcess, ProcessRegistry
-from srtctl.core.schema import TelemetryExporterConfig, TelemetryProvider
+from srtctl.core.schema import TelemetryExporterConfig
 from srtctl.core.slurm import start_srun_process
-from srtctl.core.telemetry import generate_telemetry_config
+from srtctl.core.telemetry import generate_tachometer_config
 
 if TYPE_CHECKING:
     from srtctl.core.runtime import RuntimeContext
@@ -137,19 +137,19 @@ class TelemetryStageMixin:
         return managed
 
     def start_power_telemetry(self, registry: ProcessRegistry) -> PowerTelemetrySession | None:
-        """Start the ``dcgm-power`` provider; return ``None`` for other providers.
+        """Start DCGM power telemetry when it is enabled.
 
         Every provider-originated startup failure becomes session state once the
         session exists, so the orchestrator can still finalize artifacts and
         decide the exit code after the benchmark stage.
         """
         telemetry = self.config.telemetry
-        if not telemetry.enabled or telemetry.provider != TelemetryProvider.DCGM_POWER:
+        if not telemetry.enabled:
             return None
 
         exporter_config = telemetry.dcgm_exporter
         if exporter_config is None:  # guaranteed by schema validation
-            raise ValueError("telemetry.dcgm_exporter is required for provider dcgm-power")
+            raise ValueError("telemetry.dcgm_exporter is required when telemetry is enabled")
 
         worker_nodes = sorted({process.node for process in self.backend_processes})
         power_dir = self.runtime.log_dir / telemetry.storage_subdir
@@ -183,7 +183,7 @@ class TelemetryStageMixin:
         self._power_session = session
         self._power_telemetry_ready = False
         session.initialize()
-        logger.info("Starting telemetry provider: %s (artifacts under %s)", telemetry.provider.value, power_dir)
+        logger.info("Starting DCGM power telemetry (artifacts under %s)", power_dir)
 
         def own(process: ManagedProcess) -> None:
             registry.add_process(process)
@@ -264,51 +264,54 @@ class TelemetryStageMixin:
             return 1
         return exit_code
 
-    def start_telemetry(self) -> list[ManagedProcess]:
-        """Start the configured telemetry provider."""
-        telemetry = self.config.telemetry
-        if not telemetry.enabled:
-            logger.info("Telemetry disabled")
+    def start_tachometer(self) -> list[ManagedProcess]:
+        """Start optional Tachometer collection from observability."""
+        tachometer = self.config.observability.tachometer
+        if tachometer.enabled is not True:
+            logger.info("Tachometer disabled")
             return []
 
-        logger.info("Starting telemetry provider: %s", telemetry.provider.value)
+        logger.info("Starting Tachometer")
 
+        power_telemetry = self.config.telemetry
+        dcgm_exporter = power_telemetry.dcgm_exporter if power_telemetry.enabled else tachometer.dcgm_exporter
         topology = self._compute_frontend_topology()
-        config_path = self.runtime.log_dir / "telemetry_config.toml"
+        config_path = self.runtime.log_dir / "tachometer_config.toml"
         config_path.write_text(
-            generate_telemetry_config(
+            generate_tachometer_config(
                 processes=self.backend_processes,
                 frontend_topology=topology,
                 runtime=self.runtime,
-                telemetry=telemetry,
+                tachometer=tachometer,
+                dcgm_exporter=dcgm_exporter,
                 frontend_type=self.config.frontend.type,
             )
         )
 
-        telemetry_dir = self.runtime.log_dir / telemetry.storage_subdir
-        telemetry_dir.mkdir(parents=True, exist_ok=True)
-        local_dir = telemetry_dir / "local"
+        tachometer_dir = self.runtime.log_dir / tachometer.storage_subdir
+        tachometer_dir.mkdir(parents=True, exist_ok=True)
+        local_dir = tachometer_dir / "local"
         local_dir.mkdir(parents=True, exist_ok=True)
 
         worker_nodes = sorted({process.node for process in self.backend_processes})
         processes: list[ManagedProcess] = []
-        if telemetry.dcgm_exporter is not None:
+        if not power_telemetry.enabled and tachometer.dcgm_exporter is not None:
             processes.extend(
                 self._start_exporter_container(
-                    exporter_config=telemetry.dcgm_exporter,
-                    name="telemetry_dcgm_exporter",
+                    exporter_config=tachometer.dcgm_exporter,
+                    name="tachometer_dcgm_exporter",
                     nodelist=worker_nodes,
-                    log_file=self.runtime.log_dir / "telemetry_dcgm_exporter.out",
+                    log_file=self.runtime.log_dir / "tachometer_dcgm_exporter.out",
                     default_command_template=DCGM_EXPORTER_COMMAND_TEMPLATE,
                 )
             )
-        if telemetry.node_exporter is not None:
+        if tachometer.node_exporter is not None:
             processes.extend(
                 self._start_exporter_container(
-                    exporter_config=telemetry.node_exporter,
-                    name="telemetry_node_exporter",
+                    exporter_config=tachometer.node_exporter,
+                    name="tachometer_node_exporter",
                     nodelist=worker_nodes,
-                    log_file=self.runtime.log_dir / "telemetry_node_exporter.out",
+                    log_file=self.runtime.log_dir / "tachometer_node_exporter.out",
                     default_command_template=(
                         "/bin/node_exporter --web.listen-address=:{port} "
                         "--collector.disable-defaults --collector.cpu --collector.infiniband --collector.meminfo"
@@ -317,33 +320,33 @@ class TelemetryStageMixin:
             )
 
         cmd = [
-            telemetry.binary_path,
+            tachometer.binary_path,
             "--config",
             str(config_path),
             "--local-dir",
             str(local_dir),
         ]
-        if telemetry.sync_interval_secs > 0:
-            cmd.extend(["--sync-interval", str(telemetry.sync_interval_secs)])
+        if tachometer.sync_interval_secs > 0:
+            cmd.extend(["--sync-interval", str(tachometer.sync_interval_secs)])
 
         env_to_set: dict[str, str] = {}
-        if telemetry.compaction_threads > 0:
-            env_to_set["POLARS_MAX_THREADS"] = str(telemetry.compaction_threads)
+        if tachometer.compaction_threads > 0:
+            env_to_set["POLARS_MAX_THREADS"] = str(tachometer.compaction_threads)
 
         processes.append(
             ManagedProcess(
-                name="telemetry",
+                name="tachometer",
                 popen=start_srun_process(
                     command=cmd,
                     nodelist=[self.runtime.nodes.head],
-                    output=str(self.runtime.log_dir / "telemetry.out"),
+                    output=str(self.runtime.log_dir / "tachometer.out"),
                     env_to_set=env_to_set,
                     srun_options=self.runtime.srun_options,
                     het_group=self.runtime.nodes.het_group_for(self.runtime.nodes.head),
                 ),
-                log_file=self.runtime.log_dir / "telemetry.out",
+                log_file=self.runtime.log_dir / "tachometer.out",
                 node=self.runtime.nodes.head,
             )
         )
-        logger.info("Telemetry started with artifacts under %s", telemetry_dir)
+        logger.info("Tachometer started with artifacts under %s", tachometer_dir)
         return processes

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -354,17 +354,20 @@ def show_config_details(config: SrtConfig) -> None:
         if config.benchmark.container_image:
             details.add_row("benchmark", "container_image", config.benchmark.container_image)
 
+        if config.observability.enabled:
+            details.add_row("observability", "raw_metrics", str(config.observability.scraper_enabled))
+
         if config.telemetry.enabled:
-            details.add_row("telemetry", "provider", config.telemetry.provider.value)
-            details.add_row("telemetry", "storage_subdir", config.telemetry.storage_subdir)
-            details.add_row("telemetry", "frequency", str(config.telemetry.default_frequency))
+            details.add_row("observability", "metrics_provider", config.telemetry.provider.value)
+            details.add_row("observability", "storage_subdir", config.telemetry.storage_subdir)
+            details.add_row("observability", "frequency", str(config.telemetry.default_frequency))
             if config.telemetry.provider == TelemetryProvider.SCRAPER:
-                details.add_row("telemetry", "binary_path", config.telemetry.binary_path)
+                details.add_row("observability", "binary_path", config.telemetry.binary_path)
             exporter = config.telemetry.dcgm_exporter
             if config.telemetry.provider == TelemetryProvider.DCGM_POWER and exporter is not None:
-                details.add_row("telemetry", "required", str(config.telemetry.required))
-                details.add_row("telemetry", "artifacts", f"<log_dir>/{config.telemetry.storage_subdir}")
-                details.add_row("telemetry", "dcgm_exporter", f"{exporter.container_image} (port {exporter.port})")
+                details.add_row("observability", "required", str(config.telemetry.required))
+                details.add_row("observability", "artifacts", f"<log_dir>/{config.telemetry.storage_subdir}")
+                details.add_row("observability", "dcgm_exporter", f"{exporter.container_image} (port {exporter.port})")
 
         if mooncake_cfg is not None:
             details.add_row("mooncake", "container", mooncake_cfg.container or "<job container>")

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -55,7 +55,7 @@ from srtctl.core.git_state import (
     write_git_state_snapshot,
 )
 from srtctl.core.lockfile import load_lockfile_fingerprints
-from srtctl.core.schema import SrtConfig, TelemetryProvider, installs_dynamo
+from srtctl.core.schema import SrtConfig, installs_dynamo
 from srtctl.core.status import create_job_record
 from srtctl.core.validation import preflight_config_variants
 from srtctl.ports import MOONCAKE_MASTER_PORT
@@ -333,6 +333,8 @@ def show_config_details(config: SrtConfig) -> None:
     show_extensions = (
         config.benchmark.type == "custom"
         or config.benchmark.container_image
+        or config.observability.enabled
+        or config.observability.tachometer.enabled
         or config.telemetry.enabled
         or mooncake_cfg is not None
     )
@@ -356,18 +358,20 @@ def show_config_details(config: SrtConfig) -> None:
 
         if config.observability.enabled:
             details.add_row("observability", "raw_metrics", str(config.observability.scraper_enabled))
+        tachometer = config.observability.tachometer
+        if tachometer.enabled:
+            details.add_row("observability", "tachometer", "enabled")
+            details.add_row("observability", "storage_subdir", tachometer.storage_subdir)
+            details.add_row("observability", "frequency", str(tachometer.default_frequency))
+            details.add_row("observability", "binary_path", tachometer.binary_path)
 
         if config.telemetry.enabled:
-            details.add_row("observability", "metrics_provider", config.telemetry.provider.value)
-            details.add_row("observability", "storage_subdir", config.telemetry.storage_subdir)
-            details.add_row("observability", "frequency", str(config.telemetry.default_frequency))
-            if config.telemetry.provider == TelemetryProvider.SCRAPER:
-                details.add_row("observability", "binary_path", config.telemetry.binary_path)
             exporter = config.telemetry.dcgm_exporter
-            if config.telemetry.provider == TelemetryProvider.DCGM_POWER and exporter is not None:
-                details.add_row("observability", "required", str(config.telemetry.required))
-                details.add_row("observability", "artifacts", f"<log_dir>/{config.telemetry.storage_subdir}")
-                details.add_row("observability", "dcgm_exporter", f"{exporter.container_image} (port {exporter.port})")
+            details.add_row("telemetry", "provider", "dcgm-power")
+            details.add_row("telemetry", "required", str(config.telemetry.required))
+            details.add_row("telemetry", "artifacts", f"<log_dir>/{config.telemetry.storage_subdir}")
+            if exporter is not None:
+                details.add_row("telemetry", "dcgm_exporter", f"{exporter.container_image} (port {exporter.port})")
 
         if mooncake_cfg is not None:
             details.add_row("mooncake", "container", mooncake_cfg.container or "<job container>")

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -96,6 +96,7 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
     """
     # Deep copy to avoid mutating original
     config = copy.deepcopy(user_config)
+    _normalize_observability_telemetry(config)
 
     if cluster_config is None:
         return config
@@ -581,6 +582,26 @@ def _setdefault_nested(parent: dict, key: str, values: dict) -> None:
         child.setdefault(k, v)
 
 
+def _normalize_observability_telemetry(cfg: dict) -> None:
+    """Map the canonical observability surface onto the telemetry runtime."""
+    observability = cfg.get("observability")
+    if not isinstance(observability, dict):
+        return
+
+    tachometer = observability.pop("tachometer", None)
+    if tachometer is not None and not isinstance(tachometer, dict):
+        raise TypeError("observability.tachometer must be a mapping")
+    if tachometer is not None and "telemetry" in cfg:
+        raise ValueError("use observability.tachometer or the legacy top-level telemetry block, not both")
+
+    if tachometer is not None:
+        if tachometer.get("enabled") and not observability.get("enabled"):
+            raise ValueError("observability.tachometer requires observability.enabled: true")
+        telemetry = copy.deepcopy(tachometer)
+        telemetry.setdefault("provider", "scraper")
+        cfg["telemetry"] = telemetry
+
+
 def expand_observability(cfg: dict) -> dict:
     """Expand ``observability.enabled`` into the individual launch flags.
 
@@ -599,6 +620,7 @@ def expand_observability(cfg: dict) -> dict:
         ANALYTICS_SPAN_ENV,
     )
 
+    _normalize_observability_telemetry(cfg)
     observability = cfg.get("observability")
     if not isinstance(observability, dict) or not observability.get("enabled"):
         return cfg

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -96,8 +96,6 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
     """
     # Deep copy to avoid mutating original
     config = copy.deepcopy(user_config)
-    _normalize_observability_telemetry(config)
-
     if cluster_config is None:
         return config
 
@@ -191,18 +189,12 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         config["benchmark"] = benchmark
         logger.debug(f"Resolved benchmark.container_image alias '{benchmark_container}' -> '{resolved_bench}'")
 
-    # Resolve telemetry container aliases (scraper + dcgm/node exporters). All
-    # three are nullable in the schema; only resolve fields that are set.
-    telemetry = config.get("telemetry")
-    if telemetry and containers:
-        scraper_image = telemetry.get("container_image")
-        if scraper_image and scraper_image in containers:
-            resolved_scraper = containers[scraper_image]
-            telemetry["container_image"] = resolved_scraper
-            logger.debug(f"Resolved telemetry.container_image alias '{scraper_image}' -> '{resolved_scraper}'")
-
+    # Resolve Tachometer exporter aliases from the observability block.
+    observability = config.get("observability")
+    tachometer = observability.get("tachometer") if isinstance(observability, dict) else None
+    if tachometer and containers:
         for exporter_key in ("dcgm_exporter", "node_exporter"):
-            exporter = telemetry.get(exporter_key)
+            exporter = tachometer.get(exporter_key)
             if not exporter:
                 continue
             exporter_image = exporter.get("container_image")
@@ -210,9 +202,21 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
                 resolved_exporter = containers[exporter_image]
                 exporter["container_image"] = resolved_exporter
                 logger.debug(
-                    f"Resolved telemetry.{exporter_key}.container_image alias "
+                    f"Resolved observability.tachometer.{exporter_key}.container_image alias "
                     f"'{exporter_image}' -> '{resolved_exporter}'"
                 )
+
+    # Telemetry is reserved for the DCGM power collector.
+    telemetry = config.get("telemetry")
+    if telemetry and containers:
+        exporter = telemetry.get("dcgm_exporter")
+        exporter_image = exporter.get("container_image") if isinstance(exporter, dict) else None
+        if exporter_image and exporter_image in containers:
+            resolved_exporter = containers[exporter_image]
+            exporter["container_image"] = resolved_exporter
+            logger.debug(
+                f"Resolved telemetry.dcgm_exporter.container_image alias '{exporter_image}' -> '{resolved_exporter}'"
+            )
 
     return config
 
@@ -582,26 +586,6 @@ def _setdefault_nested(parent: dict, key: str, values: dict) -> None:
         child.setdefault(k, v)
 
 
-def _normalize_observability_telemetry(cfg: dict) -> None:
-    """Map the canonical observability surface onto the telemetry runtime."""
-    observability = cfg.get("observability")
-    if not isinstance(observability, dict):
-        return
-
-    tachometer = observability.pop("tachometer", None)
-    if tachometer is not None and not isinstance(tachometer, dict):
-        raise TypeError("observability.tachometer must be a mapping")
-    if tachometer is not None and "telemetry" in cfg:
-        raise ValueError("use observability.tachometer or the legacy top-level telemetry block, not both")
-
-    if tachometer is not None:
-        if tachometer.get("enabled") and not observability.get("enabled"):
-            raise ValueError("observability.tachometer requires observability.enabled: true")
-        telemetry = copy.deepcopy(tachometer)
-        telemetry.setdefault("provider", "scraper")
-        cfg["telemetry"] = telemetry
-
-
 def expand_observability(cfg: dict) -> dict:
     """Expand ``observability.enabled`` into the individual launch flags.
 
@@ -620,7 +604,6 @@ def expand_observability(cfg: dict) -> dict:
         ANALYTICS_SPAN_ENV,
     )
 
-    _normalize_observability_telemetry(cfg)
     observability = cfg.get("observability")
     if not isinstance(observability, dict) or not observability.get("enabled"):
         return cfg

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -275,11 +275,6 @@ class ProfilingType(str, Enum):
     NONE = "none"
 
 
-class TelemetryProvider(str, Enum):
-    SCRAPER = "scraper"
-    DCGM_POWER = "dcgm-power"
-
-
 # ============================================================================
 # Marshmallow Custom Fields
 # ============================================================================
@@ -1011,6 +1006,34 @@ class ProfilingConfig:
 
 
 @dataclass(frozen=True)
+class TelemetryExporterConfig:
+    """Configuration for a metrics exporter deployed on worker nodes."""
+
+    container_image: str
+    port: int
+    command: str | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
+class TachometerConfig:
+    """Native Tachometer collection for an observability-enabled run."""
+
+    enabled: bool = False
+    binary_path: str = "tachometer-scraper"
+    default_frequency: float = 5.0
+    sync_interval_secs: int = 120
+    compaction_threads: int = 4
+    storage_subdir: str = "tachometer"
+    extra_metadata: dict[str, str] = field(default_factory=dict)
+    dcgm_exporter: TelemetryExporterConfig | None = None
+    node_exporter: TelemetryExporterConfig | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
 class ObservabilityConfig:
     """Observability configuration for OTEL tracing.
 
@@ -1061,6 +1084,8 @@ class ObservabilityConfig:
             back-to-back rather than queueing (see the drift-free pacing in
             ``RawMetricsScraper``).
         scrape_output: Filename (under the run's log dir) for the RAW capture.
+        tachometer: Optional native Tachometer capture configuration. It runs
+            alongside RAW capture when both are enabled.
     """
 
     enabled: bool = False
@@ -1070,6 +1095,7 @@ class ObservabilityConfig:
     scrape_metrics: bool | None = None
     scrape_interval_seconds: float = 1.0
     scrape_output: str = "raw_prometheus.jsonl"
+    tachometer: TachometerConfig = field(default_factory=TachometerConfig)
 
     Schema: ClassVar[type[Schema]] = Schema
 
@@ -1080,69 +1106,13 @@ class ObservabilityConfig:
 
 
 @dataclass(frozen=True)
-class TelemetryExporterConfig:
-    """Configuration for telemetry exporters deployed on worker nodes."""
-
-    container_image: str
-    port: int
-    command: str | None = None
-
-    Schema: ClassVar[type[Schema]] = Schema
-
-
-@dataclass(frozen=True)
-class LiveMetricsConfig:
-    """In-flight batch-metrics snapshotter (a form of lightweight telemetry).
-
-    When enabled, the orchestrator spawns a daemon thread during the benchmark
-    stage that re-parses prefill/decode worker logs every ``interval_seconds``
-    and atomically overwrites ``<log_dir>/batch_metrics.png``, giving a
-    near-real-time view of the run without any external monitoring stack.
-
-    Lives entirely in :mod:`srtctl.analysis.live_metrics`; this dataclass
-    only defines the user-visible knobs.
-    """
-
-    enabled: bool = False
-    interval_seconds: int = 60
-    downsample: int = 1
-
-    Schema: ClassVar[type[Schema]] = Schema
-
-
-@dataclass(frozen=True)
 class TelemetryConfig:
-    """Telemetry configuration for benchmark jobs.
-
-    The default provider runs the bundled Tachometer scraper binary. DCGM and
-    node exporters are optional additions; frontend and backend endpoints are
-    collected without them. ``container_image`` remains accepted for
-    compatibility with existing configs but is not used by the native scraper.
-
-    ``live_metrics`` is a lightweight complementary signal: it tails worker
-    logs in-process (no external stack required) and writes a per-run
-    ``batch_metrics.png`` during the benchmark.
-
-    The ``dcgm-power`` provider needs only ``dcgm_exporter``: it runs a
-    head-node collector inside srtctl instead of the Tachometer scraper, so
-    ``container_image``, ``binary_path``, and ``node_exporter`` stay unused.
-    For that provider ``default_frequency`` is the collector cycle period in
-    seconds, and ``required`` decides whether telemetry invalidity fails the job.
-    """
+    """DCGM power telemetry for benchmark measurement windows."""
 
     enabled: bool = False
-    # NOTE: without by_value the schema accepts only enum member names, not "dcgm-power".
-    provider: Annotated[TelemetryProvider, fields.Enum(TelemetryProvider, by_value=True)] = TelemetryProvider.SCRAPER
-    container_image: str | None = None
-    binary_path: str = "tachometer-scraper"
-    default_frequency: float = 5.0
-    sync_interval_secs: int = 120
-    compaction_threads: int = 4
-    storage_subdir: str = "telemetry"
-    extra_metadata: dict[str, str] = field(default_factory=dict)
     dcgm_exporter: TelemetryExporterConfig | None = None
-    node_exporter: TelemetryExporterConfig | None = None
-    live_metrics: LiveMetricsConfig | None = None
+    default_frequency: float = 1.0
+    storage_subdir: str = "power"
     required: bool = False
     startup_timeout_seconds: float = 30.0
     request_timeout_seconds: float = 2.0
@@ -1720,6 +1690,7 @@ class SrtConfig:
     def __post_init__(self):
         """Validate configuration after initialization."""
         self._validate_profiling()
+        self._validate_observability()
         self._validate_telemetry()
         self._validate_mooncake_kv_store()
         self._validate_het_jobs()
@@ -1979,7 +1950,7 @@ class SrtConfig:
                 )
 
     def _validate_dcgm_power(self):
-        """Validate the DCGM-only power provider.
+        """Validate DCGM power telemetry.
 
         It runs its collector in the orchestrator process, so it needs neither
         the scraper image nor node_exporter. Sample and window timestamps must
@@ -1989,7 +1960,7 @@ class SrtConfig:
         telemetry = self.telemetry
         exporter = telemetry.dcgm_exporter
         if exporter is None:
-            raise ValidationError("telemetry.dcgm_exporter is required for provider dcgm-power")
+            raise ValidationError("telemetry.dcgm_exporter is required when telemetry is enabled")
         if not exporter.container_image:
             raise ValidationError("telemetry.dcgm_exporter.container_image must be non-empty")
         if not 1 <= exporter.port <= 65535:
@@ -2023,53 +1994,67 @@ class SrtConfig:
             raise ValidationError("telemetry.storage_subdir must be a safe relative path below the run log directory")
 
         if self.benchmark.type != _BENCHMARK_TYPE_SA_BENCH:
-            raise ValidationError(f"telemetry provider dcgm-power requires benchmark.type: {_BENCHMARK_TYPE_SA_BENCH}")
+            raise ValidationError(f"telemetry requires benchmark.type: {_BENCHMARK_TYPE_SA_BENCH}")
         if self.benchmark.client_placement != "head":
-            raise ValidationError("telemetry provider dcgm-power requires benchmark.client_placement: head")
+            raise ValidationError("telemetry requires benchmark.client_placement: head")
 
         # NOTE: a dedicated infra node moves nodes.head off the batch host the collector runs on.
         if self.infra.etcd_nats_dedicated_node:
             raise ValidationError(
-                "telemetry provider dcgm-power requires infra.etcd_nats_dedicated_node: false, because a "
+                "telemetry requires infra.etcd_nats_dedicated_node: false, because a "
                 "dedicated infra node moves nodes.head off the batch host and power samples would no longer "
                 "share the benchmark's clock"
             )
 
         concurrencies = self.benchmark.get_concurrency_list()
         if not concurrencies or len(set(concurrencies)) != len(concurrencies) or any(c <= 0 for c in concurrencies):
+            raise ValidationError("telemetry requires a non-empty list of unique positive benchmark.concurrencies")
+
+    def _validate_observability(self):
+        """Validate optional Tachometer collection under observability."""
+        observability = self.observability
+        tachometer = observability.tachometer
+        if not tachometer.enabled:
+            return
+        if not observability.enabled:
+            raise ValidationError("observability.tachometer requires observability.enabled: true")
+        if self.telemetry.enabled and tachometer.dcgm_exporter is not None:
             raise ValidationError(
-                "telemetry provider dcgm-power requires a non-empty list of unique positive benchmark.concurrencies"
+                "configure the shared DCGM exporter under telemetry, not observability.tachometer, "
+                "when DCGM power telemetry is enabled"
+            )
+        if self.telemetry.enabled and tachometer.storage_subdir == self.telemetry.storage_subdir:
+            raise ValidationError(
+                "observability.tachometer.storage_subdir and telemetry.storage_subdir must be different"
             )
 
-    def _validate_telemetry(self):
-        """Validate telemetry configuration."""
-        telemetry = self.telemetry
-        if telemetry is None or not telemetry.enabled:
-            return
-
-        if telemetry.provider == TelemetryProvider.DCGM_POWER:
-            self._validate_dcgm_power()
-            return
-
-        if telemetry.provider != TelemetryProvider.SCRAPER:
-            raise ValidationError(f"Unsupported telemetry provider: {telemetry.provider}")
-
         for name in ("dcgm_exporter", "node_exporter"):
-            exporter = getattr(telemetry, name)
+            exporter = getattr(tachometer, name)
             if exporter is None:
                 continue
             if not exporter.container_image:
-                raise ValidationError(f"telemetry.{name}.container_image must be non-empty")
+                raise ValidationError(f"observability.tachometer.{name}.container_image must be non-empty")
             if not 1 <= exporter.port <= 65535:
-                raise ValidationError(f"telemetry.{name}.port must be in 1..65535")
-        if not telemetry.binary_path:
-            raise ValidationError("telemetry.binary_path must be non-empty")
-        if telemetry.default_frequency <= 0:
-            raise ValidationError("telemetry.default_frequency must be positive")
-        if telemetry.sync_interval_secs < 0:
-            raise ValidationError("telemetry.sync_interval_secs must be >= 0")
-        if telemetry.compaction_threads < 0:
-            raise ValidationError("telemetry.compaction_threads must be >= 0")
+                raise ValidationError(f"observability.tachometer.{name}.port must be in 1..65535")
+        if not tachometer.binary_path:
+            raise ValidationError("observability.tachometer.binary_path must be non-empty")
+        if tachometer.default_frequency <= 0:
+            raise ValidationError("observability.tachometer.default_frequency must be positive")
+        if tachometer.sync_interval_secs < 0:
+            raise ValidationError("observability.tachometer.sync_interval_secs must be >= 0")
+        if tachometer.compaction_threads < 0:
+            raise ValidationError("observability.tachometer.compaction_threads must be >= 0")
+        if not _is_safe_relative_subpath(tachometer.storage_subdir):
+            raise ValidationError(
+                "observability.tachometer.storage_subdir must be a safe relative path below the run log directory"
+            )
+
+    def _validate_telemetry(self):
+        """Validate DCGM power telemetry."""
+        telemetry = self.telemetry
+        if telemetry is None or not telemetry.enabled:
+            return
+        self._validate_dcgm_power()
 
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1054,8 +1054,8 @@ class ObservabilityConfig:
             and frontends. Requires otel_endpoint to be set. Default: False.
         otel_endpoint: OTEL collector endpoint (e.g. "http://10.0.0.1:4317").
             Required when enable_otel is True.
-        scrape_metrics: Run the in-job Prometheus scraper. Defaults to the value
-            of ``enabled``; set False to opt out while keeping the rest.
+        scrape_metrics: Run the in-job RAW Prometheus scraper. Defaults to the
+            value of ``enabled``; set False to opt out while keeping the rest.
         scrape_interval_seconds: Seconds between scrape sweeps. Default: 1.0.
             The floor is 0.5; a sweep slower than the interval simply runs
             back-to-back rather than queueing (see the drift-free pacing in
@@ -1075,7 +1075,7 @@ class ObservabilityConfig:
 
     @property
     def scraper_enabled(self) -> bool:
-        """Whether the in-job Prometheus scraper should run."""
+        """Whether the in-job RAW Prometheus scraper should run."""
         return self.enabled if self.scrape_metrics is None else self.scrape_metrics
 
 
@@ -1114,8 +1114,9 @@ class LiveMetricsConfig:
 class TelemetryConfig:
     """Telemetry configuration for benchmark jobs.
 
-    The default provider runs the bundled Tachometer scraper binary with
-    dcgm_exporter and node_exporter. ``container_image`` remains accepted for
+    The default provider runs the bundled Tachometer scraper binary. DCGM and
+    node exporters are optional additions; frontend and backend endpoints are
+    collected without them. ``container_image`` remains accepted for
     compatibility with existing configs but is not used by the native scraper.
 
     ``live_metrics`` is a lightweight complementary signal: it tails worker
@@ -2053,10 +2054,14 @@ class SrtConfig:
         if telemetry.provider != TelemetryProvider.SCRAPER:
             raise ValidationError(f"Unsupported telemetry provider: {telemetry.provider}")
 
-        if telemetry.dcgm_exporter is None:
-            raise ValidationError("telemetry.dcgm_exporter is required when telemetry is enabled")
-        if telemetry.node_exporter is None:
-            raise ValidationError("telemetry.node_exporter is required when telemetry is enabled")
+        for name in ("dcgm_exporter", "node_exporter"):
+            exporter = getattr(telemetry, name)
+            if exporter is None:
+                continue
+            if not exporter.container_image:
+                raise ValidationError(f"telemetry.{name}.container_image must be non-empty")
+            if not 1 <= exporter.port <= 65535:
+                raise ValidationError(f"telemetry.{name}.port must be in 1..65535")
         if not telemetry.binary_path:
             raise ValidationError("telemetry.binary_path must be non-empty")
         if telemetry.default_frequency <= 0:
@@ -2068,8 +2073,11 @@ class SrtConfig:
 
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":
+        from srtctl.core.config import expand_observability
+
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
+        expand_observability(data)
         schema = cls.Schema()
         return schema.load(data)
 

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Telemetry configuration helpers."""
+"""Tachometer configuration helpers."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from srtctl.ports import FRONTEND_PUBLIC_PORT
 if TYPE_CHECKING:
     from srtctl.cli.mixins.frontend_stage import FrontendTopology
     from srtctl.core.runtime import RuntimeContext
-    from srtctl.core.schema import TelemetryConfig
+    from srtctl.core.schema import TachometerConfig, TelemetryExporterConfig
     from srtctl.core.topology import Process
 
 
@@ -31,17 +31,18 @@ class TelemetryEndpoint:
     gpu_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
 
-def generate_telemetry_config(
+def generate_tachometer_config(
     *,
     processes: list[Process],
     frontend_topology: FrontendTopology,
     runtime: RuntimeContext,
-    telemetry: TelemetryConfig,
+    tachometer: TachometerConfig,
+    dcgm_exporter: TelemetryExporterConfig | None = None,
     frontend_type: str = "dynamo",
 ) -> str:
-    """Generate telemetry TOML from backend and frontend topology."""
-    dcgm_exporter = telemetry.dcgm_exporter
-    node_exporter = telemetry.node_exporter
+    """Generate Tachometer TOML from backend and frontend topology."""
+    dcgm_exporter = dcgm_exporter or tachometer.dcgm_exporter
+    node_exporter = tachometer.node_exporter
     endpoints: list[TelemetryEndpoint] = []
     physical_nodes: dict[str, list[Process]] = {}
     for process in processes:
@@ -50,7 +51,7 @@ def generate_telemetry_config(
     for node in sorted(physical_nodes):
         node_processes = physical_nodes[node]
         node_metadata = {"hostname": node, "job_id": runtime.job_id, "run_name": runtime.run_name}
-        node_metadata.update(telemetry.extra_metadata)
+        node_metadata.update(tachometer.extra_metadata)
 
         gpu_metadata: dict[str, dict[str, str]] = {}
         for process in node_processes:
@@ -66,7 +67,7 @@ def generate_telemetry_config(
                 TelemetryEndpoint(
                     name=f"dcgm_{node}",
                     url=f"http://{node}:{dcgm_exporter.port}/metrics",
-                    frequency=telemetry.default_frequency,
+                    frequency=tachometer.default_frequency,
                     filter="dcgm",
                     node_metadata=node_metadata,
                     gpu_metadata=gpu_metadata,
@@ -77,7 +78,7 @@ def generate_telemetry_config(
                 TelemetryEndpoint(
                     name=f"node_exporter_{node}",
                     url=f"http://{node}:{node_exporter.port}/metrics",
-                    frequency=telemetry.default_frequency,
+                    frequency=tachometer.default_frequency,
                     filter="node_exporter",
                     node_metadata=node_metadata,
                 )
@@ -94,12 +95,12 @@ def generate_telemetry_config(
             "worker_process": str(process.node_rank),
             "worker_role": process.endpoint_mode,
         }
-        node_metadata.update(telemetry.extra_metadata)
+        node_metadata.update(tachometer.extra_metadata)
         endpoints.append(
             TelemetryEndpoint(
                 name=f"backend_{process.endpoint_mode}{process.endpoint_index}_rank{process.node_rank}",
                 url=f"http://{node_ip}:{port}/metrics",
-                frequency=telemetry.default_frequency,
+                frequency=tachometer.default_frequency,
                 filter="backend",
                 node_metadata=node_metadata,
             )
@@ -124,12 +125,12 @@ def generate_telemetry_config(
             "frontend_index": str(frontend_index),
             "hostname": node,
         }
-        node_metadata.update(telemetry.extra_metadata)
+        node_metadata.update(tachometer.extra_metadata)
         endpoints.append(
             TelemetryEndpoint(
                 name=f"frontend{frontend_index}",
                 url=f"http://{node_ip}:{frontend_topology.frontend_port}/metrics",
-                frequency=telemetry.default_frequency,
+                frequency=tachometer.default_frequency,
                 filter="frontend",
                 node_metadata=node_metadata,
             )
@@ -137,7 +138,7 @@ def generate_telemetry_config(
 
     return _dump_toml(
         endpoints=endpoints,
-        storage=str(runtime.log_dir / telemetry.storage_subdir),
+        storage=str(runtime.log_dir / tachometer.storage_subdir),
     )
 
 

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -42,9 +42,6 @@ def generate_telemetry_config(
     """Generate telemetry TOML from backend and frontend topology."""
     dcgm_exporter = telemetry.dcgm_exporter
     node_exporter = telemetry.node_exporter
-    if dcgm_exporter is None or node_exporter is None:
-        raise ValueError("Telemetry exporters must be configured before generating telemetry config")
-
     endpoints: list[TelemetryEndpoint] = []
     physical_nodes: dict[str, list[Process]] = {}
     for process in processes:
@@ -64,25 +61,27 @@ def generate_telemetry_config(
                     "worker_role": process.endpoint_mode,
                 }
 
-        endpoints.append(
-            TelemetryEndpoint(
-                name=f"dcgm_{node}",
-                url=f"http://{node}:{dcgm_exporter.port}/metrics",
-                frequency=telemetry.default_frequency,
-                filter="dcgm",
-                node_metadata=node_metadata,
-                gpu_metadata=gpu_metadata,
+        if dcgm_exporter is not None:
+            endpoints.append(
+                TelemetryEndpoint(
+                    name=f"dcgm_{node}",
+                    url=f"http://{node}:{dcgm_exporter.port}/metrics",
+                    frequency=telemetry.default_frequency,
+                    filter="dcgm",
+                    node_metadata=node_metadata,
+                    gpu_metadata=gpu_metadata,
+                )
             )
-        )
-        endpoints.append(
-            TelemetryEndpoint(
-                name=f"node_exporter_{node}",
-                url=f"http://{node}:{node_exporter.port}/metrics",
-                frequency=telemetry.default_frequency,
-                filter="node_exporter",
-                node_metadata=node_metadata,
+        if node_exporter is not None:
+            endpoints.append(
+                TelemetryEndpoint(
+                    name=f"node_exporter_{node}",
+                    url=f"http://{node}:{node_exporter.port}/metrics",
+                    frequency=telemetry.default_frequency,
+                    filter="node_exporter",
+                    node_metadata=node_metadata,
+                )
             )
-        )
 
     for process in sorted(processes, key=lambda p: (p.endpoint_mode, p.endpoint_index, p.node_rank, p.node)):
         if frontend_type == "vllm" and process.endpoint_mode == "agg" and not process.is_leader:

--- a/src/srtctl/core/validation.py
+++ b/src/srtctl/core/validation.py
@@ -291,7 +291,7 @@ def _preflight_telemetry(
         return []
 
     aliases = (cluster_config or {}).get("containers") or {}
-    raw_telemetry = raw_config.get("telemetry") or {}
+    raw_telemetry = resolve_config_with_defaults(raw_config, None).get("telemetry") or {}
     issues: list[PreflightIssue] = []
 
     # NOTE: dcgm-power launches only the exporter, so the other images are never referenced.
@@ -306,7 +306,7 @@ def _preflight_telemetry(
             resolved_value = (resolved_value or {}).get(key) if isinstance(resolved_value, dict) else None
             raw_value = (raw_value or {}).get(key) if isinstance(raw_value, dict) else None
         if not resolved_value:
-            continue  # schema-level validator handles required-when-enabled
+            continue
         # NOTE: a registry URI is pulled at srun time, so there is no local file to stat.
         if _is_registry_uri(str(resolved_value)):
             continue

--- a/src/srtctl/core/validation.py
+++ b/src/srtctl/core/validation.py
@@ -24,7 +24,6 @@ from srtctl.core.config import (
     generate_override_configs,
     resolve_config_with_defaults,
 )
-from srtctl.core.schema import TelemetryProvider
 
 if TYPE_CHECKING:
     from srtctl.core.schema import SrtConfig
@@ -275,9 +274,12 @@ def _preflight_container(
     )
 
 
-_TELEMETRY_IMAGE_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+_TACHOMETER_IMAGE_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("observability.tachometer.dcgm_exporter.container_image", ("dcgm_exporter", "container_image")),
+    ("observability.tachometer.node_exporter.container_image", ("node_exporter", "container_image")),
+)
+_POWER_IMAGE_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("telemetry.dcgm_exporter.container_image", ("dcgm_exporter", "container_image")),
-    ("telemetry.node_exporter.container_image", ("node_exporter", "container_image")),
 )
 
 
@@ -286,46 +288,56 @@ def _preflight_telemetry(
     resolved_config: dict[str, Any],
     cluster_config: dict[str, Any] | None,
 ) -> list[PreflightIssue]:
-    telemetry = resolved_config.get("telemetry") or {}
-    if not telemetry.get("enabled"):
-        return []
-
     aliases = (cluster_config or {}).get("containers") or {}
-    raw_telemetry = resolve_config_with_defaults(raw_config, None).get("telemetry") or {}
     issues: list[PreflightIssue] = []
 
-    # NOTE: dcgm-power launches only the exporter, so the other images are never referenced.
-    fields = _TELEMETRY_IMAGE_FIELDS
-    if telemetry.get("provider") == TelemetryProvider.DCGM_POWER.value:
-        fields = tuple(field for field in fields if field[1][0] == "dcgm_exporter")
+    raw_observability = raw_config.get("observability") or {}
+    resolved_observability = resolved_config.get("observability") or {}
+    sources = (
+        (
+            "Tachometer",
+            raw_observability.get("tachometer") if isinstance(raw_observability, dict) else None,
+            resolved_observability.get("tachometer") if isinstance(resolved_observability, dict) else None,
+            _TACHOMETER_IMAGE_FIELDS,
+            "tachometer-container-not-available",
+        ),
+        (
+            "Telemetry",
+            raw_config.get("telemetry"),
+            resolved_config.get("telemetry"),
+            _POWER_IMAGE_FIELDS,
+            "telemetry-container-not-available",
+        ),
+    )
 
-    for field, path in fields:
-        resolved_value: Any = telemetry
-        raw_value: Any = raw_telemetry
-        for key in path:
-            resolved_value = (resolved_value or {}).get(key) if isinstance(resolved_value, dict) else None
-            raw_value = (raw_value or {}).get(key) if isinstance(raw_value, dict) else None
-        if not resolved_value:
+    for label, raw_block, resolved_block, fields, code in sources:
+        if not isinstance(resolved_block, dict) or not resolved_block.get("enabled"):
             continue
-        # NOTE: a registry URI is pulled at srun time, so there is no local file to stat.
-        if _is_registry_uri(str(resolved_value)):
-            continue
+        raw_block = raw_block if isinstance(raw_block, dict) else {}
+        for field, path in fields:
+            resolved_value: Any = resolved_block
+            raw_value: Any = raw_block
+            for key in path:
+                resolved_value = (resolved_value or {}).get(key) if isinstance(resolved_value, dict) else None
+                raw_value = (raw_value or {}).get(key) if isinstance(raw_value, dict) else None
+            if not resolved_value or _is_registry_uri(str(resolved_value)):
+                continue
 
-        ok, _ = _check_path(_expand_path(resolved_value), expect="file")
-        if ok:
-            continue
+            ok, _ = _check_path(_expand_path(resolved_value), expect="file")
+            if ok:
+                continue
 
-        if raw_value in aliases:
-            message = (
-                f"Telemetry alias '{raw_value}' resolved to '{resolved_value}', but that file is unavailable. "
-                "Provide or register the container yourself before submitting."
-            )
-        else:
-            message = (
-                f"Telemetry container '{resolved_value}' is not a local container path and is not defined "
-                "in srtslurm.yaml containers. Provide or register the container yourself before submitting."
-            )
-        issues.append(PreflightIssue(code="telemetry-container-not-available", field=field, message=message))
+            if raw_value in aliases:
+                message = (
+                    f"{label} alias '{raw_value}' resolved to '{resolved_value}', but that file is unavailable. "
+                    "Provide or register the container yourself before submitting."
+                )
+            else:
+                message = (
+                    f"{label} container '{resolved_value}' is not a local container path and is not defined "
+                    "in srtslurm.yaml containers. Provide or register the container yourself before submitting."
+                )
+            issues.append(PreflightIssue(code=code, field=field, message=message))
 
     return issues
 

--- a/src/srtctl/render/lifecycle.py
+++ b/src/srtctl/render/lifecycle.py
@@ -16,7 +16,7 @@ from typing import Any
 from jinja2 import Environment, FileSystemLoader
 
 from srtctl.backends.sglang import SGLangProtocol
-from srtctl.core.schema import SrtConfig, TelemetryProvider
+from srtctl.core.schema import SrtConfig
 from srtctl.core.topology import Process
 from srtctl.ports import (
     DYN_SYSTEM_PORT_BASE,
@@ -62,7 +62,7 @@ class LocalLifecycleRenderContext:
     global_environment: tuple[tuple[str, str], ...]
     benchmark_environment: tuple[tuple[str, str], ...]
     benchmark_command: str
-    telemetry_enabled: bool
+    tachometer_enabled: bool
     tachometer_binary: str | None
     tachometer_config: str | None
 
@@ -153,8 +153,8 @@ def _validate_local_config(config: SrtConfig) -> None:
         raise ValueError("--bash requires frontend.enable_multiple_frontends: false")
     if config.benchmark.type != "custom" or not config.benchmark.command:
         raise ValueError("--bash requires benchmark.type: custom with benchmark.command")
-    if config.telemetry.enabled and config.telemetry.provider != TelemetryProvider.SCRAPER:
-        raise ValueError("--bash currently supports telemetry.provider: scraper only")
+    if config.telemetry.enabled:
+        raise ValueError("--bash does not support DCGM power telemetry")
 
 
 def _direct_port(config: SrtConfig, name: str, default: int) -> int:
@@ -309,8 +309,8 @@ def _build_router_command(config: SrtConfig, processes: list[Process], *, etcd_c
 
 
 def _build_tachometer_config(config: SrtConfig, processes: list[Process]) -> str | None:
-    telemetry = config.telemetry
-    if not telemetry.enabled:
+    tachometer = config.observability.tachometer
+    if not tachometer.enabled:
         return None
 
     def append_endpoint(name: str, url: str, metric_filter: str, metadata: dict[str, str]) -> None:
@@ -319,7 +319,7 @@ def _build_tachometer_config(config: SrtConfig, processes: list[Process]) -> str
                 "[[endpoints]]",
                 f"name = {json.dumps(name)}",
                 f"url = {json.dumps(url)}",
-                f"frequency = {telemetry.default_frequency}",
+                f"frequency = {tachometer.default_frequency}",
                 f"filter = {json.dumps(metric_filter)}",
                 "[endpoints.node_metadata]",
                 *(f"{json.dumps(key)} = {json.dumps(value)}" for key, value in sorted(metadata.items())),
@@ -364,7 +364,7 @@ def build_local_lifecycle_render_context(
     etcd_peer_port = _direct_port(config, "SRTCTL_ETCD_PEER_PORT", etcd_client_port + 1)
     nats_port = _direct_port(config, "SRTCTL_NATS_PORT", NATS_PORT)
     processes, workers = _build_local_processes(config, etcd_client_port=etcd_client_port, nats_port=nats_port)
-    telemetry_config = _build_tachometer_config(config, processes)
+    tachometer_config = _build_tachometer_config(config, processes)
     resources = config.resources
     expected_prefill = resources.num_prefill
     expected_decode = resources.num_agg if resources.num_agg else resources.num_decode
@@ -389,9 +389,9 @@ def build_local_lifecycle_render_context(
         global_environment=tuple(sorted((key, str(value)) for key, value in config.environment.items())),
         benchmark_environment=tuple(sorted((key, str(value)) for key, value in config.benchmark.env.items())),
         benchmark_command=config.benchmark.command,
-        telemetry_enabled=telemetry_config is not None,
-        tachometer_binary=config.telemetry.binary_path if telemetry_config is not None else None,
-        tachometer_config=telemetry_config,
+        tachometer_enabled=tachometer_config is not None,
+        tachometer_binary=config.observability.tachometer.binary_path if tachometer_config is not None else None,
+        tachometer_config=tachometer_config,
     )
 
 

--- a/src/srtctl/templates/local_lifecycle.sh.j2
+++ b/src/srtctl/templates/local_lifecycle.sh.j2
@@ -104,7 +104,7 @@ srt_stop_tachometer() {
 }
 
 srt_compact_tachometer() {
-{% if context.telemetry_enabled %}
+{% if context.tachometer_enabled %}
     if [[ -n "${TACHOMETER_LOCAL_DIR}" ]] && find "${TACHOMETER_LOCAL_DIR}" -maxdepth 1 -type f \( -name '*.parquet' -o -name 'current.arrow' \) -print -quit | grep -q .; then
         "${SRTCTL_TACHOMETER}" compact "${TACHOMETER_LOCAL_DIR}" --output "${ARTIFACT_DIR}/tachometer/final" >>"${LOG_DIR}/tachometer.log" 2>&1
     fi
@@ -260,7 +260,7 @@ srt_launch_shell "router" "${LOG_DIR}/router.log" {{ quote(context.router_comman
 srt_wait_router_ready >"${LOG_DIR}/readiness.log" 2>&1
 srt_smoke_chat
 
-{% if context.telemetry_enabled %}
+{% if context.tachometer_enabled %}
 SRTCTL_TACHOMETER_DEFAULT={{ quote(context.tachometer_binary or '') }}
 SRTCTL_TACHOMETER="${SRTCTL_TACHOMETER:-${SRTCTL_TACHOMETER_DEFAULT}}"
 # Tachometer owns its final storage directory and rejects a pre-existing leaf.

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -840,6 +840,40 @@ class TestFrontendConfig:
         assert resolved["telemetry"]["dcgm_exporter"]["container_image"] == "/path/to/dcgm.sqsh"
         assert resolved["telemetry"]["node_exporter"]["container_image"] == "/path/to/node.sqsh"
 
+    def test_observability_tachometer_aliases_resolve(self):
+        from srtctl.core.config import resolve_config_with_defaults
+
+        user_config = {
+            "name": "test",
+            "model": {"path": "/model", "container": "sglang", "precision": "fp8"},
+            "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
+            "observability": {
+                "enabled": True,
+                "tachometer": {
+                    "enabled": True,
+                    "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},
+                    "node_exporter": {"container_image": "node-exporter", "port": 9101},
+                },
+            },
+        }
+        cluster_config = {
+            "containers": {
+                "sglang": "/path/to/sglang.sqsh",
+                "dcgm-exporter": "/path/to/dcgm.sqsh",
+                "node-exporter": "/path/to/node.sqsh",
+            }
+        }
+
+        resolved = resolve_config_with_defaults(user_config, cluster_config)
+
+        assert resolved["observability"] == {"enabled": True}
+        assert resolved["telemetry"] == {
+            "enabled": True,
+            "provider": "scraper",
+            "dcgm_exporter": {"container_image": "/path/to/dcgm.sqsh", "port": 9401},
+            "node_exporter": {"container_image": "/path/to/node.sqsh", "port": 9101},
+        }
+
     def test_telemetry_literal_paths_pass_through(self):
         from srtctl.core.config import resolve_config_with_defaults
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -811,7 +811,7 @@ class TestFrontendConfig:
 
         assert "sbatch_directives" not in resolved
 
-    def test_telemetry_container_aliases_resolve(self):
+    def test_power_telemetry_container_alias_resolves(self):
         from srtctl.core.config import resolve_config_with_defaults
 
         user_config = {
@@ -820,25 +820,19 @@ class TestFrontendConfig:
             "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
             "telemetry": {
                 "enabled": True,
-                "container_image": "telemetry-scraper",
                 "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},
-                "node_exporter": {"container_image": "node-exporter", "port": 9101},
             },
         }
         cluster_config = {
             "containers": {
                 "sglang": "/path/to/sglang.sqsh",
-                "telemetry-scraper": "/path/to/scraper.sqsh",
                 "dcgm-exporter": "/path/to/dcgm.sqsh",
-                "node-exporter": "/path/to/node.sqsh",
             }
         }
 
         resolved = resolve_config_with_defaults(user_config, cluster_config)
 
-        assert resolved["telemetry"]["container_image"] == "/path/to/scraper.sqsh"
         assert resolved["telemetry"]["dcgm_exporter"]["container_image"] == "/path/to/dcgm.sqsh"
-        assert resolved["telemetry"]["node_exporter"]["container_image"] == "/path/to/node.sqsh"
 
     def test_observability_tachometer_aliases_resolve(self):
         from srtctl.core.config import resolve_config_with_defaults
@@ -866,35 +860,38 @@ class TestFrontendConfig:
 
         resolved = resolve_config_with_defaults(user_config, cluster_config)
 
-        assert resolved["observability"] == {"enabled": True}
-        assert resolved["telemetry"] == {
+        assert resolved["observability"] == {
             "enabled": True,
-            "provider": "scraper",
-            "dcgm_exporter": {"container_image": "/path/to/dcgm.sqsh", "port": 9401},
-            "node_exporter": {"container_image": "/path/to/node.sqsh", "port": 9101},
+            "tachometer": {
+                "enabled": True,
+                "dcgm_exporter": {"container_image": "/path/to/dcgm.sqsh", "port": 9401},
+                "node_exporter": {"container_image": "/path/to/node.sqsh", "port": 9101},
+            },
         }
 
-    def test_telemetry_literal_paths_pass_through(self):
+    def test_tachometer_literal_paths_pass_through(self):
         from srtctl.core.config import resolve_config_with_defaults
 
         user_config = {
             "name": "test",
             "model": {"path": "/model", "container": "/container.sqsh", "precision": "fp8"},
             "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
-            "telemetry": {
+            "observability": {
                 "enabled": True,
-                "container_image": "/abs/scraper.sqsh",
-                "dcgm_exporter": {"container_image": "/abs/dcgm.sqsh", "port": 9401},
-                "node_exporter": {"container_image": "/abs/node.sqsh", "port": 9101},
+                "tachometer": {
+                    "enabled": True,
+                    "dcgm_exporter": {"container_image": "/abs/dcgm.sqsh", "port": 9401},
+                    "node_exporter": {"container_image": "/abs/node.sqsh", "port": 9101},
+                },
             },
         }
         cluster_config = {"containers": {"dcgm-exporter": "/aliased/dcgm.sqsh"}}
 
         resolved = resolve_config_with_defaults(user_config, cluster_config)
 
-        assert resolved["telemetry"]["container_image"] == "/abs/scraper.sqsh"
-        assert resolved["telemetry"]["dcgm_exporter"]["container_image"] == "/abs/dcgm.sqsh"
-        assert resolved["telemetry"]["node_exporter"]["container_image"] == "/abs/node.sqsh"
+        tachometer = resolved["observability"]["tachometer"]
+        assert tachometer["dcgm_exporter"]["container_image"] == "/abs/dcgm.sqsh"
+        assert tachometer["node_exporter"]["container_image"] == "/abs/node.sqsh"
 
 
 class TestSetupScript:

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -247,20 +247,20 @@ class TestDryRunExecutionExtensions:
         assert "container_image" in output
         assert "nvcr.io/nvidia/python:3.11" in output
 
-    def test_telemetry_details_shown(self, capsys):
+    def test_observability_tachometer_details_shown(self, capsys):
         config = _make_config(
             {
-                "telemetry": {
+                "observability": {
                     "enabled": True,
-                    "container_image": "telemetry:latest",
-                    "dcgm_exporter": {"container_image": "dcgm:latest", "port": 9401},
-                    "node_exporter": {"container_image": "node:latest", "port": 9101},
+                    "tachometer": {"enabled": True},
                 }
             }
         )
         show_config_details(config)
         output = capsys.readouterr().out
-        assert "telemetry" in output
+        assert "observability" in output
+        assert "raw_metrics" in output
+        assert "metrics_provider" in output
         assert "scraper" in output
         assert "binary_path" in output
         assert "tachometer-scraper" in output

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -260,8 +260,7 @@ class TestDryRunExecutionExtensions:
         output = capsys.readouterr().out
         assert "observability" in output
         assert "raw_metrics" in output
-        assert "metrics_provider" in output
-        assert "scraper" in output
+        assert "tachometer" in output
         assert "binary_path" in output
         assert "tachometer-scraper" in output
         assert "storage_subdir" in output
@@ -272,7 +271,6 @@ class TestDryRunExecutionExtensions:
                 "benchmark": {"type": "sa-bench", "isl": 8192, "osl": 1024, "concurrencies": [4]},
                 "telemetry": {
                     "enabled": True,
-                    "provider": "dcgm-power",
                     "default_frequency": 1.0,
                     "storage_subdir": "power",
                     "required": True,

--- a/tests/test_lifecycle_render.py
+++ b/tests/test_lifecycle_render.py
@@ -7,6 +7,7 @@ import subprocess
 
 import yaml
 
+from srtctl.core.config import expand_observability
 from srtctl.core.schema import SrtConfig
 from srtctl.render.lifecycle import build_local_lifecycle_render_context, render_local_lifecycle
 
@@ -49,13 +50,12 @@ def _config(
         },
         "environment": environment or {},
         "benchmark": {"type": "custom", "command": "aiperf profile --ui none"},
-        "telemetry": {
+        "observability": {
             "enabled": True,
-            "binary_path": "tachometer-scraper",
-            "dcgm_exporter": {"container_image": "unused", "port": 9401},
-            "node_exporter": {"container_image": "unused", "port": 9101},
+            "tachometer": {"enabled": True},
         },
     }
+    expand_observability(raw)
     return SrtConfig.Schema().load(yaml.safe_load(yaml.safe_dump(raw)))
 
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -3,6 +3,9 @@
 
 """Tests for the `observability.enabled` knob and its config expansion."""
 
+import pytest
+import yaml
+
 from srtctl.core.config import expand_observability
 from srtctl.core.schema import SrtConfig
 
@@ -77,6 +80,7 @@ class TestExpandObservability:
 
     def test_enabled_turns_on_metrics_surface_and_iteration_stats(self):
         cfg = expand_observability(_trtllm_config(enabled=True))
+        assert "telemetry" not in cfg
         assert cfg["backend"]["publish_events_and_metrics"] is True
         for mode in ("prefill", "decode"):
             section = cfg["backend"]["trtllm_config"][mode]
@@ -113,6 +117,47 @@ class TestExpandObservability:
         assert out["backend"]["prefill_environment"]["DYN_LOGGING_JSONL"] == "true"
         assert out["frontend"]["env"]["DYN_LOGGING_JSONL"] == "true"
 
+    def test_nested_tachometer_settings_normalize_to_runtime_config(self):
+        cfg = _trtllm_config(
+            enabled=True,
+            tachometer={
+                "enabled": True,
+                "default_frequency": 2.0,
+                "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
+            },
+        )
+
+        out = expand_observability(cfg)
+
+        assert "tachometer" not in out["observability"]
+        assert out["telemetry"] == {
+            "enabled": True,
+            "provider": "scraper",
+            "default_frequency": 2.0,
+            "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
+        }
+
+    def test_explicit_legacy_telemetry_disable_wins(self):
+        cfg = _trtllm_config(enabled=True)
+        cfg["telemetry"] = {"enabled": False}
+
+        out = expand_observability(cfg)
+
+        assert out["telemetry"] == {"enabled": False}
+
+    def test_nested_and_legacy_telemetry_are_rejected_together(self):
+        cfg = _trtllm_config(enabled=True, tachometer={"default_frequency": 2.0})
+        cfg["telemetry"] = {"enabled": True}
+
+        with pytest.raises(ValueError, match="not both"):
+            expand_observability(cfg)
+
+    def test_tachometer_requires_master_observability_knob(self):
+        cfg = _trtllm_config(enabled=False, tachometer={"enabled": True})
+
+        with pytest.raises(ValueError, match="requires observability.enabled"):
+            expand_observability(cfg)
+
 
 class TestObservabilitySchema:
     def test_defaults_are_off(self):
@@ -129,3 +174,23 @@ class TestObservabilitySchema:
         """
         cfg = SrtConfig.Schema().load({**BASE_CONFIG, "observability": {"enabled": True}})
         assert not [f for f in vars(cfg.observability) if f.startswith("aiperf")]
+
+    def test_from_yaml_normalizes_nested_tachometer(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    **BASE_CONFIG,
+                    "observability": {
+                        "enabled": True,
+                        "tachometer": {"enabled": True, "default_frequency": 2.0},
+                    },
+                }
+            )
+        )
+
+        cfg = SrtConfig.from_yaml(config_path)
+
+        assert cfg.observability.scraper_enabled is True
+        assert cfg.telemetry.enabled is True
+        assert cfg.telemetry.default_frequency == 2.0

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -5,6 +5,7 @@
 
 import pytest
 import yaml
+from marshmallow import ValidationError
 
 from srtctl.core.config import expand_observability
 from srtctl.core.schema import SrtConfig
@@ -117,7 +118,7 @@ class TestExpandObservability:
         assert out["backend"]["prefill_environment"]["DYN_LOGGING_JSONL"] == "true"
         assert out["frontend"]["env"]["DYN_LOGGING_JSONL"] == "true"
 
-    def test_nested_tachometer_settings_normalize_to_runtime_config(self):
+    def test_nested_tachometer_settings_stay_under_observability(self):
         cfg = _trtllm_config(
             enabled=True,
             tachometer={
@@ -129,34 +130,97 @@ class TestExpandObservability:
 
         out = expand_observability(cfg)
 
-        assert "tachometer" not in out["observability"]
-        assert out["telemetry"] == {
+        assert out["observability"]["tachometer"] == {
             "enabled": True,
-            "provider": "scraper",
             "default_frequency": 2.0,
             "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
         }
+        assert "telemetry" not in out
 
-    def test_explicit_legacy_telemetry_disable_wins(self):
-        cfg = _trtllm_config(enabled=True)
-        cfg["telemetry"] = {"enabled": False}
+    def test_tachometer_and_power_telemetry_can_be_enabled_together(self):
+        cfg = _trtllm_config(enabled=True, tachometer={"enabled": True})
+        cfg["telemetry"] = {
+            "enabled": True,
+            "default_frequency": 1.0,
+            "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
+        }
 
         out = expand_observability(cfg)
 
-        assert out["telemetry"] == {"enabled": False}
+        assert out["observability"]["tachometer"]["enabled"] is True
+        assert out["telemetry"]["enabled"] is True
 
-    def test_nested_and_legacy_telemetry_are_rejected_together(self):
-        cfg = _trtllm_config(enabled=True, tachometer={"default_frequency": 2.0})
-        cfg["telemetry"] = {"enabled": True}
+    def test_tachometer_reuses_the_power_dcgm_exporter(self):
+        cfg = {
+            **BASE_CONFIG,
+            "benchmark": {"type": "sa-bench", "concurrencies": [4]},
+            "observability": {"enabled": True, "tachometer": {"enabled": True}},
+            "telemetry": {
+                "enabled": True,
+                "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
+            },
+        }
 
-        with pytest.raises(ValueError, match="not both"):
-            expand_observability(cfg)
+        loaded = SrtConfig.Schema().load(cfg)
+
+        assert loaded.observability.tachometer.enabled is True
+        assert loaded.telemetry.dcgm_exporter.container_image == "dcgm"
+
+    def test_tachometer_rejects_a_duplicate_power_dcgm_exporter(self):
+        cfg = {
+            **BASE_CONFIG,
+            "benchmark": {"type": "sa-bench", "concurrencies": [4]},
+            "observability": {
+                "enabled": True,
+                "tachometer": {
+                    "enabled": True,
+                    "dcgm_exporter": {"container_image": "tach-dcgm", "port": 9401},
+                },
+            },
+            "telemetry": {
+                "enabled": True,
+                "dcgm_exporter": {"container_image": "power-dcgm", "port": 9401},
+            },
+        }
+
+        with pytest.raises(ValidationError, match="shared DCGM exporter"):
+            SrtConfig.Schema().load(cfg)
+
+    def test_tachometer_rejects_the_power_artifact_directory(self):
+        cfg = {
+            **BASE_CONFIG,
+            "benchmark": {"type": "sa-bench", "concurrencies": [4]},
+            "observability": {
+                "enabled": True,
+                "tachometer": {"enabled": True, "storage_subdir": "power"},
+            },
+            "telemetry": {
+                "enabled": True,
+                "storage_subdir": "power",
+                "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
+            },
+        }
+
+        with pytest.raises(ValidationError, match="storage_subdir"):
+            SrtConfig.Schema().load(cfg)
 
     def test_tachometer_requires_master_observability_knob(self):
         cfg = _trtllm_config(enabled=False, tachometer={"enabled": True})
 
-        with pytest.raises(ValueError, match="requires observability.enabled"):
-            expand_observability(cfg)
+        with pytest.raises(ValidationError, match="requires observability.enabled"):
+            SrtConfig.Schema().load(cfg)
+
+    def test_telemetry_rejects_tachometer_fields(self):
+        cfg = {
+            **BASE_CONFIG,
+            "telemetry": {
+                "enabled": True,
+                "binary_path": "tachometer-scraper",
+            },
+        }
+
+        with pytest.raises(ValidationError, match="binary_path"):
+            SrtConfig.Schema().load(cfg)
 
 
 class TestObservabilitySchema:
@@ -175,7 +239,7 @@ class TestObservabilitySchema:
         cfg = SrtConfig.Schema().load({**BASE_CONFIG, "observability": {"enabled": True}})
         assert not [f for f in vars(cfg.observability) if f.startswith("aiperf")]
 
-    def test_from_yaml_normalizes_nested_tachometer(self, tmp_path):
+    def test_from_yaml_loads_nested_tachometer(self, tmp_path):
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             yaml.safe_dump(
@@ -192,5 +256,5 @@ class TestObservabilitySchema:
         cfg = SrtConfig.from_yaml(config_path)
 
         assert cfg.observability.scraper_enabled is True
-        assert cfg.telemetry.enabled is True
-        assert cfg.telemetry.default_frequency == 2.0
+        assert cfg.observability.tachometer.enabled is True
+        assert cfg.observability.tachometer.default_frequency == 2.0

--- a/tests/test_power_collector.py
+++ b/tests/test_power_collector.py
@@ -22,7 +22,7 @@ from srtctl.core.power.samples import read_samples
 from srtctl.core.power.session import PowerEndpoint, PowerSessionSettings, PowerTelemetrySession, _run_daemon_workers
 from srtctl.core.power.topology import build_expected_devices
 from srtctl.core.processes import ManagedProcess, ProcessRegistry
-from srtctl.core.schema import TelemetryExporterConfig, TelemetryProvider
+from srtctl.core.schema import TelemetryExporterConfig
 from srtctl.core.topology import Process
 
 GPUS_PER_NODE = 4
@@ -644,7 +644,6 @@ class TestSessionOwnership:
             def __init__(self):
                 self.config = MagicMock()
                 self.config.telemetry.enabled = True
-                self.config.telemetry.provider = TelemetryProvider.DCGM_POWER
                 self.config.telemetry.storage_subdir = "power"
                 self.config.telemetry.default_frequency = 0.05
                 self.config.telemetry.startup_timeout_seconds = 0.2
@@ -716,7 +715,6 @@ class TestRequiredReadinessGate:
     def _orchestrator(self, tmp_path, *, required, ready):
         config = MagicMock()
         config.telemetry.enabled = True
-        config.telemetry.provider = TelemetryProvider.DCGM_POWER
         config.telemetry.required = required
         config.frontend.type = "dynamo"
         config.profiling.enabled = False
@@ -748,6 +746,7 @@ class TestRequiredReadinessGate:
         orchestrator = self._orchestrator(tmp_path, required=True, ready=False)
 
         with (
+            patch.object(SweepOrchestrator, "start_tachometer", return_value=[]) as start_tachometer,
             patch.object(SweepOrchestrator, "start_power_telemetry") as start_power,
             patch.object(SweepOrchestrator, "run_benchmark") as run_benchmark,
             patch.object(SweepOrchestrator, "start_all_workers", return_value={}),
@@ -769,6 +768,7 @@ class TestRequiredReadinessGate:
             exit_code = orchestrator.run()
 
         run_benchmark.assert_not_called()
+        start_tachometer.assert_called_once()
         assert exit_code == 1
 
     def test_eval_only_run_never_starts_power_telemetry(self, tmp_path):
@@ -777,6 +777,7 @@ class TestRequiredReadinessGate:
         orchestrator._power_session = None
 
         with (
+            patch.object(SweepOrchestrator, "start_tachometer", return_value=[]) as start_tachometer,
             patch.object(SweepOrchestrator, "start_power_telemetry") as start_power,
             patch.object(SweepOrchestrator, "run_benchmark") as run_benchmark,
             patch.object(SweepOrchestrator, "_run_post_eval", return_value=0),
@@ -798,6 +799,7 @@ class TestRequiredReadinessGate:
             exit_code = orchestrator.run()
 
         start_power.assert_not_called()
+        start_tachometer.assert_called_once()
         run_benchmark.assert_not_called()
         assert exit_code == 0
 

--- a/tests/test_sa_bench_measurement_window.py
+++ b/tests/test_sa_bench_measurement_window.py
@@ -49,17 +49,12 @@ from srtctl.core.schema import (
 SA_BENCH_DIR = Path(__file__).resolve().parents[1] / "src/srtctl/benchmarks/scripts/sa-bench"
 
 
-def _benchmark_harness(tmp_path, *, provider="dcgm-power", enabled=True):
+def _benchmark_harness(tmp_path, *, enabled=True):
     telemetry = TelemetryConfig(
         enabled=enabled,
-        provider=provider,
         default_frequency=1.0,
         storage_subdir="power",
-        container_image="scraper" if provider == "scraper" else None,
         dcgm_exporter=TelemetryExporterConfig(container_image="dcgm-exporter", port=9401),
-        node_exporter=TelemetryExporterConfig(container_image="node-exporter", port=9101)
-        if provider == "scraper"
-        else None,
     )
     harness = BenchmarkStageMixin()
     harness.config = SrtConfig(
@@ -565,19 +560,18 @@ class TestArtifactErrors:
         assert Reason.MEASUREMENT_WINDOW_RESULT_PATH_INVALID in errors[0].reason_codes
 
     def test_benchmark_stage_injects_the_container_windows_dir(self, tmp_path):
-        harness = _benchmark_harness(tmp_path, provider="dcgm-power")
+        harness = _benchmark_harness(tmp_path)
 
         env = harness._get_measurement_window_env()
 
         assert env == {"SRT_MEASUREMENT_WINDOW_DIR": f"/logs/power/{WINDOWS_DIRNAME}"}
 
     def test_other_providers_get_no_window_dir(self, tmp_path):
-        assert _benchmark_harness(tmp_path, provider="scraper")._get_measurement_window_env() == {}
         assert _benchmark_harness(tmp_path, enabled=False)._get_measurement_window_env() == {}
 
     def test_sa_bench_env_keeps_window_after_logical_endpoint_refactor(self, tmp_path):
         """One benchmark env must carry logical endpoints, slow_down, and the window dir together."""
-        harness = _benchmark_harness(tmp_path, provider="dcgm-power")
+        harness = _benchmark_harness(tmp_path)
         harness.config = SrtConfig(
             name="test",
             model=ModelConfig(path="/model", container="/image", precision="fp8"),

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -72,6 +72,12 @@ class TestTelemetryConfig:
         assert config.telemetry.container_image is None
         assert config.telemetry.binary_path == "tachometer-scraper"
 
+    def test_scraper_exporters_are_optional(self):
+        config = _make_config(telemetry=TelemetryConfig(enabled=True))
+
+        assert config.telemetry.dcgm_exporter is None
+        assert config.telemetry.node_exporter is None
+
     def test_scraper_requires_nonempty_binary_path(self):
         with pytest.raises(ValidationError, match="telemetry.binary_path"):
             _make_config(
@@ -124,15 +130,16 @@ class TestDcgmPowerConfig:
                 benchmark=_sa_bench(),
             )
 
-    def test_scraper_validation_is_unchanged(self):
-        with pytest.raises(ValidationError, match="telemetry.node_exporter"):
-            _make_config(
-                telemetry=TelemetryConfig(
-                    enabled=True,
-                    container_image="scraper:latest",
-                    dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
-                )
-            )
+    @pytest.mark.parametrize(
+        ("field_name", "exporter", "match"),
+        [
+            ("dcgm_exporter", TelemetryExporterConfig(container_image="", port=9401), "container_image"),
+            ("node_exporter", TelemetryExporterConfig(container_image="node", port=0), "port"),
+        ],
+    )
+    def test_configured_scraper_exporters_are_validated(self, field_name, exporter, match):
+        with pytest.raises(ValidationError, match=match):
+            _make_config(telemetry=TelemetryConfig(enabled=True, **{field_name: exporter}))
 
     @pytest.mark.parametrize(
         ("telemetry_overrides", "benchmark", "match"),
@@ -334,6 +341,41 @@ class TestTelemetryConfigGeneration:
         assert '"cluster" = "pdx"' in config_text
         assert 'name = "frontend0"' in config_text
 
+    @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
+    def test_generate_config_without_exporters_targets_servers_only(self, _mock_get_hostname_ip):
+        telemetry = TelemetryConfig(enabled=True)
+        runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
+        runtime.log_dir = Path("/runs/12345/logs")
+        processes = [
+            Process(
+                node="node-a",
+                gpu_indices=frozenset({0}),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="agg",
+                endpoint_index=0,
+                node_rank=0,
+            )
+        ]
+        topology = FrontendTopology(
+            nginx_node=None,
+            frontend_nodes=["node-a"],
+            frontend_port=8000,
+            public_port=8000,
+        )
+
+        config_text = generate_telemetry_config(
+            processes=processes,
+            frontend_topology=topology,
+            runtime=runtime,
+            telemetry=telemetry,
+        )
+
+        assert 'name = "backend_agg0_rank0"' in config_text
+        assert 'name = "frontend0"' in config_text
+        assert "dcgm_" not in config_text
+        assert "node_exporter_" not in config_text
+
     @patch("srtctl.core.telemetry.get_hostname_ip")
     def test_vllm_frontend_targets_only_agg_leader_metrics(self, mock_get_hostname_ip):
         mock_get_hostname_ip.side_effect = lambda host, interface=None: {
@@ -463,6 +505,47 @@ class TestTelemetryStageMixin:
         ]
         assert "container_image" not in scraper_call.kwargs
         assert "container_mounts" not in scraper_call.kwargs
+
+    @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
+    def test_start_telemetry_without_exporters_starts_only_scraper(self, mock_srun, tmp_path):
+        class Harness(TelemetryStageMixin):
+            def __init__(self):
+                self.config = _make_config(telemetry=TelemetryConfig(enabled=True))
+                self.runtime = MagicMock()
+                self.runtime.log_dir = tmp_path
+                self.runtime.nodes.head = "node-a"
+                self.runtime.nodes.het = False
+                self.runtime.srun_options = {}
+                self._backend_processes = [
+                    Process(
+                        node="node-a",
+                        gpu_indices=frozenset({0}),
+                        sys_port=8081,
+                        http_port=30000,
+                        endpoint_mode="agg",
+                        endpoint_index=0,
+                        node_rank=0,
+                    )
+                ]
+
+            @property
+            def backend_processes(self):
+                return self._backend_processes
+
+            def _compute_frontend_topology(self):
+                return FrontendTopology(
+                    nginx_node=None,
+                    frontend_nodes=["node-a"],
+                    frontend_port=8000,
+                    public_port=8000,
+                )
+
+        mock_srun.return_value = _running_exporter()
+
+        processes = Harness().start_telemetry()
+
+        assert [process.name for process in processes] == ["telemetry"]
+        assert mock_srun.call_count == 1
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
     @patch("srtctl.cli.mixins.telemetry_stage.generate_telemetry_config", return_value='storage = "/run/telemetry"\n')

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for telemetry configuration and startup."""
+"""Tests for Tachometer and DCGM power telemetry."""
 
 import json
 from pathlib import Path
@@ -18,22 +18,30 @@ from srtctl.core.schema import (
     BenchmarkConfig,
     InfraConfig,
     ModelConfig,
+    ObservabilityConfig,
     ResourceConfig,
     SrtConfig,
+    TachometerConfig,
     TelemetryConfig,
     TelemetryExporterConfig,
-    TelemetryProvider,
 )
-from srtctl.core.telemetry import generate_telemetry_config
+from srtctl.core.telemetry import generate_tachometer_config
 from srtctl.core.topology import Process
 
 
-def _make_config(*, telemetry: TelemetryConfig | None = None, benchmark: BenchmarkConfig | None = None) -> SrtConfig:
+def _make_config(
+    *,
+    tachometer: TachometerConfig | None = None,
+    telemetry: TelemetryConfig | None = None,
+    benchmark: BenchmarkConfig | None = None,
+) -> SrtConfig:
+    tachometer = tachometer or TachometerConfig()
     return SrtConfig(
         name="test",
         model=ModelConfig(path="/model", container="/image", precision="fp4"),
         resources=ResourceConfig(gpu_type="h100"),
         benchmark=benchmark or BenchmarkConfig(type="manual"),
+        observability=ObservabilityConfig(enabled=tachometer.enabled, tachometer=tachometer),
         telemetry=telemetry or TelemetryConfig(),
     )
 
@@ -45,7 +53,6 @@ def _sa_bench(**overrides) -> BenchmarkConfig:
 def _dcgm_power(**overrides) -> TelemetryConfig:
     fields: dict = {
         "enabled": True,
-        "provider": TelemetryProvider.DCGM_POWER,
         "default_frequency": 1.0,
         "storage_subdir": "power",
         "required": True,
@@ -57,31 +64,30 @@ def _dcgm_power(**overrides) -> TelemetryConfig:
     return TelemetryConfig(**fields)
 
 
-class TestTelemetryConfig:
-    """Telemetry schema validation."""
+class TestTachometerConfig:
+    """Tachometer schema validation."""
 
     def test_scraper_does_not_require_container_image(self):
         config = _make_config(
-            telemetry=TelemetryConfig(
+            tachometer=TachometerConfig(
                 enabled=True,
                 dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
                 node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
             )
         )
 
-        assert config.telemetry.container_image is None
-        assert config.telemetry.binary_path == "tachometer-scraper"
+        assert config.observability.tachometer.binary_path == "tachometer-scraper"
 
     def test_scraper_exporters_are_optional(self):
-        config = _make_config(telemetry=TelemetryConfig(enabled=True))
+        config = _make_config(tachometer=TachometerConfig(enabled=True))
 
-        assert config.telemetry.dcgm_exporter is None
-        assert config.telemetry.node_exporter is None
+        assert config.observability.tachometer.dcgm_exporter is None
+        assert config.observability.tachometer.node_exporter is None
 
     def test_scraper_requires_nonempty_binary_path(self):
-        with pytest.raises(ValidationError, match="telemetry.binary_path"):
+        with pytest.raises(ValidationError, match="observability.tachometer.binary_path"):
             _make_config(
-                telemetry=TelemetryConfig(
+                tachometer=TachometerConfig(
                     enabled=True,
                     binary_path="",
                     dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
@@ -91,19 +97,17 @@ class TestTelemetryConfig:
 
 
 class TestDcgmPowerConfig:
-    """dcgm-power provider validation is independent of the scraper provider."""
+    """DCGM power telemetry validation is independent of Tachometer."""
 
     def test_accepts_dcgm_exporter_only(self):
         config = _make_config(telemetry=_dcgm_power(), benchmark=_sa_bench())
 
-        assert config.telemetry.provider == TelemetryProvider.DCGM_POWER
-        assert config.telemetry.container_image is None
-        assert config.telemetry.node_exporter is None
+        assert config.telemetry.dcgm_exporter is not None
 
     def test_defaults_are_stable(self):
         defaults = TelemetryConfig()
 
-        assert defaults.provider == TelemetryProvider.SCRAPER
+        assert defaults.default_frequency == 1.0
         assert defaults.required is False
         assert defaults.startup_timeout_seconds == 30.0
         assert defaults.request_timeout_seconds == 2.0
@@ -137,9 +141,9 @@ class TestDcgmPowerConfig:
             ("node_exporter", TelemetryExporterConfig(container_image="node", port=0), "port"),
         ],
     )
-    def test_configured_scraper_exporters_are_validated(self, field_name, exporter, match):
+    def test_configured_tachometer_exporters_are_validated(self, field_name, exporter, match):
         with pytest.raises(ValidationError, match=match):
-            _make_config(telemetry=TelemetryConfig(enabled=True, **{field_name: exporter}))
+            _make_config(tachometer=TachometerConfig(enabled=True, **{field_name: exporter}))
 
     @pytest.mark.parametrize(
         ("telemetry_overrides", "benchmark", "match"),
@@ -189,10 +193,10 @@ class TestDcgmPowerConfig:
                 benchmark=benchmark or _sa_bench(),
             )
 
-    def test_the_shared_default_frequency_is_rejected_for_dcgm_power(self):
+    def test_dcgm_power_rejects_a_sample_interval_above_the_contract_limit(self):
         telemetry = TelemetryConfig(
             enabled=True,
-            provider=TelemetryProvider.DCGM_POWER,
+            default_frequency=5.0,
             storage_subdir="power",
             required=True,
             startup_timeout_seconds=30.0,
@@ -200,7 +204,6 @@ class TestDcgmPowerConfig:
             collector_join_timeout_seconds=10.0,
             dcgm_exporter=TelemetryExporterConfig(container_image="dcgm-exporter", port=9401),
         )
-        assert telemetry.default_frequency == 5.0
         with pytest.raises(ValidationError, match="sample_gap_exceeded"):
             _make_config(telemetry=telemetry, benchmark=_sa_bench())
 
@@ -239,31 +242,20 @@ class TestDcgmPowerConfig:
         assert contract.is_safe_relative_subpath(value) is expected
 
     @pytest.mark.parametrize(
-        ("telemetry", "benchmark", "dedicated", "rejected"),
+        ("telemetry", "dedicated", "rejected"),
         [
-            (_dcgm_power(), _sa_bench(), True, True),
-            (_dcgm_power(), _sa_bench(), False, False),
-            (
-                TelemetryConfig(
-                    enabled=True,
-                    container_image="scraper:latest",
-                    dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
-                    node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
-                ),
-                BenchmarkConfig(type="manual"),
-                True,
-                False,
-            ),
+            (_dcgm_power(), True, True),
+            (_dcgm_power(), False, False),
         ],
-        ids=["dcgm-power-dedicated", "dcgm-power-shared", "scraper-dedicated"],
+        ids=["dcgm-power-dedicated", "dcgm-power-shared"],
     )
-    def test_a_dedicated_infra_node_is_rejected_only_for_dcgm_power(self, telemetry, benchmark, dedicated, rejected):
+    def test_a_dedicated_infra_node_is_rejected_for_dcgm_power(self, telemetry, dedicated, rejected):
         def build():
             return SrtConfig(
                 name="test",
                 model=ModelConfig(path="/model", container="/image", precision="fp4"),
                 resources=ResourceConfig(gpu_type="h100"),
-                benchmark=benchmark,
+                benchmark=_sa_bench(),
                 telemetry=telemetry,
                 infra=InfraConfig(etcd_nats_dedicated_node=dedicated),
             )
@@ -275,23 +267,18 @@ class TestDcgmPowerConfig:
 
         assert build().infra.etcd_nats_dedicated_node is dedicated
 
-    def test_unknown_provider_is_rejected(self):
-        with pytest.raises(ValidationError, match="Unsupported telemetry provider"):
-            _make_config(telemetry=TelemetryConfig(enabled=True, provider="mystery"))
 
-
-class TestTelemetryConfigGeneration:
+class TestTachometerConfigGeneration:
     """Topology-to-config generation."""
 
     @patch("srtctl.core.telemetry.get_hostname_ip")
-    def test_generate_telemetry_config(self, mock_get_hostname_ip):
+    def test_generate_tachometer_config(self, mock_get_hostname_ip):
         mock_get_hostname_ip.side_effect = lambda host, interface=None: {"node-a": "10.0.0.1", "node-b": "10.0.0.2"}[
             host
         ]
 
-        telemetry = TelemetryConfig(
+        tachometer = TachometerConfig(
             enabled=True,
-            container_image="telemetry:latest",
             extra_metadata={"cluster": "pdx"},
             dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
             node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
@@ -328,14 +315,14 @@ class TestTelemetryConfigGeneration:
             public_port=8000,
         )
 
-        config_text = generate_telemetry_config(
+        config_text = generate_tachometer_config(
             processes=processes,
             frontend_topology=topology,
             runtime=runtime,
-            telemetry=telemetry,
+            tachometer=tachometer,
         )
 
-        assert 'storage = "/runs/12345/logs/telemetry"' in config_text
+        assert 'storage = "/runs/12345/logs/tachometer"' in config_text
         assert 'name = "dcgm_node-a"' in config_text
         assert 'url = "http://10.0.0.1:8081/metrics"' in config_text
         assert '"cluster" = "pdx"' in config_text
@@ -343,7 +330,7 @@ class TestTelemetryConfigGeneration:
 
     @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
     def test_generate_config_without_exporters_targets_servers_only(self, _mock_get_hostname_ip):
-        telemetry = TelemetryConfig(enabled=True)
+        tachometer = TachometerConfig(enabled=True)
         runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
         runtime.log_dir = Path("/runs/12345/logs")
         processes = [
@@ -364,11 +351,11 @@ class TestTelemetryConfigGeneration:
             public_port=8000,
         )
 
-        config_text = generate_telemetry_config(
+        config_text = generate_tachometer_config(
             processes=processes,
             frontend_topology=topology,
             runtime=runtime,
-            telemetry=telemetry,
+            tachometer=tachometer,
         )
 
         assert 'name = "backend_agg0_rank0"' in config_text
@@ -384,9 +371,8 @@ class TestTelemetryConfigGeneration:
             "node-b": "10.0.0.2",
         }[host]
 
-        telemetry = TelemetryConfig(
+        tachometer = TachometerConfig(
             enabled=True,
-            container_image="telemetry:latest",
             dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
             node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
         )
@@ -421,11 +407,11 @@ class TestTelemetryConfigGeneration:
             public_port=8000,
         )
 
-        config_text = generate_telemetry_config(
+        config_text = generate_tachometer_config(
             processes=processes,
             frontend_topology=topology,
             runtime=runtime,
-            telemetry=telemetry,
+            tachometer=tachometer,
             frontend_type="vllm",
         )
 
@@ -438,24 +424,26 @@ class TestTelemetryConfigGeneration:
         assert "10.0.0.2:8000" not in config_text
 
 
-class TestTelemetryStageMixin:
-    """Telemetry stage startup."""
+class TestTachometerStageMixin:
+    """Tachometer stage startup."""
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
-    @patch("srtctl.cli.mixins.telemetry_stage.generate_telemetry_config", return_value='storage = "/run/telemetry"\n')
-    def test_start_telemetry_starts_exporters_and_scraper(self, _mock_config, mock_srun, tmp_path):
+    @patch("srtctl.cli.mixins.telemetry_stage.generate_tachometer_config", return_value='storage = "/run/tachometer"\n')
+    def test_start_tachometer_starts_exporters_and_scraper(self, _mock_config, mock_srun, tmp_path):
         class Harness(TelemetryStageMixin):
             def __init__(self):
                 self.config = _make_config(
-                    telemetry=TelemetryConfig(
+                    tachometer=TachometerConfig(
                         enabled=True,
-                        container_image="telemetry:latest",
                         dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
                         node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
                     )
                 )
                 self.runtime = MagicMock()
                 self.runtime.log_dir = tmp_path
+                self.runtime.job_id = "12345"
+                self.runtime.run_name = "test_12345"
+                self.runtime.network_interface = "eth0"
                 self.runtime.nodes.head = "node-a"
                 self.runtime.nodes.het = False
                 self.runtime.srun_options = {}
@@ -487,19 +475,19 @@ class TestTelemetryStageMixin:
         mock_srun.return_value = _running_exporter()
         harness = Harness()
 
-        procs = harness.start_telemetry()
+        procs = harness.start_tachometer()
 
         assert len(procs) == 3
-        assert (tmp_path / "telemetry_config.toml").exists()
-        assert (tmp_path / "telemetry" / "local").exists()
+        assert (tmp_path / "tachometer_config.toml").exists()
+        assert (tmp_path / "tachometer" / "local").exists()
         assert mock_srun.call_count == 3
         scraper_call = mock_srun.call_args_list[-1]
         assert scraper_call.kwargs["command"] == [
             "tachometer-scraper",
             "--config",
-            str(tmp_path / "telemetry_config.toml"),
+            str(tmp_path / "tachometer_config.toml"),
             "--local-dir",
-            str(tmp_path / "telemetry" / "local"),
+            str(tmp_path / "tachometer" / "local"),
             "--sync-interval",
             "120",
         ]
@@ -507,12 +495,19 @@ class TestTelemetryStageMixin:
         assert "container_mounts" not in scraper_call.kwargs
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
-    def test_start_telemetry_without_exporters_starts_only_scraper(self, mock_srun, tmp_path):
+    def test_start_tachometer_reuses_the_power_dcgm_exporter(self, mock_srun, tmp_path):
         class Harness(TelemetryStageMixin):
             def __init__(self):
-                self.config = _make_config(telemetry=TelemetryConfig(enabled=True))
+                self.config = _make_config(
+                    tachometer=TachometerConfig(enabled=True),
+                    telemetry=_dcgm_power(),
+                    benchmark=_sa_bench(),
+                )
                 self.runtime = MagicMock()
                 self.runtime.log_dir = tmp_path
+                self.runtime.job_id = "12345"
+                self.runtime.run_name = "test_12345"
+                self.runtime.network_interface = "eth0"
                 self.runtime.nodes.head = "node-a"
                 self.runtime.nodes.het = False
                 self.runtime.srun_options = {}
@@ -542,13 +537,14 @@ class TestTelemetryStageMixin:
 
         mock_srun.return_value = _running_exporter()
 
-        processes = Harness().start_telemetry()
+        processes = Harness().start_tachometer()
 
-        assert [process.name for process in processes] == ["telemetry"]
+        assert [process.name for process in processes] == ["tachometer"]
         assert mock_srun.call_count == 1
+        assert 'name = "dcgm_node-a"' in (tmp_path / "tachometer_config.toml").read_text()
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
-    @patch("srtctl.cli.mixins.telemetry_stage.generate_telemetry_config", return_value='storage = "/run/telemetry"\n')
+    @patch("srtctl.cli.mixins.telemetry_stage.generate_tachometer_config", return_value='storage = "/run/tachometer"\n')
     def test_multinode_exporters_request_one_node_per_task(self, _mock_config, mock_srun, tmp_path):
         """srun rejects --nodes 1 with a longer --nodelist, so the exporter launch
         must size --nodes to the worker set."""
@@ -556,9 +552,8 @@ class TestTelemetryStageMixin:
         class Harness(TelemetryStageMixin):
             def __init__(self):
                 self.config = _make_config(
-                    telemetry=TelemetryConfig(
+                    tachometer=TachometerConfig(
                         enabled=True,
-                        container_image="telemetry:latest",
                         dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9401),
                         node_exporter=TelemetryExporterConfig(container_image="node:latest", port=9101),
                     )
@@ -597,7 +592,7 @@ class TestTelemetryStageMixin:
         mock_srun.return_value = _running_exporter()
         harness = Harness()
 
-        harness.start_telemetry()
+        harness.start_tachometer()
 
         exporter_calls = [
             call for call in mock_srun.call_args_list if call.kwargs.get("nodelist") == ["node-a", "node-b"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -461,13 +461,11 @@ class TestPreflightConfigVariants:
             issue.code == "container-not-available" for issue in results[0].errors
         )
 
-    def test_telemetry_aliases_resolve_and_pass_when_files_exist(self, tmp_path):
+    def test_tachometer_aliases_resolve_and_pass_when_files_exist(self, tmp_path):
         model_dir = tmp_path / "model"
         model_dir.mkdir()
         container_file = tmp_path / "container.sqsh"
         container_file.write_text("sqsh")
-        scraper_file = tmp_path / "scraper.sqsh"
-        scraper_file.write_text("sqsh")
         dcgm_file = tmp_path / "dcgm.sqsh"
         dcgm_file.write_text("sqsh")
         node_file = tmp_path / "node.sqsh"
@@ -475,7 +473,7 @@ class TestPreflightConfigVariants:
 
         results = preflight_config_variants(
             {
-                "name": "telemetry-ok",
+                "name": "tachometer-ok",
                 "model": {"path": "qwen32b", "container": "sglang-latest", "precision": "bf16"},
                 "resources": {
                     "gpu_type": "gb200",
@@ -485,18 +483,19 @@ class TestPreflightConfigVariants:
                     "prefill_workers": 1,
                     "decode_workers": 1,
                 },
-                "telemetry": {
+                "observability": {
                     "enabled": True,
-                    "container_image": "telemetry-scraper",
-                    "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},
-                    "node_exporter": {"container_image": "node-exporter", "port": 9101},
+                    "tachometer": {
+                        "enabled": True,
+                        "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},
+                        "node_exporter": {"container_image": "node-exporter", "port": 9101},
+                    },
                 },
             },
             cluster_config={
                 "model_paths": {"qwen32b": str(model_dir)},
                 "containers": {
                     "sglang-latest": str(container_file),
-                    "telemetry-scraper": str(scraper_file),
                     "dcgm-exporter": str(dcgm_file),
                     "node-exporter": str(node_file),
                 },
@@ -506,20 +505,18 @@ class TestPreflightConfigVariants:
         assert results[0].ok is True
         assert results[0].errors == []
 
-    def test_telemetry_missing_sqsh_fails_preflight(self, tmp_path):
+    def test_tachometer_missing_sqsh_fails_preflight(self, tmp_path):
         model_dir = tmp_path / "model"
         model_dir.mkdir()
         container_file = tmp_path / "container.sqsh"
         container_file.write_text("sqsh")
-        scraper_file = tmp_path / "scraper.sqsh"
-        scraper_file.write_text("sqsh")
         dcgm_file = tmp_path / "dcgm.sqsh"
         dcgm_file.write_text("sqsh")
         # node.sqsh deliberately missing
 
         results = preflight_config_variants(
             {
-                "name": "telemetry-bad",
+                "name": "tachometer-bad",
                 "model": {"path": str(model_dir), "container": str(container_file), "precision": "bf16"},
                 "resources": {
                     "gpu_type": "gb200",
@@ -529,40 +526,35 @@ class TestPreflightConfigVariants:
                     "prefill_workers": 1,
                     "decode_workers": 1,
                 },
-                "telemetry": {
+                "observability": {
                     "enabled": True,
-                    "container_image": str(scraper_file),
-                    "dcgm_exporter": {"container_image": str(dcgm_file), "port": 9401},
-                    "node_exporter": {"container_image": str(tmp_path / "node.sqsh"), "port": 9101},
+                    "tachometer": {
+                        "enabled": True,
+                        "dcgm_exporter": {"container_image": str(dcgm_file), "port": 9401},
+                        "node_exporter": {"container_image": str(tmp_path / "node.sqsh"), "port": 9101},
+                    },
                 },
             },
         )
 
         assert results[0].ok is False
-        telemetry_errors = [issue for issue in results[0].errors if issue.code == "telemetry-container-not-available"]
-        assert len(telemetry_errors) == 1
-        assert telemetry_errors[0].field == "telemetry.node_exporter.container_image"
+        tachometer_errors = [issue for issue in results[0].errors if issue.code == "tachometer-container-not-available"]
+        assert len(tachometer_errors) == 1
+        assert tachometer_errors[0].field == "observability.tachometer.node_exporter.container_image"
 
-    def test_scraper_preflight_ignores_legacy_container_image(self, tmp_path):
+    def test_tachometer_without_exporters_skips_exporter_preflight(self, tmp_path):
         model_dir = tmp_path / "model"
         model_dir.mkdir()
         container_file = tmp_path / "container.sqsh"
         container_file.write_text("sqsh")
-        dcgm_file = tmp_path / "dcgm.sqsh"
-        dcgm_file.write_text("sqsh")
-        node_file = tmp_path / "node.sqsh"
-        node_file.write_text("sqsh")
-
         results = preflight_config_variants(
             {
-                "name": "native-scraper",
+                "name": "native-tachometer",
                 "model": {"path": str(model_dir), "container": str(container_file), "precision": "bf16"},
                 "resources": {"gpu_type": "gb200", "gpus_per_node": 4, "agg_nodes": 1, "agg_workers": 1},
-                "telemetry": {
+                "observability": {
                     "enabled": True,
-                    "container_image": str(tmp_path / "missing-legacy-scraper.sqsh"),
-                    "dcgm_exporter": {"container_image": str(dcgm_file), "port": 9401},
-                    "node_exporter": {"container_image": str(node_file), "port": 9101},
+                    "tachometer": {"enabled": True},
                 },
             }
         )
@@ -585,7 +577,6 @@ class TestPreflightConfigVariants:
             "benchmark": {"type": "sa-bench", "isl": 8192, "osl": 1024, "concurrencies": [4]},
             "telemetry": {
                 "enabled": True,
-                "provider": "dcgm-power",
                 "default_frequency": 1.0,
                 "storage_subdir": "power",
                 "required": True,
@@ -634,24 +625,6 @@ class TestPreflightConfigVariants:
         assert results[0].ok is True
         assert not any(issue.code == "telemetry-container-not-available" for issue in results[0].errors)
 
-    def test_dcgm_power_preflight_ignores_scraper_and_node_exporter_images(self, tmp_path):
-        """Those images are never launched by this provider."""
-        model_dir = tmp_path / "model"
-        model_dir.mkdir()
-        container_file = tmp_path / "container.sqsh"
-        container_file.write_text("sqsh")
-        dcgm_file = tmp_path / "dcgm.sqsh"
-        dcgm_file.write_text("sqsh")
-
-        recipe = self._dcgm_power_recipe(model_dir, container_file, dcgm_file)
-        recipe["telemetry"]["container_image"] = str(tmp_path / "missing-scraper.sqsh")
-        recipe["telemetry"]["node_exporter"] = {"container_image": str(tmp_path / "missing-node.sqsh"), "port": 9101}
-
-        results = preflight_config_variants(recipe)
-
-        assert results[0].ok is True
-        assert not any(issue.code == "telemetry-container-not-available" for issue in results[0].errors)
-
     def test_dcgm_power_preflight_rejects_missing_exporter_image(self, tmp_path):
         model_dir = tmp_path / "model"
         model_dir.mkdir()
@@ -686,9 +659,7 @@ class TestPreflightConfigVariants:
                 },
                 "telemetry": {
                     "enabled": False,
-                    "container_image": "/does/not/exist.sqsh",
                     "dcgm_exporter": {"container_image": "/does/not/exist.sqsh", "port": 9401},
-                    "node_exporter": {"container_image": "/does/not/exist.sqsh", "port": 9101},
                 },
             },
         )


### PR DESCRIPTION
## Summary
- keep server instrumentation, Python RAW Prometheus capture, and native Tachometer collection together under `observability`
- make `telemetry` DCGM-power-only and run it independently alongside Tachometer
- share the DCGM exporter with Tachometer when both collectors are enabled, preventing duplicate worker-port launches
- document repository-local setup: `make setup ARCH=<compute-arch>` fetches and verifies the released scraper binary

## Validation
- `uv run pytest -q` (1226 passed, 2 skipped)
- `uv run ruff check src/srtctl`
- scoped `uv run ty check` for changed production modules