### PR TITLE
feat(trtllm): add numa bind config params in trtllm backend

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -81,6 +81,12 @@ class TRTLLMProtocol:
     # For dynamo.trtllm: readiness is a TCP connection on the worker's sys_port.
     sequential_node_start: int = 0
 
+    # Whether to prefix the trtllm worker command with `numactl -m 0,1`.
+    # None (default) preserves the existing auto-detected behavior (enabled
+    # only for gb200/gb300). True/False forces numactl on/off regardless of
+    # gpu_type.
+    numa_memory_bind: bool | None = None
+
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
     # =========================================================================
@@ -202,9 +208,11 @@ class TRTLLMProtocol:
         # For local models, model is mounted to /model in the container
         model_arg = runtime.worker_model_arg
 
-        numactl_prefix = (
-            ["numactl", "-m", "0,1"] if runtime.gpu_type in ("gb200", "gb300") and mode in ("prefill", "decode") else []
-        )
+        if self.numa_memory_bind is None:
+            use_numactl = runtime.gpu_type in ("gb200", "gb300") and mode in ("prefill", "decode")
+        else:
+            use_numactl = self.numa_memory_bind and mode in ("prefill", "decode")
+        numactl_prefix = ["numactl", "-m", "0,1"] if use_numactl else []
         base_prefix = list(nsys_prefix or []) + numactl_prefix + ["trtllm-llmapi-launch"]
 
         # trtllm-serve path: launch an OpenAI-compatible trtllm-serve worker. In

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3560,6 +3560,78 @@ class TestHuggingFaceModelSupport:
         idx = cmd.index("--model-path")
         assert cmd[idx + 1] == "/model"
 
+    def test_trtllm_numa_memory_bind_none_follows_gpu_type_default(self):
+        """numa_memory_bind=None (default) auto-enables numactl only for gb200/gb300."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from srtctl.backends import TRTLLMProtocol
+
+        backend = TRTLLMProtocol()
+        process = self._make_process(mode="prefill")
+        runtime = self._make_runtime(is_hf=False)
+        runtime.log_dir = Path("/tmp/test-logs")
+        runtime.gpu_type = "h100"
+
+        with (
+            patch("pathlib.Path.write_text"),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            cmd = backend.build_worker_command(process=process, endpoint_processes=[process], runtime=runtime)
+
+        assert "numactl" not in cmd
+
+        runtime.gpu_type = "gb200"
+        with (
+            patch("pathlib.Path.write_text"),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            cmd = backend.build_worker_command(process=process, endpoint_processes=[process], runtime=runtime)
+
+        assert cmd[:3] == ["numactl", "-m", "0,1"]
+
+    def test_trtllm_numa_memory_bind_true_forces_numactl(self):
+        """numa_memory_bind=True forces numactl even on non-gb200/gb300 GPUs."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from srtctl.backends import TRTLLMProtocol
+
+        backend = TRTLLMProtocol(numa_memory_bind=True)
+        process = self._make_process(mode="prefill")
+        runtime = self._make_runtime(is_hf=False)
+        runtime.log_dir = Path("/tmp/test-logs")
+        runtime.gpu_type = "h100"
+
+        with (
+            patch("pathlib.Path.write_text"),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            cmd = backend.build_worker_command(process=process, endpoint_processes=[process], runtime=runtime)
+
+        assert cmd[:3] == ["numactl", "-m", "0,1"]
+
+    def test_trtllm_numa_memory_bind_false_disables_numactl(self):
+        """numa_memory_bind=False disables numactl even on gb200/gb300."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from srtctl.backends import TRTLLMProtocol
+
+        backend = TRTLLMProtocol(numa_memory_bind=False)
+        process = self._make_process(mode="prefill")
+        runtime = self._make_runtime(is_hf=False)
+        runtime.log_dir = Path("/tmp/test-logs")
+        runtime.gpu_type = "gb300"
+
+        with (
+            patch("pathlib.Path.write_text"),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            cmd = backend.build_worker_command(process=process, endpoint_processes=[process], runtime=runtime)
+
+        assert "numactl" not in cmd
+
 
 class TestInfmaxWorkspaceMount:
     """Test that INFMAX_WORKSPACE env var creates a container mount."""


### PR DESCRIPTION
## Summary

Adds an explicit `numa_memory_bind` config knob to the TRTLLM backend, letting recipes force `numactl -m 0,1` on or off for the worker command instead of relying solely on GPU-type auto-detection.

- Today, `trtllm-llmapi-launch` is prefixed with `numactl -m 0,1` only when `runtime.gpu_type` is `gb200`/`gb300` and the worker mode is `prefill`/`decode`. There was no way to opt in on other GPU types or opt out on gb200/gb300 without code changes.
- `backend.numa_memory_bind: true | false | null` (default `null`) now overrides that decision:
  - `null` (default) — unchanged behavior, auto-enabled only for gb200/gb300.
  - `true` — forces `numactl -m 0,1` on for prefill/decode regardless of `gpu_type`.
  - `false` — forces it off, even on gb200/gb300.

## Changes

- `src/srtctl/backends/trtllm.py`: add `numa_memory_bind: bool | None = None` field to `TRTLLMProtocol`; update the `numactl` prefix logic in `build_worker_command` to honor it.
- `tests/test_configs.py`: add 3 tests covering the default/auto, forced-on, and forced-off cases.

## Usage

\`\`\`yaml
backend:
  type: trtllm
  numa_memory_bind: true
\`\`\`

## Test plan

- [x] `uv run pytest tests/test_configs.py -k "numa_memory_bind or trtllm_hf_model or trtllm_local_model" -v` — 5 passed
