### PR TITLE
Fix direct Bash ruter artifact discovery

### DIFF
--- a/src/srtctl/templates/local_lifecycle.sh.j2
+++ b/src/srtctl/templates/local_lifecycle.sh.j2
@@ -41,7 +41,6 @@ export {{ key }}={{ quote(value) }}
 
 declare -a SRT_OWNED_PIDS=()
 SRT_TACHOMETER_PID=""
-SRTCTL_TACHOMETER=""
 TACHOMETER_LOCAL_DIR=""
 
 srt_log() {


### PR DESCRIPTION
## Summary
- preserve an operator-provided `SRTCTL_TACHOMETER` binary override in rendered lifecycle Bash
- let the Python `srtctl.ruter` viewer discover an explicit, extensionless Dynamo request-trace JSONL file

## Validation
- `uv run pytest tests/test_ruter_view.py tests/test_lifecycle_render.py -q`
- ran `srtctl.ruter init` and `srtctl view` against a completed 3P2D Dynamo artifact bundle on try6767