### PR TITLE
feat(trtllm): add launch-time CPU binding for worker ranks

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -588,12 +588,81 @@ backend:
 | `prefill_environment` | dict   | {}      | Environment variables for prefill       |
 | `decode_environment`  | dict   | {}      | Environment variables for decode        |
 | `trtllm_config`       | object | null    | TRTLLM CLI configuration per mode       |
+| `cpu_binding`         | object | null    | CPU/memory pinning for worker ranks     |
 
 **Key differences from SGLang backend**:
 - No aggregated mode support (prefill/decode only)
 - Uses MPI-style launching (one srun per endpoint with all nodes)
 - Uses `trtllm-llmapi-launch` for distributed launching
 - Automatically sets `TRTLLM_EPLB_SHM_NAME` with unique UUID per endpoint
+
+#### CPU binding (`cpu_binding`)
+
+TRTLLM pins its own worker ranks: `configure_cpu_affinity()` asks NVML for the CPUs
+local to the rank's GPU and calls `sched_setaffinity`. That call happens *inside* the
+already-running worker, so it only re-pins the calling thread — threads the process
+created earlier keep the unconstrained mask and stay free to run on a remote socket.
+On a node with more than one CPU NUMA domain, a cross-domain hop is expensive enough
+that those stray threads show up as bubbles in the decode loop.
+
+`cpu_binding` moves the mask to launch time. `taskset` runs before `exec`, so every
+thread the worker will ever create inherits it:
+
+```yaml
+backend:
+  type: trtllm
+  cpu_binding:
+    # Node with 4 GPUs and 2 CPU NUMA domains:
+    # GPUs 0-1 are local to CPUs 0-71, GPUs 2-3 to CPUs 72-143.
+    gpu_types: ["gb300"]
+    cpus_per_local_gpu: ["0-71", "0-71", "72-143", "72-143"]
+    membind: "0,1"
+```
+
+renders as:
+
+```
+taskset -c 72-143 numactl -m 0,1 trtllm-llmapi-launch python3 -m dynamo.trtllm ...
+```
+
+| Field                        | Type      | Default | Description                                                                                   |
+| ---------------------------- | --------- | ------- | --------------------------------------------------------------------------------------------- |
+| `cpus`                       | string    | null    | `taskset -c` list shared by every rank of the endpoint                                          |
+| `cpus_per_local_gpu`         | list      | null    | `taskset -c` list per node-local GPU index; mutually exclusive with `cpus`                      |
+| `gpu_types`                  | list      | null    | `resources.gpu_type` values these CPU lists were written for; mismatch is a load-time error     |
+| `membind`                    | string    | `"0,1"` | Value for `numactl -m` (memory nodes only, no CPU effect). `null` drops the `numactl` wrapper   |
+| `numa_aware_worker_affinity` | string    | `"0"`   | Exported as `TLLM_NUMA_AWARE_WORKER_AFFINITY` when CPUs are pinned                              |
+
+Notes:
+
+- **Set `gpu_types` whenever you hand-write CPU lists.** They encode one node's
+  CPU/NUMA layout. Copied onto a machine type with a different layout they still
+  "work" — they just pin ranks to the wrong socket, which reads as an unexplained
+  perf loss rather than an error. Naming the GPU types the lists were derived for
+  turns that into a config error at `srtctl dry-run` time:
+
+  ```
+  backend.cpu_binding is declared for gpu_type(s) ['gb300'] but resources.gpu_type
+  is 'gb200'. CPU lists are node-layout specific: re-derive them for this GPU type,
+  drop backend.cpu_binding, or widen backend.cpu_binding.gpu_types.
+  ```
+
+- **`numa_aware_worker_affinity` is not optional in practice.** With
+  `TLLM_NUMA_AWARE_WORKER_AFFINITY` unset, TRTLLM treats an externally constrained
+  mask as a mistake and calls `process.cpu_affinity(all_cpus)` to undo it — `taskset`
+  alone silently does nothing. srtslurm exports `0` whenever `cpus` or
+  `cpus_per_local_gpu` is set; a `prefill_environment` / `decode_environment` /
+  `aggregated_environment` entry still overrides it.
+- **`cpus_per_local_gpu` describes the node, not the job.** Entry `i` is the CPU set
+  for the GPU with node-local index `i`, so the same block works whether an endpoint
+  owns the whole node or a subset of its GPUs. One srun launches every rank of an
+  endpoint, so the actual list is selected inside the task from `SLURM_LOCALID`;
+  srtslurm reorders the table for the GPUs the endpoint was allocated first. This
+  makes the worker command a `bash -c` wrapper — expected in the `Command:` log line.
+- **Leaving `cpu_binding` unset preserves the previous behavior**: `numactl -m 0,1`
+  (memory binding only) on `gb200`/`gb300` prefill and decode workers, with TRTLLM's
+  in-process affinity deciding CPU placement. Setting `cpu_binding` takes over
+  `membind` for every GPU type and every mode, including `agg`.
 
 ---
 

--- a/src/srtctl/backends/__init__.py
+++ b/src/srtctl/backends/__init__.py
@@ -12,7 +12,7 @@ Supported backends:
 from .base import BackendProtocol, BackendType, SrunConfig
 from .mocker import MockerProtocol, MockerServerConfig
 from .sglang import SGLangProtocol, SGLangServerConfig
-from .trtllm import TRTLLMProtocol, TRTLLMServerConfig
+from .trtllm import TRTLLMCpuBinding, TRTLLMProtocol, TRTLLMServerConfig
 from .vllm import VLLMProtocol, VLLMServerConfig
 
 # Union type for all backend configs
@@ -31,6 +31,7 @@ __all__ = [
     "SGLangServerConfig",
     "SrunConfig",
     # TRTLLM
+    "TRTLLMCpuBinding",
     "TRTLLMProtocol",
     "TRTLLMServerConfig",
     # vLLM

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import builtins
+import shlex
 import uuid
 from collections.abc import Sequence
 from dataclasses import field
@@ -8,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import yaml
-from marshmallow import Schema
+from marshmallow import Schema, ValidationError
 from marshmallow_dataclass import dataclass
 
 from srtctl.ports import DYN_SYSTEM_PORT_BASE
@@ -21,6 +22,109 @@ if TYPE_CHECKING:
 
 # Type alias for worker modes
 WorkerMode = Literal["prefill", "decode", "agg"]
+
+# Default memory binding applied on Grace-based nodes when `cpu_binding` is not
+# configured. Kept for backwards compatibility with recipes written before
+# `cpu_binding` existed.
+_LEGACY_MEMBIND_GPU_TYPES = ("gb200", "gb300")
+_LEGACY_MEMBIND = "0,1"
+
+# Bash array name used to select a per-task CPU list at launch time. Prefixed to
+# avoid colliding with anything the container's own entrypoint may define.
+_CPU_LIST_VAR = "__srt_cpu_list"
+
+
+@dataclass(frozen=True)
+class TRTLLMCpuBinding:
+    """Pin TRTLLM worker ranks to CPUs *before* the worker process starts.
+
+    TRTLLM has its own NUMA-aware affinity (``configure_cpu_affinity`` in
+    ``tensorrt_llm/llmapi/utils.py``), but it runs from inside the already-running
+    worker, so ``sched_setaffinity`` only re-pins the calling thread. Threads that
+    the process created earlier keep the unconstrained mask and stay free to run on
+    a remote socket. On a node with more than one CPU NUMA domain, a cross-domain
+    hop is expensive enough that those stray threads show up as decode-loop bubbles.
+
+    Applying the mask with ``taskset`` before ``exec`` fixes that: every thread the
+    worker will ever create inherits it. The companion
+    ``TLLM_NUMA_AWARE_WORKER_AFFINITY`` setting is required, because with that
+    variable unset TRTLLM treats an externally constrained mask as a mistake and
+    *removes* it again (``process.cpu_affinity(all_cpus)``).
+
+    Example YAML for a node with 4 GPUs and 2 CPU NUMA domains, where GPUs 0-1 are
+    local to CPUs 0-71 and GPUs 2-3 to CPUs 72-143::
+
+        backend:
+          type: trtllm
+          cpu_binding:
+            gpu_types: ["gb300"]
+            cpus_per_local_gpu: ["0-71", "0-71", "72-143", "72-143"]
+            membind: "0,1"
+
+    Attributes:
+        cpus: ``taskset -c`` list applied to every rank of the endpoint. Use when a
+            single CPU set is correct for all ranks on the node.
+        cpus_per_local_gpu: ``taskset -c`` list per node-local GPU index. Entry ``i``
+            is the CPU set for the GPU with node-local index ``i``, so it describes
+            the node's topology once and srtslurm maps it onto whichever GPUs an
+            endpoint was actually allocated. Mutually exclusive with ``cpus``.
+        gpu_types: ``resources.gpu_type`` values these CPU lists were written for.
+            CPU layout is a property of the node, so a stale list copied to different
+            hardware pins ranks to the wrong socket — a silent perf loss that looks
+            like nothing at all. Naming the machine types turns that into a config
+            error at load time (dry-run) instead. ``null`` (default) accepts any
+            ``gpu_type``.
+        membind: Value passed to ``numactl -m`` (memory-node binding, no CPU effect).
+            ``null`` disables the ``numactl`` wrapper entirely.
+        numa_aware_worker_affinity: Value exported as
+            ``TLLM_NUMA_AWARE_WORKER_AFFINITY``. Defaults to ``"0"`` so TRTLLM leaves
+            the externally applied mask alone; a per-mode ``*_environment`` entry
+            still wins over this.
+    """
+
+    cpus: str | None = None
+    cpus_per_local_gpu: list[str] | None = None
+    gpu_types: list[str] | None = None
+    membind: str | None = _LEGACY_MEMBIND
+    numa_aware_worker_affinity: str = "0"
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        if self.cpus and self.cpus_per_local_gpu:
+            raise ValidationError(
+                "cpu_binding.cpus and cpu_binding.cpus_per_local_gpu are mutually exclusive; "
+                "use cpus for one CPU set shared by every rank, or cpus_per_local_gpu to "
+                "describe the node's per-GPU NUMA topology."
+            )
+        if self.cpus_per_local_gpu is not None and not self.cpus_per_local_gpu:
+            raise ValidationError("cpu_binding.cpus_per_local_gpu must not be empty")
+        if self.cpus_per_local_gpu and any(not entry.strip() for entry in self.cpus_per_local_gpu):
+            raise ValidationError("cpu_binding.cpus_per_local_gpu entries must be non-empty CPU lists")
+        if self.gpu_types is not None and not self.gpu_types:
+            raise ValidationError("cpu_binding.gpu_types must not be empty; omit it to apply to every GPU type")
+
+    @property
+    def pins_cpus(self) -> bool:
+        """Whether this config actually constrains CPU affinity (vs. memory only)."""
+        return bool(self.cpus or self.cpus_per_local_gpu)
+
+    def applies_to(self, gpu_type: str | None) -> bool:
+        """Whether this binding is in scope for a run's ``resources.gpu_type``."""
+        if self.gpu_types is None:
+            return True
+        return gpu_type in self.gpu_types
+
+    def cpu_list_for_gpus(self, local_gpu_indices: Sequence[int]) -> list[str] | None:
+        """Resolve the per-task CPU lists for the node-local GPUs of one endpoint.
+
+        Returns one entry per task in node-local task order (``SLURM_LOCALID``),
+        or ``None`` when no per-GPU mapping is configured.
+        """
+        if not self.cpus_per_local_gpu:
+            return None
+        table = self.cpus_per_local_gpu
+        return [table[index % len(table)] for index in sorted(local_gpu_indices)]
 
 
 @dataclass(frozen=True)
@@ -65,6 +169,11 @@ class TRTLLMProtocol:
     aggregated_environment: dict[str, str] = field(default_factory=dict)
 
     trtllm_config: TRTLLMServerConfig | None = None
+
+    # CPU/memory pinning for worker ranks. When unset, srtslurm keeps the historical
+    # behavior: `numactl -m 0,1` (memory only) on gb200/gb300 prefill/decode workers,
+    # and TRTLLM's own in-process NUMA-aware affinity decides CPU placement.
+    cpu_binding: TRTLLMCpuBinding | None = None
 
     # Whether dynamo.trtllm workers pass `--publish-events-and-metrics`.
     # Enables the worker to publish KV-cache events (add/evict) + metrics, which
@@ -121,7 +230,15 @@ class TRTLLMProtocol:
         base_env = env_by_mode.get(mode)
         if base_env is None:
             return {}
-        return {**base_env, "TRTLLM_EPLB_SHM_NAME": eplb_prefix}
+
+        # Emitted first so an explicit `*_environment` entry still wins: pinning with
+        # taskset is pointless unless TRTLLM is told to leave the mask alone, but the
+        # recipe author keeps the final say.
+        affinity_env: dict[str, str] = {}
+        if self.cpu_binding is not None and self.cpu_binding.pins_cpus:
+            affinity_env["TLLM_NUMA_AWARE_WORKER_AFFINITY"] = self.cpu_binding.numa_aware_worker_affinity
+
+        return {**affinity_env, **base_env, "TRTLLM_EPLB_SHM_NAME": eplb_prefix}
 
     def get_process_environment(self, process: "Process") -> dict[str, str]:
         """Get process-specific environment variables.
@@ -202,10 +319,14 @@ class TRTLLMProtocol:
         # For local models, model is mounted to /model in the container
         model_arg = runtime.worker_model_arg
 
-        numactl_prefix = (
-            ["numactl", "-m", "0,1"] if runtime.gpu_type in ("gb200", "gb300") and mode in ("prefill", "decode") else []
-        )
-        base_prefix = list(nsys_prefix or []) + numactl_prefix + ["trtllm-llmapi-launch"]
+        # CPU/memory binding. `leading` (nsys) stays outermost so profiling still wraps
+        # the whole worker; the taskset/numactl pair goes between it and the launcher so
+        # the mask is installed by the last exec before TRTLLM's own threads exist.
+        leading_prefix = list(nsys_prefix or [])
+        taskset_prefix, per_task_cpus = self._cpu_pin_prefix(process)
+        membind = self._membind_for(runtime, mode)
+        numactl_prefix = ["numactl", "-m", membind] if membind else []
+        base_prefix = leading_prefix + taskset_prefix + numactl_prefix + ["trtllm-llmapi-launch"]
 
         # trtllm-serve path: launch an OpenAI-compatible trtllm-serve worker. In
         # disaggregated mode the trtllm_serve frontend fronts these via a static
@@ -237,7 +358,7 @@ class TRTLLMProtocol:
             # ai-dynamo tensorrtllm-runtime 1.3.0-dev.1 container, which accept --config;
             # some trtllm-serve builds spell this --extra_llm_api_options.
             cmd.extend(["--config", str(container_config_path)])
-            return cmd
+            return _resolve_per_task_cpus(cmd, len(leading_prefix), per_task_cpus)
 
         # dynamo.trtllm path (default): workers register into etcd/NATS and the dynamo
         # frontend discovers them.
@@ -267,4 +388,56 @@ class TRTLLMProtocol:
         if self.publish_events_and_metrics:
             cmd.append("--publish-events-and-metrics")
 
+        return _resolve_per_task_cpus(cmd, len(leading_prefix), per_task_cpus)
+
+    # =========================================================================
+    # CPU / memory binding helpers
+    # =========================================================================
+
+    def _membind_for(self, runtime: "RuntimeContext", mode: WorkerMode) -> str | None:
+        """Value for ``numactl -m``, or None to skip the numactl wrapper."""
+        if self.cpu_binding is not None:
+            return self.cpu_binding.membind
+        # Legacy default, preserved for recipes written before `cpu_binding` existed:
+        # memory-only interleave across both Grace sockets on prefill/decode workers.
+        if runtime.gpu_type in _LEGACY_MEMBIND_GPU_TYPES and mode in ("prefill", "decode"):
+            return _LEGACY_MEMBIND
+        return None
+
+    def _cpu_pin_prefix(self, process: "Process") -> tuple[list[str], list[str] | None]:
+        """Resolve CPU pinning for one endpoint.
+
+        Returns ``(taskset_prefix, per_task_cpus)``. At most one is non-empty: a
+        single CPU set becomes a literal ``taskset -c`` prefix, while a per-GPU
+        topology map has to be selected by node-local task id at launch time and is
+        returned for :func:`_resolve_per_task_cpus` to render.
+        """
+        if self.cpu_binding is None:
+            return [], None
+        if self.cpu_binding.cpus:
+            return ["taskset", "-c", self.cpu_binding.cpus], None
+        return [], self.cpu_binding.cpu_list_for_gpus(sorted(process.gpu_indices))
+
+
+def _resolve_per_task_cpus(cmd: list[str], leading: int, per_task_cpus: list[str] | None) -> list[str]:
+    """Insert a per-task ``taskset -c`` that is resolved inside the srun task.
+
+    One srun launches every rank of a TRTLLM endpoint, so a per-GPU CPU map cannot be
+    baked into the argv — the rank is only known once the task is running. Wrap the
+    command in ``bash -c`` and index the CPU table by ``SLURM_LOCALID`` instead. The
+    table is already ordered by this endpoint's node-local GPUs, so entry ``i`` belongs
+    to node-local task ``i``. ``exec`` keeps the process tree the same depth as the
+    unwrapped command.
+
+    ``leading`` is the number of argv entries (the nsys prefix) that must stay outside
+    the taskset call.
+    """
+    if not per_task_cpus:
         return cmd
+
+    head, tail = cmd[:leading], cmd[leading:]
+    table = " ".join(shlex.quote(entry) for entry in per_task_cpus)
+    index = f"${{SLURM_LOCALID:-0}} % ${{#{_CPU_LIST_VAR}[@]}}"
+    pin = f'taskset -c "${{{_CPU_LIST_VAR}[{index}]}}"'
+    parts = [part for part in (shlex.join(head), pin, shlex.join(tail)) if part]
+    return ["bash", "-c", f"{_CPU_LIST_VAR}=({table}); exec {' '.join(parts)}"]

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1707,8 +1707,28 @@ class SrtConfig:
         self._validate_het_jobs()
         self._validate_dedicated_node_placement()
         self._validate_trtllm_serve()
+        self._validate_trtllm_cpu_binding()
         self._validate_vllm_frontend()
         self._warn_dp_launch_mode()
+
+    def _validate_trtllm_cpu_binding(self):
+        """Reject CPU lists written for different hardware than this run targets.
+
+        ``backend.cpu_binding`` encodes a node's CPU/NUMA layout. Copied onto a
+        machine type with a different layout it still "works" — it just pins ranks to
+        the wrong socket, which reads as an unexplained perf loss rather than an
+        error. When a recipe names the ``gpu_types`` its lists were written for, catch
+        the mismatch here (at load time / dry-run) instead.
+        """
+        cpu_binding = getattr(self.backend, "cpu_binding", None)
+        if cpu_binding is None or cpu_binding.applies_to(self.resources.gpu_type):
+            return
+        raise ValidationError(
+            f"backend.cpu_binding is declared for gpu_type(s) {cpu_binding.gpu_types!r} "
+            f"but resources.gpu_type is {self.resources.gpu_type!r}. CPU lists are "
+            "node-layout specific: re-derive them for this GPU type, drop "
+            "backend.cpu_binding, or widen backend.cpu_binding.gpu_types."
+        )
 
     def _warn_dp_launch_mode(self):
         """Nudge vLLM DP recipes toward the per-node launch topology.

--- a/tests/test_trtllm_cpu_binding.py
+++ b/tests/test_trtllm_cpu_binding.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TRTLLM worker CPU/memory binding (`backend.cpu_binding`).
+
+TRTLLM's in-process NUMA-aware affinity only re-pins the calling thread, so helper
+threads that already exist keep roaming across sockets. These tests cover the
+launch-time `taskset` pinning that fixes that, and pin down the legacy
+`numactl -m 0,1` behavior so opting out stays byte-identical to before.
+"""
+
+import shlex
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from marshmallow import ValidationError
+
+from srtctl.backends import TRTLLMCpuBinding, TRTLLMProtocol
+from srtctl.core.topology import Process
+
+GB200_CPU_MAP = ["0-71", "0-71", "72-143", "72-143"]
+"""Measured GB200/GB300 layout: 4 GPUs and 2 CPU NUMA domains per node, GPUs 0-1
+local to CPUs 0-71 and GPUs 2-3 local to CPUs 72-143."""
+
+
+@pytest.fixture
+def runtime(tmp_path):
+    def _runtime(gpu_type="gb300"):
+        rt = MagicMock()
+        rt.log_dir = tmp_path
+        rt.worker_model_arg = "/model"
+        rt.model_path = Path("/models/DeepSeek-V4")
+        rt.request_plane = "nats"
+        rt.gpu_type = gpu_type
+        rt.frontend_port = 8000
+        return rt
+
+    return _runtime
+
+
+def make_process(gpu_indices, mode="decode"):
+    return Process(
+        node="node0",
+        gpu_indices=frozenset(gpu_indices),
+        sys_port=8081,
+        http_port=8100,
+        endpoint_mode=mode,
+        endpoint_index=0,
+        node_rank=0,
+    )
+
+
+def build(backend, runtime, gpu_indices=(0, 1, 2, 3), mode="decode", **kwargs):
+    return backend.build_worker_command(
+        process=make_process(gpu_indices, mode),
+        endpoint_processes=[],
+        runtime=runtime,
+        **kwargs,
+    )
+
+
+class TestLegacyDefaults:
+    """Recipes without `cpu_binding` must keep the exact pre-existing command."""
+
+    def test_grace_prefill_decode_get_membind_only(self, runtime):
+        for gpu_type in ("gb200", "gb300"):
+            for mode in ("prefill", "decode"):
+                cmd = build(TRTLLMProtocol(), runtime(gpu_type), mode=mode)
+                assert cmd[:3] == ["numactl", "-m", "0,1"]
+                assert cmd[3] == "trtllm-llmapi-launch"
+                assert "taskset" not in cmd
+
+    def test_agg_and_non_grace_get_no_prefix(self, runtime):
+        assert build(TRTLLMProtocol(), runtime("gb300"), mode="agg")[0] == "trtllm-llmapi-launch"
+        assert build(TRTLLMProtocol(), runtime("b200"))[0] == "trtllm-llmapi-launch"
+
+    def test_no_affinity_env_injected(self, runtime):
+        env = TRTLLMProtocol().get_environment_for_mode("decode")
+        assert "TLLM_NUMA_AWARE_WORKER_AFFINITY" not in env
+
+
+class TestUniformPinning:
+    def test_cpus_emits_literal_taskset_before_numactl(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus="0-71"))
+        cmd = build(backend, runtime())
+        assert cmd[:6] == ["taskset", "-c", "0-71", "numactl", "-m", "0,1"]
+        assert cmd[6] == "trtllm-llmapi-launch"
+
+    def test_membind_none_drops_numactl(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus="0-71", membind=None))
+        cmd = build(backend, runtime())
+        assert cmd[:3] == ["taskset", "-c", "0-71"]
+        assert "numactl" not in cmd
+
+    def test_membind_applies_to_agg_and_non_grace_when_explicit(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus="0-71", membind="0"))
+        cmd = build(backend, runtime("b200"), mode="agg")
+        assert cmd[:6] == ["taskset", "-c", "0-71", "numactl", "-m", "0"]
+
+
+class TestAffinityEnvironment:
+    """taskset is useless unless TRTLLM is told not to clear the mask again."""
+
+    def test_pinning_sets_numa_aware_worker_affinity_off(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus="0-71"))
+        for mode in ("prefill", "decode", "agg"):
+            assert backend.get_environment_for_mode(mode)["TLLM_NUMA_AWARE_WORKER_AFFINITY"] == "0"
+
+    def test_membind_only_binding_does_not_touch_affinity_env(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(membind="0,1"))
+        assert "TLLM_NUMA_AWARE_WORKER_AFFINITY" not in backend.get_environment_for_mode("decode")
+
+    def test_explicit_mode_environment_wins(self, runtime):
+        backend = TRTLLMProtocol(
+            cpu_binding=TRTLLMCpuBinding(cpus="0-71"),
+            decode_environment={"TLLM_NUMA_AWARE_WORKER_AFFINITY": "1"},
+        )
+        assert backend.get_environment_for_mode("decode")["TLLM_NUMA_AWARE_WORKER_AFFINITY"] == "1"
+
+    def test_eplb_shm_name_still_injected(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus="0-71"))
+        assert "TRTLLM_EPLB_SHM_NAME" in backend.get_environment_for_mode("decode")
+
+
+class TestPerLocalGpuPinning:
+    """One srun launches every rank, so the per-GPU map resolves inside the task."""
+
+    def test_wraps_command_in_bash_with_localid_lookup(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus_per_local_gpu=GB200_CPU_MAP))
+        cmd = build(backend, runtime())
+        assert cmd[0] == "bash"
+        assert cmd[1] == "-c"
+        assert cmd[2].startswith("__srt_cpu_list=(0-71 0-71 72-143 72-143); exec taskset -c ")
+        assert "SLURM_LOCALID" in cmd[2]
+        assert "numactl -m 0,1 trtllm-llmapi-launch python3 -m dynamo.trtllm" in cmd[2]
+
+    def test_table_is_reordered_for_a_partial_node_endpoint(self, runtime):
+        """An endpoint on GPUs 2-3 has SLURM_LOCALID 0-1, but must use the CPUs of
+        the NUMA node those GPUs actually live on."""
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus_per_local_gpu=GB200_CPU_MAP))
+        cmd = build(backend, runtime(), gpu_indices=(2, 3))
+        assert cmd[2].startswith("__srt_cpu_list=(72-143 72-143);")
+
+    def test_nsys_prefix_stays_outermost(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus_per_local_gpu=GB200_CPU_MAP))
+        cmd = build(backend, runtime(), nsys_prefix=["nsys", "profile", "-o", "/logs/w.nsys-rep"])
+        assert "exec nsys profile -o /logs/w.nsys-rep taskset -c " in cmd[2]
+
+    def test_trtllm_serve_frontend_is_wrapped_too(self, runtime):
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus_per_local_gpu=GB200_CPU_MAP))
+        cmd = build(backend, runtime(), mode="agg", frontend_type="trtllm_serve")
+        assert cmd[0] == "bash"
+        assert "trtllm-llmapi-launch trtllm-serve /model" in cmd[2]
+
+    @pytest.mark.parametrize(
+        ("local_id", "expected"),
+        [("0", "0-71"), ("1", "0-71"), ("2", "72-143"), ("3", "72-143"), ("9", "0-71"), ("", "0-71")],
+    )
+    def test_resolves_to_the_right_cpu_list_under_bash(self, runtime, local_id, expected):
+        """Run the emitted snippet through the same `bash -c` wrapping that
+        `start_srun_process` applies, and read back the argv taskset would get."""
+        backend = TRTLLMProtocol(cpu_binding=TRTLLMCpuBinding(cpus_per_local_gpu=GB200_CPU_MAP))
+        cmd = build(backend, runtime())
+        script = shlex.join(cmd).replace("exec taskset", "exec echo taskset", 1)
+        result = subprocess.run(
+            ["bash", "-c", f"export SLURM_LOCALID={local_id}; {script}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.stdout.split()[:3] == ["taskset", "-c", expected]
+
+
+class TestValidation:
+    def test_cpus_and_cpus_per_local_gpu_are_mutually_exclusive(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            TRTLLMCpuBinding(cpus="0-71", cpus_per_local_gpu=GB200_CPU_MAP)
+
+    def test_empty_cpu_map_rejected(self):
+        with pytest.raises(ValidationError, match="must not be empty"):
+            TRTLLMCpuBinding(cpus_per_local_gpu=[])
+
+    def test_blank_cpu_map_entry_rejected(self):
+        with pytest.raises(ValidationError, match="non-empty CPU lists"):
+            TRTLLMCpuBinding(cpus_per_local_gpu=["0-71", "  "])
+
+    def test_empty_gpu_types_rejected(self):
+        with pytest.raises(ValidationError, match="gpu_types must not be empty"):
+            TRTLLMCpuBinding(cpus="0-71", gpu_types=[])
+
+
+class TestGpuTypeGuard:
+    """CPU lists encode one node's layout; a mismatch must fail loudly, not silently
+    pin ranks to the wrong socket."""
+
+    @pytest.mark.parametrize(
+        ("gpu_types", "gpu_type", "expected"),
+        [
+            (None, "gb300", True),
+            (None, None, True),
+            (["gb300"], "gb300", True),
+            (["gb200", "gb300"], "gb200", True),
+            (["gb300"], "gb200", False),
+            (["gb300"], None, False),
+        ],
+    )
+    def test_applies_to(self, gpu_types, gpu_type, expected):
+        binding = TRTLLMCpuBinding(cpus="0-71", gpu_types=gpu_types)
+        assert binding.applies_to(gpu_type) is expected
+
+    def test_config_load_rejects_mismatched_gpu_type(self, tmp_path):
+        from srtctl.core.config import validate_config_file
+
+        recipe = tmp_path / "mismatch.yaml"
+        recipe.write_text(_RECIPE.format(gpu_type="gb200", gpu_types='["gb300"]'))
+        errors = validate_config_file(recipe)
+        assert any("backend.cpu_binding is declared for gpu_type(s)" in str(e) for e in errors), errors
+
+    def test_config_load_accepts_matching_gpu_type(self, tmp_path):
+        from srtctl.core.config import validate_config_file
+
+        recipe = tmp_path / "match.yaml"
+        recipe.write_text(_RECIPE.format(gpu_type="gb300", gpu_types='["gb300"]'))
+        assert validate_config_file(recipe) == []
+
+    def test_config_load_accepts_unscoped_binding(self, tmp_path):
+        from srtctl.core.config import validate_config_file
+
+        recipe = tmp_path / "unscoped.yaml"
+        recipe.write_text(_RECIPE.format(gpu_type="gb200", gpu_types="null"))
+        assert validate_config_file(recipe) == []
+
+
+_RECIPE = """
+name: cpu-binding-guard
+model:
+  path: hf:fake/mock-model
+  container: nvcr.io/fake:latest
+  precision: fp8
+resources:
+  gpu_type: "{gpu_type}"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+backend:
+  type: trtllm
+  cpu_binding:
+    gpu_types: {gpu_types}
+    cpus_per_local_gpu: ["0-71", "0-71", "72-143", "72-143"]
+benchmark:
+  type: custom
+  command: echo hi
+"""
+
+
+class TestYamlRoundTrip:
+    def test_cpu_binding_loads_from_backend_yaml(self):
+        backend = TRTLLMProtocol.Schema().load(
+            {
+                "type": "trtllm",
+                "cpu_binding": {
+                    "cpus_per_local_gpu": GB200_CPU_MAP,
+                    "membind": "0,1",
+                },
+            }
+        )
+        assert backend.cpu_binding.cpus_per_local_gpu == GB200_CPU_MAP
+        assert backend.cpu_binding.membind == "0,1"
+        assert backend.cpu_binding.numa_aware_worker_affinity == "0"


### PR DESCRIPTION
Follow-up to an internal perf thread: TRTLLM's automatic CPU binding leaves a worker's secondary threads unbound, and [`trtllm.py#L205`](https://github.com/NVIDIA/srt-slurm/blob/465c6d0b/src/srtctl/backends/trtllm.py#L205-L208) is the hard-coded spot that needs to change to fix it.

## Why

TRTLLM pins its own worker ranks in `configure_cpu_affinity()` — it asks NVML for the CPUs local to the rank's GPU and calls `sched_setaffinity`:

```python
# tensorrt_llm/llmapi/utils.py
if ((numa_aware_affinity is None and not constrained_affinity)
        or (numa_aware_affinity == "1")):
    process.cpu_affinity(get_numa_aware_cpu_affinity(device_id))
```

That call runs from *inside* the already-running worker, so `sched_setaffinity` only re-pins the calling thread. Threads the process created earlier keep the unconstrained mask and stay free to run on a remote socket. On a node with more than one CPU NUMA domain, a cross-domain hop is expensive enough that those stray threads show up as bubbles in the decode loop.

There is a second trap in the same function. With `TLLM_NUMA_AWARE_WORKER_AFFINITY` unset, TRTLLM treats an externally constrained mask as a mistake and removes it:

```python
if constrained_affinity:
    ...
    if numa_aware_affinity is None:
        logger.warning(f"Worker process {pid} has constrained CPU affinity "
                       f"but `TLLM_NUMA_AWARE_WORKER_AFFINITY` is not set. "
                       f"Removing CPU affinity constraints.")
        process.cpu_affinity(all_cpus)
```

So wrapping the launch in `taskset` *without* also setting that variable is a silent no-op. Both halves are needed together.

## What this adds

A `backend.cpu_binding` block that installs the mask with `taskset` before `exec`, where every thread the worker will ever create inherits it:

```yaml
backend:
  type: trtllm
  cpu_binding:
    # Node with 4 GPUs and 2 CPU NUMA domains:
    # GPUs 0-1 are local to CPUs 0-71, GPUs 2-3 to CPUs 72-143.
    gpu_types: ["gb300"]
    cpus_per_local_gpu: ["0-71", "0-71", "72-143", "72-143"]
    membind: "0,1"
```

renders per rank as:

```
taskset -c 72-143 numactl -m 0,1 trtllm-llmapi-launch python3 -m dynamo.trtllm ...
```

| Field | Default | Description |
|---|---|---|
| `cpus` | `null` | `taskset -c` list shared by every rank |
| `cpus_per_local_gpu` | `null` | `taskset -c` list per node-local GPU index; mutually exclusive with `cpus` |
| `gpu_types` | `null` | `resources.gpu_type` values these CPU lists were written for; mismatch is a load-time error |
| `membind` | `"0,1"` | `numactl -m` value (memory nodes only). `null` drops the `numactl` wrapper |
| `numa_aware_worker_affinity` | `"0"` | Exported as `TLLM_NUMA_AWARE_WORKER_AFFINITY` when CPUs are pinned |

Notes on the design:

- **`cpus_per_local_gpu` describes the node, not the job.** One srun launches every rank of an endpoint, so the argv cannot carry a per-rank value. The list is selected inside the task from `SLURM_LOCALID`, against a table srtslurm has already reordered for the GPUs that endpoint was actually allocated — an endpoint on GPUs 2-3 gets the CPUs of the NUMA domain *those* GPUs live on, not the entries for GPUs 0-1. This makes the worker command a `bash -c` wrapper (visible in the `Command:` log line); `cpus` covers the single-set case with no wrapper.
- **`gpu_types` guards against stale lists.** CPU layout is a property of the node, so a block copied to different hardware still "works" — it just pins ranks to the wrong socket, which reads as an unexplained perf loss rather than an error. Naming the GPU types the lists were derived for turns a mismatch into a config error at `srtctl dry-run` time.
- **`numa_aware_worker_affinity` defaults to `"0"`** for the reason above. A `prefill_environment` / `decode_environment` / `aggregated_environment` entry still overrides it.
- **nsys stays outermost**, so profiling still wraps the whole worker.

## Compatibility

**Leaving `cpu_binding` unset is byte-identical to today** — `numactl -m 0,1` (memory binding only) on `gb200`/`gb300` prefill and decode workers, with TRTLLM's in-process affinity deciding CPU placement. No existing recipe changes behavior, and no recipe in this repo sets `cpu_binding` yet.

I deliberately did **not** change the `gb200`/`gb300` default. Measurements there show TRTLLM's NVML-derived mapping is already correct (ranks 0-1 → CPUs 0-71, ranks 2-3 → CPUs 72-143), so this is opt-in per recipe, for machine types where the automatic mapping is known to be a poor fit.

## Testing

`make check` — 1311 passed, 2 skipped; `ruff check` / `ruff format --check` on `src/srtctl/` clean.

New `tests/test_trtllm_cpu_binding.py` (34 cases) covers the legacy no-op path, uniform and per-GPU pinning, the affinity env var and its override precedence, `membind: null`, nsys ordering, the `trtllm_serve` frontend path, the `gpu_types` guard end-to-end through `validate_config_file`, validation errors, and YAML round-trip. The per-rank test runs the emitted snippet through the same `bash -c` wrapping `start_srun_process` applies and asserts the resolved `taskset` argv for `SLURM_LOCALID` 0/1/2/3, an out-of-range id, and an unset id.

**What is not verified here:** this change only makes the incantation expressible from a recipe — the end-to-end perf win is not re-measured in this PR. Worth a confirming run before any recipe adopts it, and note the equivalent fix is also being looked at on the TRTLLM side.
