### PR TITLE
[feat](vllm) Make per-node DP topology-aware

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -524,8 +524,8 @@ Each worker leader gets a globally unique port starting at 5550:
 ### vLLM DP launch mode
 
 vLLM data-parallel endpoints use one process per GPU by default. Set
-`dp_launch_mode: per_node` to launch one process per node and let vLLM
-manage the local DP ranks in a shared CUDA namespace:
+`dp_launch_mode: per_node` to launch one process per node. srtslurm derives
+whether each TP/PP replica is node-local or spans multiple nodes:
 
 ```yaml
 backend:
@@ -538,26 +538,28 @@ backend:
       data-parallel-size: 16
 ```
 
-| Value      | Process layout                                      |
-| ---------- | --------------------------------------------------- |
-| `per_gpu`  | One process per DP rank/GPU (default)               |
-| `per_node` | One process manages all DP ranks allocated per node |
+| Value      | Process layout                                                               |
+| ---------- | ---------------------------------------------------------------------------- |
+| `per_gpu`  | One process per DP rank/GPU (default)                                        |
+| `per_node` | One process per node; automatically supports node-local or distributed TP/PP |
 
 `per_gpu` remains the compatibility default for now, but srtslurm will switch
 the default to `per_node` in a future release. Existing vLLM DP configurations
 should set `backend.dp_launch_mode: per_node` now; srtslurm emits a
 configuration-time migration warning while they still use `per_gpu`.
 
-In `per_node` mode, srtslurm derives `--data-parallel-size-local` and
-`--data-parallel-start-rank` from the allocated topology. Do not set those
-two flags manually. srtslurm also always enables `--data-parallel-hybrid-lb`
-so every node-local process registers with the Dynamo frontend. This is the
-recommended vLLM topology for Dynamo and ensures the frontend can route to
-each node-local DP engine. Do not set `data-parallel-hybrid-lb` manually;
-srtslurm enables it automatically, warns when it is configured, and ignores
-the configured value. `headless` is incompatible with `per_node` DP because a
-headless process does not register with Dynamo, so srtslurm rejects that
-combination during configuration loading.
+When `TP x PP` fits on one node, srtslurm derives
+`--data-parallel-size-local` and `--data-parallel-start-rank`, then enables
+`--data-parallel-hybrid-lb` so every node-local process registers with the
+Dynamo frontend. When `TP x PP` is larger than the node-local GPU allocation,
+srtslurm instead derives the multi-node rendezvous arguments and makes every
+process except the global leader headless. For example, both DP4 x TP4 and
+DP2 x TP8 are selected automatically on four-GPU nodes.
+
+Do not set `data-parallel-size-local`, `data-parallel-start-rank`,
+`data-parallel-hybrid-lb`, or `headless` manually; srtslurm owns those values.
+The allocation must be regular: `DP x TP x PP` must match the endpoint GPU
+count, and a TP/PP replica must divide evenly within or across nodes.
 
 ### TRTLLM Backend
 

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -294,7 +294,9 @@ class VLLMProtocol:
     allow_prefill_decode_colocation_across_nodes: bool = False
 
     # DP process layout. Keep the existing per-GPU behavior by default;
-    # per-node lets vLLM manage local DP ranks in one CUDA namespace.
+    # per-node lets vLLM manage the node-local portion of a DP x TP x PP
+    # topology in one CUDA namespace and derives cross-node TP/PP rendezvous
+    # when a replica is larger than the node-local GPU allocation.
     # TODO: Change the default to per_node after the per_gpu migration window.
     dp_launch_mode: DPLaunchMode = "per_gpu"
 
@@ -327,6 +329,9 @@ class VLLMProtocol:
         if not dp_mode_configs or self.dp_launch_mode == "per_gpu":
             return
 
+        if self.dp_launch_mode != "per_node":
+            return
+
         hybrid_lb_modes: list[str] = []
         headless_modes: list[str] = []
         for mode_name, mode_config in dp_mode_configs:
@@ -340,14 +345,14 @@ class VLLMProtocol:
             fields = ", ".join(f"vllm_config.{mode}.headless" for mode in headless_modes)
             raise ValidationError(
                 f"{fields} cannot be set when dp_launch_mode=per_node. "
-                "Every node-local process must register with the Dynamo frontend; remove headless."
+                "srtslurm derives headless ranks from the DP x TP x PP topology; remove headless."
             )
 
         if hybrid_lb_modes:
             fields = ", ".join(f"vllm_config.{mode}.data-parallel-hybrid-lb" for mode in hybrid_lb_modes)
             logger.warning(
                 "%s is unnecessary when dp_launch_mode=per_node; "
-                "srtslurm always enables --data-parallel-hybrid-lb and ignores the configured value",
+                "srtslurm derives --data-parallel-hybrid-lb from the topology and ignores the configured value",
                 fields,
             )
 
@@ -577,6 +582,11 @@ class VLLMProtocol:
         config = self.get_config_for_mode(mode)
         return config.get("tensor-parallel-size") or config.get("tensor_parallel_size") or 1
 
+    def _get_pp_size(self, mode: WorkerMode) -> int:
+        """Get the pipeline-parallel-size for a mode, defaulting to 1."""
+        config = self.get_config_for_mode(mode)
+        return config.get("pipeline-parallel-size") or config.get("pipeline_parallel_size") or 1
+
     def should_set_cuda_visible_devices(self, process: Process) -> bool:
         """Whether worker_stage should set CUDA_VISIBLE_DEVICES.
 
@@ -702,7 +712,7 @@ class VLLMProtocol:
         base_sys_port: int = DYN_SYSTEM_PORT_BASE,
         port_allocator: NodePortAllocator | None = None,
     ) -> list[Process]:
-        """Convert DP endpoints to one process per node."""
+        """Convert DP endpoints to one topology-aware process per node."""
         from srtctl.core.topology import NodePortAllocator, Process, endpoints_to_processes
 
         processes: list[Process] = []
@@ -722,15 +732,49 @@ class VLLMProtocol:
                 continue
 
             tp_size = self._get_tp_size(endpoint.mode)
-            dp_size = self._get_dp_size(endpoint.mode) or endpoint.total_gpus // tp_size
-            if dp_size * tp_size != endpoint.total_gpus:
+            pp_size = self._get_pp_size(endpoint.mode)
+            replica_size = tp_size * pp_size
+            dp_size = self._get_dp_size(endpoint.mode) or endpoint.total_gpus // replica_size
+            expected_gpus = dp_size * replica_size
+            if expected_gpus != endpoint.total_gpus:
                 raise ValueError(
-                    f"{endpoint.mode} data-parallel-size={dp_size} x "
-                    f"tensor-parallel-size={tp_size} does not match "
-                    f"the endpoint's {endpoint.total_gpus} allocated GPUs"
+                    f"{endpoint.mode} data-parallel-size={dp_size}, tensor-parallel-size={tp_size}, "
+                    f"and pipeline-parallel-size={pp_size} require {expected_gpus} GPUs, but the endpoint "
+                    f"has {endpoint.total_gpus} allocated GPUs"
                 )
 
-            local_dp_size = len(endpoint.gpu_indices) // tp_size
+            local_gpu_count = len(endpoint.gpu_indices)
+            spans_nodes = replica_size > local_gpu_count
+            if spans_nodes:
+                if len(endpoint.nodes) < 2:
+                    raise ValueError("cross-node per_node DP requires a multi-node endpoint")
+                if replica_size % local_gpu_count != 0:
+                    raise ValueError(
+                        f"{endpoint.mode} TP x PP replica size {replica_size} does not divide evenly across "
+                        f"nodes with {local_gpu_count} allocated GPUs each"
+                    )
+                nodes_per_dp_rank = replica_size // local_gpu_count
+                if len(endpoint.nodes) != dp_size * nodes_per_dp_rank:
+                    raise ValueError(
+                        f"{endpoint.mode} requires {nodes_per_dp_rank} nodes per DP rank and "
+                        f"{dp_size * nodes_per_dp_rank} nodes total, but the endpoint has {len(endpoint.nodes)}"
+                    )
+                multinode_processes = endpoints_to_processes(
+                    [endpoint],
+                    base_sys_port=current_sys_port,
+                    port_allocator=port_allocator,
+                )
+                processes.extend(multinode_processes)
+                current_sys_port += len(multinode_processes)
+                continue
+
+            if local_gpu_count % replica_size != 0:
+                raise ValueError(
+                    f"{endpoint.mode} TP x PP replica size {replica_size} does not divide the node's "
+                    f"{local_gpu_count} allocated GPUs"
+                )
+
+            local_dp_size = local_gpu_count // replica_size
             dp_rpc_port = port_allocator.next_dp_rpc_port(endpoint.leader_node)
             nixl_base_port = port_allocator.next_nixl_port_block(dp_size)
             dp_start_rank = 0
@@ -921,19 +965,46 @@ class VLLMProtocol:
             config.pop("data_parallel_hybrid_lb", None)
             config.pop("headless", None)
 
-            cmd.extend(
-                [
-                    "--data-parallel-size-local",
-                    str(len(process.gpu_indices)),
-                    "--data-parallel-start-rank",
-                    str(process.node_rank),
-                    "--data-parallel-address",
-                    leader_ip,
-                    "--data-parallel-rpc-port",
-                    str(dp_rpc_port),
-                    "--data-parallel-hybrid-lb",
-                ]
-            )
+            replica_size = self._get_tp_size(mode) * self._get_pp_size(mode)
+            local_gpu_count = len(process.gpu_indices)
+            spans_nodes = replica_size > local_gpu_count
+
+            if spans_nodes:
+                if not is_multi_node:
+                    raise ValueError("cross-node per_node DP requires a multi-node endpoint")
+                node_rank = endpoint_nodes.index(process.node)
+                cmd.extend(
+                    [
+                        "--master-addr",
+                        leader_ip,
+                        "--nnodes",
+                        str(len(endpoint_nodes)),
+                        "--node-rank",
+                        str(node_rank),
+                        "--data-parallel-address",
+                        leader_ip,
+                        "--data-parallel-rpc-port",
+                        str(dp_rpc_port),
+                    ]
+                )
+                # A single global API/DPLB leader owns the shared DP address.
+                if node_rank > 0:
+                    cmd.append("--headless")
+            else:
+                local_dp_size = local_gpu_count // replica_size
+                cmd.extend(
+                    [
+                        "--data-parallel-size-local",
+                        str(local_dp_size),
+                        "--data-parallel-start-rank",
+                        str(process.node_rank),
+                        "--data-parallel-address",
+                        leader_ip,
+                        "--data-parallel-rpc-port",
+                        str(dp_rpc_port),
+                        "--data-parallel-hybrid-lb",
+                    ]
+                )
         elif is_dp_mode:
             # DP+EP mode: each GPU runs its own process
             # process.node_rank is the dp_rank (set in endpoints_to_processes)

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -63,11 +63,30 @@ def _vllm_health_entries(
 ) -> int:
     """Return expected Dynamo generate registrations for a vLLM worker mode."""
     dp_size = _vllm_data_parallel_size(config, mode)
-    if dp_size > 1 and getattr(config.backend, "dp_launch_mode", "per_gpu") == "per_node":
+    dp_launch_mode = getattr(config.backend, "dp_launch_mode", "per_gpu")
+    if dp_size > 1 and dp_launch_mode == "per_node":
         if backend_processes is None:
             raise ValueError("backend_processes are required for per-node DP health expectations")
         endpoint_mode = "agg" if mode == "aggregated" else mode
-        return sum(process.endpoint_mode == endpoint_mode for process in backend_processes)
+        mode_processes = [process for process in backend_processes if process.endpoint_mode == endpoint_mode]
+        if not mode_processes:
+            return 0
+
+        vllm_config = getattr(config.backend, "vllm_config", None)
+        mode_config = getattr(vllm_config, mode, None) if vllm_config else None
+        mode_config = mode_config or {}
+        tp_size = int(mode_config.get("tensor-parallel-size") or mode_config.get("tensor_parallel_size") or 1)
+        pp_size = int(mode_config.get("pipeline-parallel-size") or mode_config.get("pipeline_parallel_size") or 1)
+        gpu_indices = getattr(mode_processes[0], "gpu_indices", None)
+        if gpu_indices is None:
+            # Compatibility for callers that provide only registration-count
+            # process stubs. Real launch processes always carry GPU indices.
+            return len(mode_processes)
+        local_gpu_count = len(gpu_indices)
+        spans_nodes = tp_size * pp_size > local_gpu_count
+        if spans_nodes:
+            return logical_workers
+        return len(mode_processes)
 
     return logical_workers * dp_size
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -2961,6 +2961,143 @@ class TestVLLMDataParallelMode:
         assert cmd.count("--data-parallel-hybrid-lb") == 1
         assert "--headless" not in cmd
 
+    def test_dp_per_node_uses_local_dp_rank_for_dp4_tp4(self):
+        """DP4 x TP4 on four-GPU nodes launches one local DP rank per process."""
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            dp_launch_mode="per_node",
+            vllm_config=VLLMServerConfig(
+                aggregated={"data-parallel-size": 4, "tensor-parallel-size": 4},
+            ),
+        )
+        endpoint = Endpoint(
+            mode="agg",
+            index=0,
+            nodes=("node0", "node1", "node2", "node3"),
+            gpu_indices=frozenset(range(4)),
+            gpus_per_node=4,
+        )
+        processes = backend.endpoints_to_processes([endpoint])
+        runtime = MagicMock(model_path=Path("/model"), is_hf_model=False, request_plane="tcp")
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            commands = [backend.build_worker_command(process, processes, runtime) for process in processes]
+
+        assert [process.node_rank for process in processes] == [0, 1, 2, 3]
+        assert [cmd[cmd.index("--data-parallel-size-local") + 1] for cmd in commands] == ["1"] * 4
+        assert [cmd[cmd.index("--data-parallel-start-rank") + 1] for cmd in commands] == ["0", "1", "2", "3"]
+        assert all("--data-parallel-hybrid-lb" in cmd for cmd in commands)
+        assert all("--nnodes" not in cmd and "--headless" not in cmd for cmd in commands)
+
+    def test_dp_per_node_uses_multinode_rendezvous_for_dp2_tp8(self):
+        """DP2 x TP8 on four-GPU nodes automatically selects cross-node TP."""
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            dp_launch_mode="per_node",
+            vllm_config=VLLMServerConfig(
+                aggregated={"data-parallel-size": 2, "tensor-parallel-size": 8},
+            ),
+        )
+        endpoint = Endpoint(
+            mode="agg",
+            index=0,
+            nodes=("node0", "node1", "node2", "node3"),
+            gpu_indices=frozenset(range(4)),
+            gpus_per_node=4,
+        )
+        processes = backend.endpoints_to_processes([endpoint])
+        runtime = MagicMock(model_path=Path("/model"), is_hf_model=False, request_plane="tcp")
+
+        with patch("srtctl.core.slurm.get_hostname_ip", side_effect=lambda node: f"10.0.0.{int(node[-1]) + 1}"):
+            commands = [backend.build_worker_command(process, processes, runtime) for process in processes]
+
+        assert [process.node_rank for process in processes] == [0, 1, 2, 3]
+        assert [cmd[cmd.index("--master-addr") + 1] for cmd in commands] == ["10.0.0.1"] * 4
+        assert [cmd[cmd.index("--nnodes") + 1] for cmd in commands] == ["4"] * 4
+        assert ["--headless" in cmd for cmd in commands] == [False, True, True, True]
+        assert all("--data-parallel-size-local" not in cmd for cmd in commands)
+
+    @pytest.mark.parametrize(
+        ("dp_size", "tp_size", "pp_size", "node_count"),
+        [
+            (8, 8, 1, 16),
+            (2, 8, 1, 4),
+            (4, 16, 1, 16),
+            (2, 4, 2, 4),
+        ],
+    )
+    def test_dp_per_node_supports_regular_cross_node_topologies(self, dp_size, tp_size, pp_size, node_count):
+        """Topology-aware per_node accepts regular DP x TP x PP layouts."""
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            dp_launch_mode="per_node",
+            vllm_config=VLLMServerConfig(
+                aggregated={
+                    "data-parallel-size": dp_size,
+                    "tensor-parallel-size": tp_size,
+                    "pipeline-parallel-size": pp_size,
+                },
+            ),
+        )
+        endpoint = Endpoint(
+            mode="agg",
+            index=0,
+            nodes=tuple(f"node{rank}" for rank in range(node_count)),
+            gpu_indices=frozenset(range(4)),
+            gpus_per_node=4,
+        )
+
+        processes = backend.endpoints_to_processes([endpoint])
+
+        assert len(processes) == node_count
+        assert [process.node_rank for process in processes] == list(range(node_count))
+
+    def test_dp_per_node_accounts_for_pipeline_parallel_size(self):
+        """The local DP-rank count divides node GPUs by TP x PP."""
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from srtctl.backends import VLLMProtocol, VLLMServerConfig
+        from srtctl.core.topology import Endpoint
+
+        backend = VLLMProtocol(
+            dp_launch_mode="per_node",
+            vllm_config=VLLMServerConfig(
+                aggregated={
+                    "data-parallel-size": 2,
+                    "tensor-parallel-size": 2,
+                    "pipeline-parallel-size": 2,
+                },
+            ),
+        )
+        endpoint = Endpoint(
+            mode="agg",
+            index=0,
+            nodes=("node0", "node1"),
+            gpu_indices=frozenset(range(4)),
+            gpus_per_node=4,
+        )
+        processes = backend.endpoints_to_processes([endpoint])
+        runtime = MagicMock(model_path=Path("/model"), is_hf_model=False, request_plane="tcp")
+
+        with patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"):
+            commands = [backend.build_worker_command(process, processes, runtime) for process in processes]
+
+        assert [process.node_rank for process in processes] == [0, 1]
+        assert [cmd[cmd.index("--data-parallel-size-local") + 1] for cmd in commands] == ["1", "1"]
+
     def test_standard_tp_mode_still_works(self):
         """Test that standard TP mode (no DP) still creates per-node processes."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig

--- a/tests/test_health_expectations.py
+++ b/tests/test_health_expectations.py
@@ -27,12 +27,19 @@ def _config(
     )
 
 
-def _processes(*, prefill=0, decode=0, agg=0):
+def _processes(*, prefill=0, decode=0, agg=0, gpu_count=None):
     """Build backend-process stand-ins grouped by endpoint mode."""
+
+    def process(mode):
+        fields = {"endpoint_mode": mode}
+        if gpu_count is not None:
+            fields["gpu_indices"] = frozenset(range(gpu_count))
+        return SimpleNamespace(**fields)
+
     return [
-        *(SimpleNamespace(endpoint_mode="prefill") for _ in range(prefill)),
-        *(SimpleNamespace(endpoint_mode="decode") for _ in range(decode)),
-        *(SimpleNamespace(endpoint_mode="agg") for _ in range(agg)),
+        *(process("prefill") for _ in range(prefill)),
+        *(process("decode") for _ in range(decode)),
+        *(process("agg") for _ in range(agg)),
     ]
 
 
@@ -99,6 +106,27 @@ def test_dynamo_vllm_per_node_aggregated_counts_node_processes():
 
     assert (n_prefill, n_decode, num_workers) == (0, 2, 2)
     assert count_desc == "0P + 2D Dynamo generate instances; logical workers: 1 agg"
+
+
+def test_dynamo_vllm_per_node_cross_node_tp_counts_dplb_endpoints():
+    """Topology-aware per_node counts the global DPLB endpoint when TP spans nodes."""
+    vllm_config = SimpleNamespace(
+        prefill=None,
+        decode=None,
+        aggregated={"data-parallel-size": 2, "tensor-parallel-size": 8},
+    )
+    config = _config(
+        "dynamo",
+        "vllm",
+        num_agg=1,
+        vllm_config=vllm_config,
+        dp_launch_mode="per_node",
+    )
+
+    n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(config, _processes(agg=4, gpu_count=4))
+
+    assert (n_prefill, n_decode, num_workers) == (0, 1, 1)
+    assert count_desc == "0P + 1D Dynamo generate instances; logical workers: 1 agg"
 
 
 def test_dynamo_vllm_without_dp_config_defaults_to_logical_counts():


### PR DESCRIPTION
## Summary

Makes `dp_launch_mode: per_node` topology-aware for regular `DP x TP x PP` deployments. srt-slurm derives whether each TP/PP replica is node-local or spans multiple nodes from the configured parallel sizes and GPU allocation.

## Why

The process layout is one vLLM process per allocated node. Whether a TP/PP replica fits locally or requires distributed rendezvous is a property of the topology and should not require a separate user-selected launch mode:

- If `TP x PP` fits in the node-local GPU allocation, one process manages one or more local DP replicas.
- If `TP x PP` exceeds the node-local GPU allocation, each DP replica spans multiple node processes participating in one global vLLM rendezvous.

## Behavior

With `dp_launch_mode: per_node`, srt-slurm now:

- Validates that `DP x TP x PP` equals the endpoint GPU allocation.
- Validates that every TP/PP replica divides evenly within or across nodes.
- Creates one process per allocated node.
- For node-local replicas:
  - Computes `--data-parallel-size-local` as `local_gpus / (TP x PP)`.
  - Computes `--data-parallel-start-rank` from preceding node-local DP ranks.
  - Enables `--data-parallel-hybrid-lb` so every node-local process registers with Dynamo.
- For replicas spanning nodes:
  - Passes one shared `--master-addr`, total `--nnodes`, and global `--node-rank` to all processes.
  - Passes one shared `--data-parallel-address` and RPC port.
  - Keeps only global node rank 0 non-headless; every other process is an engine-only participant.
  - Expects one Dynamo DPLB registration per logical endpoint.
- Derives and owns the local-DP, hybrid-LB, and headless flags instead of accepting conflicting recipe values.

Supported regular layouts include:

- DP4 x TP4 on four-GPU nodes: one local TP4/DP rank per node.
- DP8 x TP8 on four-GPU nodes: two nodes per DP rank.
- DP2 x TP8 on four-GPU nodes: two nodes per DP rank.
- DP4 x TP16 on four-GPU nodes: four nodes per DP rank.
- Equivalent layouts using pipeline parallelism through `TP x PP`.

`per_gpu` remains the legacy default, and standard non-DP TP/PP launching is unchanged.

## Validation

- The PR is a single commit rebased onto the latest `main`.
- 49 focused vLLM topology and Dynamo health tests pass.
- Added explicit coverage for DP4/TP4, DP8/TP8, DP2/TP8, DP4/TP16, local PP, distributed PP, and cross-node DPLB health counts.
- Ruff checks pass for the changed source files.
- Full repository suite: 1,284 passed, 2 skipped, and 1 unrelated existing failure in `test_mcp_spec.py` caused by Python 3.14 rendering `Union[str, NoneType]` instead of `UnionType[str, NoneType]`.
- The distributed global-rendezvous/headless path was previously validated through a complete DP4 x TP4 x EP16 C1-C256 benchmark sweep on four four-GPU GB300 nodes with zero request errors. The node-local selection is covered by command-generation and topology tests in this update.
