### PR TITLE
feat(topology): add dedicated-node flags for frontend and benchmark client

### DIFF
--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -157,10 +157,15 @@ class BenchmarkStageMixin:
         return self._orchestrator_node()
 
     def _benchmark_node(self) -> str:
-        """Node the benchmark client runs on (honors benchmark.client_placement)."""
+        """Node the benchmark client runs on (honors benchmark.client_placement).
+
+        ``nodes.bench`` equals ``nodes.head`` unless a dedicated client node was
+        carved out (benchmark.client_dedicated_node), in which case it points at
+        that reserved node instead.
+        """
         placement = getattr(self.config.benchmark, "client_placement", "head")
         if placement == "head":
-            return self.runtime.nodes.head
+            return self.runtime.nodes.bench
         from srtctl.core.topology import placed_node
 
         return placed_node(

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -478,11 +478,31 @@ def generate_minimal_sbatch_script(
         infra_dedicated=config.infra.etcd_nats_dedicated_node,
         cluster_default=get_srtslurm_setting("use_het_jobs", False),
     )
+    if het_components is not None and (config.frontend.dedicated_node or config.benchmark.client_dedicated_node):
+        # SrtConfig validation only catches resources.het_jobs: true explicitly
+        # set in the recipe — it can't see a cluster-level use_het_jobs default,
+        # which is only resolved here via het_components(). Catch the combo now,
+        # before sbatch submits a heterogeneous allocation that Nodes.from_slurm
+        # will then reject at job startup after the nodes are already granted.
+        raise ValueError(
+            "frontend.dedicated_node/benchmark.client_dedicated_node are not supported with heterogeneous "
+            "SLURM jobs, and this job resolved to heterogeneous (either resources.het_jobs: true or the "
+            "cluster's use_het_jobs default)"
+        )
     if het_components is None:
         total_nodes = config.total_nodes
-        # Add extra node for dedicated etcd/nats infrastructure
-        if config.infra.etcd_nats_dedicated_node:
-            total_nodes += 1
+        # Add extra node(s) for any dedicated-node role requested (etcd/nats,
+        # frontend, benchmark client). Colocated roles share one reserved node;
+        # otherwise each gets its own.
+        num_dedicated_roles = sum(
+            (
+                config.infra.etcd_nats_dedicated_node,
+                config.frontend.dedicated_node,
+                config.benchmark.client_dedicated_node,
+            )
+        )
+        if num_dedicated_roles > 0:
+            total_nodes += 1 if config.benchmark.colocate_with_frontend else num_dedicated_roles
     else:
         # Sum is informational only — the template iterates het_components and
         # ignores total_nodes when het_components is set.

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -70,44 +70,98 @@ class Nodes:
     @classmethod
     def from_slurm(
         cls,
-        benchmark_on_separate_node: bool = False,
+        frontend_dedicated_node: bool = False,
+        client_dedicated_node: bool = False,
         etcd_nats_dedicated_node: bool = False,
+        colocate_dedicated_nodes: bool = True,
     ) -> "Nodes":
         """Create Nodes from SLURM environment.
 
         Args:
-            benchmark_on_separate_node: If True, first node is benchmark-only,
-                                        second is head, rest are workers.
-            etcd_nats_dedicated_node: If True, dedicate first node for etcd/nats,
-                                      second node is head, rest are workers.
+            frontend_dedicated_node: If True, reserve a node exclusively for the
+                                     frontend/orchestrator; it is excluded from
+                                     the worker pool.
+            client_dedicated_node: If True, reserve a node exclusively for the
+                                   benchmark client; it is excluded from the
+                                   worker pool. Reserved from the tail of the
+                                   nodelist (never the first node), since SLURM
+                                   runs the do_sweep batch script unsandboxed
+                                   on the first node and co-locating the
+                                   benchmark client there would undermine the
+                                   isolation this flag exists to provide.
+            etcd_nats_dedicated_node: If True, reserve a node exclusively for
+                                      etcd/nats.
+            colocate_dedicated_nodes: Governs how the dedicated-node flags above
+                                      combine when more than one is set. If True
+                                      (default), every requested role (infra,
+                                      frontend, client) shares a single reserved
+                                      node. If False, each requested role gets
+                                      its own reserved node. A role that is not
+                                      requested keeps its normal default
+                                      placement (frontend/client fall back to
+                                      colocating with whichever node ends up
+                                      being head; infra falls back to head).
         """
+        dedicated_roles = [
+            role
+            for role, wanted in (
+                ("infra", etcd_nats_dedicated_node),
+                ("frontend", frontend_dedicated_node),
+                ("client", client_dedicated_node),
+            )
+            if wanted
+        ]
+
         het_lists = get_slurm_het_nodelists()
         if het_lists is not None:
+            if frontend_dedicated_node or client_dedicated_node:
+                raise ValueError(
+                    "frontend_dedicated_node/client_dedicated_node are not supported for heterogeneous SLURM jobs"
+                )
             return cls._from_het_slurm(het_lists, etcd_nats_dedicated_node)
 
         nodelist = get_slurm_nodelist()
         if not nodelist:
             raise RuntimeError("SLURM_NODELIST not set - are we running in SLURM?")
 
-        if etcd_nats_dedicated_node:
-            if len(nodelist) < 2:
-                raise ValueError("etcd_nats_dedicated_node requires at least 2 nodes")
-            infra = nodelist[0]
-            head = nodelist[1]
-            bench = head
-            worker = tuple(nodelist[1:])
-        elif benchmark_on_separate_node:
-            if len(nodelist) < 2:
-                raise ValueError("benchmark_on_separate_node requires at least 2 nodes")
-            bench = nodelist[0]
-            head = nodelist[1]
-            infra = head
-            worker = tuple(nodelist[1:])
+        if not dedicated_roles:
+            head = bench = infra = nodelist[0]
+            worker = tuple(nodelist)
+            return cls(head=head, bench=bench, infra=infra, worker=worker)
+
+        num_reserved = 1 if colocate_dedicated_nodes else len(dedicated_roles)
+        if len(nodelist) <= num_reserved:
+            raise ValueError(
+                f"dedicated node(s) for {'+'.join(dedicated_roles)} require at least {num_reserved + 1} nodes"
+            )
+
+        # SLURM runs the batch script (the do_sweep orchestrator) on the first
+        # node of the allocation, unsandboxed. A dedicated *client* node exists
+        # to isolate benchmark measurements from noisy neighbors, so it must
+        # never land on that first node — reserve it from the tail instead.
+        # Non-client roles (infra, frontend) keep the original front-of-list
+        # reservation for backward compatibility.
+        has_client = "client" in dedicated_roles
+        if colocate_dedicated_nodes:
+            if has_client:
+                shared = nodelist[-1]
+                worker = tuple(nodelist[:-1])
+            else:
+                shared = nodelist[0]
+                worker = tuple(nodelist[1:])
+            reserved = {role: shared for role in dedicated_roles}
         else:
-            head = nodelist[0]
-            bench = head
-            infra = head
-            worker = tuple(nodelist[:])
+            front_roles = [role for role in dedicated_roles if role != "client"]
+            reserved = dict(zip(front_roles, nodelist, strict=False))
+            if has_client:
+                reserved["client"] = nodelist[-1]
+                worker = tuple(nodelist[len(front_roles) : -1])
+            else:
+                worker = tuple(nodelist[len(front_roles) :])
+
+        head = reserved.get("frontend", worker[0])
+        bench = reserved.get("client", head)
+        infra = reserved.get("infra", head)
 
         return cls(head=head, bench=bench, infra=infra, worker=worker)
 
@@ -221,8 +275,10 @@ class RuntimeContext:
         """
         # Get nodes from SLURM
         nodes = Nodes.from_slurm(
-            benchmark_on_separate_node=False,
+            frontend_dedicated_node=config.frontend.dedicated_node,
+            client_dedicated_node=config.benchmark.client_dedicated_node,
             etcd_nats_dedicated_node=config.infra.etcd_nats_dedicated_node,
+            colocate_dedicated_nodes=config.benchmark.colocate_with_frontend,
         )
 
         # Compute run_name

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -691,6 +691,18 @@ class BenchmarkConfig:
     #                       a different node than the orchestrator, use the injected
     #                       $SRT_FRONTEND_HOST env in the benchmark command's URL.
     client_placement: str = "head"
+    # If True, reserve a node exclusively for the benchmark client instead of
+    # running it on a worker node. Requires at least 2 nodes. Not supported
+    # together with resources.het_jobs: true.
+    # Default: False.
+    client_dedicated_node: bool = False
+    # Governs how the dedicated-node flags combine when more than one of
+    # client_dedicated_node, frontend.dedicated_node, and
+    # infra.etcd_nats_dedicated_node is set. If True (default), every
+    # requested role shares a single reserved node. If False, each requested
+    # role gets its own reserved node (requires enough total nodes: worker
+    # count + number of dedicated roles).
+    colocate_with_frontend: bool = True
     sweep: Annotated[SweepConfig, SweepConfigField(allow_none=True, load_default=None, dump_default=None)] | None = None
     # Accuracy benchmark fields
     num_examples: int | None = None
@@ -1585,6 +1597,10 @@ class FrontendConfig:
     #   "head" (default) -> nodes.head (first prefill/CTX node)
     #   "first_decode"   -> first decode/GEN worker-leader node
     orchestrator_placement: str = "head"
+    # If True, reserve a node exclusively for the frontend/orchestrator instead
+    # of running it on a worker node. Requires at least 2 nodes. Not supported
+    # together with resources.het_jobs: true. Default: False.
+    dedicated_node: bool = False
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
@@ -1689,6 +1705,7 @@ class SrtConfig:
         self._validate_telemetry()
         self._validate_mooncake_kv_store()
         self._validate_het_jobs()
+        self._validate_dedicated_node_placement()
         self._validate_trtllm_serve()
         self._validate_vllm_frontend()
         self._warn_dp_launch_mode()
@@ -1785,6 +1802,27 @@ class SrtConfig:
         if self.backend_type != "sglang":
             raise ValidationError(
                 f"het_jobs=true is only supported on the sglang backend; got backend.type={self.backend_type!r}"
+            )
+        if self.frontend.dedicated_node or self.benchmark.client_dedicated_node:
+            raise ValidationError(
+                "frontend.dedicated_node/benchmark.client_dedicated_node are not supported together with "
+                "het_jobs=true (a dedicated frontend/client node is not carved out of a het allocation)"
+            )
+
+    def _validate_dedicated_node_placement(self):
+        """A dedicated node is wasted if a placement override routes the
+        orchestrator/client somewhere else — the reserved node would then sit
+        idle while the intended workload runs on a worker node instead.
+        """
+        if self.frontend.dedicated_node and self.frontend.orchestrator_placement != "head":
+            raise ValidationError(
+                f"frontend.dedicated_node requires frontend.orchestrator_placement: head "
+                f"(got {self.frontend.orchestrator_placement!r}); otherwise the reserved node is never used"
+            )
+        if self.benchmark.client_dedicated_node and self.benchmark.client_placement != "head":
+            raise ValidationError(
+                f"benchmark.client_dedicated_node requires benchmark.client_placement: head "
+                f"(got {self.benchmark.client_placement!r}); otherwise the reserved node is never used"
             )
 
     def _validate_mooncake_kv_store(self):

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -110,10 +110,6 @@ echo ""
 # For override jobs it also writes the resolved runtime config below.
 echo "Runtime config: ${OUTPUT_DIR}/{{ runtime_config_filename }}"
 
-# Get head node
-HEAD_NODE=$(scontrol show hostnames ${SLURM_NODELIST} | head -n1)
-echo "Head node: ${HEAD_NODE}"
-
 # Set source directory for container mounts (/configs)
 export SRTCTL_SOURCE_DIR="${SRTCTL_SOURCE}"
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1354,6 +1354,103 @@ class TestNodesInfraAllocation:
         ):
             Nodes.from_slurm(etcd_nats_dedicated_node=True)
 
+    def test_nodes_dedicated_frontend_only(self):
+        """frontend_dedicated_node alone puts head+bench on node0, client rides along."""
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import Nodes
+
+        with patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0", "node1", "node2"]):
+            nodes = Nodes.from_slurm(frontend_dedicated_node=True)
+
+        assert nodes.head == "node0"
+        assert nodes.bench == "node0"  # client defaults to colocating with the frontend
+        assert nodes.worker == ("node1", "node2")
+
+    def test_nodes_dedicated_client_only(self):
+        """client_dedicated_node reserves the LAST node (never the first/batch node,
+        since SLURM runs the do_sweep orchestrator there unsandboxed).
+        """
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import Nodes
+
+        with patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0", "node1", "node2"]):
+            nodes = Nodes.from_slurm(client_dedicated_node=True)
+
+        assert nodes.bench == "node2"
+        assert nodes.head == "node0"  # frontend still doubles as a worker
+        assert nodes.worker == ("node0", "node1")
+
+    def test_nodes_dedicated_frontend_and_client_colocated(self):
+        """Both dedicated + colocate=True (default) share the LAST node (client's
+        tail reservation takes precedence over frontend's front-of-list default).
+        """
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import Nodes
+
+        with patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0", "node1", "node2"]):
+            nodes = Nodes.from_slurm(frontend_dedicated_node=True, client_dedicated_node=True)
+
+        assert nodes.head == "node2"
+        assert nodes.bench == "node2"
+        assert nodes.worker == ("node0", "node1")
+
+    def test_nodes_dedicated_frontend_and_client_separate(self):
+        """Both dedicated + colocate=False: frontend from the front, client from the tail."""
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import Nodes
+
+        with patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0", "node1", "node2", "node3"]):
+            nodes = Nodes.from_slurm(
+                frontend_dedicated_node=True, client_dedicated_node=True, colocate_dedicated_nodes=False
+            )
+
+        assert nodes.head == "node0"
+        assert nodes.bench == "node3"
+        assert nodes.worker == ("node1", "node2")
+
+    def test_nodes_dedicated_frontend_requires_two_nodes(self):
+        from unittest.mock import patch
+
+        import pytest
+
+        from srtctl.core.runtime import Nodes
+
+        with (
+            patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0"]),
+            pytest.raises(ValueError, match="at least 2 nodes"),
+        ):
+            Nodes.from_slurm(frontend_dedicated_node=True)
+
+    def test_nodes_dedicated_client_requires_two_nodes(self):
+        from unittest.mock import patch
+
+        import pytest
+
+        from srtctl.core.runtime import Nodes
+
+        with (
+            patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0"]),
+            pytest.raises(ValueError, match="at least 2 nodes"),
+        ):
+            Nodes.from_slurm(client_dedicated_node=True)
+
+    def test_nodes_dedicated_separate_requires_three_nodes(self):
+        from unittest.mock import patch
+
+        import pytest
+
+        from srtctl.core.runtime import Nodes
+
+        with (
+            patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0", "node1"]),
+            pytest.raises(ValueError, match="at least 3 nodes"),
+        ):
+            Nodes.from_slurm(frontend_dedicated_node=True, client_dedicated_node=True, colocate_dedicated_nodes=False)
+
 
 class TestSbatchNodeCount:
     """Tests for sbatch node count calculation with infra config."""
@@ -1411,6 +1508,117 @@ class TestSbatchNodeCount:
 
         # Should request 2 nodes: just the workers
         assert "#SBATCH --nodes=2" in script
+
+    def _dedicated_node_config(self, **overrides):
+        from srtctl.core.schema import (
+            BenchmarkConfig,
+            FrontendConfig,
+            InfraConfig,
+            ModelConfig,
+            ResourceConfig,
+            SrtConfig,
+        )
+
+        benchmark_kwargs = {}
+        if "client_dedicated_node" in overrides:
+            benchmark_kwargs["client_dedicated_node"] = overrides.pop("client_dedicated_node")
+        if "colocate_with_frontend" in overrides:
+            benchmark_kwargs["colocate_with_frontend"] = overrides.pop("colocate_with_frontend")
+        frontend_kwargs = {}
+        if "frontend_dedicated_node" in overrides:
+            frontend_kwargs["dedicated_node"] = overrides.pop("frontend_dedicated_node")
+        infra_kwargs = {}
+        if "etcd_nats_dedicated_node" in overrides:
+            infra_kwargs["etcd_nats_dedicated_node"] = overrides.pop("etcd_nats_dedicated_node")
+
+        return SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/container.sqsh", precision="fp8"),
+            resources=ResourceConfig(
+                gpu_type="h100",
+                gpus_per_node=8,
+                prefill_nodes=1,
+                decode_nodes=1,
+                prefill_workers=1,
+                decode_workers=1,
+            ),
+            benchmark=BenchmarkConfig(**benchmark_kwargs),
+            frontend=FrontendConfig(**frontend_kwargs),
+            infra=InfraConfig(**infra_kwargs),
+        )
+
+    def test_sbatch_adds_node_for_dedicated_frontend_only(self):
+        from pathlib import Path
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        config = self._dedicated_node_config(frontend_dedicated_node=True)
+        script = generate_minimal_sbatch_script(config, Path("/tmp/test.yaml"))
+
+        assert "#SBATCH --nodes=3" in script
+
+    def test_sbatch_adds_node_for_dedicated_client_only(self):
+        from pathlib import Path
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        config = self._dedicated_node_config(client_dedicated_node=True)
+        script = generate_minimal_sbatch_script(config, Path("/tmp/test.yaml"))
+
+        assert "#SBATCH --nodes=3" in script
+
+    def test_sbatch_adds_one_node_for_colocated_frontend_and_client(self):
+        from pathlib import Path
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        config = self._dedicated_node_config(frontend_dedicated_node=True, client_dedicated_node=True)
+        script = generate_minimal_sbatch_script(config, Path("/tmp/test.yaml"))
+
+        # 2 workers + 1 shared dedicated node
+        assert "#SBATCH --nodes=3" in script
+
+    def test_sbatch_adds_two_nodes_for_separate_frontend_and_client(self):
+        from pathlib import Path
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        config = self._dedicated_node_config(
+            frontend_dedicated_node=True, client_dedicated_node=True, colocate_with_frontend=False
+        )
+        script = generate_minimal_sbatch_script(config, Path("/tmp/test.yaml"))
+
+        # 2 workers + 2 separately dedicated nodes
+        assert "#SBATCH --nodes=4" in script
+
+    def test_sbatch_adds_one_node_for_all_three_colocated(self):
+        from pathlib import Path
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        config = self._dedicated_node_config(
+            frontend_dedicated_node=True, client_dedicated_node=True, etcd_nats_dedicated_node=True
+        )
+        script = generate_minimal_sbatch_script(config, Path("/tmp/test.yaml"))
+
+        # 2 workers + 1 shared dedicated node for infra+frontend+client
+        assert "#SBATCH --nodes=3" in script
+
+    def test_sbatch_adds_three_nodes_for_all_three_separate(self):
+        from pathlib import Path
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        config = self._dedicated_node_config(
+            frontend_dedicated_node=True,
+            client_dedicated_node=True,
+            etcd_nats_dedicated_node=True,
+            colocate_with_frontend=False,
+        )
+        script = generate_minimal_sbatch_script(config, Path("/tmp/test.yaml"))
+
+        # 2 workers + 3 separately dedicated nodes
+        assert "#SBATCH --nodes=5" in script
 
     def test_vllm_colocation_reduces_sbatch_to_one_node_when_fit(self):
         """Test vLLM P/D colocation requests one worker node when all workers fit."""
@@ -1718,6 +1926,194 @@ class TestHetJobsValidation:
         )
         assert cfg.resources.het_jobs is False
 
+    def test_het_jobs_rejected_with_frontend_dedicated_node(self):
+        import pytest
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import FrontendConfig
+
+        SrtConfig, kwargs = self._make()
+        kwargs["frontend"] = FrontendConfig(dedicated_node=True)
+        with pytest.raises(ValidationError, match="not supported together with het_jobs"):
+            SrtConfig(**kwargs)
+
+    def test_het_jobs_rejected_with_client_dedicated_node(self):
+        import pytest
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import BenchmarkConfig
+
+        SrtConfig, kwargs = self._make()
+        kwargs["benchmark"] = BenchmarkConfig(client_dedicated_node=True)
+        with pytest.raises(ValidationError, match="not supported together with het_jobs"):
+            SrtConfig(**kwargs)
+
+
+class TestDedicatedNodeValidation:
+    """SrtConfig.__post_init__ allows combining all dedicated-node flags."""
+
+    def test_allows_infra_and_frontend_dedicated_node_together(self):
+        from srtctl.core.schema import FrontendConfig, InfraConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        cfg = SrtConfig(
+            name="t",
+            model=ModelConfig(path="/m", container="/c.sqsh", precision="fp8"),
+            resources=ResourceConfig(gpu_type="h100", gpus_per_node=8, agg_nodes=1),
+            infra=InfraConfig(etcd_nats_dedicated_node=True),
+            frontend=FrontendConfig(dedicated_node=True),
+        )
+        assert cfg.infra.etcd_nats_dedicated_node is True
+        assert cfg.frontend.dedicated_node is True
+
+    def test_allows_infra_and_client_dedicated_node_together(self):
+        from srtctl.core.schema import BenchmarkConfig, InfraConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        cfg = SrtConfig(
+            name="t",
+            model=ModelConfig(path="/m", container="/c.sqsh", precision="fp8"),
+            resources=ResourceConfig(gpu_type="h100", gpus_per_node=8, agg_nodes=1),
+            infra=InfraConfig(etcd_nats_dedicated_node=True),
+            benchmark=BenchmarkConfig(client_dedicated_node=True),
+        )
+        assert cfg.infra.etcd_nats_dedicated_node is True
+        assert cfg.benchmark.client_dedicated_node is True
+
+    def test_allows_frontend_and_client_dedicated_node_together(self):
+        from srtctl.core.schema import BenchmarkConfig, FrontendConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        cfg = SrtConfig(
+            name="t",
+            model=ModelConfig(path="/m", container="/c.sqsh", precision="fp8"),
+            resources=ResourceConfig(gpu_type="h100", gpus_per_node=8, agg_nodes=1),
+            frontend=FrontendConfig(dedicated_node=True),
+            benchmark=BenchmarkConfig(client_dedicated_node=True, colocate_with_frontend=False),
+        )
+        assert cfg.frontend.dedicated_node is True
+        assert cfg.benchmark.client_dedicated_node is True
+        assert cfg.benchmark.colocate_with_frontend is False
+
+
+class TestDedicatedNodePlacementValidation:
+    """A dedicated node is wasted if a placement override routes the
+    orchestrator/client elsewhere, so SrtConfig rejects that combination.
+    """
+
+    def test_rejects_frontend_dedicated_node_with_non_head_placement(self):
+        import pytest
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import FrontendConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        with pytest.raises(ValidationError, match="frontend.dedicated_node requires"):
+            SrtConfig(
+                name="t",
+                model=ModelConfig(path="/m", container="/c.sqsh", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    gpus_per_node=8,
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                frontend=FrontendConfig(dedicated_node=True, orchestrator_placement="first_decode"),
+            )
+
+    def test_rejects_client_dedicated_node_with_non_head_placement(self):
+        import pytest
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        with pytest.raises(ValidationError, match="benchmark.client_dedicated_node requires"):
+            SrtConfig(
+                name="t",
+                model=ModelConfig(path="/m", container="/c.sqsh", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="h100",
+                    gpus_per_node=8,
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                benchmark=BenchmarkConfig(client_dedicated_node=True, client_placement="last_decode"),
+            )
+
+    def test_allows_dedicated_node_with_default_head_placement(self):
+        from srtctl.core.schema import BenchmarkConfig, FrontendConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        cfg = SrtConfig(
+            name="t",
+            model=ModelConfig(path="/m", container="/c.sqsh", precision="fp8"),
+            resources=ResourceConfig(gpu_type="h100", gpus_per_node=8, agg_nodes=1),
+            frontend=FrontendConfig(dedicated_node=True),
+            benchmark=BenchmarkConfig(client_dedicated_node=True),
+        )
+        assert cfg.frontend.orchestrator_placement == "head"
+        assert cfg.benchmark.client_placement == "head"
+
+
+class TestNodesAllThreeDedicated:
+    """Tests for combining etcd/nats + frontend + client dedicated-node flags."""
+
+    def test_all_three_colocate_on_one_node(self):
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import Nodes
+
+        with patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0", "node1", "node2"]):
+            nodes = Nodes.from_slurm(
+                frontend_dedicated_node=True,
+                client_dedicated_node=True,
+                etcd_nats_dedicated_node=True,
+                colocate_dedicated_nodes=True,
+            )
+
+        # All three share the LAST node — the client's tail reservation takes
+        # precedence, keeping the shared node off the SLURM batch/orchestrator node.
+        assert nodes.head == "node2"
+        assert nodes.bench == "node2"
+        assert nodes.infra == "node2"
+        assert nodes.worker == ("node0", "node1")
+
+    def test_all_three_get_separate_nodes_when_not_colocated(self):
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import Nodes
+
+        with patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0", "node1", "node2", "node3"]):
+            nodes = Nodes.from_slurm(
+                frontend_dedicated_node=True,
+                client_dedicated_node=True,
+                etcd_nats_dedicated_node=True,
+                colocate_dedicated_nodes=False,
+            )
+
+        # infra/frontend reserved from the front, client from the tail.
+        assert nodes.infra == "node0"
+        assert nodes.head == "node1"
+        assert nodes.bench == "node3"
+        assert nodes.worker == ("node2",)
+
+    def test_infra_and_frontend_colocate_client_not_requested(self):
+        """etcd/nats + frontend dedicated (colocated); client not dedicated still rides along."""
+        from unittest.mock import patch
+
+        from srtctl.core.runtime import Nodes
+
+        with patch("srtctl.core.runtime.get_slurm_nodelist", return_value=["node0", "node1", "node2"]):
+            nodes = Nodes.from_slurm(
+                frontend_dedicated_node=True,
+                etcd_nats_dedicated_node=True,
+                colocate_dedicated_nodes=True,
+            )
+
+        assert nodes.head == "node0"
+        assert nodes.infra == "node0"
+        assert nodes.bench == "node0"  # not requested, falls back to head
+        assert nodes.worker == ("node1", "node2")
+
 
 class TestHetComponents:
     """ResourceConfig.het_components() shape."""
@@ -1861,6 +2257,85 @@ class TestHetJobsSbatchScript:
         assert "#SBATCH hetjob" not in script
         # Single --nodes line (12 prefill + 10 decode = 22)
         assert "#SBATCH --nodes=22" in script
+
+
+class TestDedicatedNodeRejectedForClusterDefaultHet:
+    """A recipe with resources.het_jobs unset (None) passes SrtConfig validation
+
+    (which only checks the explicit `true` case), but should still be rejected
+    before submission if the cluster's use_het_jobs default resolves the job
+    to heterogeneous — otherwise it fails only after SLURM already granted a
+    heterogeneous allocation.
+    """
+
+    def _config(self, *, dedicated_frontend=False, dedicated_client=False):
+        from srtctl.core.schema import BenchmarkConfig, FrontendConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        return SrtConfig(
+            name="t",
+            model=ModelConfig(path="/m", container="/c.sqsh", precision="fp8"),
+            resources=ResourceConfig(
+                gpu_type="gb200",
+                gpus_per_node=4,
+                prefill_nodes=12,
+                decode_nodes=10,
+                prefill_workers=12,
+                decode_workers=10,
+                het_jobs=None,
+            ),
+            frontend=FrontendConfig(dedicated_node=dedicated_frontend),
+            benchmark=BenchmarkConfig(client_dedicated_node=dedicated_client),
+        )
+
+    def test_rejects_frontend_dedicated_node_when_cluster_default_is_het(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        import pytest
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        cfg = self._config(dedicated_frontend=True)
+        with (
+            patch(
+                "srtctl.cli.submit.get_srtslurm_setting",
+                side_effect=lambda key, default=None: True if key == "use_het_jobs" else default,
+            ),
+            pytest.raises(ValueError, match="not supported with heterogeneous"),
+        ):
+            generate_minimal_sbatch_script(cfg, Path("/tmp/test.yaml"))
+
+    def test_rejects_client_dedicated_node_when_cluster_default_is_het(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        import pytest
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        cfg = self._config(dedicated_client=True)
+        with (
+            patch(
+                "srtctl.cli.submit.get_srtslurm_setting",
+                side_effect=lambda key, default=None: True if key == "use_het_jobs" else default,
+            ),
+            pytest.raises(ValueError, match="not supported with heterogeneous"),
+        ):
+            generate_minimal_sbatch_script(cfg, Path("/tmp/test.yaml"))
+
+    def test_allows_dedicated_node_when_cluster_default_is_not_het(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from srtctl.cli.submit import generate_minimal_sbatch_script
+
+        cfg = self._config(dedicated_frontend=True)
+        with patch(
+            "srtctl.cli.submit.get_srtslurm_setting",
+            side_effect=lambda key, default=None: False if key == "use_het_jobs" else default,
+        ):
+            script = generate_minimal_sbatch_script(cfg, Path("/tmp/test.yaml"))
+        assert "#SBATCH hetjob" not in script
 
 
 class TestNodesHetGroupParsing:


### PR DESCRIPTION
## Summary
- Adds `frontend.dedicated_node` and `benchmark.client_dedicated_node` to reserve a node for the orchestrator/client outside the prefill/decode worker pool, plus `benchmark.colocate_with_frontend` to control whether these combine with `infra.etcd_nats_dedicated_node` onto one shared node or separate ones.
- The dedicated client node is always reserved from the **tail** of the SLURM nodelist, never the front, since SLURM runs the `do_sweep` orchestrator unsandboxed on the first node — colocating the benchmark client there would undermine the isolation the flag exists to provide.
- Placement overrides that would silently strand a dedicated node (`frontend.orchestrator_placement` / `benchmark.client_placement` set to anything but `"head"`) are now rejected at config-validation time.
- A cluster-level `use_het_jobs` default resolving to heterogeneous is now caught before `sbatch` submission (in `generate_minimal_sbatch_script`), instead of failing at job startup after SLURM has already granted the allocation.
- Fixes `_benchmark_node()` to resolve via `nodes.bench` instead of `nodes.head` — `nodes.bench` was previously computed but never actually read, so a dedicated client node was silently ignored.
- Removes the sbatch script's `"Head node"` log line, which always reported the first SLURM node and is now wrong whenever a dedicated-node flag moves the real head to the tail; `do_sweep.py` already logs the correct resolved head node.

## Test plan
- [x] `uv run pytest tests/` — 1273 passed, 2 skipped (pre-existing, unrelated), 10 deselected
- [x] `uv run ruff check src/srtctl/` and `uv run ruff format --check src/srtctl/` — clean
- [x] New/updated tests cover: node-topology resolution for each dedicated-node flag combination (colocated and separate, including all three together), sbatch `--nodes` count math, placement-conflict validation, and the cluster-default heterogeneous-job rejection path

🤖 Generated with [Claude Code](https://claude.com/claude-code)