### PR TITLE
feat: add experimental sgl-router frontend

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -280,10 +280,12 @@ srtctl apply -f config.yaml --tags "experiment-1,baseline"
 ```
 
 `--bash` renders a self-contained script for one direct host; it is not an sbatch script. It currently
-supports a one-node SGLang backend with a Dynamo or SGLang Model Gateway frontend, with
+supports a one-node SGLang backend with a Dynamo, SGLang Model Gateway, or experimental Rust `sgl-router` frontend, with
 `frontend.enable_multiple_frontends: false` and a `benchmark.type: custom` command. The host must already
 provide the configured Python environment and, for Dynamo, the `configs/nats-server` and `configs/etcd`
-binaries. The script creates one process group and log per worker/router, waits for worker and router
+binaries. For `sgl-router`, `frontend.sgl_router.source` must name a local SGLang checkout; the script builds
+`experimental/sgl-router` unless `frontend.sgl_router.binary` or `SRTCTL_SGL_ROUTER` provides an executable.
+The script creates one process group and log per worker/router, waits for worker and router
 readiness plus a chat-completions smoke request, starts the configured Tachometer scraper, runs the benchmark,
 then stops only its owned process groups and compacts Tachometer artifacts.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -271,7 +271,7 @@ Frontend/router configuration.
 
 ```yaml
 frontend:
-  # Frontend type: "dynamo" (default), "sglang", "trtllm_serve", or "vllm"
+  # Frontend type: "dynamo" (default), "sglang", "sgl-router", "trtllm_serve", or "vllm"
   type: dynamo
 
   # Scaling
@@ -295,13 +295,38 @@ frontend:
 
 | Field                       | Type | Default       | Description                         |
 | --------------------------- | ---- | ------------- | ----------------------------------- |
-| `type`                      | str  | dynamo        | Frontend type: "dynamo", "sglang", "trtllm_serve", or "vllm" |
+| `type`                      | str  | dynamo        | Frontend type: "dynamo", "sglang", "sgl-router", "trtllm_serve", or "vllm" |
 | `enable_multiple_frontends` | bool | true          | Scale with nginx + multiple routers |
 | `num_additional_frontends`  | int  | 9             | Additional routers beyond master    |
 | `nginx_container`           | str  | nginx:1.27.4  | Custom nginx container image        |
 | `nginx_raise_ulimit`      | bool | false         | When true with nginx in use, run `ulimit -n 1048576` before nginx and emit `worker_rlimit_nofile 1048576` in generated `nginx.conf`. Off by default so restrictive clusters do not fail. Cluster `srtslurm.yaml` may set `nginx_raise_ulimit` for jobs that omit this field. |
 | `args`                      | dict | null          | CLI args for the frontend           |
 | `env`                       | dict | null          | Env vars for frontend processes     |
+
+### Experimental `sgl-router` frontend
+
+`frontend.type: sgl-router` launches SGLang's experimental Rust router against static HTTP aggregate workers. It requires `backend.type: sglang`, `frontend.enable_multiple_frontends: false`, and an aggregate-only resource layout. Static prefill/decode jobs are rejected because upstream's P/D mode uses Kubernetes EndpointSlice discovery rather than worker URLs.
+
+The binary is built from the configured SGLang checkout when the job starts. In a Slurm container, `source` must be the path inside the container; mount the host checkout using `container_mounts`. Set `binary` to use a prebuilt executable instead.
+
+```yaml
+container_mounts:
+  /data/src/sglang: /opt/sglang
+
+frontend:
+  type: sgl-router
+  enable_multiple_frontends: false
+  sgl_router:
+    source: /opt/sglang
+    # binary: /opt/sglang/experimental/sgl-router/target/release/sgl-router
+  args:
+    policy: cache_aware_zmq
+```
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `sgl_router.source` | str | yes | SGLang checkout that contains `experimental/sgl-router` |
+| `sgl_router.binary` | str | no | Prebuilt `sgl-router` binary; otherwise srtctl runs Cargo build |
 
 See [SGLang Router](sglang-router.md) for detailed architecture.
 

--- a/src/srtctl/backends/sglang.py
+++ b/src/srtctl/backends/sglang.py
@@ -297,7 +297,8 @@ class SGLangProtocol:
             process: The process to start
             endpoint_processes: All processes for this endpoint (for multi-node)
             runtime: Runtime context with paths and settings
-            frontend_type: Frontend type - "sglang" uses sglang.launch_server, "dynamo" uses dynamo.sglang
+            frontend_type: Frontend type - "sglang" and "sgl-router" use sglang.launch_server,
+                "dynamo" uses dynamo.sglang
             nsys_prefix: Optional nsys profiling command prefix
             dump_config_path: Path to dump config JSON
         """
@@ -327,7 +328,7 @@ class SGLangProtocol:
         dist_init_port = SGLANG_DIST_INIT_PORT_BASE
 
         # Choose Python module based on frontend type
-        use_sglang = frontend_type == "sglang"
+        use_sglang = frontend_type in {"sglang", "sgl-router"}
         python_module = "sglang.launch_server" if use_sglang else "dynamo.sglang"
 
         # Get served model name from config
@@ -384,8 +385,8 @@ class SGLangProtocol:
                 ]
             )
 
-        # Add config dump path (not when using sglang frontend)
-        if dump_config_path and frontend_type != "sglang":
+        # Add config dump path (not when using either direct SGLang frontend).
+        if dump_config_path and not use_sglang:
             cmd.extend(["--dump-config-to", str(dump_config_path)])
 
         # Add kv-events-config if enabled for this mode and we have an allocated port

--- a/src/srtctl/core/health.py
+++ b/src/srtctl/core/health.py
@@ -14,6 +14,7 @@ This module provides:
 """
 
 import logging
+import re
 import socket
 import threading
 import time
@@ -116,6 +117,45 @@ def check_sglang_router_health(
         prefill_ready=actual_prefill,
         prefill_expected=expected_prefill,
         decode_ready=effective_decode,
+        decode_expected=expected_decode,
+    )
+
+
+def check_sgl_router_health(
+    metrics: str,
+    expected_prefill: int,
+    expected_decode: int,
+) -> WorkerHealthResult:
+    """Check the experimental router's static aggregate worker count.
+
+    ``sgl-router`` exports one ``sgl_router_workers{mode=\"plain\"}`` gauge
+    for static ``--worker-urls`` registration.  Its prefill/decode modes are
+    Kubernetes discovery-only and are therefore rejected by schema validation.
+    """
+    match = re.search(r'^sgl_router_workers\{mode="plain"\}\s+(\d+(?:\.\d+)?)\s*$', metrics, re.MULTILINE)
+    if match is None:
+        return WorkerHealthResult(
+            ready=False,
+            message='Metric sgl_router_workers{mode="plain"} not found in /metrics response',
+            prefill_expected=expected_prefill,
+            decode_expected=expected_decode,
+        )
+
+    actual_decode = int(float(match.group(1)))
+    ready = expected_prefill == 0 and actual_decode >= expected_decode
+    if ready:
+        message = f"Model is ready. Have {actual_decode} aggregate workers."
+    else:
+        message = (
+            "Model is not ready, waiting for static aggregate workers. "
+            f"Have {actual_decode}/{expected_decode}; prefill expected={expected_prefill}."
+        )
+    return WorkerHealthResult(
+        ready=ready,
+        message=message,
+        prefill_ready=0,
+        prefill_expected=expected_prefill,
+        decode_ready=actual_decode,
         decode_expected=expected_decode,
     )
 
@@ -422,7 +462,8 @@ def wait_for_model(
         poll_interval: Seconds between health checks
         timeout: Maximum wait time in seconds
         report_every: Log progress every N seconds
-        frontend_type: Frontend type - "sglang" uses /workers, "dynamo" uses /health
+        frontend_type: Frontend type - "sglang" uses /workers, "sgl-router" uses /metrics,
+            "dynamo" uses /health
         stop_event: Optional threading.Event to abort waiting
 
     Returns:
@@ -435,6 +476,14 @@ def wait_for_model(
             health_url,
             poll_interval,
             n_prefill,
+            n_decode,
+        )
+    elif frontend_type == "sgl-router":
+        health_url = f"http://{host}:{port}/metrics"
+        logger.info(
+            "Polling %s every %.1fs for %d aggregate workers (experimental sgl-router)",
+            health_url,
+            poll_interval,
             n_decode,
         )
     else:
@@ -482,13 +531,15 @@ def wait_for_model(
                     time.sleep(poll_interval)
                     continue
 
-                response_json = response.json()
-
                 # Check worker counts based on frontend type
-                if frontend_type == "sglang":
-                    result = check_sglang_router_health(response_json, n_prefill, n_decode)
+                if frontend_type == "sgl-router":
+                    result = check_sgl_router_health(response.text, n_prefill, n_decode)
                 else:
-                    result = check_dynamo_health(response_json, n_prefill, n_decode)
+                    response_json = response.json()
+                    if frontend_type == "sglang":
+                        result = check_sglang_router_health(response_json, n_prefill, n_decode)
+                    else:
+                        result = check_dynamo_health(response_json, n_prefill, n_decode)
 
                 if result.ready:
                     logger.info(result.message)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1547,11 +1547,27 @@ class DynamoConfig:
 
 
 @dataclass(frozen=True)
+class SGLRouterConfig:
+    """Configuration for the experimental Rust ``sgl-router`` frontend.
+
+    ``source`` is the path to an SGLang checkout as seen by the frontend
+    process.  srtctl builds ``experimental/sgl-router`` there on first use
+    unless ``binary`` names a prebuilt executable.
+    """
+
+    source: str
+    binary: str | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+
+@dataclass(frozen=True)
 class FrontendConfig:
     """Frontend/router configuration.
 
     Attributes:
-        type: Frontend type - "dynamo" (default), "sglang", "trtllm_serve", or "vllm"
+        type: Frontend type - "dynamo" (default), "sglang", "sgl-router",
+            "trtllm_serve", or "vllm"
         enable_multiple_frontends: Scale with nginx + multiple routers.
             When ``True`` (default), srtctl stands up nginx and fans out
             to ``num_additional_frontends + 1`` router replicas. When
@@ -1589,6 +1605,8 @@ class FrontendConfig:
     nginx_keepalive_timeout: str = "600s"
     args: dict[str, Any] | None = None
     env: dict[str, str] | None = None
+    # Experimental Rust router options. Required when type is ``sgl-router``.
+    sgl_router: SGLRouterConfig | None = None
     # trtllm_serve orchestrator (ser.yaml) options; ignored by other frontends.
     ctx_router: dict[str, Any] | None = None  # context_servers.router, e.g. {type: conversation}
     gen_router: dict[str, Any] | None = None  # generation_servers.router
@@ -1708,6 +1726,7 @@ class SrtConfig:
         self._validate_dedicated_node_placement()
         self._validate_trtllm_serve()
         self._validate_vllm_frontend()
+        self._validate_sgl_router_frontend()
         self._warn_dp_launch_mode()
 
     def _warn_dp_launch_mode(self):
@@ -1780,6 +1799,64 @@ class SrtConfig:
                 "replicas, so extra workers would either idle or collide on the port. "
                 "Use frontend.type: dynamo to run multiple aggregate workers, or scale a single "
                 "worker across nodes with resources.agg_nodes."
+            )
+
+    def _validate_sgl_router_frontend(self):
+        """Validate the static-worker subset supported by experimental sgl-router.
+
+        The Rust router's P/D support uses Kubernetes EndpointSlice discovery.
+        srtctl has static Slurm worker endpoints, for which upstream exposes
+        only the aggregate ``--worker-urls`` API.
+        """
+        if self.frontend.type != "sgl-router":
+            return
+        if self.backend_type != "sglang":
+            raise ValidationError(f"frontend.type: sgl-router requires backend.type: sglang; got {self.backend_type!r}")
+        if self.frontend.enable_multiple_frontends:
+            raise ValidationError(
+                "frontend.type: sgl-router uses one public endpoint; set frontend.enable_multiple_frontends: false"
+            )
+        if self.resources.is_disaggregated:
+            raise ValidationError(
+                "frontend.type: sgl-router supports aggregate jobs only. The experimental router's P/D mode "
+                "requires Kubernetes EndpointSlice discovery, which static srt-slurm workers do not provide."
+            )
+        if self.resources.num_agg < 1:
+            raise ValidationError("frontend.type: sgl-router requires at least one aggregate worker")
+        if self.frontend.sgl_router is None:
+            raise ValidationError(
+                "frontend.type: sgl-router requires frontend.sgl_router.source (an SGLang checkout visible to the router)"
+            )
+        if not self.frontend.sgl_router.source.strip():
+            raise ValidationError("frontend.sgl_router.source must not be empty")
+
+        managed_args = {
+            "host",
+            "port",
+            "model-id",
+            "model_id",
+            "tokenizer-path",
+            "tokenizer_path",
+            "worker-urls",
+            "worker_urls",
+            "service-discovery",
+            "service_discovery",
+            "service-discovery-namespace",
+            "service_discovery_namespace",
+            "selector",
+            "prefill-selector",
+            "prefill_selector",
+            "decode-selector",
+            "decode_selector",
+        }
+        supplied_managed_args = sorted(managed_args.intersection(self.frontend.args or {}))
+        if supplied_managed_args:
+            raise ValidationError(
+                "frontend.type: sgl-router manages these arguments: " + ", ".join(supplied_managed_args)
+            )
+        if isinstance(self.backend, SGLangProtocol) and self.backend.is_grpc_mode("agg"):
+            raise ValidationError(
+                "frontend.type: sgl-router currently requires HTTP aggregate workers; disable grpc-mode"
             )
 
     def _validate_het_jobs(self):

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -88,7 +88,12 @@ def generate_tachometer_config(
         if frontend_type == "vllm" and process.endpoint_mode == "agg" and not process.is_leader:
             continue
         node_ip = get_hostname_ip(process.node, runtime.network_interface)
-        port = FRONTEND_PUBLIC_PORT if frontend_type == "vllm" and process.endpoint_mode == "agg" else process.sys_port
+        if frontend_type == "vllm" and process.endpoint_mode == "agg":
+            port = FRONTEND_PUBLIC_PORT
+        elif frontend_type in {"sglang", "sgl-router"}:
+            port = process.http_port
+        else:
+            port = process.sys_port
         node_metadata = {
             "hostname": process.node,
             "worker_index": str(process.endpoint_index),

--- a/src/srtctl/frontends/__init__.py
+++ b/src/srtctl/frontends/__init__.py
@@ -7,6 +7,7 @@ Frontend implementations for routing requests to backend workers.
 Supported frontend types:
 - dynamo: Dynamo frontend with NATS/etcd communication
 - sglang: SGLang native router with direct worker connections
+- sgl-router: Experimental Rust SGLang router with static aggregate workers
 - vllm: Direct vLLM OpenAI server for aggregate jobs
 """
 
@@ -16,6 +17,7 @@ from srtctl.frontends.base import (
     get_frontend,
 )
 from srtctl.frontends.dynamo import DynamoFrontend
+from srtctl.frontends.sgl_router import SGLRouterFrontend
 from srtctl.frontends.sglang import SGLangFrontend
 from srtctl.frontends.trtllm_serve import TRTLLMServeFrontend
 from srtctl.frontends.vllm import VLLMFrontend
@@ -24,6 +26,7 @@ __all__ = [
     "DynamoFrontend",
     "FrontendProtocol",
     "FrontendType",
+    "SGLRouterFrontend",
     "SGLangFrontend",
     "TRTLLMServeFrontend",
     "VLLMFrontend",

--- a/src/srtctl/frontends/base.py
+++ b/src/srtctl/frontends/base.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from srtctl.core.topology import Process
 
 # Supported frontend types - extensible by adding new literals
-FrontendType = Literal["dynamo", "sglang", "trtllm_serve", "vllm"]
+FrontendType = Literal["dynamo", "sglang", "sgl-router", "trtllm_serve", "vllm"]
 
 
 class FrontendProtocol(Protocol):
@@ -44,7 +44,7 @@ class FrontendProtocol(Protocol):
 
     def parse_health(
         self,
-        response_json: dict,
+        response_json: Any,
         expected_prefill: int,
         expected_decode: int,
     ) -> "WorkerHealthResult":
@@ -95,6 +95,7 @@ def get_frontend(frontend_type: str) -> FrontendProtocol:
     """
     # Import here to avoid circular imports
     from srtctl.frontends.dynamo import DynamoFrontend
+    from srtctl.frontends.sgl_router import SGLRouterFrontend
     from srtctl.frontends.sglang import SGLangFrontend
     from srtctl.frontends.trtllm_serve import TRTLLMServeFrontend
     from srtctl.frontends.vllm import VLLMFrontend
@@ -103,9 +104,13 @@ def get_frontend(frontend_type: str) -> FrontendProtocol:
         return DynamoFrontend()
     elif frontend_type == "sglang":
         return SGLangFrontend()
+    elif frontend_type == "sgl-router":
+        return SGLRouterFrontend()
     elif frontend_type == "trtllm_serve":
         return TRTLLMServeFrontend()
     elif frontend_type == "vllm":
         return VLLMFrontend()
     else:
-        raise ValueError(f"Unknown frontend type: {frontend_type!r}. Supported: dynamo, sglang, trtllm_serve, vllm")
+        raise ValueError(
+            f"Unknown frontend type: {frontend_type!r}. Supported: dynamo, sglang, sgl-router, trtllm_serve, vllm"
+        )

--- a/src/srtctl/frontends/sgl_router.py
+++ b/src/srtctl/frontends/sgl_router.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental Rust ``sgl-router`` frontend.
+
+The upstream router accepts a static aggregate ``--worker-urls`` pool.  Its
+prefill/decode discovery API is Kubernetes-only, so this frontend deliberately
+does not model srt-slurm's static disaggregated topology.
+"""
+
+import logging
+import shlex
+import threading
+from typing import TYPE_CHECKING, Any
+
+from srtctl.core.health import WorkerHealthResult, check_sgl_router_health
+from srtctl.core.slurm import get_hostname_ip, start_srun_process
+
+if TYPE_CHECKING:
+    from srtctl.core.processes import ManagedProcess
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.topology import Process
+
+logger = logging.getLogger(__name__)
+
+
+class SGLRouterFrontend:
+    """Launch the experimental Rust router against static aggregate workers."""
+
+    @property
+    def type(self) -> str:
+        return "sgl-router"
+
+    @property
+    def health_endpoint(self) -> str:
+        return "/metrics"
+
+    def parse_health(
+        self,
+        response_json: Any,
+        expected_prefill: int,
+        expected_decode: int,
+    ) -> WorkerHealthResult:
+        """Parse the router's Prometheus worker-count metric."""
+        if not isinstance(response_json, str):
+            return WorkerHealthResult(
+                ready=False,
+                message="Expected Prometheus text from sgl-router /metrics",
+                prefill_expected=expected_prefill,
+                decode_expected=expected_decode,
+            )
+        return check_sgl_router_health(response_json, expected_prefill, expected_decode)
+
+    def get_frontend_args_list(self, args: dict[str, Any] | None) -> list[str]:
+        """Convert frontend arguments to CLI arguments."""
+        if not args:
+            return []
+        result: list[str] = []
+        for key, value in args.items():
+            if value is True:
+                result.append(f"--{key.replace('_', '-')}")
+            elif value is not False and value is not None:
+                result.extend([f"--{key.replace('_', '-')}", str(value)])
+        return result
+
+    @staticmethod
+    def _build_preamble(source: str, configured_binary: str | None) -> str:
+        """Build the router once when no executable override is supplied."""
+        default_binary = configured_binary or ""
+        manifest_path = f"{source.rstrip('/')}/experimental/sgl-router/Cargo.toml"
+        built_binary = f"{source.rstrip('/')}/experimental/sgl-router/target/release/sgl-router"
+        return "\n".join(
+            (
+                f"SRTCTL_SGL_ROUTER_SOURCE={shlex.quote(source)}",
+                f"SRTCTL_SGL_ROUTER_BINARY=${{SRTCTL_SGL_ROUTER_BINARY:-{shlex.quote(default_binary)}}}",
+                'if [[ -z "${SRTCTL_SGL_ROUTER_BINARY}" ]]; then',
+                '  echo "Building experimental sgl-router from ${SRTCTL_SGL_ROUTER_SOURCE}"',
+                f"  cargo build --manifest-path {shlex.quote(manifest_path)} --release",
+                f"  SRTCTL_SGL_ROUTER_BINARY={shlex.quote(built_binary)}",
+                "fi",
+                '[[ -x "${SRTCTL_SGL_ROUTER_BINARY}" ]] || { echo "sgl-router binary is not executable: ${SRTCTL_SGL_ROUTER_BINARY}" >&2; exit 1; }',
+                "export SRTCTL_SGL_ROUTER_BINARY",
+            )
+        )
+
+    def start_frontends(
+        self,
+        topology: Any,  # FrontendTopology
+        runtime: "RuntimeContext",
+        config: Any,  # SrtConfig
+        backend: Any,  # BackendProtocol
+        backend_processes: list["Process"],
+        stop_event: threading.Event | None = None,  # unused: returns immediately
+    ) -> list["ManagedProcess"]:
+        """Start one static-worker router per selected frontend node."""
+        from srtctl.core.processes import ManagedProcess
+
+        del backend, stop_event
+        router_config = config.frontend.sgl_router
+        assert router_config is not None  # validated by SrtConfig
+
+        worker_urls = [
+            f"http://{get_hostname_ip(process.node)}:{process.http_port}"
+            for process in backend_processes
+            if process.is_leader and process.endpoint_mode == "agg"
+        ]
+        if not worker_urls:
+            raise ValueError("sgl-router requires at least one aggregate worker leader")
+
+        tokenizer_path = (
+            runtime.worker_model_arg if runtime.is_hf_model else f"{runtime.worker_model_arg}/tokenizer.json"
+        )
+        router_args = [
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(topology.frontend_port),
+            "--model-id",
+            config.served_model_name,
+            "--tokenizer-path",
+            tokenizer_path,
+            "--worker-urls",
+            *worker_urls,
+            *self.get_frontend_args_list(config.frontend.args),
+        ]
+        command = [
+            "bash",
+            "-lc",
+            'exec "$SRTCTL_SGL_ROUTER_BINARY" "$@"',
+            "sgl-router",
+            *router_args,
+        ]
+        preamble = self._build_preamble(router_config.source, router_config.binary)
+        env_to_set = dict(config.frontend.env or {})
+
+        processes: list[ManagedProcess] = []
+        for index, node in enumerate(topology.frontend_nodes):
+            router_log = runtime.log_dir / f"{node}_sgl_router_{index}.out"
+            logger.info("Starting experimental sgl-router %d on %s: %s", index, node, shlex.join(router_args))
+            proc = start_srun_process(
+                command=command,
+                nodelist=[node],
+                output=str(router_log),
+                container_image=str(runtime.container_image),
+                container_mounts=runtime.container_mounts,
+                env_to_set=env_to_set or None,
+                bash_preamble=preamble,
+                het_group=runtime.nodes.het_group_for(node),
+            )
+            processes.append(
+                ManagedProcess(
+                    name=f"sgl_router_{index}",
+                    popen=proc,
+                    log_file=router_log,
+                    node=node,
+                    critical=True,
+                )
+            )
+        return processes

--- a/src/srtctl/render/lifecycle.py
+++ b/src/srtctl/render/lifecycle.py
@@ -67,6 +67,8 @@ class LocalLifecycleRenderContext:
     tachometer_binary: str | None
     tachometer_config: str | None
     ruter_enabled: bool
+    sgl_router_source: str | None
+    sgl_router_binary: str | None
 
 
 def heredoc_marker(payload: str, *, prefix: str = "SRTCTL_RUNTIME_CONFIG") -> str:
@@ -78,8 +80,10 @@ def heredoc_marker(payload: str, *, prefix: str = "SRTCTL_RUNTIME_CONFIG") -> st
     return marker
 
 
-def _shell_command(args: list[str], environment: dict[str, str] | None = None) -> str:
-    """Return a shell-safe command that uses the script-selected Python."""
+def _shell_command(
+    args: list[str], environment: dict[str, str] | None = None, *, executable: str = "$SRTCTL_PYTHON"
+) -> str:
+    """Return a shell-safe command with a script-selected executable."""
     parts = []
     for key, value in sorted((environment or {}).items()):
         if not key.replace("_", "").isalnum() or key[0].isdigit():
@@ -90,7 +94,7 @@ def _shell_command(args: list[str], environment: dict[str, str] | None = None) -
         # expand in the child process that owns the frontend.
         quoted_value = quoted_value.replace(_ARTIFACT_DIR_PLACEHOLDER, '"${ARTIFACT_DIR}"')
         parts.append(f"{key}={quoted_value}")
-    parts.append("$SRTCTL_PYTHON")
+    parts.append(executable)
     parts.extend(shlex.quote(str(arg)) for arg in args)
     return " ".join(parts)
 
@@ -147,8 +151,8 @@ def _validate_local_config(config: SrtConfig) -> None:
         raise ValueError("--bash requires a single-node resource topology")
     if config.infra.etcd_nats_dedicated_node:
         raise ValueError("--bash does not support infra.etcd_nats_dedicated_node on a single host")
-    if config.frontend.type not in {"dynamo", "sglang"}:
-        raise ValueError("--bash currently supports frontend.type: dynamo or sglang")
+    if config.frontend.type not in {"dynamo", "sglang", "sgl-router"}:
+        raise ValueError("--bash currently supports frontend.type: dynamo, sglang, or sgl-router")
     if config.frontend.type == "sglang" and (config.frontend.args or {}).get("policy") == "cache-aware-zmq":
         raise ValueError("--bash uses the SGLang Model Gateway; use frontend.args.policy: cache_aware")
     if config.frontend.enable_multiple_frontends:
@@ -305,6 +309,25 @@ def _build_router_command(config: SrtConfig, processes: list[Process], *, etcd_c
         for process in sorted(processes, key=lambda item: (item.endpoint_mode, item.endpoint_index, item.node_rank))
         if process.is_leader
     ]
+    if config.frontend.type == "sgl-router":
+        tokenizer_path = _local_model_path(config)
+        if not config.model.path.startswith("hf:"):
+            tokenizer_path = f"{tokenizer_path}/tokenizer.json"
+        args = [
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(FRONTEND_PUBLIC_PORT),
+            "--model-id",
+            config.served_model_name,
+            "--tokenizer-path",
+            tokenizer_path,
+            "--worker-urls",
+            *worker_urls,
+            *_cli_args(config.frontend.args),
+        ]
+        return _shell_command(args, frontend_environment, executable="$SRTCTL_SGL_ROUTER")
+
     args = [
         "-m",
         "sglang_router.launch_router",
@@ -380,6 +403,7 @@ def build_local_lifecycle_render_context(
     expected_prefill = resources.num_prefill
     expected_decode = resources.num_agg if resources.num_agg else resources.num_decode
     health_interval = max(1, int(config.health_check.interval_seconds))
+    sgl_router_config = config.frontend.sgl_router
     return LocalLifecycleRenderContext(
         name=config.name,
         source_dir=str(source_dir.resolve()),
@@ -404,6 +428,8 @@ def build_local_lifecycle_render_context(
         tachometer_binary=config.observability.tachometer.binary_path if tachometer_config is not None else None,
         tachometer_config=tachometer_config,
         ruter_enabled=config.frontend.type == "dynamo" and config.observability.enabled,
+        sgl_router_source=sgl_router_config.source if sgl_router_config is not None else None,
+        sgl_router_binary=sgl_router_config.binary if sgl_router_config is not None else None,
     )
 
 

--- a/src/srtctl/templates/local_lifecycle.sh.j2
+++ b/src/srtctl/templates/local_lifecycle.sh.j2
@@ -175,10 +175,13 @@ srt_wait_router_ready() {
     local path="/health"
     if [[ "${FRONTEND_TYPE}" == "sglang" ]]; then
         path="/workers"
+    elif [[ "${FRONTEND_TYPE}" == "sgl-router" ]]; then
+        path="/metrics"
     fi
     SRT_WATCH_PIDS="${SRT_OWNED_PIDS[*]}" "${SRTCTL_PYTHON}" - "http://127.0.0.1:${FRONTEND_PORT}${path}" {{ context.expected_prefill }} {{ context.expected_decode }} "${FRONTEND_TYPE}" "${SRT_READY_TIMEOUT}" "${SRT_READY_INTERVAL}" <<'PY'
 import json
 import os
+import re
 import sys
 import time
 import urllib.error
@@ -205,6 +208,12 @@ def sglang_counts(payload):
     stats = payload.get("stats", {})
     return int(stats.get("prefill_count", 0) or 0), int(stats.get("decode_count", 0) or 0) + int(stats.get("regular_count", 0) or 0)
 
+def sgl_router_counts(metrics):
+    match = re.search(r'^sgl_router_workers\{mode="plain"\}\s+(\d+(?:\.\d+)?)\s*$', metrics, re.MULTILINE)
+    if match is None:
+        return 0, 0
+    return 0, int(float(match.group(1)))
+
 while time.monotonic() < deadline:
     for raw_pid in os.environ.get("SRT_WATCH_PIDS", "").split():
         try:
@@ -213,8 +222,15 @@ while time.monotonic() < deadline:
             raise SystemExit(f"Owned process {raw_pid} exited before router readiness")
     try:
         with urllib.request.urlopen(url, timeout=5) as response:
-            payload = json.loads(response.read().decode())
-        prefill, decode = sglang_counts(payload) if frontend_type == "sglang" else dynamo_counts(payload)
+            body = response.read().decode()
+        if frontend_type == "sgl-router":
+            ready_url = url.rsplit("/", 1)[0] + "/readyz"
+            with urllib.request.urlopen(ready_url, timeout=5):
+                pass
+            prefill, decode = sgl_router_counts(body)
+        else:
+            payload = json.loads(body)
+            prefill, decode = sglang_counts(payload) if frontend_type == "sglang" else dynamo_counts(payload)
         if prefill >= expected_prefill and decode >= expected_decode:
             print(f"Router ready: prefill={prefill}/{expected_prefill} decode={decode}/{expected_decode}")
             raise SystemExit(0)
@@ -266,8 +282,20 @@ mkdir -p "${OUTPUT_DIR}/nats" "${OUTPUT_DIR}/etcd"
 srt_launch "nats" "${LOG_DIR}/nats.log" "${SRTCTL_NATS_BINARY}" -js -a "127.0.0.1" -p {{ context.nats_port }} -sd "${OUTPUT_DIR}/nats"
 srt_launch "etcd" "${LOG_DIR}/etcd.log" "${SRTCTL_ETCD_BINARY}" --data-dir "${OUTPUT_DIR}/etcd" --listen-client-urls "http://127.0.0.1:{{ context.etcd_client_port }}" --advertise-client-urls "http://127.0.0.1:{{ context.etcd_client_port }}" --listen-peer-urls "http://127.0.0.1:{{ context.etcd_peer_port }}" --initial-advertise-peer-urls "http://127.0.0.1:{{ context.etcd_peer_port }}" --initial-cluster "default=http://127.0.0.1:{{ context.etcd_peer_port }}"
 srt_wait_http_ready "http://127.0.0.1:{{ context.etcd_client_port }}/health" "etcd"
-{% else %}
+{% elif context.frontend_type == "sglang" %}
 "${SRTCTL_PYTHON}" -c 'import sglang_router' || srt_die "sglang-router (Model Gateway) is not installed for ${SRTCTL_PYTHON}"
+{% else %}
+SRTCTL_SGL_ROUTER_SOURCE={{ quote(context.sgl_router_source or '') }}
+SRTCTL_SGL_ROUTER_DEFAULT={{ quote(context.sgl_router_binary or '') }}
+SRTCTL_SGL_ROUTER="${SRTCTL_SGL_ROUTER:-${SRTCTL_SGL_ROUTER_DEFAULT}}"
+if [[ -z "${SRTCTL_SGL_ROUTER}" ]]; then
+    [[ -n "${SRTCTL_SGL_ROUTER_SOURCE}" ]] || srt_die "frontend.sgl_router.source is required to build experimental sgl-router"
+    srt_log "Building experimental sgl-router from ${SRTCTL_SGL_ROUTER_SOURCE}"
+    cargo build --manifest-path "${SRTCTL_SGL_ROUTER_SOURCE}/experimental/sgl-router/Cargo.toml" --release >"${LOG_DIR}/sgl-router-build.log" 2>&1 || srt_die "sgl-router build failed; inspect ${LOG_DIR}/sgl-router-build.log"
+    SRTCTL_SGL_ROUTER="${SRTCTL_SGL_ROUTER_SOURCE}/experimental/sgl-router/target/release/sgl-router"
+fi
+[[ -x "${SRTCTL_SGL_ROUTER}" ]] || srt_die "sgl-router binary is not executable: ${SRTCTL_SGL_ROUTER}"
+export SRTCTL_SGL_ROUTER
 {% endif %}
 
 {% for worker in context.worker_processes %}

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from srtctl.core.schema import ObservabilityConfig
-from srtctl.frontends import DynamoFrontend, SGLangFrontend, VLLMFrontend, get_frontend
+from srtctl.frontends import DynamoFrontend, SGLangFrontend, SGLRouterFrontend, VLLMFrontend, get_frontend
 
 # ============================================================================
 # get_frontend() Tests
@@ -32,6 +32,12 @@ class TestGetFrontend:
         frontend = get_frontend("sglang")
         assert isinstance(frontend, SGLangFrontend)
         assert frontend.type == "sglang"
+
+    def test_get_sgl_router_frontend(self):
+        """get_frontend('sgl-router') returns the experimental Rust router."""
+        frontend = get_frontend("sgl-router")
+        assert isinstance(frontend, SGLRouterFrontend)
+        assert frontend.type == "sgl-router"
 
     def test_get_vllm_frontend(self):
         """get_frontend('vllm') returns VLLMFrontend."""
@@ -66,6 +72,11 @@ class TestFrontendProperties:
         frontend = SGLangFrontend()
         assert frontend.type == "sglang"
 
+    def test_sgl_router_type(self):
+        """SGLRouterFrontend.type is 'sgl-router'."""
+        frontend = SGLRouterFrontend()
+        assert frontend.type == "sgl-router"
+
     def test_vllm_type(self):
         """VLLMFrontend.type is 'vllm'."""
         frontend = VLLMFrontend()
@@ -80,6 +91,11 @@ class TestFrontendProperties:
         """SGLangFrontend uses /workers endpoint."""
         frontend = SGLangFrontend()
         assert frontend.health_endpoint == "/workers"
+
+    def test_sgl_router_health_endpoint(self):
+        """SGLRouterFrontend uses /metrics for static worker registration."""
+        frontend = SGLRouterFrontend()
+        assert frontend.health_endpoint == "/metrics"
 
     def test_vllm_health_endpoint(self):
         """VLLMFrontend uses /health endpoint."""
@@ -403,6 +419,81 @@ class TestSGLangGrpcScheme:
         # Check aggregated mode flags
         assert "--worker-urls" in cmd
         assert "--pd-disaggregation" not in cmd
+
+
+class TestSGLRouterFrontend:
+    """Tests for the experimental Rust router's static worker launch path."""
+
+    @patch("srtctl.frontends.sgl_router.start_srun_process")
+    @patch("srtctl.frontends.sgl_router.get_hostname_ip")
+    def test_builds_binary_and_registers_static_http_workers(self, mock_get_ip, mock_srun):
+        mock_get_ip.side_effect = lambda node: {"node1": "10.0.0.1", "node2": "10.0.0.2"}[node]
+        mock_srun.return_value = MagicMock()
+        frontend = SGLRouterFrontend()
+        topology = MockTopology(frontend_nodes=["router0"])
+        config = SimpleNamespace(
+            frontend=SimpleNamespace(
+                sgl_router=SimpleNamespace(source="/opt/sglang", binary=None),
+                args={"policy": "cache_aware_zmq"},
+                env={"RUST_LOG": "info"},
+            ),
+            served_model_name="Qwen/Qwen3-32B-FP8",
+        )
+        runtime = SimpleNamespace(
+            log_dir=Path("/logs"),
+            container_image=Path("/containers/sglang.sqsh"),
+            container_mounts={},
+            worker_model_arg="/model",
+            is_hf_model=False,
+            nodes=SimpleNamespace(het_group_for=lambda node: None),
+        )
+        workers = [
+            MockProcess(node="node1", endpoint_mode="agg", http_port=30000),
+            MockProcess(node="node2", endpoint_mode="agg", http_port=30001),
+        ]
+
+        processes = frontend.start_frontends(topology, runtime, config, MagicMock(), workers)
+
+        assert processes[0].name == "sgl_router_0"
+        assert processes[0].log_file == Path("/logs/router0_sgl_router_0.out")
+        call = mock_srun.call_args.kwargs
+        assert call["command"][:4] == ["bash", "-lc", 'exec "$SRTCTL_SGL_ROUTER_BINARY" "$@"', "sgl-router"]
+        assert "--tokenizer-path" in call["command"]
+        assert "/model/tokenizer.json" in call["command"]
+        assert "http://10.0.0.1:30000" in call["command"]
+        assert "http://10.0.0.2:30001" in call["command"]
+        assert (
+            "cargo build --manifest-path /opt/sglang/experimental/sgl-router/Cargo.toml --release"
+            in call["bash_preamble"]
+        )
+        assert call["env_to_set"] == {"RUST_LOG": "info"}
+
+    def test_worker_command_uses_direct_sglang_server(self):
+        """The experimental router needs HTTP SGLang workers, not dynamo.sglang."""
+        from srtctl.backends import SGLangProtocol
+        from srtctl.core.topology import Process
+
+        process = Process(
+            node="node0",
+            gpu_indices=frozenset({0}),
+            sys_port=7500,
+            http_port=6100,
+            endpoint_mode="agg",
+            endpoint_index=0,
+        )
+        runtime = SimpleNamespace(model_path=Path("/model"), is_hf_model=False)
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            command = SGLangProtocol().build_worker_command(
+                process,
+                [process],
+                runtime,
+                frontend_type="sgl-router",
+            )
+
+        assert "sglang.launch_server" in command
+        assert "dynamo.sglang" not in command
+        assert "--request-plane" not in command
 
 
 # ============================================================================

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -6,6 +6,7 @@
 from srtctl.core.health import (
     WorkerHealthResult,
     check_dynamo_health,
+    check_sgl_router_health,
     check_sglang_router_health,
 )
 
@@ -364,6 +365,35 @@ class TestSGLangRouterHealthAggregated:
 
         assert result.ready is True
         assert result.decode_ready == 4  # 2 decode + 2 regular
+
+
+class TestExperimentalSGLRouterHealth:
+    """Test experimental sgl-router Prometheus worker-count parsing."""
+
+    def test_static_workers_ready(self):
+        metrics = '# HELP sgl_router_workers Connected workers\nsgl_router_workers{mode="plain"} 8\n'
+
+        result = check_sgl_router_health(metrics, expected_prefill=0, expected_decode=8)
+
+        assert result.ready is True
+        assert result.decode_ready == 8
+
+    def test_static_workers_wait_for_full_pool(self):
+        result = check_sgl_router_health('sgl_router_workers{mode="plain"} 7\n', expected_prefill=0, expected_decode=8)
+
+        assert result.ready is False
+        assert result.decode_ready == 7
+
+    def test_disaggregated_expectation_never_reports_ready(self):
+        result = check_sgl_router_health('sgl_router_workers{mode="plain"} 8\n', expected_prefill=1, expected_decode=8)
+
+        assert result.ready is False
+
+    def test_missing_metric_is_not_ready(self):
+        result = check_sgl_router_health("other_metric 1\n", expected_prefill=0, expected_decode=1)
+
+        assert result.ready is False
+        assert "not found" in result.message
 
 
 class TestSGLangRouterHealthErrors:

--- a/tests/test_lifecycle_render.py
+++ b/tests/test_lifecycle_render.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
 import yaml
+from marshmallow import ValidationError
 
 from srtctl.core.config import expand_observability
 from srtctl.core.schema import SrtConfig
@@ -45,7 +47,13 @@ def _config(
         "frontend": {
             "type": frontend_type,
             "enable_multiple_frontends": False,
-            "args": {"policy": "cache_aware"} if frontend_type == "sglang" else {"router-mode": "kv"},
+            "args": (
+                {"policy": "cache_aware"}
+                if frontend_type == "sglang"
+                else {"policy": "cache_aware_zmq"}
+                if frontend_type == "sgl-router"
+                else {"router-mode": "kv"}
+            ),
             "env": frontend_env,
         },
         "environment": environment or {},
@@ -55,6 +63,8 @@ def _config(
             "tachometer": {"enabled": True},
         },
     }
+    if frontend_type == "sgl-router":
+        raw["frontend"]["sgl_router"] = {"source": "/opt/sglang"}
     expand_observability(raw)
     return SrtConfig.Schema().load(yaml.safe_load(yaml.safe_dump(raw)))
 
@@ -69,7 +79,9 @@ def test_local_lifecycle_renders_eight_tp1_workers_with_separate_logs(tmp_path) 
 
     assert len(context.worker_processes) == 8
     assert {worker.log_name for worker in context.worker_processes} == {f"worker-{index}.log" for index in range(8)}
-    assert all(f"CUDA_VISIBLE_DEVICES={index}" in worker.command for index, worker in enumerate(context.worker_processes))
+    assert all(
+        f"CUDA_VISIBLE_DEVICES={index}" in worker.command for index, worker in enumerate(context.worker_processes)
+    )
     assert "-m sglang_router.launch_router" in context.router_command
     assert "--policy cache_aware" in context.router_command
     assert 'name = "router"' in context.tachometer_config
@@ -100,18 +112,70 @@ def test_local_dynamo_lifecycle_starts_owned_infrastructure(tmp_path) -> None:
     assert "DYN_SYSTEM_PORT=7500" in context.worker_processes[0].command
     assert 'DYN_REQUEST_TRACE_FILE_PATH="${ARTIFACT_DIR}"/dynamo-request-trace' in context.router_command
     assert all(
-        f"--nccl-port {17_500 + index}" in worker.command
-        for index, worker in enumerate(context.worker_processes)
+        f"--nccl-port {17_500 + index}" in worker.command for index, worker in enumerate(context.worker_processes)
     )
     assert 'srt_wait_http_ready "http://127.0.0.1:6100/health"' not in script
     assert "srt_wait_router_ready" in script
     assert 'TACHOMETER_STORAGE="${ARTIFACT_DIR}/tachometer/raw/scrape"' in script
     assert context.ruter_enabled
     assert 'SRTCTL_RUTER_PYTHON="${SRTCTL_RUTER_PYTHON:-${SRTCTL_SOURCE}/.venv/bin/python}"' in script
-    assert 'Observability enabled: Dynamo request tracing is on (DYN_REQUEST_TRACE=1; request-end gzip JSONL: ${ARTIFACT_DIR}/dynamo-request-trace.*.jsonl.gz)' in script
+    assert (
+        "Observability enabled: Dynamo request tracing is on (DYN_REQUEST_TRACE=1; request-end gzip JSONL: ${ARTIFACT_DIR}/dynamo-request-trace.*.jsonl.gz)"
+        in script
+    )
     assert '"${SRTCTL_RUTER_PYTHON}" -m srtctl.ruter init "${OUTPUT_DIR}" --output "${LOG_DIR}/.ruter"' in script
     syntax = subprocess.run(["bash", "-n"], input=script, text=True, capture_output=True, check=False)
     assert syntax.returncode == 0, syntax.stderr
+
+
+def test_local_sgl_router_lifecycle_builds_and_waits_for_all_static_workers(tmp_path) -> None:
+    context = build_local_lifecycle_render_context(
+        _config(frontend_type="sgl-router"),
+        source_dir=tmp_path / "srt-slurm",
+        output_base=tmp_path / "outputs",
+    )
+    script = render_local_lifecycle(context)
+
+    assert context.sgl_router_source == "/opt/sglang"
+    assert "$SRTCTL_SGL_ROUTER --host 127.0.0.1 --port 8000" in context.router_command
+    assert "--model-id fake/mock-model" in context.router_command
+    assert "--tokenizer-path fake/mock-model" in context.router_command
+    assert f"--worker-urls http://127.0.0.1:{context.worker_processes[0].http_port}" in context.router_command
+    assert "--policy cache_aware_zmq" in context.router_command
+    assert (
+        'cargo build --manifest-path "${SRTCTL_SGL_ROUTER_SOURCE}/experimental/sgl-router/Cargo.toml" --release'
+        in script
+    )
+    assert '"${LOG_DIR}/sgl-router-build.log"' in script
+    assert 'path="/metrics"' in script
+    assert 'sgl_router_workers\\{mode="plain"\\}' in script
+    assert '"${LOG_DIR}/router.log"' in script
+    syntax = subprocess.run(["bash", "-n"], input=script, text=True, capture_output=True, check=False)
+    assert syntax.returncode == 0, syntax.stderr
+
+
+def test_local_sgl_router_rejects_disaggregated_topology() -> None:
+    raw = {
+        "name": "direct-sgl-router-disagg",
+        "model": {"path": "hf:fake/mock-model", "container": "unused", "precision": "fp8"},
+        "resources": {
+            "gpu_type": "h100",
+            "gpus_per_node": 8,
+            "prefill_nodes": 1,
+            "decode_nodes": 1,
+            "prefill_workers": 1,
+            "decode_workers": 1,
+        },
+        "backend": {"type": "sglang", "sglang_config": {"prefill": {}, "decode": {}}},
+        "frontend": {
+            "type": "sgl-router",
+            "enable_multiple_frontends": False,
+            "sgl_router": {"source": "/opt/sglang"},
+        },
+    }
+
+    with pytest.raises(ValidationError, match="aggregate jobs only"):
+        SrtConfig.Schema().load(raw)
 
 
 def test_local_lifecycle_expands_artifact_dir_in_frontend_environment(tmp_path) -> None:
@@ -126,8 +190,8 @@ def test_local_lifecycle_expands_artifact_dir_in_frontend_environment(tmp_path) 
     script = render_local_lifecycle(context)
 
     assert 'DYN_REQUEST_TRACE_FILE_PATH="${ARTIFACT_DIR}"/dynamo-request-trace.jsonl' in context.router_command
-    assert "DYN_REQUEST_TRACE_FILE_PATH=\"${ARTIFACT_DIR}\"/dynamo-request-trace.jsonl" in script
-    assert 'export OUTPUT_DIR LOG_DIR ARTIFACT_DIR' in script
+    assert 'DYN_REQUEST_TRACE_FILE_PATH="${ARTIFACT_DIR}"/dynamo-request-trace.jsonl' in script
+    assert "export OUTPUT_DIR LOG_DIR ARTIFACT_DIR" in script
     syntax = subprocess.run(["bash", "-n"], input=script, text=True, capture_output=True, check=False)
     assert syntax.returncode == 0, syntax.stderr
 
@@ -152,4 +216,4 @@ def test_local_dynamo_lifecycle_accepts_isolated_infra_ports(tmp_path) -> None:
     assert "NATS_SERVER=nats://127.0.0.1:24222" in context.router_command
     assert '"${SRTCTL_NATS_BINARY}" -js -a "127.0.0.1" -p 24222' in script
     assert "http://127.0.0.1:22379/health" in script
-    assert "--listen-peer-urls \"http://127.0.0.1:22380\"" in script
+    assert '--listen-peer-urls "http://127.0.0.1:22380"' in script

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -363,6 +363,40 @@ class TestTachometerConfigGeneration:
         assert "dcgm_" not in config_text
         assert "node_exporter_" not in config_text
 
+    @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
+    def test_sgl_router_targets_worker_http_metrics(self, _mock_get_hostname_ip):
+        tachometer = TachometerConfig(enabled=True)
+        runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
+        runtime.log_dir = Path("/runs/12345/logs")
+        processes = [
+            Process(
+                node="node-a",
+                gpu_indices=frozenset({0}),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="agg",
+                endpoint_index=0,
+                node_rank=0,
+            )
+        ]
+        topology = FrontendTopology(
+            nginx_node=None,
+            frontend_nodes=["node-a"],
+            frontend_port=8000,
+            public_port=8000,
+        )
+
+        config_text = generate_tachometer_config(
+            processes=processes,
+            frontend_topology=topology,
+            runtime=runtime,
+            tachometer=tachometer,
+            frontend_type="sgl-router",
+        )
+
+        assert 'url = "http://10.0.0.1:30000/metrics"' in config_text
+        assert 'url = "http://10.0.0.1:8081/metrics"' not in config_text
+
     @patch("srtctl.core.telemetry.get_hostname_ip")
     def test_vllm_frontend_targets_only_agg_leader_metrics(self, mock_get_hostname_ip):
         mock_get_hostname_ip.side_effect = lambda host, interface=None: {


### PR DESCRIPTION
## Summary

- add aggregate-only `frontend.type: sgl-router` backed by the experimental Rust binary
- build the binary from a configured, container-visible SGLang source checkout or use a supplied executable
- gate startup on `/readyz` plus all static workers registered; scrape router and worker metrics with Tachometer
- render the same lifecycle for `srtctl apply --bash` with separate worker, router, and build logs

## Scope

Static Slurm P/D layouts are rejected. Upstream experimental `sgl-router` exposes P/D discovery through Kubernetes EndpointSlices, while its static `--worker-urls` API is aggregate-only.

## Validation

- `uvx pre-commit run --files ...`
- `uv run ty check src/srtctl/backends/sglang.py src/srtctl/core/schema.py src/srtctl/core/health.py src/srtctl/core/telemetry.py src/srtctl/frontends src/srtctl/render/lifecycle.py`
- `uv run pytest tests/test_lifecycle_render.py tests/test_frontends.py tests/test_health.py tests/test_telemetry.py tests/test_configs.py -q` (311 passed)