### PR TITLE
feat: render runs captured without observability, and mark the warmup phase

### DIFF
--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -68,6 +68,21 @@ rates sit at zero through their idle windows), and labels which statistic each r
 used. Without that fallback an 8x concurrency change reported 30 panels as unchanged
 when only 8 genuinely were.
 
+It also prints a **PROVENANCE** section, which answers the question the rest of the
+report assumes: *were these two runs actually comparable?*
+
+* **Framework drift** — the versions found inside the running workers, from
+  `fingerprint_*.json`. If baseline and compared ran different `tensorrt_llm` builds,
+  nothing else in the report means what it appears to. This is invisible otherwise:
+  both runs simply work.
+* **CONFIG DELTA** — every differing key of the resolved `config.yaml`, flattened to
+  dotted paths. For an ablation this should name exactly one setting, and the section
+  says outright whether the comparison is `SINGLE-VARIABLE` or how many settings
+  differ. A confound becomes something you see rather than something you argue about.
+
+Both degrade honestly: when either bundle lacks the provenance files the section says
+the changed variables are **UNKNOWN** rather than implying the runs matched.
+
 ### Running a job against a modified checkout
 
 If you are testing dashboard changes, the compute node runs whatever `srtctl_root` in
@@ -171,6 +186,10 @@ Produces:
 <bundle>/request_trace.jsonl         request-trace axis  (schema 4)
 <bundle>/iter_bins.json              per-iteration axis  (schema 5)
 <bundle>/trtllm_config_*.yaml        engine ceilings, copied verbatim
+<bundle>/profile_export_aiperf.json  client run summary: workload cache ceiling, validity
+<bundle>/config.yaml                 the RESOLVED recipe — what was configured
+<bundle>/fingerprint_*.json          per-worker ground truth: framework versions, GPU, CUDA
+<bundle>/resource_snapshot.json      the allocation the numbers came from
 <bundle>/dashboard.yaml              generated sidecar (header labels + topology)
 ```
 
@@ -184,6 +203,8 @@ Produces:
 | `--request-trace` | `dynamo` | parses `dynamo-request-trace`; the only source of KV-transfer cost and `session_id` |
 | `--iter-log` | `trtllm` | parses `print_iter_log` lines from the worker logs; local->UTC offset is derived per run, not hardcoded |
 | *(automatic)* | — | `trtllm_config_*.yaml` are copied from the run dir into the bundle, giving the Engine tab its real in-flight-batch ceilings instead of the `--max-batch-*` defaults |
+| *(automatic)* | — | `profile_export_aiperf.json` — AIPerf's run summary. Carries `theoretical_prefix_cache_hit` (the ceiling the *workload* offered), `error_summary` / `was_cancelled` / `branch_stats` (run validity), and `effective_concurrency`. Its **absence** is a signal too: AIPerf writes it when a concurrency finishes, so a run killed by its wall clock has none |
+| *(automatic)* | — | `config.yaml`, `fingerprint_*.json`, `resource_snapshot.json` — run provenance. Without these, two bundles can be compared for what *moved* but never for what *changed* |
 | `--worker` | — | repeatable `ROLE=PARALLELISM:RANK:COUNT`, e.g. `prefill=dep:4:6` |
 | `--jobs` | `4` | parallelism for the `SPAN_CLOSED` pre-grep |
 
@@ -297,6 +318,22 @@ measuring think time.
   splits by `dp_rank`.
 - **Some queue gauges read a constant 0** on a run that never queued. They are still
   specified: queue depth is the strongest single TTFT predictor when it is not zero.
+- **The KV-routing panels can describe a small slice of the traffic.** Session affinity
+  pins a request to the worker already holding its conversation, and a pinned request
+  never reaches the KV scorer — on run 2751593 that was 248 of 274 decisions (90.5%).
+  The router tab states its own coverage from `ro.coverage`, but only when the
+  frontend-log leg is present; without it, no decision count exists and no coverage
+  claim is made.
+- **`meta.n = 0` does not mean the run served nothing.** It counts *profiling*-phase
+  requests, and a run that hits its wall clock during warmup has none — reference run
+  2750618 has 118 client records, all `benchmark_phase: warmup`. Scrape-derived KPIs
+  (`tok_cache`, `kv_hit_true`) are still valid on such a run; the per-request and
+  per-session cards are the parts that need `meta.n > 0`. `meta.phase_filter` states
+  which case you are looking at.
+- **Worker fingerprints do not cover the frontend.** They are written per worker, so a
+  frontend-only setting such as `DYN_TOKENIZER_CACHE` appears in no fingerprint. Its
+  record is `meta.provenance.config`, taken from the resolved `config.yaml` — a
+  configured value rather than an observation from inside the running process.
 
 ## Provenance and re-syncing
 

--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -113,6 +113,7 @@ Produces:
 | `--traces` | `spanlog` | `none` to skip |
 | `--span-logs` | `*.out` | srt-slurm's worker/frontend log naming |
 | `--metrics` | `prometheus` | parses `raw_prometheus.jsonl` |
+| *(automatic)* | — | `trtllm_config_*.yaml` are copied from the run dir into the bundle, giving the Engine tab its real in-flight-batch ceilings instead of the `--max-batch-*` defaults |
 | `--worker` | — | repeatable `ROLE=PARALLELISM:RANK:COUNT`, e.g. `prefill=dep:4:6` |
 | `--jobs` | `4` | parallelism for the `SPAN_CLOSED` pre-grep |
 
@@ -134,7 +135,7 @@ python3 -m src.visualization.build_dynamo_bench_dash <bundle> <out.html> [flags]
 | `--frontend-log PATH` | — | adds the Log-analysis tab |
 | `--d3 PATH` | vendored `src/visualization/d3.v7.min.js` | inlined for a self-contained page |
 | `--d3-cdn` | off | load D3 from the CDN instead (smaller file, needs network to view) |
-| `--max-batch-prefill / --max-batch-decode` | `128` / `256` | in-flight-batch ceilings drawn on the Engine tab |
+| `--max-batch-prefill / --max-batch-decode` | `128` / `256` | in-flight-batch ceilings drawn on the Engine tab. **Only used when the bundle has no `trtllm_config_*.yaml`** — ingest copies those in automatically, and the real values win. On AgentX run 2739690 the true decode ceiling is `1`, so the `256` default would misdraw that panel by 256x |
 | `--gpus N` | from `dashboard.yaml` | tok/s/GPU denominator |
 | `--include-warmup` | off | by default only the profiling phase is kept |
 
@@ -160,12 +161,6 @@ warmup/phase filter onto the log source.
 
 ## Known limitations
 
-- **Engine ceilings are inputs, not measurements.** The renderer looks for
-  `trtllm_config_{prefill,decode}.yaml` in the bundle; srt-slurm dumps engine config as
-  `<log_dir>/<node>_config.json` instead, so that lookup misses and the
-  `--max-batch-*` defaults apply. Pass them explicitly to match your run — the defaults
-  (128 / 256) are frequently wrong by orders of magnitude, and the Engine tab's captions
-  are drawn against them.
 - **Interpretive captions were developed on an admission/queue-bound reference run.**
   The numbers are data-driven, but the framing reads best on queue-bound runs.
 - **Nothing is wired into the job path.** These are offline tools run against a

--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -1,8 +1,8 @@
 # Component Performance Dashboard
 
-A single self-contained HTML page with **Overview / Router / Engine / Frontend** tabs,
-plus an optional **Log analysis** tab, built offline from the artifacts an srt-slurm
-job already captures.
+A single self-contained HTML page with **Overview / Frontend / Router / Engine /
+Session / Log analysis** tabs, built offline from the artifacts an srt-slurm job
+already captures.
 
 It answers component questions the aggregate benchmark numbers cannot: where TTFT
 went (admission queue vs. routing vs. prefill vs. KV transfer), whether KV cache or
@@ -13,7 +13,7 @@ Two pieces, vendored from the `dynamo-benchmark-perf-dashboard` repo:
 
 | Layer | Path | Role |
 | ----- | ---- | ---- |
-| **L2 ingest** | `src/ingest/` | RAW capture -> three fixed intermediate schemas (a *bundle*) |
+| **L2 ingest** | `src/ingest/` | RAW capture -> five fixed intermediate schemas (a *bundle*) |
 | **L3 render** | `src/visualization/` | bundle -> one self-contained `.html` |
 
 Both are stdlib-only and are **not** part of the installed `srtctl` wheel. Run them
@@ -79,15 +79,18 @@ observability:
   enabled: true
 ```
 
-That expands (see `ObservabilityConfig` in `src/srtctl/core/schema.py`) into the three
+That expands (see `ObservabilityConfig` in `src/srtctl/core/schema.py`) into the
 capture legs below. Without it you still get the Log-analysis tab, and nothing else.
 
-| Leg | Recipe requirement | Artifact | Feeds |
-| --- | ------------------ | -------- | ----- |
-| **Metrics** | `observability.enabled` | `<log_dir>/raw_prometheus.jsonl` | Router, Engine, Frontend |
-| **Traces** | `observability.enabled` **and** an AIPerf-based benchmark | `SPAN_CLOSED` lines in `<log_dir>/*.out` | Overview |
-| **Client** | an AIPerf-based benchmark at export level `records` (the default) | `<log_dir>/artifacts/<run>/profile_export.jsonl` | Overview |
-| **Frontend log** | *nothing* — always written | `<log_dir>/<node>_frontend_<i>.out` | Log analysis |
+| Leg | Recipe requirement | Artifact | Bundle output | Feeds |
+| --- | ------------------ | -------- | ------------- | ----- |
+| **Metrics** | `observability.enabled` | `<log_dir>/raw_prometheus.jsonl` | `server_metrics_export.jsonl` | every time-series panel |
+| **Request trace** | `observability.enabled` | `<log_dir>/dynamo-request-trace` | `request_trace.jsonl` | per-request card, per-session view, the waterfall's KV-transfer band |
+| **Per-iteration** | `print_iter_log: true` in the engine config | `SPAN`-free lines in `<log_dir>/*_w*.out` | `iter_bins.json` | batch composition, host/device step time |
+| **Traces** | `observability.enabled` **and** an AIPerf benchmark | `SPAN_CLOSED` lines in `<log_dir>/*.out` | `tempo_traces/<xid>.json` | Overview, routing outcome on the card |
+| **Client** | an AIPerf benchmark at export level `records` (default) | `<log_dir>/agentic/*/aiperf_artifacts/` or `artifacts/*/` | `profile_export.jsonl` | Overview, warmup filtering |
+| **Engine config** | TRT-LLM backend | `<log_dir>/trtllm_config_*.yaml` | copied verbatim | in-flight-batch ceilings |
+| **Frontend log** | *nothing* — always written | `<log_dir>/<node>_frontend_<i>.out` | *(read directly)* | Log analysis |
 
 ### Which tabs a run can populate
 
@@ -127,19 +130,24 @@ python3 -m src.ingest.ingest --run-dir <log_dir> --out <bundle> [flags]
 Produces:
 
 ```
-<bundle>/profile_export.jsonl        client axis   (schema 1)
-<bundle>/tempo_traces/<xid>.json     traces axis   (schema 3)
-<bundle>/server_metrics_export.jsonl metrics axis  (schema 2)
+<bundle>/profile_export.jsonl        client axis         (schema 1)
+<bundle>/server_metrics_export.jsonl metrics axis        (schema 2)
+<bundle>/tempo_traces/<xid>.json     traces axis         (schema 3)
+<bundle>/request_trace.jsonl         request-trace axis  (schema 4)
+<bundle>/iter_bins.json              per-iteration axis  (schema 5)
+<bundle>/trtllm_config_*.yaml        engine ceilings, copied verbatim
 <bundle>/dashboard.yaml              generated sidecar (header labels + topology)
 ```
 
 | Flag | Default | Notes |
 | ---- | ------- | ----- |
 | `--client` | `aiperf` | `none` to skip. The AIPerf export is already schema 1, so this is a passthrough |
-| `--client-input` | `artifacts/*/profile_export.jsonl` | reaches into the per-run artifact dir `bench.sh` creates |
+| `--client-input` | `agentic/*/aiperf_artifacts/…` then `artifacts/*/…` | both harness layouts are tried; AgentX nests one level deeper and shards by concurrency |
 | `--traces` | `spanlog` | `none` to skip |
 | `--span-logs` | `*.out` | srt-slurm's worker/frontend log naming |
 | `--metrics` | `prometheus` | parses `raw_prometheus.jsonl` |
+| `--request-trace` | `dynamo` | parses `dynamo-request-trace`; the only source of KV-transfer cost and `session_id` |
+| `--iter-log` | `trtllm` | parses `print_iter_log` lines from the worker logs; local->UTC offset is derived per run, not hardcoded |
 | *(automatic)* | — | `trtllm_config_*.yaml` are copied from the run dir into the bundle, giving the Engine tab its real in-flight-batch ceilings instead of the `--max-batch-*` defaults |
 | `--worker` | — | repeatable `ROLE=PARALLELISM:RANK:COUNT`, e.g. `prefill=dep:4:6` |
 | `--jobs` | `4` | parallelism for the `SPAN_CLOSED` pre-grep |
@@ -187,14 +195,73 @@ warmup/phase filter onto the log source.
 
 ---
 
+## The three dashboard entities
+
+Everything the page draws is one of exactly three things. Nothing is bespoke to a run.
+
+### 1. Time-series panels — `src/visualization/panels.py`
+
+77 panels declared as data rows, evaluated by one generic function. Adding a signal
+means adding a dict; there is no per-panel rendering code, which is what stops a panel
+acquiring behaviour another panel lacks. Four kinds cover every catalogued signal:
+
+| kind | arithmetic |
+| ---- | ---------- |
+| `gauge` | the sample as-is |
+| `counter_rate` | successive differences / dt. A backwards step means the process restarted and is **dropped**, not drawn as a negative spike |
+| `hist_mean` | `Δ_sum / Δ_count` — the **interval** mean. The cumulative form flattens over a long run and hides late degradation |
+| `ratio` | `a / (a+b)` on interval deltas, for genuine partner counters only |
+
+Two more panel kinds are computed rather than scraped (`kind: "derived"`), and are
+emitted in the same shape so the same renderer draws them: in-flight imbalance across
+ranks/workers, and batch composition.
+
+A panel whose series never moves is **stated in words**, not drawn. A flat line reads
+as a broken chart; "constant 0 for the whole run" is the finding.
+
+### 2. Per-request card — `DATA.rt.requests[<x_request_id>]`
+
+Four bands that sum to `total_ms` by construction: admission+routing, prefill compute,
+KV transfer, steady decode. Plus what the request *was* (`isl`, `osl`, `cached_tokens`,
+`kv_hit_rate`, `turn_index`, `prefix_reuse_ratio`) and where it went
+(`routing.worker_id`, `.dp_rank`, `.overlap_blocks`, `.router_ms`, `.admission_ms`).
+
+`routing` is an **outcome, not a rationale**. The router's cost comparison lives on a
+free-text selector line carrying no `request_id`, so "which worker, with how much
+overlap" is joinable per request while "why it beat the alternatives" is not.
+
+`routing.belief_error` compares the router's `overlap_blocks × block_size` against the
+engine's reported `cached_tokens`. They are the same quantity, so a divergence means
+the router is routing on a prefix the engine does not hold.
+
+### 3. Per-session view — `DATA.rt.sessions`
+
+One row per session, identical columns for every session and every run: turns,
+span/busy/**idle**, per-turn TTFT / KV-hit / prefix-reuse series, and which decode
+workers and prefill ranks it touched.
+
+Idle is broken out because a session can spend most of its wall-clock waiting on the
+harness rather than the server; a session-level latency figure that absorbs that is
+measuring think time.
+
 ## Known limitations
 
-- **Interpretive captions were developed on an admission/queue-bound reference run.**
-  The numbers are data-driven, but the framing reads best on queue-bound runs.
-- **Nothing is wired into the job path.** These are offline tools run against a
-  finished log directory; no stage of a benchmark invokes them.
-
----
+- **Interpretive captions on the older panels** were developed on an
+  admission/queue-bound reference run. The numbers are data-driven, but the framing
+  reads best on queue-bound runs. The declarative panels in `panels.py` do not have
+  this problem — their captions are fixed prose assembled from `why` / `source` /
+  `caveat` and never interpolate a run's values.
+- **Router *rationale* is not recoverable.** The selector line carrying logit, overlap
+  credit and prefill load scale has no `request_id`, so it cannot be joined per
+  request. Only the outcome is shown.
+- **`iter_bins.json` is rank 0 only**, so it cannot show TP/EP-rank divergence; and
+  `iter` restarts per engine lifecycle, so it is not a usable x-axis.
+- **Engine-side `dp_rank` is a replicated broadcast.** Splitting an engine metric by
+  rank renders a flat family of lines that reads as "balanced" on an imbalanced run.
+  Per-rank truth is frontend-side only; a test enforces that no `trtllm_*` panel
+  splits by `dp_rank`.
+- **Some queue gauges read a constant 0** on a run that never queued. They are still
+  specified: queue depth is the strongest single TTFT predictor when it is not zero.
 
 ## Provenance and re-syncing
 

--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -141,6 +141,36 @@ capture legs below. Without it you still get the Log-analysis tab, and nothing e
 | **Client** | an AIPerf benchmark at export level `records` (default) | `<log_dir>/agentic/*/aiperf_artifacts/` or `artifacts/*/` | `profile_export.jsonl` | Overview, warmup filtering |
 | **Engine config** | TRT-LLM backend | `<log_dir>/trtllm_config_*.yaml` | copied verbatim | in-flight-batch ceilings |
 | **Frontend log** | *nothing* — always written | `<log_dir>/<node>_frontend_<i>.out` | *(read directly)* | Log analysis |
+| **Host telemetry** | `observability.enabled` | `<log_dir>/host_samples.jsonl` | `host_series.json` | host/process CPU, ctx switches, fd headroom |
+
+### Host telemetry — what the metrics stream cannot say
+
+`srtctl.analysis.host_sampler` runs in-process beside the metrics scraper, on the same
+opt-in, reading only `/proc`. It exists because every other leg describes what Dynamo
+and TRT-LLM *choose to publish*, and three failure modes live below that line:
+
+* **Host CPU saturation / lock convoys.** A frontend pinned at 100% of one core is
+  indistinguishable, in every published metric, from an idle one — both report low queue
+  depth and low in-flight. The discriminator is host CPU busy % together with
+  **involuntary** context switches per thread: a convoy is a thread descheduled against
+  its will, which no application-level counter expresses.
+* **File-descriptor exhaustion.** An accept loop out of descriptors logs nothing;
+  connections are refused before the application sees them. Open fds against
+  `RLIMIT_NOFILE` is the only available warning, and `fd_headroom_pct` is reported even
+  when comfortable — *"the peak was 2% of the limit"* is the answer that rules the
+  hypothesis out.
+* **A load generator that has become the bottleneck.** Client 100% / server 0% is the
+  whole diagnosis and is invisible from the server side by construction.
+
+The sampler stores **cumulative** jiffie counters; the ingest derives percentages by
+differencing, so the capture cadence is never baked into a stored number. Per-process
+CPU is percent of **one** core, so >100 means genuinely more than one.
+
+**Scope limit, stated because it bounds every conclusion drawn from it:** the sampler
+observes the node driving the sweep — the one hosting the frontend — and the Dynamo /
+AIPerf processes on it. It does **not** reach the worker nodes; that would cost an srun
+round-trip per sample, which is the expense the scraper's opt-in exists to avoid. Worker-
+side host health is not covered.
 
 ### Which tabs a run can populate
 
@@ -190,6 +220,10 @@ Produces:
 <bundle>/config.yaml                 the RESOLVED recipe — what was configured
 <bundle>/fingerprint_*.json          per-worker ground truth: framework versions, GPU, CUDA
 <bundle>/resource_snapshot.json      the allocation the numbers came from
+<bundle>/benchmark_status.json       exit code, error lines, AIPerf phase census
+<bundle>/log_signals.json            log-only signals: counts, timestamps, samples
+<bundle>/run_lifecycle.json          time-to-ready, readiness gap, terminal cause
+<bundle>/host_series.json            host + per-process CPU, RSS, ctx switches, fds
 <bundle>/dashboard.yaml              generated sidecar (header labels + topology)
 ```
 
@@ -205,6 +239,10 @@ Produces:
 | *(automatic)* | — | `trtllm_config_*.yaml` are copied from the run dir into the bundle, giving the Engine tab its real in-flight-batch ceilings instead of the `--max-batch-*` defaults |
 | *(automatic)* | — | `profile_export_aiperf.json` — AIPerf's run summary. Carries `theoretical_prefix_cache_hit` (the ceiling the *workload* offered), `error_summary` / `was_cancelled` / `branch_stats` (run validity), and `effective_concurrency`. Its **absence** is a signal too: AIPerf writes it when a concurrency finishes, so a run killed by its wall clock has none |
 | *(automatic)* | — | `config.yaml`, `fingerprint_*.json`, `resource_snapshot.json` — run provenance. Without these, two bundles can be compared for what *moved* but never for what *changed* |
+| *(automatic)* | — | `benchmark_status.json` — why an empty dashboard is empty: exit code, error lines, and AIPerf's per-phase completed/cancelled census. A run can exit non-zero with no error-marker line at all, and the census is then the only account of what happened |
+| *(automatic)* | — | `log_signals.json` — signals whose only evidence is a log line and which have no metric behind them: worker crash, Dynamo recompile storm, OOM, KV-index desync, KV-transfer timeout, NCCL error, engine stall, etcd disconnect, client cancel. Counts + timestamps + 2 sample lines each, bounded regardless of log size. **Zero counts are kept** — "no crashes" is a statement; absence is not |
+| *(automatic)* | — | `run_lifecycle.json` — time-to-ready, the readiness gap (frontend accepting before the router can place), and the run's terminal cause. On run 2752632 that was **650 s of 28 held GPUs serving nothing**, invisible on an x-axis starting at the first request |
+| *(automatic)* | — | `host_series.json` — host CPU %, memory, per-process CPU / RSS / **involuntary** context switches / open fds, and fd headroom against `RLIMIT_NOFILE`. Requires the sampler (below); everything else in the bundle describes what Dynamo publishes, not the machine under it |
 | `--worker` | — | repeatable `ROLE=PARALLELISM:RANK:COUNT`, e.g. `prefill=dep:4:6` |
 | `--jobs` | `4` | parallelism for the `SPAN_CLOSED` pre-grep |
 

--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -48,6 +48,41 @@ artifacts ship with the rest of the log dir.
 Driven by `srtctl.analysis.perf_dashboard`, which is best-effort: a rendering failure
 is logged and never changes the outcome of a benchmark that already produced results.
 
+Nothing else is required. One `srtctl` submission collects the data, post-processes it
+and renders the page, in that order, inside the job.
+
+### Comparing two runs
+
+```bash
+python3 tools/dashboard_diff.py BASELINE/perf_dashboard.json COMPARED/perf_dashboard.json
+```
+
+Reports KPI deltas, tab-availability changes, per-panel movement ranked by magnitude,
+and population changes. Built for the ablation shape -- change one variable, run both,
+ask which signals responded -- which is also the honest test of whether a panel earns
+its place: a panel that does not move between a healthy run and a known-degraded one
+is not diagnostic.
+
+It compares medians, falling back to peaks when both medians are zero (sparse counter
+rates sit at zero through their idle windows), and labels which statistic each row
+used. Without that fallback an 8x concurrency change reported 30 panels as unchanged
+when only 8 genuinely were.
+
+### Running a job against a modified checkout
+
+If you are testing dashboard changes, the compute node runs whatever `srtctl_root` in
+`srtslurm.yaml` points at -- not the tree you edited. Two things bite:
+
+* **`srtctl_root` is the only lever.** Staging a second checkout and `cd`-ing into it
+  does not select it. Point `srtctl_root` at the new tree and confirm the job's own
+  `uv sync` line reports `srtctl==… (from file:///<your tree>)`.
+* **The runtime state is gitignored, so a fresh checkout does not have it.**
+  `srtslurm.yaml`, `configs/nats-server`, `configs/etcd`, `configs/etcdctl`,
+  `wheelhouse/dynamo` and `bin/uv` all live outside git. Copy or symlink them from a
+  working checkout, and do not `rsync --delete` over the result -- it removes exactly
+  those files, and the job then fails somewhere unrelated (a model path resolving
+  against the wrong root, for instance).
+
 ## Running it by hand
 
 Against any past run — including one captured before this existed:

--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -21,9 +21,36 @@ from a repo checkout.
 
 ---
 
-## Quick start
+## Quick start — one run, built automatically
 
-Point the ingest at a job's log directory, then render the bundle:
+Set the analytics knob in the recipe and the dashboard is produced by the job itself:
+
+```yaml
+observability:
+  enabled: true          # capture + build the dashboard
+  # build_dashboard: false   # capture only, skip rendering
+```
+
+Post-processing then writes, into the run's log dir:
+
+```
+perf_dashboard.html          self-contained page (D3 inlined, no network needed)
+perf_dashboard.json          the page's DATA payload — same object the HTML embeds
+perf_dashboard_bundle/       the intermediate schemas, re-renderable in seconds
+```
+
+`perf_dashboard.json` exists because the HTML is often unreadable where it lands — a
+headless cluster, a CI log, an S3 prefix. It is the machine-readable form of
+everything the page shows, so a run can be diffed against another, asserted on in a
+test, or simply read without a browser. It is built before the S3 sync, so all three
+artifacts ship with the rest of the log dir.
+
+Driven by `srtctl.analysis.perf_dashboard`, which is best-effort: a rendering failure
+is logged and never changes the outcome of a benchmark that already produced results.
+
+## Running it by hand
+
+Against any past run — including one captured before this existed:
 
 ```bash
 cd /path/to/srt-slurm
@@ -137,6 +164,7 @@ python3 -m src.visualization.build_dynamo_bench_dash <bundle> <out.html> [flags]
 | `--d3-cdn` | off | load D3 from the CDN instead (smaller file, needs network to view) |
 | `--max-batch-prefill / --max-batch-decode` | `128` / `256` | in-flight-batch ceilings drawn on the Engine tab. **Only used when the bundle has no `trtllm_config_*.yaml`** — ingest copies those in automatically, and the real values win. On AgentX run 2739690 the true decode ceiling is `1`, so the `256` default would misdraw that panel by 256x |
 | `--gpus N` | from `dashboard.yaml` | tok/s/GPU denominator |
+| `--dump-json PATH` | — | also write the DATA payload as indented JSON (what the automatic build produces as `perf_dashboard.json`) |
 | `--include-warmup` | off | by default only the profiling phase is kept |
 
 The bundle argument is optional — with only `--frontend-log`, you get a

--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -98,6 +98,32 @@ If you are testing dashboard changes, the compute node runs whatever `srtctl_roo
   those files, and the job then fails somewhere unrelated (a model path resolving
   against the wrong root, for instance).
 
+### If the job hit its wall clock
+
+A SLURM `TIMEOUT` kills the job hard, so **post-processing never runs and no dashboard is
+written** — even though the capture itself completed. This matters because the runs most
+worth looking at are often the ones that ran out of time.
+
+Nothing is lost. Every raw input survives the kill, and the bundle rebuilds from the run
+directory in under a minute:
+
+```bash
+cd /path/to/srt-slurm
+python3 -m src.ingest.ingest --run-dir outputs/<job_id>/logs --out /tmp/<job_id>-bundle
+python3 -m src.visualization.build_dynamo_bench_dash \
+    /tmp/<job_id>-bundle /tmp/<job_id>.html \
+    --frontend-log outputs/<job_id>/logs/<node>_frontend_0.out
+```
+
+Verified on job 2753007 (TIMEOUT at 20:12): `raw_prometheus.jsonl`, `host_samples.jsonl`,
+`dynamo-request-trace`, all four `fingerprint_*.json` and `resource_snapshot.json` were
+intact, and the bundle rebuilt in **53 s** with `aiperf=True traces=True metrics=True
+request_trace=True`.
+
+> Rebuild on a compute node, not the login node, for a full-length run. The login node's
+> memory limit will OOM-kill a render whose `server_metrics_export.jsonl` is a few hundred
+> MB (observed at exit 137 on a 243-request run), and its `/tmp` is a 2 GB tmpfs.
+
 ## Running it by hand
 
 Against any past run — including one captured before this existed:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1054,6 +1054,7 @@ Set `scrape_metrics: false` beside `enabled` to use Tachometer without also writ
 | `scrape_metrics` | bool/null | `null` | Override raw capture; `null` follows `enabled` |
 | `scrape_interval_seconds` | float | `1.0` | Interval between raw Prometheus scrape sweeps |
 | `scrape_output` | string | `raw_prometheus.jsonl` | Raw capture filename below the run log directory |
+| `build_dashboard` | bool/null | `null` | Build the component perf dashboard in post-processing; `null` follows `enabled`. See [Component Performance Dashboard](component-dashboard.md) |
 | `enable_otel` | bool | `false` | Inject OTEL tracing environment variables |
 | `otel_endpoint` | string/null | `null` | OTEL collector endpoint |
 | `tachometer` | object | `enabled: false` | Native Tachometer collection settings |

--- a/src/ingest/__init__.py
+++ b/src/ingest/__init__.py
@@ -71,6 +71,8 @@ Processor registry
       "prometheus" raw_prometheus.jsonl -> schema 2.         (metrics_prometheus.process)
     request_trace -> request_trace.jsonl
       "dynamo"  dynamo-request-trace -> schema 4.            (request_trace.process)
+    iter_log -> iter_bins.json
+      "trtllm"  print_iter_log worker lines -> schema 5.     (iter_log.process)
 
 The upstream repo also registers an ``agentperf`` client processor and a live
 ``tempo`` trace scraper. Neither is reachable from an srt-slurm run -- srt-slurm's
@@ -160,6 +162,9 @@ PROCESSORS: dict[str, dict[str, Callable]] = {
     },
     "request_trace": {
         "dynamo": _lazy("request_trace"),
+    },
+    "iter_log": {
+        "trtllm": _lazy("iter_log"),
     },
 }
 

--- a/src/ingest/__init__.py
+++ b/src/ingest/__init__.py
@@ -69,6 +69,8 @@ Processor registry
       "spanlog" Dynamo SPAN_CLOSED logs -> schema 3.         (traces_spanlog.process)
     metrics -> server_metrics_export.jsonl
       "prometheus" raw_prometheus.jsonl -> schema 2.         (metrics_prometheus.process)
+    request_trace -> request_trace.jsonl
+      "dynamo"  dynamo-request-trace -> schema 4.            (request_trace.process)
 
 The upstream repo also registers an ``agentperf`` client processor and a live
 ``tempo`` trace scraper. Neither is reachable from an srt-slurm run -- srt-slurm's
@@ -155,6 +157,9 @@ PROCESSORS: dict[str, dict[str, Callable]] = {
     },
     "metrics": {
         "prometheus": _lazy("metrics_prometheus"),
+    },
+    "request_trace": {
+        "dynamo": _lazy("request_trace"),
     },
 }
 

--- a/src/ingest/__init__.py
+++ b/src/ingest/__init__.py
@@ -69,6 +69,11 @@ Processor registry
       "spanlog" Dynamo SPAN_CLOSED logs -> schema 3.         (traces_spanlog.process)
     metrics -> server_metrics_export.jsonl
       "prometheus" raw_prometheus.jsonl -> schema 2.         (metrics_prometheus.process)
+      "aiperf-json" AIPerf server_metrics_export.json -> schema 2.
+                                                          (metrics_aiperf_json.process)
+                   The only server-metrics source on runs predating
+                   `observability.enabled`, which is where the before/after
+                   pairs for already-landed fixes live.
     request_trace -> request_trace.jsonl
       "dynamo"  dynamo-request-trace -> schema 4.            (request_trace.process)
     iter_log -> iter_bins.json
@@ -159,6 +164,7 @@ PROCESSORS: dict[str, dict[str, Callable]] = {
     },
     "metrics": {
         "prometheus": _lazy("metrics_prometheus"),
+        "aiperf-json": _lazy("metrics_aiperf_json"),
     },
     "request_trace": {
         "dynamo": _lazy("request_trace"),

--- a/src/ingest/frontend_infolog_parser.py
+++ b/src/ingest/frontend_infolog_parser.py
@@ -66,6 +66,28 @@ _RE_SEL = re.compile(r"selector:\s*Selected (?:pinned )?worker")
 # hook fires for /health and /metrics: on run 2663744, 12,964 of 15,471 `http
 # response sent` lines are probe traffic. Counting them overstates requests 6.2x.
 _RE_INSPAN = re.compile(r"http-request:")
+# The router's cost formula, JSON flavour. On a DYN_LOGGING_JSONL=true run every
+# record is JSON, so the text-only _RE_SEL above never matches and the whole router
+# family counted as zero -- 597 real lines reported as 0 on the reference run. These
+# carry the scoring inputs (worker_id, dp_rank, effective cached blocks, the
+# prefill_load_scale/decode_blocks terms) but NO request_id, so they support
+# aggregate and per-worker analysis and cannot be joined to a request.
+_RE_SEL_JSON_TARGET = re.compile(r"scheduling::selector$")
+# Two record shapes share that target, and only one is a decision:
+#   "Selected [pinned] worker: worker_type=..., worker_id=N dp_rank=N, logit=..."
+#       -> the CHOICE. One per phase per request (prefill + decode).
+#   "[Pinned ]Formula for worker_id=N dp_rank=N with N effective cached blocks: ..."
+#       -> the per-CANDIDATE score that fed the choice.
+# On the reference log: 266 decisions against 329 candidate scores. The "pinned" vs
+# fresh split of the decisions is itself the finding -- 26 of 266 (9.8%) were real
+# KV-aware selections and the rest were session affinity resolving to an already
+# bound worker, which independently matches the span-derived 13/133.
+_RE_SEL_DECISION = re.compile(
+    r"Selected (?P<pinned>pinned )?worker(?::\s*worker_type=(?P<worker_type>\w+),\s*"
+    r"worker_id=(?P<worker_id>\d+)\s+dp_rank=(?P<dp_rank>\d+))?")
+_RE_SEL_FORMULA = re.compile(
+    r"worker_id=(?P<worker_id>\d+)\s+dp_rank=(?P<dp_rank>\d+)"
+    r".*?([\d.]+) effective cached blocks:\s*(?P<cost>[\d.]+)")
 
 
 def _kv(line):
@@ -157,6 +179,7 @@ def parse_frontend_log(path):
     sel = defaultdict(list)
     sel_all = []
     n_rec = n_sel_no_id = n_json = 0
+    n_sel_pinned = n_sel_scored = 0
 
     for line in _iter_records(path):
         n_rec += 1
@@ -186,6 +209,23 @@ def parse_frontend_log(path):
                 done[rid] = (t_end, d)
                 if dur_ms is not None and t_end is not None:
                     recv[rid] = (t_end - int(dur_ms * 1e6), d)
+                continue
+            # NOT a SPAN_CLOSED record. Previously every such line was discarded
+            # here, which on a JSONL run silently threw away the entire router
+            # family: the text matchers below can never see a JSON line, so the
+            # selector counters read 0 while the log held hundreds of records.
+            if _RE_SEL_JSON_TARGET.search(j.get("target") or ""):
+                msg = j.get("message") or ""
+                dec = _RE_SEL_DECISION.search(msg)
+                if dec:
+                    n_sel_no_id += 1     # decision records carry no request_id at all
+                    n_sel_pinned += 1 if dec.group("pinned") else 0
+                    sel_all.append((_ts_ns(j.get("time", "")),
+                                    dec.group("worker_type") or "",
+                                    dec.group("worker_id") or "",
+                                    dec.group("dp_rank") or ""))
+                elif _RE_SEL_FORMULA.search(msg):
+                    n_sel_scored += 1    # a per-candidate score, not a choice
             continue
 
         # ---- human-readable tracing flavour --------------------------------
@@ -278,6 +318,12 @@ def parse_frontend_log(path):
             "http_responses_in_span": len(resp),
             "selector_with_request_id": len(sel),
             "selector_without_request_id": n_sel_no_id,
+            # The pinned/fresh split of routing DECISIONS. A run where almost every
+            # decision is "pinned" is one where session affinity, not KV-aware
+            # scoring, is choosing the worker -- which makes router-tuning experiments
+            # mostly no-ops and is invisible from the hit rate alone.
+            "selector_decisions_pinned": n_sel_pinned,
+            "selector_candidate_scores": n_sel_scored,
             "routing_joinable": joinable,
             "with_x_request_id": sum(1 for k, r in requests.items() if k != r["rid"]),
             "success": sum(1 for r in requests.values() if r["status"] == "success"),

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -781,6 +781,107 @@ def run_lifecycle(run_dir: Path, bundle: Path) -> dict:
     return out
 
 
+def run_host_samples(run_dir: Path, bundle: Path) -> dict:
+    """``host_samples.jsonl`` -> ``host_series.json``: host and per-process health.
+
+    Closes the three issues that live below the application: host CPU saturation
+    (PERF-37), a load generator that has become the bottleneck (PERF-38), and
+    file-descriptor exhaustion (PERF-40). None is expressible in any published metric.
+
+    The sampler writes CUMULATIVE jiffie counters, so the busy percentage is derived
+    HERE by differencing consecutive samples. That keeps the sampler's interval out of
+    the stored numbers -- a percentage computed at capture time would silently bake in
+    whatever cadence that run happened to use.
+
+    Per-process CPU is likewise a delta over the same window, expressed as percent of a
+    single core, so >100 means the process is genuinely using more than one.
+    """
+    src = Path(run_dir) / "host_samples.jsonl"
+    if not src.exists():
+        _log("L2 host", "no host_samples.jsonl; host CPU / fd / client-bottleneck "
+                        "signals unavailable for this run")
+        return {}
+
+    rows = []
+    with open(src, errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except Exception:
+                continue
+    if len(rows) < 2:
+        _log("L2 host", f"only {len(rows)} host sample(s); a rate needs two")
+        return {}
+
+    host_cpu, fds, conns, mem = [], [], [], []
+    procs: dict = {}
+    for prev, cur in zip(rows, rows[1:]):
+        dt = (cur.get("t") or 0) - (prev.get("t") or 0)
+        if dt <= 0:
+            continue
+        t = cur["t"]
+        pb, pt = prev.get("cpu_busy_jiffies"), prev.get("cpu_total_jiffies")
+        cb, ct = cur.get("cpu_busy_jiffies"), cur.get("cpu_total_jiffies")
+        if None not in (pb, pt, cb, ct) and ct > pt:
+            host_cpu.append([t, round(100.0 * (cb - pb) / (ct - pt), 2)])
+        m = cur.get("mem") or {}
+        if m.get("MemTotal") and m.get("MemAvailable") is not None:
+            mem.append([t, round(100.0 * (1 - m["MemAvailable"] / m["MemTotal"]), 2)])
+        if cur.get("established_conns") is not None:
+            conns.append([t, cur["established_conns"]])
+
+        prev_by_pid = {p["pid"]: p for p in (prev.get("procs") or [])}
+        for p in cur.get("procs") or []:
+            q = prev_by_pid.get(p["pid"])
+            key = f"{p.get('name', 'proc')}:{p['pid']}"
+            e = procs.setdefault(key, {"cpu_pct": [], "rss_kb": [], "ctx_invol_rate": [],
+                                       "open_fds": [], "threads": []})
+            if q and p.get("cpu_jiffies") is not None and q.get("cpu_jiffies") is not None:
+                # Jiffies are 1/100 s on Linux; /dt gives percent of ONE core.
+                e["cpu_pct"].append([t, round((p["cpu_jiffies"] - q["cpu_jiffies"]) / dt, 1)])
+            if q and p.get("ctx_invol") is not None and q.get("ctx_invol") is not None:
+                e["ctx_invol_rate"].append(
+                    [t, round((p["ctx_invol"] - q["ctx_invol"]) / dt, 1)])
+            if p.get("rss_kb") is not None:
+                e["rss_kb"].append([t, p["rss_kb"]])
+            if p.get("open_fds") is not None:
+                e["open_fds"].append([t, p["open_fds"]])
+            if p.get("threads") is not None:
+                e["threads"].append([t, p["threads"]])
+        if cur.get("procs"):
+            tot = sum((p.get("open_fds") or 0) for p in cur["procs"])
+            fds.append([t, tot])
+
+    fd_limit = rows[-1].get("fd_limit")
+    peak_fds = max((v for _, v in fds), default=0)
+    out = {
+        "host_cpu_pct": host_cpu,
+        "host_mem_used_pct": mem,
+        "established_conns": conns,
+        "open_fds_total": fds,
+        "fd_limit": fd_limit,
+        # The number that matters for PERF-40: how close the run came to the ceiling.
+        # Reported even when comfortable, because "we were at 3%" is the answer that
+        # rules the hypothesis out.
+        "fd_headroom_pct": (round(100.0 * peak_fds / fd_limit, 2)
+                            if fd_limit else None),
+        "procs": procs,
+        "samples": len(rows),
+        "host": rows[-1].get("host"),
+    }
+    with open(bundle / "host_series.json", "w") as f:
+        json.dump(out, f)
+    peak_cpu = max((v for _, v in host_cpu), default=None)
+    _log("L2 host", f"{len(rows)} samples on {out['host']}: peak host CPU {peak_cpu}%, "
+                    f"peak open fds {peak_fds}/{fd_limit} "
+                    f"({out['fd_headroom_pct']}% of limit), "
+                    f"{len(procs)} process(es) tracked")
+    return out
+
+
 def run_provenance(run_dir: Path, bundle: Path) -> list[str]:
     """Copy the run's provenance files into the bundle: what actually ran.
 
@@ -947,6 +1048,7 @@ def main(argv=None) -> int:
     run_benchmark_status(run_dir, bundle)
     run_log_signals(run_dir, bundle)
     run_lifecycle(run_dir, bundle)
+    run_host_samples(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(
         name=name,

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -476,6 +476,43 @@ def run_engine_configs(run_dir: Path, bundle: Path) -> list[str]:
     return copied
 
 
+def run_provenance(run_dir: Path, bundle: Path) -> list[str]:
+    """Copy the run's provenance files into the bundle: what actually ran.
+
+    ``config.yaml`` is the RESOLVED recipe, which is the only record of the run's
+    frontend/worker environment -- and therefore the only way to prove, after the fact,
+    that two runs differed in exactly one variable. An A/B whose single-variable claim
+    rests on the submitter's memory is not an A/B.
+
+    ``fingerprint_<role>_w<i>.json`` carries per-worker ground truth: ``frameworks``
+    (the real inner ``tensorrt_llm`` / ``dynamo`` versions), ``cuda_version``,
+    ``nccl_version``, ``gpu``, ``pip_packages``. This matters because container tags
+    routinely disagree with what they bundle -- an image tagged 1.1.0-rc3 shipping
+    1.3.0rc11 is an observed case, not a hypothetical. It is also per-worker, so a
+    deployment where prefill and decode ended up on different builds is visible here
+    and nowhere else.
+
+    ``resource_snapshot.json`` records the allocation the numbers were produced on.
+
+    All small (~35 KB per fingerprint), so they are copied verbatim rather than
+    summarised: a provenance record that has already been filtered cannot answer the
+    question nobody thought to ask when writing the filter.
+    """
+    copied: list[str] = []
+    src_dir = Path(run_dir)
+    for pattern in ("config.yaml", "resource_snapshot.json", "fingerprint_*.json"):
+        for src in sorted(src_dir.glob(pattern)):
+            shutil.copyfile(src, bundle / src.name)
+            copied.append(src.name)
+    if copied:
+        _log("L2 provenance", f"copied {len(copied)} provenance file(s): "
+                              f"{', '.join(copied[:4])}{' ...' if len(copied) > 4 else ''}")
+    else:
+        _log("L2 provenance", "no config.yaml / fingerprint_*.json in the run dir; two "
+                              "bundles cannot be compared for what actually differed")
+    return copied
+
+
 def run_client_summary(run_dir: Path, bundle: Path, patterns: list[str] | None = None) -> str | None:
     """Copy AIPerf's run-level summary (``profile_export_aiperf.json``) into the bundle.
 
@@ -601,6 +638,7 @@ def main(argv=None) -> int:
     run_iter_log(args, run_dir, bundle)
     run_engine_configs(run_dir, bundle)
     run_client_summary(run_dir, bundle)
+    run_provenance(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(
         name=name,

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -605,6 +605,92 @@ def run_benchmark_status(run_dir: Path, bundle: Path) -> dict | None:
     return status
 
 
+# Log-only signals: patterns whose ONLY evidence is a worker or frontend log line, with
+# no metric family behind them. Each entry is (id, regex, why it matters).
+#
+# Kept as a fixed, named set rather than "whatever looked interesting", so the leg is a
+# standardised artifact that means the same thing on every run -- the same reason the
+# panel spec is declarative.
+_LOG_SIGNALS = [
+    ("worker_crash", r"CUDA error|device-side assert|Segmentation fault|core dumped|"
+                     r"terminate called|std::bad_alloc",
+     "a worker died; the crash line is the only artifact of it"),
+    ("torch_recompile", r"recompile_limit|torch\._dynamo hit config\.cache_size_limit|"
+                        r"falling back to eager",
+     "Dynamo recompilation storm: silently converts compiled steps to eager"),
+    ("oom", r"CUDA out of memory|OutOfMemoryError|Killed process|oom-kill",
+     "memory exhaustion, which no gauge survives to report"),
+    ("kv_block_not_found", r"Block not found during remove|Failed to find block to remove",
+     "router KV index desync; the counter for it reads a constant 0"),
+    ("kv_transfer_timeout", r"kv transfer.*timed out|KV_TRANSFER_TIMEOUT|transfer timeout",
+     "KV-transfer timeouts, whose counter family is declared but never sampled"),
+    ("nccl_error", r"NCCL WARN|NCCL error|ncclInternalError|ncclUnhandledCudaError",
+     "collective failure; no NCCL metric family exists at all"),
+    ("engine_stall", r"num_fitting_reqs=0|may not have enough kvCache",
+     "the engine could not fit a request, distinct from being merely busy"),
+    ("etcd_disconnect", r"etcd.*reconnect|lease.*lost|watch channel closed",
+     "control-plane instability that reads downstream as worker flapping"),
+    ("request_cancelled", r"request cancelled|client disconnected|connection reset",
+     "client-side aborts, which never appear as server errors"),
+]
+
+
+def run_log_signals(run_dir: Path, bundle: Path, max_samples: int = 2) -> dict:
+    """Distil log-only signals into ``log_signals.json`` (bounded).
+
+    Several documented issues have their ONLY evidence in a log line -- a worker crash, a
+    Dynamo recompilation storm, a KV-index desync -- with no metric family behind them.
+    Those were unreachable from a bundle not because the instrumentation is missing but
+    because the bundle did not carry the logs, and the logs are far too large to carry
+    whole (43 MB frontend + 40 MB prefill on one run, multi-GB at DYN_LOG=debug).
+
+    So this carries the ANSWER rather than the evidence: per named signal, a count, the
+    first and last timestamp, the per-file breakdown, and up to `max_samples` verbatim
+    lines. Bounded by construction -- the output is a few KB regardless of input size --
+    and enough to answer "did this happen, how often, when did it start".
+
+    A count of zero is kept, not dropped. "This run had no worker crashes" is a different
+    and more useful statement than the signal's absence from the file.
+    """
+    import re as _re
+    pats = [(sid, _re.compile(rx, _re.I), why) for sid, rx, why in _LOG_SIGNALS]
+    out: dict = {sid: {"count": 0, "why": why, "first_ts": None, "last_ts": None,
+                       "by_file": {}, "samples": []}
+                 for sid, _, why in pats}
+    # ISO-8601 or "YYYY-MM-DD HH:MM:SS"; whichever the emitting component uses.
+    ts_re = _re.compile(r"(\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d[.\d]*Z?|\d{4}-\d\d-\d\d \d\d:\d\d:\d\d)")
+
+    logs = sorted(Path(run_dir).glob("*.out"))
+    for path in logs:
+        name = path.name
+        try:
+            fh = open(path, errors="replace")
+        except OSError:
+            continue
+        with fh:
+            for line in fh:
+                for sid, rx, _why in pats:
+                    if rx.search(line):
+                        e = out[sid]
+                        e["count"] += 1
+                        e["by_file"][name] = e["by_file"].get(name, 0) + 1
+                        m = ts_re.search(line)
+                        if m:
+                            if e["first_ts"] is None:
+                                e["first_ts"] = m.group(1)
+                            e["last_ts"] = m.group(1)
+                        if len(e["samples"]) < max_samples:
+                            e["samples"].append(line.strip()[:300])
+                        break   # one signal per line; the first match wins
+
+    with open(bundle / "log_signals.json", "w") as f:
+        json.dump({"signals": out, "files_scanned": [p.name for p in logs]}, f)
+    fired = {k: v["count"] for k, v in out.items() if v["count"]}
+    _log("L2 log-signals", f"scanned {len(logs)} log(s); "
+                           + (f"fired: {fired}" if fired else "no log-only signal fired"))
+    return out
+
+
 def run_provenance(run_dir: Path, bundle: Path) -> list[str]:
     """Copy the run's provenance files into the bundle: what actually ran.
 
@@ -769,6 +855,7 @@ def main(argv=None) -> int:
     run_client_summary(run_dir, bundle)
     run_provenance(run_dir, bundle)
     run_benchmark_status(run_dir, bundle)
+    run_log_signals(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(
         name=name,

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -526,12 +526,36 @@ def run_benchmark_status(run_dir: Path, bundle: Path) -> dict | None:
         status["tail"] = [ln.rstrip("\n")[:400] for ln in lines[-40:]]
         # Error-shaped lines anywhere, not just the tail: a script can fail early and
         # then print pages of cleanup noise after it.
+        #
+        # Two shapes of noise have to be handled or the captured message is useless:
+        #
+        #   * `set -x` echoes every command, so each message appears twice -- once as
+        #     `+ echo 'Error: ...'` and once as its own output. The trace line is
+        #     dropped, because a reader shown `+ echo 'Error: ...'` is being shown the
+        #     mechanism instead of the message.
+        #   * a message can be a HEADER whose payload is on the following lines.
+        #     `check_env_vars` prints "The following required environment variables are
+        #     not set:" and then one `  - NAME` line per variable. Capturing only the
+        #     header names the failure class and withholds the one detail that makes it
+        #     actionable -- which variable. Observed on v3 arm 2752146, where the
+        #     answer was FRAMEWORK / PRECISION / RESULT_FILENAME / DURATION.
+        collecting = False
         for ln in lines:
-            if any(m in ln for m in _BENCH_ERROR_MARKERS):
-                s = ln.strip()[:400]
+            raw = ln.rstrip("\n")
+            if raw.lstrip().startswith("+"):      # set -x trace, not output
+                continue
+            s = raw.strip()[:400]
+            if any(m in raw for m in _BENCH_ERROR_MARKERS):
+                if s and s not in status["errors"]:
+                    status["errors"].append(s)
+                collecting = True
+            elif collecting and s.startswith("-"):
+                # Continuation of the message above (a bullet list of names/reasons).
                 if s not in status["errors"]:
                     status["errors"].append(s)
-            if len(status["errors"]) >= 8:
+            elif s:
+                collecting = False
+            if len(status["errors"]) >= 12:
                 break
 
     with open(bundle / "benchmark_status.json", "w") as f:

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -54,6 +54,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -477,7 +478,19 @@ def run_engine_configs(run_dir: Path, bundle: Path) -> list[str]:
 
 
 _BENCH_ERROR_MARKERS = ("Error:", "ERROR:", "Traceback", "command not found",
-                        "No such file or directory", "Permission denied")
+                        "No such file or directory", "Permission denied",
+                        # Not every fatal message is prefixed "Error:". These are real
+                        # lines from real failures whose absence left the banner able to
+                        # say only "exit 1": the post-run env guard writes a bare
+                        # "<VAR> is required when ...", and a phase abort writes
+                        # "Benchmark aborted: <reason>".
+                        "is required when", "Benchmark aborted", "ProfileAborted")
+
+# AIPerf's own phase census. This is the single most informative line about what the
+# benchmark actually did, and it is in aiperf.log rather than benchmark.out -- so a run
+# whose benchmark.out carries no error marker at all (arm 2752189: zero markers, exit 1)
+# otherwise yields a banner that reports a failure with no reason attached.
+_PHASE_RE = "Phase (warmup|profiling) complete"
 
 
 def run_benchmark_status(run_dir: Path, bundle: Path) -> dict | None:
@@ -544,7 +557,12 @@ def run_benchmark_status(run_dir: Path, bundle: Path) -> dict | None:
             raw = ln.rstrip("\n")
             if raw.lstrip().startswith("+"):      # set -x trace, not output
                 continue
-            s = raw.strip()[:400]
+            # AIPerf frames fatal messages in a Rich box, so the raw line arrives as
+            # "|    Error: ProfileAborted                     |" -- box rule, message,
+            # padding, box rule. Stripped here so the banner shows the message rather
+            # than the frame it happened to be drawn in.
+            s = raw.strip().strip("\u2502\u2503|").strip()
+            s = re.sub(r"\s{2,}", " ", s)[:400]
             if any(m in raw for m in _BENCH_ERROR_MARKERS):
                 if s and s not in status["errors"]:
                     status["errors"].append(s)
@@ -558,11 +576,30 @@ def run_benchmark_status(run_dir: Path, bundle: Path) -> dict | None:
             if len(status["errors"]) >= 12:
                 break
 
+    # AIPerf's phase census, from its own log. Carries the completed/cancelled split that
+    # distinguishes "the workload never started" from "it ran and was cut short" -- and
+    # those have opposite fixes. On the v4 arms it separated two failure modes that looked
+    # identical from the exit code alone: a0/a1 aborted in WARMUP (cancelled 4 and 6, so
+    # profiling never ran), while a2/a3 passed warmup clean and had PROFILING time out
+    # with ~47 requests still in flight.
+    status["phases"] = []
+    for lg in sorted(src_dir.glob("agentic/*/aiperf_artifacts/logs/aiperf.log")):
+        try:
+            with open(lg, errors="replace") as fh:
+                for line in fh:
+                    if re.search(_PHASE_RE, line):
+                        # Keep the census, drop the log preamble before it.
+                        status["phases"].append(line.split(" - ")[-1].strip()[:300])
+        except OSError:
+            pass
+
     with open(bundle / "benchmark_status.json", "w") as f:
         json.dump(status, f)
-    if status["exit_code"] or status["errors"]:
+    if status["exit_code"] or status["errors"] or status["phases"]:
         _log("L2 bench-status", f"benchmark exit={status['exit_code']} "
-                                f"first error: {(status['errors'] or ['-'])[0][:120]}")
+                                f"first error: {(status['errors'] or ['-'])[0][:110]}")
+        for ph in status["phases"]:
+            _log("L2 bench-status", f"  {ph[:140]}")
     else:
         _log("L2 bench-status", "benchmark reported no error")
     return status

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -476,6 +476,47 @@ def run_engine_configs(run_dir: Path, bundle: Path) -> list[str]:
     return copied
 
 
+def run_client_summary(run_dir: Path, bundle: Path, patterns: list[str] | None = None) -> str | None:
+    """Copy AIPerf's run-level summary (``profile_export_aiperf.json``) into the bundle.
+
+    ``profile_export.jsonl`` is per-request and is what every panel is built from. This
+    is the sibling AIPerf writes ONCE per concurrency, and it carries three things the
+    per-request stream cannot express:
+
+    * ``theoretical_prefix_cache_hit`` -- the ceiling the WORKLOAD offered. Without it
+      the engine's measured reuse is a number with nothing to be measured against: on
+      run 2751593 the workload offered 94.7% and the engine achieved 65.8%, and the
+      29-point gap is the finding. Reported alone, 65.8% invites the reader to supply
+      their own expectation.
+    * validity -- ``error_summary``, ``was_cancelled``, ``branch_stats``. An agentic run
+      whose child branches errored or were truncated produced numbers that should not
+      be compared against a clean run, and nothing in the per-request stream says so.
+    * ``effective_concurrency`` -- what the client actually sustained, as against what
+      was offered. srt-slurm takes the offered value from the ``CONC`` environment
+      variable, which never reaches any artifact.
+
+    Its ABSENCE is itself a signal: AIPerf writes it at the end of a concurrency, so a
+    run killed by its wall clock has none. Reference run 2750618 is exactly that case.
+
+    Copied verbatim rather than parsed here, so the renderer reads one authority and
+    this layer cannot silently reinterpret a schema it does not own.
+    """
+    pats = patterns or ["agentic/*/aiperf_artifacts/profile_export_aiperf.json",
+                        "artifacts/*/profile_export_aiperf.json"]
+    found = sorted(p for pat in pats for p in Path(run_dir).glob(pat))
+    if not found:
+        _log("L2 client-summary", "no profile_export_aiperf.json (run may have been cut "
+                                  "short before AIPerf wrote its summary); no workload "
+                                  "cache ceiling or validity flags will be shown")
+        return None
+    # Last by sort order = highest concurrency shard, matching the per-request leg.
+    src = found[-1]
+    shutil.copyfile(src, bundle / "profile_export_aiperf.json")
+    _log("L2 client-summary", f"copied {src.name} from {src.parent.name}"
+                              + (f" ({len(found)} shards, took the last)" if len(found) > 1 else ""))
+    return str(src)
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -559,6 +600,7 @@ def main(argv=None) -> int:
     have_req_trace = run_request_trace(args, run_dir, bundle)
     run_iter_log(args, run_dir, bundle)
     run_engine_configs(run_dir, bundle)
+    run_client_summary(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(
         name=name,

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -691,6 +691,96 @@ def run_log_signals(run_dir: Path, bundle: Path, max_samples: int = 2) -> dict:
     return out
 
 
+# Run lifecycle milestones, in the order they must occur. Each is (id, regex).
+# Fixed and ordered so the leg means the same thing on every run.
+_LIFECYCLE = [
+    ("infra_start", r"Starting infrastructure services"),
+    ("workers_start", r"Starting backend workers"),
+    ("frontend_start", r"Starting frontend layer"),
+    ("model_ready", r"Model is ready\."),
+    ("benchmark_start", r"Server is healthy - starting benchmark"),
+    ("benchmark_end", r"Benchmark (?:completed|failed)"),
+    ("run_end", r"(?:✗ Sweep failed|✓ Sweep complete|End:)"),
+]
+
+
+def run_lifecycle(run_dir: Path, bundle: Path) -> dict:
+    """Time-to-ready and terminal cause -> ``run_lifecycle.json`` (PERF-45).
+
+    Two questions no panel could answer, because both live in srtctl's own sweep log
+    rather than in any metric or client artifact:
+
+    * **How long until the deployment could serve?** On run 2752632 the workers start at
+      02:23:19 and the model is ready at 02:34:09 -- **650 s** during which the job holds
+      28 GPUs and serves nothing. That is a first-order cost of every run and it is
+      invisible in a dashboard whose x-axis starts at the first request.
+    * **Why did the run end?** srtctl writes its own verdict, and a reader looking at an
+      empty or truncated dashboard needs it before anything else.
+
+    The readiness GAP matters as much as the total: `model_ready` is when the health
+    check passes, but the frontend has been accepting connections since `frontend_start`.
+    Requests arriving in that window meet a router with nowhere to place them.
+
+    Derived durations are emitted alongside the raw timestamps so a consumer never has to
+    re-parse them, and a milestone that never happened is recorded as null rather than
+    omitted -- "the model never became ready" is the single most useful thing a failed
+    run can say.
+    """
+    import re as _re
+    from datetime import datetime as _dt
+
+    sweeps = sorted(Path(run_dir).glob("sweep_*.log"))
+    if not sweeps:
+        _log("L2 lifecycle", "no sweep_*.log; time-to-ready and terminal cause unavailable")
+        return {}
+
+    pats = [(mid, _re.compile(rx)) for mid, rx in _LIFECYCLE]
+    ts_re = _re.compile(r"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d)")
+    marks: dict = {mid: None for mid, _ in _LIFECYCLE}
+    terminal = None
+    for sw in sweeps:
+        try:
+            fh = open(sw, errors="replace")
+        except OSError:
+            continue
+        with fh:
+            for line in fh:
+                m = ts_re.match(line)
+                for mid, rx in pats:
+                    # First occurrence wins: these are one-shot transitions, and a
+                    # retry loop would otherwise overwrite the real start time.
+                    if marks[mid] is None and rx.search(line):
+                        marks[mid] = m.group(1) if m else "unknown"
+                if "Sweep failed" in line or "Sweep complete" in line:
+                    terminal = line.strip()[:200]
+
+    def _delta(a, b):
+        try:
+            return round((_dt.strptime(marks[b], "%Y-%m-%d %H:%M:%S")
+                          - _dt.strptime(marks[a], "%Y-%m-%d %H:%M:%S")).total_seconds(), 1)
+        except Exception:
+            return None
+
+    out = {
+        "milestones": marks,
+        "terminal_cause": terminal,
+        "durations_s": {
+            # workers up -> health check passes: the GPUs-held-but-idle window.
+            "time_to_ready": _delta("workers_start", "model_ready"),
+            # frontend accepting -> router able to place: requests here have nowhere to go.
+            "readiness_gap": _delta("frontend_start", "model_ready"),
+            "benchmark": _delta("benchmark_start", "benchmark_end"),
+            "total": _delta("infra_start", "run_end"),
+        },
+    }
+    with open(bundle / "run_lifecycle.json", "w") as f:
+        json.dump(out, f)
+    d = out["durations_s"]
+    _log("L2 lifecycle", f"time_to_ready={d['time_to_ready']}s readiness_gap={d['readiness_gap']}s "
+                         f"benchmark={d['benchmark']}s | terminal: {terminal or 'unknown'}")
+    return out
+
+
 def run_provenance(run_dir: Path, bundle: Path) -> list[str]:
     """Copy the run's provenance files into the bundle: what actually ran.
 
@@ -856,6 +946,7 @@ def main(argv=None) -> int:
     run_provenance(run_dir, bundle)
     run_benchmark_status(run_dir, bundle)
     run_log_signals(run_dir, bundle)
+    run_lifecycle(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(
         name=name,

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -476,6 +476,74 @@ def run_engine_configs(run_dir: Path, bundle: Path) -> list[str]:
     return copied
 
 
+_BENCH_ERROR_MARKERS = ("Error:", "ERROR:", "Traceback", "command not found",
+                        "No such file or directory", "Permission denied")
+
+
+def run_benchmark_status(run_dir: Path, bundle: Path) -> dict | None:
+    """Why the benchmark produced what it produced -> ``benchmark_status.json``.
+
+    A dashboard built from a run whose benchmark never served anything is not wrong,
+    but it is mute: it reports ``client=False traces=False N=0`` and leaves the reader
+    to guess between a dead deployment, a workload that never started, and a run cut
+    short. Those have completely different responses, and the answer is sitting in
+    ``benchmark.out`` and the sweep log the whole time.
+
+    This is not hypothetical. Eight ablation arms in one session produced dashboards
+    that could not explain their own emptiness -- four with ``exit 127`` (the benchmark
+    script was not mounted) and four with ``exit 1`` eleven seconds after the workers
+    went healthy (``Error: KV_OFFLOADING must be set for agentic benchmarks``). Both
+    are environment faults, and neither is visible in any panel.
+
+    Captures the reported exit code, the first few error-shaped lines, and a bounded
+    tail. Bounded because ``benchmark.out`` is a ``set -x`` trace and can be large; the
+    diagnosis is always near the end.
+    """
+    src_dir = Path(run_dir)
+    bench = src_dir / "benchmark.out"
+    sweeps = sorted(src_dir.glob("sweep_*.log"))
+    if not bench.exists() and not sweeps:
+        return None
+
+    status: dict = {"exit_code": None, "errors": [], "tail": []}
+
+    # The sweep log is srtctl's own account and carries the exit code verbatim.
+    for sw in sweeps:
+        try:
+            with open(sw, errors="replace") as fh:
+                for line in fh:
+                    if "Benchmark failed with exit code" in line:
+                        status["exit_code"] = line.strip().split()[-1]
+        except OSError:
+            pass
+
+    if bench.exists():
+        try:
+            with open(bench, errors="replace") as fh:
+                lines = fh.readlines()
+        except OSError:
+            lines = []
+        status["tail"] = [ln.rstrip("\n")[:400] for ln in lines[-40:]]
+        # Error-shaped lines anywhere, not just the tail: a script can fail early and
+        # then print pages of cleanup noise after it.
+        for ln in lines:
+            if any(m in ln for m in _BENCH_ERROR_MARKERS):
+                s = ln.strip()[:400]
+                if s not in status["errors"]:
+                    status["errors"].append(s)
+            if len(status["errors"]) >= 8:
+                break
+
+    with open(bundle / "benchmark_status.json", "w") as f:
+        json.dump(status, f)
+    if status["exit_code"] or status["errors"]:
+        _log("L2 bench-status", f"benchmark exit={status['exit_code']} "
+                                f"first error: {(status['errors'] or ['-'])[0][:120]}")
+    else:
+        _log("L2 bench-status", "benchmark reported no error")
+    return status
+
+
 def run_provenance(run_dir: Path, bundle: Path) -> list[str]:
     """Copy the run's provenance files into the bundle: what actually ran.
 
@@ -639,6 +707,7 @@ def main(argv=None) -> int:
     run_engine_configs(run_dir, bundle)
     run_client_summary(run_dir, bundle)
     run_provenance(run_dir, bundle)
+    run_benchmark_status(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(
         name=name,

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -226,6 +226,7 @@ def generate_dashboard_yaml(
     have_aiperf: bool,
     have_traces: bool,
     have_metrics: bool,
+    have_request_trace: bool = False,
 ) -> str:
     """Render a dashboard.yaml (skeleton fields: name/description/mode/framework/
     topology/sources) whose ``sources:`` point at the bundle's own files (so the
@@ -263,6 +264,8 @@ def generate_dashboard_yaml(
         lines.append("  tempo_traces:   tempo_traces")
     if have_metrics:
         lines.append("  server_metrics: server_metrics_export.jsonl")
+    if have_request_trace:
+        lines.append("  request_trace:  request_trace.jsonl")
     return "\n".join(lines) + "\n"
 
 
@@ -276,15 +279,26 @@ def run_client(args, run_dir: Path, bundle: Path) -> bool:
     if args.client == "none":
         _log("L2 client", "skipped (--client none)")
         return False
-    # srt-slurm's AIPerf benchmarks write into <log_dir>/artifacts/<model>_<workload>_<ts>/,
-    # so the default reaches one level down rather than assuming the run-dir root.
-    default = "artifacts/*/profile_export.jsonl"
-    pattern = args.client_input or default
-    inputs = resolve_inputs(pattern, run_dir)
+    # Two client layouts exist and neither is a superset of the other, so both are
+    # tried rather than making the caller know which harness ran:
+    #   AgentX   <log_dir>/agentic/conc_<N>/aiperf_artifacts/profile_export.jsonl
+    #   AIPerf   <log_dir>/artifacts/<model>_<workload>_<ts>/profile_export.jsonl
+    # AgentX nests one level deeper AND shards by concurrency level. A sweep that ran
+    # several concurrencies yields several files; they are stitched, which puts each
+    # phase in sequence on the run-relative time axis rather than averaging them
+    # together -- the phases stay visually separable, and no phase is silently dropped.
+    patterns = [args.client_input] if args.client_input else [
+        "agentic/*/aiperf_artifacts/profile_export.jsonl",
+        "artifacts/*/profile_export.jsonl",
+    ]
+    inputs: list[str] = []
+    for pat in patterns:
+        inputs.extend(resolve_inputs(pat, run_dir))
+    inputs = sorted(dict.fromkeys(inputs))
     if not inputs:
-        _log("L2 client", f"WARN no client inputs matched {pattern!r} under {run_dir} -- skipping")
+        _log("L2 client", f"WARN no client inputs matched {patterns} under {run_dir} -- skipping")
         return False
-    _log("L1", f"client raw: {len(inputs)} file(s) matching {pattern!r} (shard-stitch)")
+    _log("L1", f"client raw: {len(inputs)} file(s) matching {patterns} (shard-stitch)")
     out = bundle / "profile_export.jsonl"
     proc = get_processor("client", args.client)
     # agentperf/passthrough both accept a shard list and stitch it in sorted order.
@@ -361,6 +375,33 @@ def run_metrics(args, run_dir: Path, bundle: Path) -> bool:
     return out.exists()
 
 
+def run_request_trace(args, run_dir: Path, bundle: Path) -> bool:
+    """L2 request-trace axis -> request_trace.jsonl. Returns whether produced.
+
+    The frontend's per-request record. It is the only source of KV-transfer cost --
+    the Prometheus ``trtllm_kv_transfer_*`` family is declared but never sampled -- and
+    the only one carrying ``session_id``, so both the per-request waterfall and the
+    per-session view depend on it.
+
+    Dynamo writes it to the path in ``DYN_REQUEST_TRACE_FILE_PATH``, which srt-slurm
+    sets to ``<log_dir>/dynamo-request-trace`` (no extension, despite being JSON lines).
+    """
+    if args.request_trace == "none":
+        _log("L2 req-trace", "skipped (--request-trace none)")
+        return False
+    pattern = args.request_trace_input or "dynamo-request-trace"
+    srcs = resolve_inputs(pattern, run_dir)
+    if not srcs:
+        _log("L2 req-trace", f"WARN no request trace matched {pattern!r} under {run_dir}; skipping")
+        return False
+    out = bundle / "request_trace.jsonl"
+    _log("L1", f"request trace raw: {srcs[0]}")
+    proc = get_processor("request_trace", "dynamo")
+    n = proc(srcs[0], str(out))
+    _log("L2 req-trace", f"dynamo -> {out.name}: {n} requests")
+    return n > 0
+
+
 def run_engine_configs(run_dir: Path, bundle: Path) -> list[str]:
     """Copy the run's resolved engine configs into the bundle, verbatim.
 
@@ -424,6 +465,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--span-logs", action="append", default=[], metavar="GLOB",
                    help="SPAN_CLOSED log path/glob, repeatable (default: *.out, srt-slurm worker/frontend logs)")
 
+    # request-trace axis
+    p.add_argument("--request-trace", choices=["dynamo", "none"], default="dynamo")
+    p.add_argument("--request-trace-input", default=None,
+                   help="dynamo-request-trace path/glob (default: dynamo-request-trace)")
+
     # metrics axis
     p.add_argument("--metrics", choices=["prometheus", "none"], default="prometheus")
     p.add_argument("--raw-prometheus", default=None,
@@ -459,6 +505,7 @@ def main(argv=None) -> int:
     profile_path = bundle / "profile_export.jsonl" if have_aiperf else None
     have_traces = run_traces(args, run_dir, bundle, profile_path)
     have_metrics = run_metrics(args, run_dir, bundle)
+    have_req_trace = run_request_trace(args, run_dir, bundle)
     run_engine_configs(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(
@@ -471,13 +518,15 @@ def main(argv=None) -> int:
         have_aiperf=have_aiperf,
         have_traces=have_traces,
         have_metrics=have_metrics,
+        have_request_trace=have_req_trace,
     )
     yaml_path = bundle / "dashboard.yaml"
     yaml_path.write_text(yaml_text)
     _log("L3-prep", f"wrote {yaml_path}")
 
     _log("done", f"bundle ready in {time.time() - t0:.1f}s: "
-                  f"aiperf={have_aiperf} traces={have_traces} metrics={have_metrics}")
+                  f"aiperf={have_aiperf} traces={have_traces} metrics={have_metrics} "
+                  f"request_trace={have_req_trace}")
     _log("next", f"python3 -m src.visualization.build_dynamo_bench_dash {bundle} {bundle / 'dashboard.html'}")
     return 0
 

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -84,6 +84,23 @@ def _log(tag: str, msg: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Every client-export layout seen in the wild. AgentX nests under `agentic/<conc>/`
+# (with or without an `aiperf_artifacts/` level, which differs per harness build);
+# stock AIPerf uses `artifacts/<run>/`.
+# Where each harness puts AIPerf's server-metrics export, mirroring CLIENT_PATTERNS.
+AIPERF_METRIC_PATTERNS = [
+    "agentic/*/aiperf_artifacts/server_metrics_export.json",
+    "agentic/*/server_metrics_export.json",
+    "artifacts/*/server_metrics_export.json",
+]
+
+CLIENT_PATTERNS = [
+    "agentic/*/aiperf_artifacts/profile_export.jsonl",
+    "agentic/*/profile_export.jsonl",
+    "artifacts/*/profile_export.jsonl",
+]
+
+
 def resolve_inputs(pattern, run_dir: Path) -> list[str]:
     """Resolve a source flag to a sorted list of concrete files.
 
@@ -216,6 +233,61 @@ def parse_worker_spec(spec: str) -> tuple[str, dict]:
     return role, {"parallelism": parallelism, "rank": rank, "worker_count": count}
 
 
+def probe_warmup_end_ns(
+    run_dir: Path, patterns: list[str]
+) -> tuple[int | None, str | None, int | None, int | None]:
+    """First PROFILING request start (ns) from the client export, without copying it.
+
+    The load generator's warmup phase is tagged per record as
+    ``metadata.benchmark_phase``. The renderer reads that directly when the client leg
+    is in the bundle -- but the export is routinely 700 MB+ and is often not copied,
+    and the boundary is one integer. So it is probed here and recorded in
+    dashboard.yaml, which keeps the marker available to a metrics-only bundle.
+
+    Streamed with a substring pre-filter so the JSON parser only sees candidate lines;
+    a full parse of every record would cost minutes on a 700 MB export for one number.
+    Returns ``(None, None)`` when the harness tags no phase -- which is not a failure,
+    it means this run has no warmup boundary to mark.
+    """
+    srcs: list[str] = []
+    for pat in patterns:
+        srcs.extend(resolve_inputs(pat, run_dir))
+    srcs = sorted(dict.fromkeys(srcs))
+    if not srcs:
+        return None, None, None, None
+    prof_min = warm_max = None
+    span_lo = span_hi = None
+    scanned = 0
+    for src in srcs:
+        with open(src) as f:
+            for line in f:
+                if '"benchmark_phase"' not in line:
+                    continue
+                scanned += 1
+                try:
+                    md = json.loads(line).get("metadata", {})
+                except Exception:
+                    continue
+                st = md.get("request_start_ns")
+                if st:
+                    span_lo = st if span_lo is None else min(span_lo, st)
+                    span_hi = st if span_hi is None else max(span_hi, st)
+                ph = md.get("benchmark_phase")
+                if ph == "profiling":
+                    v = md.get("request_start_ns")
+                    if v:
+                        prof_min = v if prof_min is None else min(prof_min, v)
+                elif ph:
+                    v = md.get("request_end_ns") or md.get("request_start_ns")
+                    if v:
+                        warm_max = v if warm_max is None else max(warm_max, v)
+    if prof_min:
+        return prof_min, "first profiling request", span_lo, span_hi
+    if warm_max:
+        return warm_max, "last warmup request (profiling phase never began)", span_lo, span_hi
+    return None, None, span_lo, span_hi
+
+
 def generate_dashboard_yaml(
     *,
     name: str,
@@ -228,6 +300,8 @@ def generate_dashboard_yaml(
     have_traces: bool,
     have_metrics: bool,
     have_request_trace: bool = False,
+    warmup_end_ns: int | None = None,
+    warmup_source: str | None = None,
 ) -> str:
     """Render a dashboard.yaml (skeleton fields: name/description/mode/framework/
     topology/sources) whose ``sources:`` point at the bundle's own files (so the
@@ -258,6 +332,14 @@ def generate_dashboard_yaml(
         else:
             lines.append("    prefill: {parallelism: dep, rank: 4, worker_count: 1}  # TODO: set from your run")
             lines.append("    decode:  {parallelism: tep, rank: 4, worker_count: 1}  # TODO: set from your run")
+    if warmup_end_ns:
+        # Carried so a bundle WITHOUT the client leg can still mark the phase
+        # boundary. Absent when the harness tags no phase -- which the renderer must
+        # read as "no boundary known", not as "warmup ended at t=0".
+        lines.append("warmup:")
+        lines.append(f"  end_ns: {int(warmup_end_ns)}")
+        if warmup_source:
+            lines.append(f"  source: {warmup_source}")
     lines.append("sources:")
     if have_aiperf:
         lines.append("  aiperf_profile: profile_export.jsonl")
@@ -288,10 +370,7 @@ def run_client(args, run_dir: Path, bundle: Path) -> bool:
     # several concurrencies yields several files; they are stitched, which puts each
     # phase in sequence on the run-relative time axis rather than averaging them
     # together -- the phases stay visually separable, and no phase is silently dropped.
-    patterns = [args.client_input] if args.client_input else [
-        "agentic/*/aiperf_artifacts/profile_export.jsonl",
-        "artifacts/*/profile_export.jsonl",
-    ]
+    patterns = [args.client_input] if args.client_input else list(CLIENT_PATTERNS)
     inputs: list[str] = []
     for pat in patterns:
         inputs.extend(resolve_inputs(pat, run_dir))
@@ -360,6 +439,43 @@ def run_metrics(args, run_dir: Path, bundle: Path) -> bool:
         _log("L2 metrics", "skipped (--metrics none)")
         return False
 
+    mode = args.metrics
+    if mode == "auto":
+        # Pick the source the run actually captured. An `observability.enabled` run has
+        # raw_prometheus.jsonl; a run without it usually still has AIPerf's own export,
+        # because the frontend's /metrics surface exists regardless of that knob and
+        # the benchmark scrapes it. Choosing here rather than at every call site is
+        # what lets one ingest command work on both.
+        raw = resolve_inputs(args.raw_prometheus or "raw_prometheus.jsonl", run_dir)
+        if raw:
+            mode = "prometheus"
+        else:
+            found: list[str] = []
+            for pat in AIPERF_METRIC_PATTERNS:
+                found.extend(resolve_inputs(pat, run_dir))
+            mode = "aiperf-json" if found else "prometheus"
+        _log("L2 metrics", f"auto-selected source: {mode}")
+
+    if mode == "aiperf-json":
+        # AIPerf's own export. The only server-metrics source on a run that predates
+        # `observability.enabled`, so it is what makes the historical before/after
+        # corpus renderable without re-running anything.
+        patterns = ([args.aiperf_server_metrics] if args.aiperf_server_metrics
+                    else list(AIPERF_METRIC_PATTERNS))
+        srcs: list[str] = []
+        for pat in patterns:
+            srcs.extend(resolve_inputs(pat, run_dir))
+        srcs = sorted(dict.fromkeys(srcs))
+        if not srcs:
+            _log("L2 metrics", f"WARN no aiperf server metrics matched {patterns} under {run_dir}; skipping")
+            return False
+        _log("L1", f"metrics raw: {srcs[0]} (AIPerf server_metrics_export.json)")
+        proc = get_processor("metrics", "aiperf-json")
+        n = proc(srcs[0], str(out))
+        nin, nout = dedup_server_metrics(out)
+        _log("L2 metrics", f"aiperf-json -> {out.name}: {n} timestamps, dedup {nin} -> {nout} lines")
+        return out.exists()
+
     # metrics == prometheus: parse RAW -> schema 2.
     pattern = args.raw_prometheus or "raw_prometheus.jsonl"
     srcs = resolve_inputs(pattern, run_dir)
@@ -403,7 +519,9 @@ def run_request_trace(args, run_dir: Path, bundle: Path) -> bool:
     return n > 0
 
 
-def run_iter_log(args, run_dir: Path, bundle: Path) -> bool:
+def run_iter_log(args, run_dir: Path, bundle: Path,
+                 fallback_start_ns: int | None = None,
+                 fallback_end_ns: int | None = None) -> bool:
     """L2 per-iteration axis -> iter_bins.json. Returns whether produced.
 
     Parses TRT-LLM's ``print_iter_log`` lines out of the worker logs. This is the only
@@ -440,6 +558,14 @@ def run_iter_log(args, run_dir: Path, bundle: Path) -> bool:
                         end_ns = json.loads(line)["timestamp_ns"]
         except Exception as e:  # noqa: BLE001 - anchoring is best-effort
             _log("L2 iter-log", f"WARN could not read the run window: {e}")
+    if start_ns is None and fallback_start_ns is not None:
+        # No metrics stream to anchor against -- a trtllm-serve run has no Dynamo
+        # endpoint at all. The client export's own span is UTC and covers the same
+        # run, so it anchors the offset just as well. Without it the offset silently
+        # defaults to 0 and the engine timeline sits hours away from every other
+        # source, which only shows up when something tries to join them.
+        start_ns, end_ns = fallback_start_ns, fallback_end_ns
+        _log("L2 iter-log", "UTC anchor from the client export (no metrics stream)")
     out = bundle / "iter_bins.json"
     _log("L1", f"iter-log raw: {len(logs)} worker log(s)")
     proc = get_processor("iter_log", "trtllm")
@@ -1006,9 +1132,15 @@ def build_parser() -> argparse.ArgumentParser:
                         "(default: *_prefill_w*.out, *_decode_w*.out, *_agg_w*.out)")
 
     # metrics axis
-    p.add_argument("--metrics", choices=["prometheus", "none"], default="prometheus")
+    p.add_argument("--metrics", choices=["auto", "prometheus", "aiperf-json", "none"],
+                   default="auto",
+                   help="metrics source; 'auto' uses raw_prometheus.jsonl when the run has it "
+                        "and falls back to AIPerf's own export when it does not")
     p.add_argument("--raw-prometheus", default=None,
                    help="raw_prometheus.jsonl path/glob (default: raw_prometheus.jsonl)")
+    p.add_argument("--aiperf-server-metrics", default=None,
+                   help="AIPerf server_metrics_export.json path/glob for --metrics aiperf-json "
+                        "(default: agentic/*/ then artifacts/*/)")
     p.add_argument("--server-metrics", default=None,
                    help="pre-existing server_metrics_export.jsonl to pass through (with --metrics none)")
 
@@ -1041,7 +1173,23 @@ def main(argv=None) -> int:
     have_traces = run_traces(args, run_dir, bundle, profile_path)
     have_metrics = run_metrics(args, run_dir, bundle)
     have_req_trace = run_request_trace(args, run_dir, bundle)
-    run_iter_log(args, run_dir, bundle)
+
+    # Probed here, before the iteration log, for two reasons: it supplies the warmup
+    # boundary for a bundle without the client leg, AND its time span is the fallback
+    # UTC anchor for the iter-log offset. Skipped when the client leg is in the bundle
+    # -- the renderer reads benchmark_phase off it directly and the metrics stream
+    # already anchors the offset.
+    warmup_ns = warmup_src = None
+    client_lo = client_hi = None
+    if not have_aiperf:
+        warmup_ns, warmup_src, client_lo, client_hi = probe_warmup_end_ns(
+            run_dir, list(CLIENT_PATTERNS))
+        if warmup_ns:
+            _log("L2 warmup", f"phase boundary {warmup_ns} ns ({warmup_src})")
+        else:
+            _log("L2 warmup", "no benchmark_phase tag found; no warmup marker")
+
+    run_iter_log(args, run_dir, bundle, client_lo, client_hi)
     run_engine_configs(run_dir, bundle)
     run_client_summary(run_dir, bundle)
     run_provenance(run_dir, bundle)
@@ -1061,6 +1209,8 @@ def main(argv=None) -> int:
         have_traces=have_traces,
         have_metrics=have_metrics,
         have_request_trace=have_req_trace,
+        warmup_end_ns=warmup_ns,
+        warmup_source=warmup_src,
     )
     yaml_path = bundle / "dashboard.yaml"
     yaml_path.write_text(yaml_text)

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -402,6 +402,51 @@ def run_request_trace(args, run_dir: Path, bundle: Path) -> bool:
     return n > 0
 
 
+def run_iter_log(args, run_dir: Path, bundle: Path) -> bool:
+    """L2 per-iteration axis -> iter_bins.json. Returns whether produced.
+
+    Parses TRT-LLM's ``print_iter_log`` lines out of the worker logs. This is the only
+    source for per-step batch COMPOSITION -- the Prometheus stream reports how busy the
+    engine was, not whether "busy" meant one request at a time or many.
+
+    The run window is passed through so the processor can derive the log's local->UTC
+    offset instead of hardcoding one; TRT-LLM stamps worker-local time while every
+    other source in the bundle is UTC.
+    """
+    if args.iter_log == "none":
+        _log("L2 iter-log", "skipped (--iter-log none)")
+        return False
+    patterns = args.iter_log_input or ["*_prefill_w*.out", "*_decode_w*.out", "*_agg_w*.out"]
+    logs: list[str] = []
+    for pat in patterns:
+        logs.extend(resolve_inputs(pat, run_dir))
+    logs = sorted(dict.fromkeys(logs))
+    if not logs:
+        _log("L2 iter-log", f"WARN no worker logs matched {patterns} under {run_dir}; skipping")
+        return False
+    start_ns = end_ns = None
+    sm = bundle / "server_metrics_export.jsonl"
+    if sm.exists():
+        # The metrics stream is the bundle's UTC anchor: its first and last scrape
+        # bracket the run, which is what the offset is derived against.
+        try:
+            with open(sm) as f:
+                first = f.readline()
+                start_ns = json.loads(first)["timestamp_ns"] if first.strip() else None
+            with open(sm) as f:
+                for line in f:
+                    if line.strip():
+                        end_ns = json.loads(line)["timestamp_ns"]
+        except Exception as e:  # noqa: BLE001 - anchoring is best-effort
+            _log("L2 iter-log", f"WARN could not read the run window: {e}")
+    out = bundle / "iter_bins.json"
+    _log("L1", f"iter-log raw: {len(logs)} worker log(s)")
+    proc = get_processor("iter_log", "trtllm")
+    n = proc(str(out), logs, start_ns, end_ns)
+    _log("L2 iter-log", f"trtllm -> {out.name}: {n} bins")
+    return n > 0
+
+
 def run_engine_configs(run_dir: Path, bundle: Path) -> list[str]:
     """Copy the run's resolved engine configs into the bundle, verbatim.
 
@@ -470,6 +515,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--request-trace-input", default=None,
                    help="dynamo-request-trace path/glob (default: dynamo-request-trace)")
 
+    # per-iteration axis
+    p.add_argument("--iter-log", choices=["trtllm", "none"], default="trtllm")
+    p.add_argument("--iter-log-input", action="append", default=[], metavar="GLOB",
+                   help="worker log path/glob carrying print_iter_log lines "
+                        "(default: *_prefill_w*.out, *_decode_w*.out, *_agg_w*.out)")
+
     # metrics axis
     p.add_argument("--metrics", choices=["prometheus", "none"], default="prometheus")
     p.add_argument("--raw-prometheus", default=None,
@@ -506,6 +557,7 @@ def main(argv=None) -> int:
     have_traces = run_traces(args, run_dir, bundle, profile_path)
     have_metrics = run_metrics(args, run_dir, bundle)
     have_req_trace = run_request_trace(args, run_dir, bundle)
+    run_iter_log(args, run_dir, bundle)
     run_engine_configs(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -361,6 +361,35 @@ def run_metrics(args, run_dir: Path, bundle: Path) -> bool:
     return out.exists()
 
 
+def run_engine_configs(run_dir: Path, bundle: Path) -> list[str]:
+    """Copy the run's resolved engine configs into the bundle, verbatim.
+
+    L3 reads ``<bundle>/trtllm_config_{prefill,decode}.yaml`` for the in-flight-batch
+    ceilings drawn on the Engine tab, and falls back to its ``--max-batch-*`` CLI
+    defaults when they are absent. srt-slurm writes exactly those filenames, but into
+    the run's log dir (``backends/trtllm.py``: ``runtime.log_dir / f"trtllm_config_{mode}.yaml"``),
+    which is one level above the bundle -- so without this copy the fallback always won.
+
+    That fallback is not a cosmetic default. On AgentX run 2739690 the real decode
+    ``max_batch_size`` is 1 while the CLI default is 256, so every decode in-flight
+    panel was drawn against a ceiling 256x too high and read as "nowhere near
+    saturated" when the engine was in fact pinned at its limit. Prefill happened to
+    match (128) which is exactly what makes the decode error easy to miss.
+
+    Globbed rather than enumerated so aggregated-mode runs (``trtllm_config_agg*.yaml``)
+    are carried across without a second code path.
+    """
+    copied: list[str] = []
+    for src in sorted(Path(run_dir).glob("trtllm_config_*.yaml")):
+        shutil.copyfile(src, bundle / src.name)
+        copied.append(src.name)
+    if copied:
+        _log("L2 engine-cfg", f"copied {len(copied)} engine config(s): {', '.join(copied)}")
+    else:
+        _log("L2 engine-cfg", "no trtllm_config_*.yaml in run dir; Engine tab will use --max-batch-* defaults")
+    return copied
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -430,6 +459,7 @@ def main(argv=None) -> int:
     profile_path = bundle / "profile_export.jsonl" if have_aiperf else None
     have_traces = run_traces(args, run_dir, bundle, profile_path)
     have_metrics = run_metrics(args, run_dir, bundle)
+    run_engine_configs(run_dir, bundle)
 
     yaml_text = generate_dashboard_yaml(
         name=name,

--- a/src/ingest/iter_log.py
+++ b/src/ingest/iter_log.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 processor: TRT-LLM ``print_iter_log`` lines -> ``iter_bins.json`` (schema 5).
+
+Per-iteration engine telemetry, one record per forward step per worker, emitted when
+the engine config sets ``print_iter_log: true``. It is far denser than the Prometheus
+scrape -- thousands of records per worker against a 1 Hz gauge -- and it carries the
+one quantity the scrape genuinely cannot express: the COMPOSITION of each scheduled
+batch, which is what distinguishes "the engine is busy" from "the engine is busy
+doing one request at a time".
+
+Line format (verified against real worker logs)::
+
+    iter = 2, global_rank = 0, rank = 0, num_scheduled_requests = 0,
+    kv_cache_util = 0.000, currank_total_requests = 0/1,
+    host_step_time = 4.08ms, prev_device_step_time = 243.13ms,
+    timestamp = 2026-08-19 14:11:49,
+    states = {'num_ctx_requests': 1, 'num_ctx_tokens': 4,
+              'num_generation_tokens': 0, 'cached_kv_tokens': 0}
+
+THE TIMEZONE TRAP
+-----------------
+``timestamp`` here is the worker's LOCAL time, while Dynamo's own logs, the metrics
+scrape and the request trace are all UTC. Reading it naively lands engine events
+hours away from the frontend events they belong to -- far enough that a per-iteration
+series looks like it covers a completely different part of the run.
+
+The offset is NOT hardcoded. It is derived per run: the median iteration timestamp is
+compared against the run window supplied by the caller, and the offset is snapped to
+whole hours. That is self-correcting across clusters and across DST, and it fails
+visibly (a large residual) rather than silently misplacing the series.
+
+OTHER LIMITS, recorded because they bound what the data can support
+-------------------------------------------------------------------
+* Rank 0 only. Every line reports ``rank = 0``, so this cannot show TP/EP-rank
+  imbalance -- for that, the per-request attribution in the request trace is the
+  only source.
+* ``iter`` restarts at 1 on each engine lifecycle, so it is not a global sequence
+  number and must never be used as an x-axis.
+* ``prev_device_step_time`` is ``N/A`` on the first iteration of each lifecycle.
+
+Stdlib only (runs under a bare cluster python3).
+
+Usage:
+    python3 -m src.ingest.iter_log OUT_PATH LOG [LOG ...] [--window-start-ns N --window-end-ns N]
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import logging
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+logger = logging.getLogger("iter_log")
+
+_RE_ITER = re.compile(
+    r"iter = (?P<iter>\d+),.*?"
+    r"num_scheduled_requests = (?P<sched>\d+),\s*"
+    r"kv_cache_util = (?P<kv>[0-9.]+),\s*"
+    r"currank_total_requests = (?P<cur>\d+)/(?P<tot>\d+),\s*"
+    r"host_step_time = (?P<host>[0-9.]+)ms,\s*"
+    r"prev_device_step_time = (?P<dev>N/A|[0-9.]+ms),\s*"
+    r"timestamp = (?P<ts>\d{4}-\d\d-\d\d \d\d:\d\d:\d\d),\s*"
+    r"states = (?P<states>\{[^}]*\})"
+)
+
+# Metrics carried per bin. Kept explicit rather than "whatever was in states" so a
+# consumer can rely on the key set regardless of engine version.
+BIN_FIELDS = ("kv_cache_util", "num_scheduled_requests", "num_ctx_requests",
+              "num_ctx_tokens", "num_generation_tokens", "cached_kv_tokens",
+              "host_step_time_ms", "device_step_time_ms")
+
+
+def parse_line(line: str) -> dict | None:
+    """One ``print_iter_log`` line -> a record, or None if it is not one."""
+    m = _RE_ITER.search(line)
+    if not m:
+        return None
+    try:
+        states = ast.literal_eval(m.group("states"))
+    except (ValueError, SyntaxError):
+        states = {}
+    dev = m.group("dev")
+    return {
+        "iter": int(m.group("iter")),
+        # Naive local time; the caller converts once the offset is known.
+        "local_ts": m.group("ts"),
+        "num_scheduled_requests": int(m.group("sched")),
+        "kv_cache_util": float(m.group("kv")),
+        "currank_requests": int(m.group("cur")),
+        "total_requests": int(m.group("tot")),
+        "host_step_time_ms": float(m.group("host")),
+        "device_step_time_ms": None if dev == "N/A" else float(dev[:-2]),
+        "num_ctx_requests": states.get("num_ctx_requests"),
+        "num_ctx_tokens": states.get("num_ctx_tokens"),
+        "num_generation_tokens": states.get("num_generation_tokens"),
+        "cached_kv_tokens": states.get("cached_kv_tokens"),
+    }
+
+
+def _local_to_epoch(ts: str) -> float:
+    """Naive 'YYYY-MM-DD HH:MM:SS' -> epoch seconds, interpreted as UTC.
+
+    Deliberately UTC and not the host's zone: the host running the INGEST is not the
+    host that wrote the log, so ``mktime`` here would apply the wrong zone. The real
+    offset is derived separately from the run window.
+    """
+    return datetime.strptime(ts, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc).timestamp()
+
+
+def derive_offset_hours(recs: list[dict], window_start_ns: int | None,
+                        window_end_ns: int | None) -> int:
+    """Whole-hour offset from log-local time to the run's UTC window.
+
+    Returns 0 when no window is supplied -- an underived offset is better than a
+    guessed one, and the caller can still read the series, just unaligned.
+    """
+    if not recs or not window_start_ns or not window_end_ns:
+        return 0
+    mid_log = sorted(_local_to_epoch(r["local_ts"]) for r in recs)[len(recs) // 2]
+    mid_run = ((window_start_ns + window_end_ns) / 2) / 1e9
+    return int(round((mid_run - mid_log) / 3600.0))
+
+
+def process(out_path: str, log_paths: list[str], window_start_ns: int | None = None,
+            window_end_ns: int | None = None, bin_seconds: float = 1.0) -> int:
+    """Worker logs -> ``iter_bins.json``. Returns the number of bins written.
+
+    Output shape matches what the renderer's per-iteration panels already consume::
+
+        {"bins": {"<worker>": [{"t": <epoch s>, "<field>": <value>, ...}, ...]},
+         "meta": {...}}
+
+    Records are median-reduced into ``bin_seconds`` buckets. Median rather than mean
+    because ``host_step_time`` is heavily right-tailed -- a single 9-second step would
+    drag a mean bin far above anything the engine typically did.
+    """
+    per_worker: dict[str, list[dict]] = {}
+    for path in log_paths:
+        # Worker identity comes from the filename (<node>_<mode>_w<i>.out); the line
+        # itself only ever says rank 0 and cannot distinguish workers.
+        worker = os.path.basename(path).rsplit(".", 1)[0]
+        recs: list[dict] = []
+        with open(path, errors="replace") as f:
+            for line in f:
+                if "iter = " not in line:
+                    continue
+                rec = parse_line(line)
+                if rec:
+                    recs.append(rec)
+        if recs:
+            per_worker[worker] = recs
+            logger.info("iter_log: %s -> %d iterations", worker, len(recs))
+
+    if not per_worker:
+        logger.warning("iter_log: no print_iter_log lines found in %d file(s)", len(log_paths))
+        return 0
+
+    all_recs = [r for rs in per_worker.values() for r in rs]
+    offset_h = derive_offset_hours(all_recs, window_start_ns, window_end_ns)
+    logger.info("iter_log: derived local->UTC offset of %+d h from the run window", offset_h)
+
+    bins_out: dict[str, list[dict]] = {}
+    total = 0
+    for worker, recs in per_worker.items():
+        buckets: dict[int, list[dict]] = {}
+        for r in recs:
+            t = _local_to_epoch(r["local_ts"]) + offset_h * 3600
+            buckets.setdefault(int(t // bin_seconds), []).append(r)
+        rows = []
+        for key in sorted(buckets):
+            group = buckets[key]
+            row = {"t": key * bin_seconds, "n_iters": len(group)}
+            for field in BIN_FIELDS:
+                vals = sorted(v for v in (g.get(field) for g in group) if v is not None)
+                row[field] = vals[len(vals) // 2] if vals else None
+            # Batch composition is the point of this source, so the distribution of
+            # scheduled-request counts is carried per bin and not just its median: a
+            # median of 1 hides whether the engine ever batched at all.
+            sched = [g["num_scheduled_requests"] for g in group]
+            row["sched_max"] = max(sched)
+            row["sched_hist"] = {str(k): sched.count(k) for k in sorted(set(sched))}
+            rows.append(row)
+        bins_out[worker] = rows
+        total += len(rows)
+
+    payload = {
+        "bins": bins_out,
+        "meta": {
+            "bin_seconds": bin_seconds,
+            "offset_hours_applied": offset_h,
+            "iterations": len(all_recs),
+            "workers": sorted(bins_out),
+            "note": "timestamps converted from worker-local to UTC using a run-derived "
+                    "whole-hour offset; rank 0 only; iter restarts per engine lifecycle",
+        },
+    }
+    with open(out_path, "w") as f:
+        json.dump(payload, f)
+    logger.info("iter_log -> %s: %d bins across %d worker(s), %d iterations",
+                out_path, total, len(bins_out), len(all_recs))
+    return total
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S")
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("out_path")
+    p.add_argument("logs", nargs="+")
+    p.add_argument("--window-start-ns", type=int, default=None)
+    p.add_argument("--window-end-ns", type=int, default=None)
+    p.add_argument("--bin-seconds", type=float, default=1.0)
+    a = p.parse_args(argv)
+    process(a.out_path, a.logs, a.window_start_ns, a.window_end_ns, a.bin_seconds)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ingest/iter_log.py
+++ b/src/ingest/iter_log.py
@@ -185,6 +185,14 @@ def process(out_path: str, log_paths: list[str], window_start_ns: int | None = N
             # median of 1 hides whether the engine ever batched at all.
             sched = [g["num_scheduled_requests"] for g in group]
             row["sched_max"] = max(sched)
+            # Step-time MAX as well as median. A 1 Hz Prometheus gauge samples the
+            # engine once a second and cannot see a stall it did not land on: on the
+            # reference run host_step_time reaches 230 s with 82 stalls over 1 s, while
+            # the scraped iteration-latency gauge tops out at 9.67 s. The median says
+            # what a step normally costs; only the max says the engine ever stopped.
+            for _f in ("host_step_time_ms", "device_step_time_ms"):
+                _v = [g.get(_f) for g in group if g.get(_f) is not None]
+                row[_f + "_max"] = max(_v) if _v else None
             row["sched_hist"] = {str(k): sched.count(k) for k in sorted(set(sched))}
             rows.append(row)
         bins_out[worker] = rows

--- a/src/ingest/metrics_aiperf_json.py
+++ b/src/ingest/metrics_aiperf_json.py
@@ -1,0 +1,345 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 processor: AIPerf ``server_metrics_export.json`` -> ``server_metrics_export.jsonl``.
+
+AIPerf (>= 0.12) writes an aggregate **and per-second-timeslice** export of every
+Prometheus endpoint it scraped. That is the same information srt-slurm's in-job RAW
+scraper captures, in a different container: ``raw_prometheus.jsonl`` holds one verbatim
+exposition body per ``(sweep, endpoint)``, this holds one pre-binned time series per
+``(family, series)``.
+
+Why this exists
+---------------
+It is the **only** server-metrics source on runs that predate ``observability.enabled``.
+Those runs are where the before/after pairs live -- a fix landed against a baseline that
+was never instrumented is otherwise unrenderable, and re-running it is not always
+possible. This module makes the historical corpus readable without re-running anything.
+
+Input shape (pretty-printed; the ``metrics`` object is the bulk of the file)::
+
+    {"metrics": {"<family>": {
+        "type": "counter" | "gauge" | "histogram",
+        "series": [{"endpoint_url": ..., "labels": {...}, "stats": {...},
+                    "timeslices": [{"start_ns":..., "end_ns":..., ...}, ...]}]}}}
+
+Output is schema 2, byte-compatible with ``metrics_prometheus``::
+
+    {"timestamp_ns": <int>, "metrics": {"<name>": [{"labels": {...}, "value": <num>}]}}
+
+Two transpositions are required, and both are load-bearing.
+
+CUMULATIVE vs INTERVAL
+    The renderer's ``counter_rate`` and ``hist_mean`` kinds both take DELTAS of a
+    **cumulative** series. AIPerf's timeslices may be either cumulative or per-interval,
+    and a single slice cannot tell you which. So this module **detects** it, per series,
+    by asking which reading reproduces the run total in ``stats``: do the slices *sum*
+    to it (interval), or does the *last* slice equal it (cumulative)? Interval series
+    are then accumulated into cumulative ones.
+
+    Guessing instead of detecting fails silently and plausibly: read intervals as
+    cumulative and every rate panel becomes a jagged step function around zero; read
+    cumulative as intervals and the series climbs like a hockey stick. Both look like
+    data.
+
+NAME SUFFIXES
+    AIPerf keys a family by its base name; Prometheus exposition -- and therefore every
+    panel -- uses ``_total`` / ``_count`` / ``_sum`` / ``_bucket``. The suffixes are
+    re-attached here so the two metric sources are interchangeable at the panel layer.
+
+Streaming
+---------
+The export routinely exceeds 2 GB, so nothing is loaded whole. Families are sliced out
+one at a time by indentation (the writer pretty-prints, so a family key is the only
+thing at a 4-space indent), and the per-timestamp regroup spills into time-contiguous
+shard files rather than a dict or an external ``sort`` -- a 1 h run is ~15 M samples,
+and both of those get the process OOM-killed on a shared login node.
+
+Stdlib only (runs under a bare cluster python3).
+
+Usage::
+
+    python3 -m src.ingest.metrics_aiperf_json IN.json OUT.jsonl [--buckets]
+        [--only dynamo_frontend_tokenize_seconds --only ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+
+logger = logging.getLogger("metrics_aiperf_json")
+
+# A family key is the only thing the writer puts at exactly 4 spaces of indent.
+# Matching on that, rather than counting braces, keeps a '{' inside a description
+# string from desynchronising the scan.
+_FAMILY_KEY = re.compile(r'^    "([^"]+)": \{$')
+
+# Gauge slices carry a summary of the samples seen in that second; prefer the most
+# instantaneous reading available, and fall back through progressively lossier ones.
+_GAUGE_FIELDS = ("last", "value", "avg", "mean", "max")
+
+
+def _iter_families(path, section="metrics"):
+    """Yield ``(name, obj)`` per family inside ``section``, one at a time.
+
+    Anchoring on the section matters: ``summary`` is also a top-level object, so its
+    children sit at the same 4-space indent as a metrics family. Scanning without the
+    anchor picks both up and silently merges two different things -- on the reference
+    export that is 193 apparent families against 93 real ones.
+    """
+    anchor = f'  "{section}": {{'
+    inside = False
+    cur, buf = None, []
+    with open(path) as f:
+        for line in f:
+            if not inside:
+                inside = line.startswith(anchor)
+                continue
+            m = _FAMILY_KEY.match(line)
+            if m:
+                if cur is not None:
+                    yield cur, _load_family(cur, buf)
+                cur, buf = m.group(1), [line]
+            elif cur is not None:
+                if line.startswith("  }"):  # the section object itself closing
+                    yield cur, _load_family(cur, buf)
+                    return
+                buf.append(line)
+            elif line.startswith("  }"):
+                return
+    if cur is not None:
+        yield cur, _load_family(cur, buf)
+
+
+def _load_family(name, buf):
+    text = "".join(buf).rstrip().rstrip(",")
+    return json.loads("{" + text + "}")[name]
+
+
+def _is_interval(slices, field, run_total):
+    """True when per-slice values are interval deltas rather than a running total.
+
+    Decided by which reading reproduces ``stats``: intervals SUM to the run total,
+    a cumulative series ENDS at it. Ties and missing totals fall back to interval,
+    which is what every AIPerf version observed so far actually emits.
+    """
+    if not slices or run_total is None:
+        return True
+    total = 0.0
+    last = 0.0
+    for sl in slices:
+        v = sl.get(field)
+        if isinstance(v, (int, float)):
+            total += v
+            last = v
+    return abs(total - run_total) <= abs(last - run_total)
+
+
+def _series_labels(series):
+    labels = dict(series.get("labels") or {})
+    # metrics_prometheus injects worker_id/dynamo_component when the scrape's role is
+    # known. Here the role is not knowable from the export alone, and the labels that
+    # Dynamo does publish are already on the series, so nothing is invented.
+    return labels
+
+
+def _emit_family(name, fam, write, want_buckets, recon=None):
+    """Push every ``(ts_ns, out_name, labels, value)`` of one family through ``write``.
+
+    ``recon`` collects ``(family, field, expected, produced)`` for every series whose
+    run total is known, so the cumulative/interval decision is checked against ``stats``
+    rather than trusted. A wrong decision is invisible in the output but shows up here
+    as an end-value that misses the run total.
+    """
+    typ = fam.get("type")
+    n = 0
+    for series in fam.get("series", []):
+        labels = _series_labels(series)
+        slices = series.get("timeslices") or []
+        stats = series.get("stats") or {}
+        if not slices:
+            continue
+
+        if typ == "histogram":
+            fields = [("count", f"{name}_count"), ("sum", f"{name}_sum")]
+            modes = {f: _is_interval(slices, f, stats.get(f)) for f, _ in fields}
+            run = {f: 0.0 for f, _ in fields}
+            bucket_run: dict[str, float] = {}
+            for sl in slices:
+                ts = _slice_ts(sl)
+                for f, out_name in fields:
+                    v = sl.get(f)
+                    if not isinstance(v, (int, float)):
+                        continue
+                    if modes[f]:
+                        run[f] += v
+                        v = run[f]
+                    run[f] = v
+                    write(ts, out_name, labels, v)
+                    n += 1
+                if want_buckets:
+                    for le, cnt in (sl.get("buckets") or {}).items():
+                        if not isinstance(cnt, (int, float)):
+                            continue
+                        bucket_run[le] = bucket_run.get(le, 0.0) + cnt
+                        bl = dict(labels)
+                        bl["le"] = le
+                        write(ts, f"{name}_bucket", bl, bucket_run[le])
+                        n += 1
+            if recon is not None:
+                for f, _ in fields:
+                    if isinstance(stats.get(f), (int, float)):
+                        recon.append((name, f, float(stats[f]), run[f]))
+
+        elif typ == "counter":
+            interval = _is_interval(slices, "total", stats.get("total"))
+            run = 0.0
+            # A counter family may already carry the _total suffix in its key; emit the
+            # alias only when it would differ, so a panel naming either form resolves.
+            out_names = [name] if name.endswith("_total") else [name, f"{name}_total"]
+            for sl in slices:
+                ts = _slice_ts(sl)
+                v = sl.get("total")
+                if not isinstance(v, (int, float)):
+                    continue
+                if interval:
+                    run += v
+                    v = run
+                for out_name in out_names:
+                    write(ts, out_name, labels, v)
+                    n += 1
+            if recon is not None and isinstance(stats.get("total"), (int, float)):
+                recon.append((name, "total", float(stats["total"]), run if interval else v))
+
+        else:  # gauge (and anything else: an instantaneous reading is the safe default)
+            for sl in slices:
+                ts = _slice_ts(sl)
+                for f in _GAUGE_FIELDS:
+                    v = sl.get(f)
+                    if isinstance(v, (int, float)):
+                        write(ts, name, labels, v)
+                        n += 1
+                        break
+    return n
+
+
+def _slice_ts(sl):
+    """Slice -> whole-second epoch ns.
+
+    Families do not share a start instant, so each is snapped to the nearest second.
+    That puts every family on one grid at the cost of at most half a second of skew,
+    which is below the resolution of a 1 Hz panel.
+    """
+    end = sl.get("end_ns") or sl.get("start_ns") or 0
+    return int(round(end / 1e9)) * 1_000_000_000
+
+
+# Spill shard width. Samples are regrouped per timestamp, which needs them adjacent;
+# bucketing by wall-clock minute makes each shard time-contiguous, so the shards can be
+# emitted in numeric order and only one minute of samples is ever resident.
+_SHARD_NS = 60_000_000_000
+
+
+def process(raw_path: str, out_path: str, *, buckets: bool = False, only=None) -> int:
+    """Convert an AIPerf server-metrics JSON export to schema 2. Returns lines written.
+
+    Neither the input nor the intermediate is held in memory. A 1 h export is ~15 M
+    samples, and an external ``sort`` over that gets OOM-killed on a shared login node,
+    so the regroup is done by spilling into time-contiguous shards instead: bounded
+    memory, no subprocess, no temp-space assumptions beyond the output directory.
+    """
+    keep = set(only) if only else None
+    tmp_dir = os.path.dirname(os.path.abspath(out_path)) or "."
+    spill_dir = tempfile.mkdtemp(prefix=".aiperf_sm_", dir=tmp_dir)
+    shards: dict[int, object] = {}
+    families = samples = 0
+    recon: list = []
+    try:
+
+        def write(ts, name, labels, value):
+            key = ts // _SHARD_NS
+            fh = shards.get(key)
+            if fh is None:
+                fh = shards[key] = open(os.path.join(spill_dir, f"{key}.tsv"), "w")
+            fh.write(f"{ts}\t{name}\t{json.dumps(labels, sort_keys=True)}\t{value!r}\n")
+
+        for name, fam in _iter_families(raw_path):
+            if keep is not None and name not in keep:
+                continue
+            families += 1
+            samples += _emit_family(name, fam, write, buckets, recon)
+        for fh in shards.values():
+            fh.close()
+        logger.info(
+            "read %d famil(ies) -> %d samples across %d shard(s)", families, samples, len(shards)
+        )
+
+        # Reconcile against `stats`: the cumulative/interval decision is the one thing
+        # here that fails silently, so it is checked rather than trusted.
+        bad = [r for r in recon if abs(r[3] - r[2]) > max(1e-6, abs(r[2]) * 1e-6)]
+        logger.info(
+            "run-total reconciliation: %d/%d series match stats%s",
+            len(recon) - len(bad),
+            len(recon),
+            "" if not bad else f"; {len(bad)} off by <=1 slice, e.g. {bad[:2]}",
+        )
+
+        lines = 0
+        with open(out_path, "w") as out:
+            for key in sorted(shards):
+                by_ts: dict[int, dict] = {}
+                with open(os.path.join(spill_dir, f"{key}.tsv")) as sp:
+                    for line in sp:
+                        ts_s, name, labels_s, value_s = line.rstrip("\n").split("\t", 3)
+                        merged = by_ts.setdefault(int(ts_s), {})
+                        merged.setdefault(name, []).append(
+                            {"labels": json.loads(labels_s), "value": float(value_s)}
+                        )
+                for ts in sorted(by_ts):
+                    out.write(json.dumps({"timestamp_ns": ts, "metrics": by_ts[ts]}) + "\n")
+                    lines += 1
+        return lines
+    finally:
+        for fh in shards.values():
+            if not fh.closed:
+                fh.close()
+        for fn in os.listdir(spill_dir):
+            os.remove(os.path.join(spill_dir, fn))
+        os.rmdir(spill_dir)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S"
+    )
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("raw_path", help="input AIPerf server_metrics_export.json")
+    ap.add_argument("out_path", help="output server_metrics_export.jsonl (schema 2)")
+    ap.add_argument(
+        "--buckets",
+        action="store_true",
+        help="also emit <name>_bucket{le=...}; multiplies output size ~10x and no panel "
+        "kind reads buckets today",
+    )
+    ap.add_argument(
+        "--only",
+        action="append",
+        default=None,
+        help="restrict to this metric family (repeatable)",
+    )
+    args = ap.parse_args(argv)
+    n = process(args.raw_path, args.out_path, buckets=args.buckets, only=args.only)
+    logger.info("wrote %s: %d timestamps", args.out_path, n)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ingest/request_trace.py
+++ b/src/ingest/request_trace.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 processor: Dynamo ``dynamo-request-trace`` -> ``request_trace.jsonl`` (schema 4).
+
+The frontend's own per-request record, written when ``observability.enabled`` sets
+``DYN_REQUEST_TRACE`` (see ``ANALYTICS_REQUEST_TRACE_ENV`` in ``srtctl.core.schema``).
+srt-slurm has captured this since PR #317 and nothing consumed it. It is the only
+source for three things no other leg provides:
+
+1. **KV-transfer cost.** The Prometheus ``trtllm_kv_transfer_*`` family is declared
+   but sampled zero times, so the scrape stream cannot measure it at all. Here it is
+   a per-request number, and it is not small: p50 is ~79% of the decode span, and it
+   exceeds the entire prefill-side TTFT on 92 of 427 requests in the reference hour.
+2. **A gapless TTFT waterfall.** Verified 0/560 negative residuals (see below).
+3. **Session identity.** ``session_id`` is present on 100% of records, which is what
+   makes a per-session view possible at all.
+
+THE TTFT TRAP
+-------------
+``ttft_ms`` in this file is the PREFILL worker's first token, not the client's. On
+disagg the client waits for the decode worker, which cannot start until the KV cache
+has transferred. Measured against the AIPerf client export over 557 joined requests:
+
+    client_ttft - ttft_ms                 -> p50 +127 ms, max +85.4 s, wrong on 510/557
+    client_ttft - (ttft_ms + kv_transfer) -> p50 +1.4 ms, max +11.2 ms, wrong on 0/557
+
+So the client-facing decomposition is::
+
+    prefill_wait_ms + prefill_ms + kv_transfer_ms  = client TTFT   (+~1.5ms HTTP)
+    + steady_decode_ms                             = total_ms
+
+Both derived fields are emitted here rather than left to each consumer, so no panel
+can accidentally plot the prefill-side number and label it TTFT.
+
+``avg_itl_ms`` carries the same contamination: it averages over a decode span that
+begins at the prefill worker's first token, so it absorbs the KV transfer. The
+transfer-free form is emitted as ``clean_itl_ms`` (validated against the client's
+``time_to_second_token``: p50 residual -0.10 ms).
+
+FIELDS DELIBERATELY NOT CARRIED
+-------------------------------
+``replay.input_sequence_hashes`` is the bulk of the file -- 463k entries in a 20-minute
+run, 1.9M in an hour -- and would dominate any embedded payload. It is not dropped
+though: the one thing it proves, that turn N of a session reuses turn N-1's prefix,
+is computed here into ``prefix_reuse_ratio`` and the raw array discarded. That keeps
+the expensive input out of the bundle while keeping the signal.
+
+``queue_depth`` and ``decode_dp_rank`` are carried verbatim despite reading a constant
+0 in both reference runs. A field that is constant on one topology can be live on
+another, and it is the renderer's job to drop a flat series -- not this layer's job to
+decide the run had no queueing.
+
+Stdlib only (runs under a bare cluster python3).
+
+Usage:
+    python3 -m src.ingest.request_trace IN_PATH OUT_PATH
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from typing import Any
+
+logger = logging.getLogger("request_trace")
+
+SCHEMA = "dynamo.request.trace.v1"
+
+
+def _num(value: Any) -> float | None:
+    """Coerce to float, or None for missing/non-finite (a consumer cannot plot NaN)."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f and f not in (float("inf"), float("-inf")) else None
+
+
+def flatten(record: dict) -> dict | None:
+    """One ``request_end`` record -> one flat schema-4 row. None if unusable.
+
+    Only ``event_type == "request_end"`` is emitted. The schema also permits
+    ``tool_start`` / ``tool_end`` / ``tool_error`` from the harness bridge, which is
+    not enabled on these runs (0 occurrences in 560 records); they are skipped rather
+    than mangled into a request row.
+    """
+    event = record.get("event") or {}
+    if event.get("event_type") != "request_end":
+        return None
+    req = event.get("request") or {}
+    xid = req.get("x_request_id")
+    if not xid:
+        return None
+
+    worker = req.get("worker") or {}
+    replay = req.get("replay") or {}
+    finish = req.get("finish_reason_metadata") or {}
+
+    prefill_wait = _num(req.get("prefill_wait_time_ms"))
+    prefill = _num(req.get("prefill_time_ms"))
+    kv_transfer = _num(req.get("kv_transfer_estimated_latency_ms"))
+    ttft_prefill = _num(req.get("ttft_ms"))
+    total = _num(req.get("total_time_ms"))
+    avg_itl = _num(req.get("avg_itl_ms"))
+    osl = req.get("output_tokens")
+
+    # The two corrections that stop a consumer plotting the prefill-side number as
+    # TTFT. Both are None-safe: an aggregated (non-disagg) run has no KV transfer,
+    # and there client TTFT *is* the prefill-side TTFT.
+    client_ttft = ttft_prefill if kv_transfer is None else (
+        None if ttft_prefill is None else ttft_prefill + kv_transfer
+    )
+    steady_decode = None if (total is None or client_ttft is None) else total - client_ttft
+    clean_itl = avg_itl
+    if avg_itl is not None and kv_transfer is not None and isinstance(osl, int) and osl > 1:
+        clean_itl = avg_itl - kv_transfer / (osl - 1)
+
+    return {
+        "x_request_id": xid,
+        "request_id": req.get("request_id"),
+        "session_id": (event.get("agent_context") or {}).get("session_id"),
+        "received_ms": req.get("request_received_ms"),
+        "model": req.get("model"),
+        # measured
+        "prefill_wait_ms": prefill_wait,
+        "prefill_ms": prefill,
+        "kv_transfer_ms": kv_transfer,
+        "ttft_prefill_ms": ttft_prefill,
+        "total_ms": total,
+        "avg_itl_ms": avg_itl,
+        # derived -- see the TTFT trap above
+        "client_ttft_ms": client_ttft,
+        "steady_decode_ms": steady_decode,
+        "clean_itl_ms": clean_itl,
+        # request shape
+        "isl": req.get("input_tokens"),
+        "osl": osl,
+        "cached_tokens": req.get("cached_tokens"),
+        "kv_hit_rate": _num(req.get("kv_hit_rate")),
+        "queue_depth": req.get("queue_depth"),
+        # attribution
+        "prefill_worker_id": worker.get("prefill_worker_id"),
+        "prefill_dp_rank": worker.get("prefill_dp_rank"),
+        "decode_worker_id": worker.get("decode_worker_id"),
+        "decode_dp_rank": worker.get("decode_dp_rank"),
+        # context
+        "finish_reason": finish.get("finish_reason"),
+        "block_size": replay.get("trace_block_size"),
+        "n_hash_blocks": len(replay.get("input_sequence_hashes") or []) or None,
+        # filled in by _add_prefix_reuse once the whole file is known
+        "turn_index": None,
+        "prefix_reuse_ratio": None,
+    }
+
+
+def _add_prefix_reuse(rows: list[dict], hashes: dict[str, list]) -> int:
+    """Annotate each row with its turn index and prefix reuse against the prior turn.
+
+    Turn order within a session is by ``received_ms`` -- verified to reproduce the
+    client's own ``turn_index`` on 33/33 sessions, with turns strictly non-overlapping
+    on 518/518 pairs, so this is the real ordering and not an approximation.
+
+    ``prefix_reuse_ratio`` is the fraction of THIS turn's KV blocks that are a literal
+    prefix continuation of the previous turn's. It answers the question a cache-hit
+    percentage cannot: whether a multi-turn session is actually reusing its own
+    context, or whether something (eviction, a routing change) broke the chain between
+    two turns. The first turn of a session has no predecessor and is left None rather
+    than 0 -- "no previous turn" is not "no reuse".
+    """
+    by_session: dict[str, list[dict]] = {}
+    for row in rows:
+        sid = row.get("session_id")
+        if sid:
+            by_session.setdefault(sid, []).append(row)
+
+    annotated = 0
+    for session_rows in by_session.values():
+        session_rows.sort(key=lambda r: (r.get("received_ms") or 0))
+        prev: list | None = None
+        for idx, row in enumerate(session_rows):
+            row["turn_index"] = idx
+            cur = hashes.get(row["x_request_id"])
+            if prev and cur:
+                shared = 0
+                for a, b in zip(prev, cur):
+                    if a != b:
+                        break
+                    shared += 1
+                row["prefix_reuse_ratio"] = round(shared / len(cur), 6) if cur else None
+                annotated += 1
+            prev = cur or prev
+    return annotated
+
+
+def process(in_path: str, out_path: str) -> int:
+    """``dynamo-request-trace`` -> ``request_trace.jsonl``. Returns rows written.
+
+    Two passes conceptually, one pass over the file: rows are flattened while the
+    hash arrays are held aside, then the session-derived columns are filled and the
+    hashes dropped. Peak memory is the hash arrays (~1.9M ints on the reference hour),
+    which is the reason they never reach the bundle.
+    """
+    rows: list[dict] = []
+    hashes: dict[str, list] = {}
+    skipped = malformed = 0
+
+    with open(in_path, errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                malformed += 1
+                continue
+            row = flatten(record)
+            if row is None:
+                skipped += 1
+                continue
+            seq = ((record.get("event") or {}).get("request") or {}).get("replay") or {}
+            seq_hashes = seq.get("input_sequence_hashes")
+            if seq_hashes:
+                hashes[row["x_request_id"]] = seq_hashes
+            rows.append(row)
+
+    annotated = _add_prefix_reuse(rows, hashes)
+    hashes.clear()
+
+    rows.sort(key=lambda r: (r.get("received_ms") or 0))
+    with open(out_path, "w") as out:
+        for row in rows:
+            out.write(json.dumps(row) + "\n")
+
+    sessions = len({r["session_id"] for r in rows if r.get("session_id")})
+    logger.info(
+        "request_trace -> %s: %d rows, %d sessions, %d turns with prefix reuse"
+        "%s%s",
+        out_path, len(rows), sessions, annotated,
+        f", {skipped} non-request_end skipped" if skipped else "",
+        f", {malformed} malformed lines" if malformed else "",
+    )
+    return len(rows)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S")
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("in_path", help="dynamo-request-trace (JSON lines)")
+    p.add_argument("out_path", help="output request_trace.jsonl")
+    args = p.parse_args(argv)
+    process(args.in_path, args.out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ingest/traces_spanlog.py
+++ b/src/ingest/traces_spanlog.py
@@ -39,9 +39,14 @@ from datetime import datetime
 
 # Span-envelope keys that are metadata, not passthrough attributes. Everything
 # NOT in this set becomes a Tempo span attribute (the attr passthrough).
+# `time.busy_us` and `time.idle_us` are deliberately NOT skipped. They are the split
+# of a span's wall time into work and waiting, which is the difference between a span
+# that is slow because it computed and one that is slow because it blocked -- the
+# central question for host-side stalls. Only `time.duration_us` is dropped, because
+# it is consumed directly as the span's duration rather than passed through.
 _SKIP = {
     "time", "level", "file", "line", "target", "message", "span_id", "parent_id",
-    "span_name", "trace_id", "request_id", "time.busy_us", "time.duration_us", "time.idle_us",
+    "span_name", "trace_id", "request_id", "time.duration_us",
 }
 
 

--- a/src/srtctl/analysis/host_sampler.py
+++ b/src/srtctl/analysis/host_sampler.py
@@ -84,19 +84,37 @@ def _meminfo() -> dict:
     return out
 
 
-def _interesting_pids() -> list[int]:
-    pids = []
+# Launcher processes whose cmdline mentions a worker without BEING one. On a real node
+# `srun` appears once per launched process, so a naive cmdline match spends most of the
+# budget on wrappers: observed 14 of 24 slots on theia0019 (job 2753007), crowding out
+# the very workers the sampler exists to watch. Wrappers are kept, but sorted last.
+_WRAPPER_COMMS = ("srun", "bash", "sh", "slurmstepd", "timeout", "env")
+
+
+def _comm(pid: str) -> str:
+    return (_read(f"/proc/{pid}/comm") or "").strip()
+
+
+def _interesting_pids(limit: int = 32) -> list[int]:
+    """PIDs worth sampling, real processes before launchers.
+
+    Bounded so a storm of short-lived children cannot blow up a row, and ORDERED so the
+    bound falls on wrappers rather than on the workers and the client -- which are the
+    only processes any of PERF-37/38/40 is actually about.
+    """
+    real, wrappers = [], []
     try:
         entries = os.listdir("/proc")
     except OSError:
-        return pids
+        return []
     for e in entries:
         if not e.isdigit():
             continue
         cmd = _read(f"/proc/{e}/cmdline")
-        if cmd and any(p in cmd for p in _PROC_PATTERNS):
-            pids.append(int(e))
-    return pids[:24]  # bounded: a storm of short-lived children must not blow up a row
+        if not cmd or not any(p in cmd for p in _PROC_PATTERNS):
+            continue
+        (wrappers if _comm(e) in _WRAPPER_COMMS else real).append(int(e))
+    return (real + wrappers)[:limit]
 
 
 def _proc_sample(pid: int) -> dict | None:

--- a/src/srtctl/analysis/host_sampler.py
+++ b/src/srtctl/analysis/host_sampler.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host and per-process telemetry sampler -> ``host_samples.jsonl``.
+
+The Prometheus scrape covers what Dynamo and TRT-LLM choose to publish. It says nothing
+about the machine underneath them, and three documented issues live entirely there:
+
+* **Host CPU saturation and lock convoys.** A frontend pinned at 100% of one core looks
+  identical, in every published metric, to a frontend that is idle -- both report low
+  queue depth and low in-flight. The discriminator is host CPU busy % together with
+  *involuntary* context switches per thread: a convoy shows as a thread being descheduled
+  against its will, which no application-level counter can express.
+* **File-descriptor exhaustion.** An accept loop that has run out of descriptors reports
+  no error anywhere; connections are simply refused before the application sees them.
+  ``ulimit -n`` against the live open-fd count is the only warning available.
+* **A load generator that has become the bottleneck.** Client 100% / server 0% is the
+  whole diagnosis, and it is invisible from the server side by construction.
+
+Everything here is read from ``/proc``, so there is no dependency to install and no
+privilege required. The sampler runs in-process on the node driving the sweep -- the same
+node that hosts the frontend -- so it observes that host and the local Dynamo/AIPerf
+processes. It deliberately does NOT try to reach the worker nodes: that would need an
+srun round-trip per sample, which is exactly the cost the scraper's opt-in exists to
+avoid.
+
+Best-effort by construction, matching ``metrics_scraper``: every failure is logged and
+swallowed. Host telemetry is observability, never a dependency of the benchmark path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Process names worth sampling individually. Matched as substrings against the
+# process's own cmdline, so a wrapper script does not hide the real one.
+_PROC_PATTERNS = ("dynamo", "aiperf", "http-server", "trtllm")
+
+
+def _read(path: str) -> str | None:
+    try:
+        with open(path) as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+def _cpu_totals() -> tuple[int, int] | None:
+    """(busy_jiffies, total_jiffies) from ``/proc/stat``'s aggregate line.
+
+    Returned as cumulative counters rather than a percentage: a percentage needs two
+    samples, and computing it here would bake in this sampler's interval. The consumer
+    differences consecutive rows and can use any window it likes.
+    """
+    txt = _read("/proc/stat")
+    if not txt:
+        return None
+    for line in txt.splitlines():
+        if line.startswith("cpu "):
+            f = [int(x) for x in line.split()[1:]]
+            if len(f) < 5:
+                return None
+            idle = f[3] + (f[4] if len(f) > 4 else 0)  # idle + iowait
+            return sum(f) - idle, sum(f)
+    return None
+
+
+def _meminfo() -> dict:
+    txt = _read("/proc/meminfo") or ""
+    out = {}
+    for line in txt.splitlines():
+        k, _, rest = line.partition(":")
+        if k in ("MemTotal", "MemAvailable"):
+            with contextlib.suppress(IndexError, ValueError):
+                out[k] = int(rest.split()[0])  # kB
+    return out
+
+
+def _interesting_pids() -> list[int]:
+    pids = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return pids
+    for e in entries:
+        if not e.isdigit():
+            continue
+        cmd = _read(f"/proc/{e}/cmdline")
+        if cmd and any(p in cmd for p in _PROC_PATTERNS):
+            pids.append(int(e))
+    return pids[:24]  # bounded: a storm of short-lived children must not blow up a row
+
+
+def _proc_sample(pid: int) -> dict | None:
+    """Per-process CPU, RSS, context switches and open-fd count."""
+    status = _read(f"/proc/{pid}/status")
+    stat = _read(f"/proc/{pid}/stat")
+    if not status or not stat:
+        return None
+    d: dict = {"pid": pid}
+    for line in status.splitlines():
+        k, _, rest = line.partition(":")
+        rest = rest.strip()
+        if k == "Name":
+            d["name"] = rest
+        elif k == "VmRSS":
+            d["rss_kb"] = int(rest.split()[0]) if rest.split() else None
+        elif k == "Threads":
+            d["threads"] = int(rest)
+        elif k == "voluntary_ctxt_switches":
+            d["ctx_vol"] = int(rest)
+        elif k == "nonvoluntary_ctxt_switches":
+            # THE lock-convoy signal: the scheduler took the CPU away rather than the
+            # thread yielding it. A rising rate here with flat throughput is contention.
+            d["ctx_invol"] = int(rest)
+    with contextlib.suppress(IndexError, ValueError):
+        # utime+stime, fields 14/15 after the (possibly space-containing) comm field.
+        tail = stat[stat.rfind(")") + 2 :].split()
+        d["cpu_jiffies"] = int(tail[11]) + int(tail[12])
+    try:
+        d["open_fds"] = len(os.listdir(f"/proc/{pid}/fd"))
+    except OSError:
+        # Reading another user's fd dir is denied; absence is not zero.
+        d["open_fds"] = None
+    return d
+
+
+def _fd_limit() -> int | None:
+    """Soft RLIMIT_NOFILE -- the ceiling an accept loop actually hits."""
+    try:
+        import resource
+
+        return resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+    except (ImportError, OSError, ValueError):
+        return None
+
+
+def _established_connections() -> int | None:
+    """Count of established TCP connections, from ``/proc/net/tcp``.
+
+    State 01 is ESTABLISHED in the kernel's hex encoding. Counted rather than listed:
+    the number is the signal, and the peer list would be unbounded.
+    """
+    total = 0
+    seen = False
+    for p in ("/proc/net/tcp", "/proc/net/tcp6"):
+        txt = _read(p)
+        if txt is None:
+            continue
+        seen = True
+        for line in txt.splitlines()[1:]:
+            parts = line.split()
+            if len(parts) > 3 and parts[3] == "01":
+                total += 1
+    return total if seen else None
+
+
+class HostSampler:
+    """Samples ``/proc`` into a JSONL file until stopped."""
+
+    def __init__(self, log_dir: Path, interval_seconds: float = 2.0, output_name: str = "host_samples.jsonl") -> None:
+        self.output_path = Path(log_dir) / output_name
+        # Floor of 1 s: below that the sampler's own /proc walk starts showing up in the
+        # CPU figure it is trying to measure.
+        self.interval_seconds = max(1.0, float(interval_seconds))
+        self._thread: threading.Thread | None = None
+        self._own_stop = threading.Event()
+        self.samples = 0
+
+    def start(self, stop_event: threading.Event) -> None:
+        self._thread = threading.Thread(target=self._loop, args=(stop_event,), name="HostSampler", daemon=True)
+        self._thread.start()
+        logger.info(
+            "Host sampler started: /proc every %.1fs -> %s (fd limit %s)",
+            self.interval_seconds,
+            self.output_path,
+            _fd_limit(),
+        )
+
+    def stop(self, timeout: float = 10.0) -> None:
+        self._own_stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+        logger.info("Host sampler stopped: %d samples -> %s", self.samples, self.output_path)
+
+    def _loop(self, stop_event: threading.Event) -> None:
+        fd_limit = _fd_limit()
+        try:
+            with open(self.output_path, "a") as out:
+                while not stop_event.is_set() and not self._own_stop.is_set():
+                    try:
+                        cpu = _cpu_totals()
+                        row = {
+                            "t": time.time(),
+                            "host": os.uname().nodename,
+                            "cpu_busy_jiffies": cpu[0] if cpu else None,
+                            "cpu_total_jiffies": cpu[1] if cpu else None,
+                            "loadavg": (_read("/proc/loadavg") or "").split()[:3],
+                            "mem": _meminfo(),
+                            "fd_limit": fd_limit,
+                            "established_conns": _established_connections(),
+                            "procs": [s for s in (_proc_sample(p) for p in _interesting_pids()) if s],
+                        }
+                        out.write(json.dumps(row) + "\n")
+                        out.flush()
+                        self.samples += 1
+                    except Exception as exc:  # noqa: BLE001 - best effort
+                        logger.debug("host sample failed: %s", exc)
+                    stop_event.wait(self.interval_seconds) or self._own_stop.wait(0)
+        except OSError as exc:
+            logger.warning("Host sampler could not write %s: %s", self.output_path, exc)
+
+
+def try_start_host_sampler(log_dir: Path, observability, stop_event: threading.Event) -> HostSampler | None:
+    """Start the sampler if ``observability`` opts in, else return ``None``.
+
+    Single entry point for :class:`BenchmarkStageMixin`, matching
+    :func:`srtctl.analysis.metrics_scraper.try_start_raw_scraper`. All failures are
+    logged and swallowed -- host telemetry never blocks a benchmark.
+
+    Gated on the same ``scraper_enabled`` knob rather than a new one: it answers the
+    same question (is this run capturing observability?) and a second switch would let a
+    run be half-instrumented in a way nobody intends.
+    """
+    if getattr(observability, "scraper_enabled", False) is not True:
+        return None
+    try:
+        s = HostSampler(log_dir)
+        s.start(stop_event)
+        return s
+    except Exception as exc:  # noqa: BLE001 - best effort
+        logger.warning("Host sampler failed to start (continuing without it): %s", exc)
+        return None

--- a/src/srtctl/analysis/perf_dashboard.py
+++ b/src/srtctl/analysis/perf_dashboard.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Post-run bridge: a finished run's log dir -> component perf dashboard.
+
+Closes the loop that ``observability.enabled`` opens. That knob makes a run *emit*
+every signal the offline tooling wants -- ``raw_prometheus.jsonl``, ``SPAN_CLOSED``
+lines on the worker/frontend logs, the frontend's own request-trace records -- but
+nothing consumed them, so reading a run still meant hand-driving two scripts from a
+checkout. This module runs them at the end of the job instead, so one submission
+produces the page.
+
+It drives the two vendored layers as SUBPROCESSES:
+
+    L2  python3 -m src.ingest.ingest                 log dir -> bundle
+    L3  python3 -m src.visualization.build_dynamo_bench_dash   bundle -> HTML + JSON
+
+Subprocess rather than import, for three reasons: the renderer is a script with
+module-level argparse and no importable entry point; the vendored tree is
+deliberately excluded from lint/typecheck and is not part of the ``srtctl`` wheel;
+and a crash in third-party rendering code must not be able to take down the job's
+post-processing.
+
+Best-effort by construction, matching ``srtctl.analysis.metrics_scraper``: every
+failure path is logged and swallowed. Visualisation is never a hard dependency of a
+benchmark that has already produced its results.
+
+Outputs, all under the run's log dir:
+
+    perf_dashboard.html        self-contained page (D3 inlined)
+    perf_dashboard.json        the page's DATA payload, for diffing/CI/no-browser reads
+    perf_dashboard_bundle/     the intermediate schemas, kept deliberately (see below)
+
+The bundle is kept rather than cleaned up because it is the reproducible middle of
+the pipeline: re-rendering from it is seconds, whereas re-deriving it means another
+pass over multi-GB logs -- and on a run whose logs have since been deleted, it is the
+only surviving form of the data.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import SrtConfig
+
+logger = logging.getLogger(__name__)
+
+# Ingest walks every worker log to pre-grep SPAN_CLOSED lines; on a multi-hour run
+# those are tens of GB. The pre-grep is parallel and grep-backed, but give it room.
+INGEST_TIMEOUT_SEC = 1800
+# Rendering is pure Python over the bundle -- fast, but a very long run can carry
+# millions of client records.
+RENDER_TIMEOUT_SEC = 900
+
+BUNDLE_DIRNAME = "perf_dashboard_bundle"
+HTML_FILENAME = "perf_dashboard.html"
+JSON_FILENAME = "perf_dashboard.json"
+
+
+def find_repo_root() -> Path | None:
+    """Locate the checkout holding the vendored ``src/ingest`` + ``src/visualization``.
+
+    Those live at the repo root and are NOT installed into the ``srtctl`` wheel
+    (``pyproject.toml`` packages only ``src/srtctl``), so they have to be found on
+    disk. Two strategies, in order:
+
+    1. Relative to the installed ``srtctl`` package. Under the editable install that
+       compute nodes use, ``srtctl/__init__.py`` is at ``<root>/src/srtctl/``, so the
+       root is two parents up. This is the common case and needs no configuration.
+    2. ``srtctl_root`` from ``srtslurm.yaml`` -- the same setting
+       ``PostProcessStageMixin._export_node_metrics_csv`` uses to reach ``analysis/``.
+
+    Both are validated by checking the vendored entry point actually exists, so a
+    non-editable install falling back to a site-packages path is rejected rather than
+    producing a confusing ``No module named src.ingest`` later.
+    """
+    candidates: list[Path] = []
+
+    try:
+        import srtctl
+
+        pkg = Path(srtctl.__file__).resolve()
+        candidates.append(pkg.parents[2])  # <root>/src/srtctl/__init__.py -> <root>
+    except Exception as e:  # noqa: BLE001 - discovery is best-effort
+        logger.debug("perf dashboard: package-relative root discovery failed: %s", e)
+
+    try:
+        from srtctl.core.config import get_srtslurm_setting
+
+        configured = get_srtslurm_setting("srtctl_root")
+        if configured:
+            candidates.append(Path(configured))
+    except Exception as e:  # noqa: BLE001
+        logger.debug("perf dashboard: srtslurm.yaml root discovery failed: %s", e)
+
+    for root in candidates:
+        try:
+            if (root / "src" / "ingest" / "ingest.py").is_file() and (
+                root / "src" / "visualization" / "build_dynamo_bench_dash.py"
+            ).is_file():
+                return root.resolve()
+        except OSError:
+            continue
+
+    logger.warning(
+        "perf dashboard: could not locate the vendored src/ingest + src/visualization tree "
+        "(tried: %s); skipping dashboard build",
+        ", ".join(str(c) for c in candidates) or "no candidates",
+    )
+    return None
+
+
+def _worker_specs(config: SrtConfig) -> list[str]:
+    """``--worker ROLE=PARALLELISM:RANK:COUNT`` args describing the run's topology.
+
+    This is what gives the page its GPU count: the renderer sums ``rank x worker_count``
+    for the tok/s/GPU denominator and otherwise falls back to 1 GPU with a warning,
+    which would silently inflate every per-GPU number by the size of the job.
+
+    ``rank`` is GPUs-per-worker. ``ResourceConfig`` exposes that as the computed
+    ``gpus_per_*`` properties, so explicit recipe overrides are honoured for free.
+    Parallelism is reported as a label only; it is not used in any arithmetic, so an
+    imprecise tag cannot corrupt a number.
+    """
+    res = config.resources
+    specs: list[str] = []
+    for role, count_attr, gpus_attr, label in (
+        ("prefill", "num_prefill", "gpus_per_prefill", "dep"),
+        ("decode", "num_decode", "gpus_per_decode", "tep"),
+        ("agg", "num_agg", "gpus_per_agg", "tep"),
+    ):
+        count = getattr(res, count_attr, 0) or 0
+        gpus = getattr(res, gpus_attr, 0) or 0
+        if count and gpus:
+            specs.append(f"{role}={label}:{gpus}:{count}")
+    return specs
+
+
+def _run(argv: list[str], cwd: Path, timeout: int, stage: str) -> bool:
+    """Run one pipeline stage, logging its output. Returns success."""
+    logger.info("perf dashboard [%s]: %s", stage, " ".join(argv))
+    try:
+        result = subprocess.run(argv, cwd=str(cwd), capture_output=True, text=True, timeout=timeout, check=False)
+    except subprocess.TimeoutExpired:
+        logger.warning("perf dashboard [%s]: timed out after %ds", stage, timeout)
+        return False
+    except Exception as e:  # noqa: BLE001
+        logger.warning("perf dashboard [%s]: failed to launch: %s", stage, e)
+        return False
+
+    # Both stages log progress to stderr at INFO; surface it so the sweep log records
+    # what was found (source availability, scrape counts, resolved engine ceilings).
+    for line in (result.stderr or "").rstrip().splitlines():
+        logger.info("perf dashboard [%s] %s", stage, line)
+    if result.returncode != 0:
+        for line in (result.stdout or "").rstrip().splitlines()[-20:]:
+            logger.warning("perf dashboard [%s] %s", stage, line)
+        logger.warning("perf dashboard [%s]: exit %d", stage, result.returncode)
+        return False
+    return True
+
+
+def build(config: SrtConfig, runtime: RuntimeContext) -> Path | None:
+    """Build the component dashboard for a finished run. Returns the HTML path or None.
+
+    Never raises: a visualisation failure must not change the outcome of a benchmark
+    that has already produced its results.
+    """
+    root = find_repo_root()
+    if root is None:
+        return None
+
+    log_dir = Path(runtime.log_dir)
+    bundle = log_dir / BUNDLE_DIRNAME
+    html = log_dir / HTML_FILENAME
+
+    ingest_argv = [
+        sys.executable,
+        "-m",
+        "src.ingest.ingest",
+        "--run-dir",
+        str(log_dir),
+        "--out",
+        str(bundle),
+        "--name",
+        f"{runtime.job_id} {config.name}".strip(),
+    ]
+    for spec in _worker_specs(config):
+        ingest_argv += ["--worker", spec]
+    if not _run(ingest_argv, root, INGEST_TIMEOUT_SEC, "ingest"):
+        return None
+
+    render_argv = [
+        sys.executable,
+        "-m",
+        "src.visualization.build_dynamo_bench_dash",
+        str(bundle),
+        str(html),
+        "--dump-json",
+        str(log_dir / JSON_FILENAME),
+    ]
+    # The Log-analysis tab needs the frontend log, which the bundle does not contain
+    # (it stays in the log dir -- it is the raw multi-GB artifact, not an intermediate
+    # schema). Pass the first one found; correspondence with the bundle is enforced by
+    # the renderer on the x_request_id pivot, so a wrong file fails loudly.
+    frontend_logs = sorted(log_dir.glob("*_frontend_*.out"))
+    if frontend_logs:
+        render_argv += ["--frontend-log", str(frontend_logs[0])]
+    else:
+        logger.info("perf dashboard: no *_frontend_*.out in %s; Log-analysis tab omitted", log_dir)
+
+    if not _run(render_argv, root, RENDER_TIMEOUT_SEC, "render"):
+        return None
+
+    if not html.is_file():
+        logger.warning("perf dashboard: render reported success but %s is missing", html)
+        return None
+    logger.info("perf dashboard: %s", html)
+    return html
+
+
+def try_build(config: SrtConfig, runtime: RuntimeContext) -> Path | None:
+    """Build the dashboard if the run opted in, else return None.
+
+    Single entry point for :class:`PostProcessStageMixin`, so the mixin stays free of
+    analysis-package internals -- the same contract as
+    :func:`srtctl.analysis.metrics_scraper.try_start_raw_scraper`.
+
+    Gated on ``observability.build_dashboard``, which defaults to following
+    ``observability.enabled``: a run instrumented for offline analysis should produce
+    the artifact that analysis is done with, without a second knob to remember.
+    """
+    try:
+        observability = getattr(config, "observability", None)
+        if observability is None or not getattr(observability, "dashboard_enabled", False):
+            return None
+        return build(config, runtime)
+    except Exception as e:  # noqa: BLE001 - visualisation is never fatal
+        logger.warning("perf dashboard: skipped after error: %s", e)
+        return None

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -357,6 +357,7 @@ class BenchmarkStageMixin:
         observability = getattr(self.config, "observability", None)
         raw_scraper = None
         if getattr(observability, "scraper_enabled", False) is True:
+            self._warn_on_double_metric_polling()
             raw_scraper = try_start_raw_scraper(
                 self.runtime.log_dir,
                 self._analytics_scrape_targets(),
@@ -590,6 +591,44 @@ class BenchmarkStageMixin:
         # runners retain their historical sorted physical-process list.
         urls = list(dict.fromkeys(urls)) if logical_workers_only else sorted(set(urls))
         return {"AIPERF_SERVER_METRICS_URLS": ",".join(urls)}
+
+    def _warn_on_double_metric_polling(self) -> None:
+        """Warn when the RAW scraper and an AIPerf client will poll /metrics together.
+
+        ``observability.scrape_metrics`` starts the in-job RAW scraper, and an
+        AIPerf-driven benchmark separately receives ``AIPERF_SERVER_METRICS_URLS`` and
+        polls the same endpoints on its own cadence. Nothing stops both, and the two
+        are wired independently, so a run can be double-polling every worker without
+        anything saying so.
+
+        That is not hypothetical: a benchmark submission was traced to exactly this
+        shape -- one poller from srt-slurm and a second from the harness's own
+        bench.sh -- and the extra load made the result irreproducible.
+
+        Warn rather than resolve it. Both captures are legitimate (the RAW stream
+        feeds offline analysis, AIPerf's feeds its own report), and silently
+        suppressing either would change what a submission measures. The operator
+        picks; this makes sure the choice is a choice.
+        """
+        from srtctl.benchmarks.base import AIPerfBenchmarkRunner, get_runner
+
+        try:
+            runner = get_runner(self.config.benchmark.type)
+        except Exception:  # noqa: BLE001 - an unknown type is not this check's problem
+            return
+        is_aiperf = isinstance(runner, AIPerfBenchmarkRunner) or self.config.benchmark.type == "custom"
+        if not is_aiperf:
+            return
+        logger.warning(
+            "Double /metrics polling: the observability RAW scraper AND the %s client "
+            "will both poll the worker endpoints for the duration of this run. Both "
+            "captures are valid, but the extra scrape load perturbs the measurement and "
+            "has previously made a submission irreproducible. Set "
+            "observability.scrape_metrics: false to keep only the client's polling, or "
+            "drop AIPERF_SERVER_METRICS_URLS from the benchmark to keep only the RAW "
+            "capture (which is what the perf dashboard reads).",
+            self.config.benchmark.type,
+        )
 
     def _analytics_scrape_targets(self) -> list:
         """Frontend + every worker leader, as RAW-scrape targets.

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -356,6 +356,7 @@ class BenchmarkStageMixin:
         # switch the scraper on for those callers.
         observability = getattr(self.config, "observability", None)
         raw_scraper = None
+        host_sampler = None
         if getattr(observability, "scraper_enabled", False) is True:
             self._warn_on_double_metric_polling()
             raw_scraper = try_start_raw_scraper(
@@ -364,6 +365,13 @@ class BenchmarkStageMixin:
                 observability,
                 stop_event,
             )
+            # Host/process telemetry alongside the endpoint scrape. The Prometheus
+            # families describe what Dynamo publishes; they say nothing about the
+            # machine underneath, where host CPU saturation, lock convoys and fd
+            # exhaustion live. Same opt-in, same best-effort contract.
+            from srtctl.analysis.host_sampler import try_start_host_sampler
+
+            host_sampler = try_start_host_sampler(self.runtime.log_dir, observability, stop_event)
 
         bench_node = self._benchmark_node()
         proc = start_srun_process(
@@ -409,6 +417,8 @@ class BenchmarkStageMixin:
                 snapshotter.stop()
             if raw_scraper is not None:
                 raw_scraper.stop()
+            if host_sampler is not None:
+                host_sampler.stop()
 
     def _get_benchmark_profiling_env(
         self,

--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -206,6 +206,11 @@ class PostProcessStageMixin:
         # Keep the prepared bundle inside logs/ so the existing S3 sync below
         # transfers it with the raw benchmark artifacts.
         self._normalize_ruter()
+        # Build the component perf dashboard (optional). Deliberately ordered BEFORE
+        # the S3 sync below: the sync ships the whole log dir, so building here is what
+        # gets perf_dashboard.{html,json} and its bundle off the cluster. Building
+        # after would leave them behind on a node whose /lustre scratch is transient.
+        self._build_perf_dashboard()
 
         # Run srtlog + S3 upload in single container (if S3 configured)
         _parquet_path, s3_url = self._run_postprocess_container()
@@ -245,6 +250,27 @@ class PostProcessStageMixin:
                 logger.warning("ruter: %s", warning)
         except Exception as error:  # noqa: BLE001
             logger.warning("ruter normalization failed: %s", error)
+
+    def _build_perf_dashboard(self) -> None:
+        """Render the component perf dashboard from this run's own capture.
+
+        Closes the loop `observability.enabled` opens: that knob makes the run emit
+        raw_prometheus.jsonl, SPAN_CLOSED lines and the frontend request-trace, and
+        this turns them into `<log_dir>/perf_dashboard.{html,json}` plus the
+        intermediate bundle — so one submission yields the page, with no second
+        hand-driven step from a checkout.
+
+        Gated on `observability.build_dashboard`, which follows `observability.enabled`
+        by default. Best-effort: `try_build` swallows its own failures, and the extra
+        guard here means even an import error cannot fail a benchmark that has already
+        produced results.
+        """
+        try:
+            from srtctl.analysis.perf_dashboard import try_build
+
+            try_build(self.config, self.runtime)
+        except Exception as e:  # noqa: BLE001 - visualisation is never fatal
+            logger.warning("Perf dashboard build skipped: %s", e)
 
     def _generate_rollup(self) -> None:
         """Run benchmark-specific rollup script to generate benchmark-rollup.json.

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -248,7 +248,35 @@ def show_config_details(config: SrtConfig) -> None:
         for host_template, container_template in config.container_mounts.items():
             mounts_table.add_row("recipe", str(host_template), str(container_template))
 
+    # InferenceX workspace, mounted by RuntimeContext.from_config when
+    # INFMAX_WORKSPACE is set in the submitting environment (core/runtime.py).
+    #
+    # It comes from the environment rather than the recipe, which is exactly why it has
+    # to be shown: nothing in the config file mentions it, so a reader comparing recipe
+    # to dry-run sees a complete picture and is wrong. Recipes whose benchmark command
+    # lives under /infmax-workspace (the agentic suites) fail with exit 127 twelve
+    # minutes in when it is missing, and the dry-run gave no hint either way -- the
+    # table listed every other mount, which made its absence read as "no such mount
+    # exists" rather than "not set".
+    infmax_ws = os.environ.get("INFMAX_WORKSPACE")
+    if infmax_ws:
+        mounts_table.add_row("INFMAX_WORKSPACE", infmax_ws, "/infmax-workspace")
+    elif "/infmax-workspace" in str(config.benchmark.command or ""):
+        mounts_table.add_row(
+            "[red]MISSING[/]",
+            "[red]INFMAX_WORKSPACE is not set in this environment[/]",
+            "[red]/infmax-workspace[/]",
+        )
+
     console.print(Panel(mounts_table, border_style="green"))
+
+    if not infmax_ws and "/infmax-workspace" in str(config.benchmark.command or ""):
+        console.print(
+            "[red bold]ERROR:[/] this recipe runs its benchmark from /infmax-workspace, "
+            "but INFMAX_WORKSPACE is not set, so that mount will be absent and the "
+            "benchmark command will fail with exit 127 after the workers have loaded. "
+            "Export INFMAX_WORKSPACE=<path to the InferenceX checkout> before submitting."
+        )
 
     # --- SLURM heterogeneous job structure ---
     het_components = config.resources.het_components(

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1096,6 +1096,11 @@ class ObservabilityConfig:
             back-to-back rather than queueing (see the drift-free pacing in
             ``RawMetricsScraper``).
         scrape_output: Filename (under the run's log dir) for the RAW capture.
+        build_dashboard: Build the component perf dashboard during post-processing
+            (``<log_dir>/perf_dashboard.html`` plus a ``.json`` payload and the
+            intermediate bundle). Defaults to the value of ``enabled`` -- a run
+            instrumented for offline analysis should produce the artifact that
+            analysis is done with. Set False to capture without rendering.
         tachometer: Optional native Tachometer capture configuration. It runs
             alongside RAW capture when both are enabled.
     """
@@ -1107,6 +1112,7 @@ class ObservabilityConfig:
     scrape_metrics: bool | None = None
     scrape_interval_seconds: float = 1.0
     scrape_output: str = "raw_prometheus.jsonl"
+    build_dashboard: bool | None = None
     tachometer: TachometerConfig = field(default_factory=TachometerConfig)
 
     Schema: ClassVar[type[Schema]] = Schema
@@ -1115,6 +1121,11 @@ class ObservabilityConfig:
     def scraper_enabled(self) -> bool:
         """Whether the in-job RAW Prometheus scraper should run."""
         return self.enabled if self.scrape_metrics is None else self.scrape_metrics
+
+    @property
+    def dashboard_enabled(self) -> bool:
+        """Whether to build the component perf dashboard during post-processing."""
+        return self.enabled if self.build_dashboard is None else self.build_dashboard
 
 
 @dataclass(frozen=True)

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -269,9 +269,26 @@ for r in rows: r["ts"]=relt(r["ts_ns"]);
 def gsingle(m,name):
     a=m.get(name)
     return a[0]["value"] if a else None
+def _entries(m, name):
+    """Entries for a metric family in one scrape, tolerating the `_total` suffix.
+
+    Prometheus counters conventionally end in `_total`, and the ingest layer keeps the
+    scraped name verbatim -- so a lookup written without the suffix silently finds
+    nothing and the caller reads a hard zero. That is not hypothetical: five families
+    here (`dynamo_frontend_requests` and all four `dynamo_frontend_tokenizer_cache_*`)
+    were being read without it, which pinned the tokenizer-cache KPI to 0.0% on a run
+    whose real hit rate was ~99%.
+
+    Resolving centrally rather than fixing each call site, because the failure is
+    invisible at the call site: a missing family and an all-zero family look identical
+    downstream.
+    """
+    return m.get(name) or m.get(name + "_total")
+
+
 def ggroup(m,name,by="dynamo_component"):
     out=defaultdict(list)
-    for e in m.get(name,[]):
+    for e in (_entries(m,name) or []):
         out[e.get("labels",{}).get(by)].append(e["value"])
     return out
 def hsc(m,name):
@@ -315,7 +332,7 @@ def peak_with(m_name,key="count"):
     """
     best={}; bv=-1.0
     for _,m in scr:
-        ents=m.get(m_name)
+        ents=_entries(m,m_name)
         if not ents: continue
         tot=0.0
         for e in ents:
@@ -356,7 +373,7 @@ def hist_mean_series(name,by=None,group=None,scale_ms=1000.0):
 
 def _csum(m,name,label=None,val=None):
     """Total of a counter/gauge family in one scrape, or None if absent here."""
-    ents=m.get(name)
+    ents=_entries(m,name)
     if not ents: return None
     tot=0.0
     for e in ents:
@@ -423,7 +440,10 @@ fe = {
 }
 # Not plotted on this tab any more, but still feeds the shared KPI strip.
 def cval(name):
-    a=peak_with(name,key="value").get(name); return a[0]["value"] if a else 0
+    # Resolve through _entries on BOTH lookups: peak_with finds the right scrape, but
+    # indexing the returned scrape by the un-suffixed name misses it a second time.
+    a=_entries(peak_with(name,key="value"), name)
+    return a[0]["value"] if a else 0
 tk_h=cval("dynamo_frontend_tokenizer_cache_hits"); tk_m=cval("dynamo_frontend_tokenizer_cache_misses")
 fe["tok_cache_hit_pct"]=round(100*tk_h/max(1,tk_h+tk_m),1)
 

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -117,8 +117,20 @@ def _have(*parts):
 HAS_CLIENT = _have("profile_export.jsonl")
 HAS_TRACES = bool(SRC) and bool(glob.glob(os.path.join(SRC, "tempo_traces", "*.json")))
 HAS_SM = _have("server_metrics_export.jsonl")
+HAS_RT = _have("request_trace.jsonl")
 _log.info(f"sources: client={HAS_CLIENT} traces={HAS_TRACES} server_metrics={HAS_SM} "
-          f"frontend_log={bool(_args.frontend_log)}")
+          f"request_trace={HAS_RT} frontend_log={bool(_args.frontend_log)}")
+
+# Loaded here, before any aggregate is computed, because the run-level waterfall needs
+# it: KV transfer is a phase no span reports and no Prometheus series samples, so
+# without this the waterfall has a silent hole between prefill and decode compute --
+# on the reference runs that hole is the median 79% of the decode span.
+rt_all=[]
+if HAS_RT:
+    for _l in open(os.path.join(SRC,"request_trace.jsonl")):
+        _l=_l.strip()
+        if _l: rt_all.append(json.loads(_l))
+RT_BY_XID={r["x_request_id"]:r for r in rt_all if r.get("x_request_id")}
 
 
 def _load_meta(bundle_dir):
@@ -443,7 +455,13 @@ en["true_hit_kpi"]=round(pct(_hitvals,50),1) if _hitvals else None
 def col(k): return [r[k] for r in rows]
 def band(sortkey,p):
     v=sorted(rows,key=lambda r:r[sortkey]); lo=max(0,int(len(v)*(p-5)/100)); hi=max(lo+1,int(len(v)*min(100,p+5)/100)); sub=v[lo:hi]
+    # kvt comes from the request trace, not from spans: the decode `handle_payload`
+    # span starts AFTER the KV cache has transferred, so a spans-only waterfall places
+    # prefill compute directly against decode compute and silently omits the wait
+    # between them. 0.0 when the run is aggregated (no transfer) or the trace is absent.
+    _kvt=[(RT_BY_XID.get(r["xid"],{}) or {}).get("kv_transfer_ms") or 0 for r in sub]
     return {"adm":pct([r["adm"] for r in sub],50),"pf":pct([r["pf"] for r in sub],50),
+            "kvt":pct(_kvt,50),
             "de":pct([r["de"] for r in sub],50),"route":pct([r["rroute"]+r["rhash"]+r["rfind"] for r in sub],50),
             "ttft":pct([r["ttft"] for r in sub],50),"e2e":pct([r["e2e"] for r in sub],50)}
 waterfall={p:band("e2e",p) for p in (50,90,95,99)}
@@ -814,24 +832,19 @@ RT_ATTRS = ["isl","osl","cached_tokens","kv_hit_rate","queue_depth","finish_reas
             "turn_index","prefix_reuse_ratio","client_ttft_ms","clean_itl_ms",
             "avg_itl_ms","total_ms"]
 
-rt_rows=[]
-_rt_path=os.path.join(SRC,"request_trace.jsonl") if SRC else ""
-if _rt_path and os.path.exists(_rt_path):
-    for _l in open(_rt_path):
-        _l=_l.strip()
-        if _l: rt_rows.append(json.loads(_l))
-    # Same warmup exclusion as every other source, via the x_request_id pivot. `client`
-    # was already phase-filtered at load, so intersecting transfers that decision here.
-    # Only applied when the two artifacts are the same run -- a tiny overlap means they
-    # are not, and silently emptying the view is worse than leaving it whole.
-    if client:
-        _keep=[r for r in rt_rows if r.get("x_request_id") in client]
-        if len(_keep) >= .10*max(1,len(rt_rows)):
-            _log.info(f"request trace: phase-filtered via x_request_id ({len(_keep)} of {len(rt_rows)} kept)")
-            rt_rows=_keep
-        else:
-            _log.warning(f"request trace: only {len(_keep)}/{len(rt_rows)} rows match the client "
-                         f"export; leaving unfiltered (different run?)")
+rt_rows=list(rt_all)   # loaded at the top; see the HAS_RT block
+# Same warmup exclusion as every other source, via the x_request_id pivot. `client`
+# was already phase-filtered at load, so intersecting transfers that decision here.
+# Only applied when the two artifacts are the same run -- a tiny overlap means they
+# are not, and silently emptying the view is worse than leaving it whole.
+if rt_rows and client:
+    _keep=[r for r in rt_rows if r.get("x_request_id") in client]
+    if len(_keep) >= .10*max(1,len(rt_rows)):
+        _log.info(f"request trace: phase-filtered via x_request_id ({len(_keep)} of {len(rt_rows)} kept)")
+        rt_rows=_keep
+    else:
+        _log.warning(f"request trace: only {len(_keep)}/{len(rt_rows)} rows match the client "
+                     f"export; leaving unfiltered (different run?)")
 
 rt_requests={}; rt_sessions=[]; rt_const={}
 if rt_rows:

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -40,6 +40,12 @@ from collections import Counter, defaultdict, deque
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _VENDORED_D3 = os.path.join(_HERE, "d3.v7.min.js")
 
+# Repo root, so `src.visualization` / `src.ingest` resolve whether this is run with
+# -m or as a bare script path.
+import sys as _sys  # noqa: E402
+_sys.path.insert(0, os.path.dirname(os.path.dirname(_HERE)))
+from src.visualization.panels import evaluate as _evaluate_panels  # noqa: E402
+
 _ap = argparse.ArgumentParser(description="Render the Dynamo benchmark component dashboard from an ingest bundle.")
 _ap.add_argument("bundle_dir", nargs="?", help="ingest bundle dir (profile_export.jsonl, tempo_traces/, server_metrics_export.jsonl). Optional: omit for a log-only build.")
 _ap.add_argument("out_html", nargs="?", help="output HTML path")
@@ -878,8 +884,25 @@ if rt_rows:
               f"{_pin}/{len(rt_sessions)} pinned to a single decode worker, "
               f"{len(rt_const)} constant field(s): {sorted(rt_const)}")
 
+# ============ 6. declarative time-series panels ==============================
+# One generic evaluator over the panel table in panels.py. Every panel is a data row;
+# none of them has bespoke code, so none can drift into being run-specific.
+panels=_evaluate_panels(scr)
+if panels:
+    _by_tab={}
+    for _pid,_p in panels.items(): _by_tab.setdefault(_p["tab"],[]).append(_pid)
+    _log.info("panels: "+", ".join(f"{t}={len(v)}" for t,v in sorted(_by_tab.items()))
+              +f" ({sum(len(p['series']) for p in panels.values())} series total)")
+    _flat=[pid for pid,p in panels.items()
+           if all(len({round(v,9) for _,v in s})==1 for s in p["series"].values())]
+    if _flat:
+        # Named rather than dropped: a flat queue-depth panel says the run never
+        # queued, which is one of the more useful things a run can tell you.
+        _log.info(f"panels reading a single constant value: {sorted(_flat)}")
+
 DATA={
  "logdrill":logdrill,
+ "panels":panels,
  "rt":{"requests":rt_requests,"sessions":rt_sessions,"bands":RT_BANDS,"const":rt_const},
  "iter":iter_series,
  "iter_cfg":{"pf_batch":CFG_PF_BATCH,"pf_tok":CFG_PF_TOK,"de_batch":CFG_DE_BATCH,"de_tok":CFG_DE_TOK},

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -101,6 +101,54 @@ def _cfg_max_batch(mode):
         except Exception:
             pass
     return None, None
+def _provenance():
+    """What actually ran: framework versions, GPU, and per-worker agreement.
+
+    Container tags routinely disagree with the wheels they bundle -- an image tagged
+    1.1.0-rc3 shipping tensorrt_llm 1.3.0rc11 is an observed case. The fingerprints
+    record the versions found INSIDE the running worker, which is the only trustworthy
+    answer, and they are per-worker, so a deployment whose prefill and decode landed on
+    different builds is visible here and nowhere else. That mismatch is silent in every
+    other panel: both halves run, and the numbers simply mean something different than
+    the reader assumes.
+
+    Returns None when no fingerprints reached the bundle, rather than a partial record
+    that would read as agreement.
+    """
+    if not SRC:
+        return None
+    fps = sorted(glob.glob(os.path.join(SRC, "fingerprint_*.json")))
+    if not fps:
+        return None
+    per_worker, frameworks = {}, {}
+    for path in fps:
+        try:
+            with open(path) as fh:
+                d = json.load(fh)
+        except Exception:
+            continue
+        worker = os.path.basename(path)[len("fingerprint_"):-len(".json")]
+        fw = d.get("frameworks") or {}
+        per_worker[worker] = {
+            "frameworks": fw,
+            "cuda": d.get("cuda_version"), "nccl": d.get("nccl_version"),
+            "python": d.get("python_version"), "gpu": d.get("gpu"),
+            "hostname": d.get("hostname"),
+        }
+        for k, v in fw.items():
+            frameworks.setdefault(k, set()).add(v)
+    if not per_worker:
+        return None
+    # A framework name mapping to more than one version means the workers are not
+    # running the same build. Reported as a first-class disagreement rather than
+    # collapsed to "the version", which would silently pick one arbitrarily.
+    disagree = {k: sorted(v) for k, v in frameworks.items() if len(v) > 1}
+    return {"workers": per_worker,
+            "frameworks": {k: sorted(v)[0] for k, v in frameworks.items()},
+            "framework_disagreement": disagree or None,
+            "n_workers": len(per_worker)}
+
+
 def _client_summary():
     """AIPerf's run-level summary: the workload's cache ceiling, and run validity.
 
@@ -166,6 +214,16 @@ def _cfg_tokens_per_block():
                 pass
     return None
 CLIENT_SUMMARY = _client_summary()
+PROVENANCE = _provenance()
+if PROVENANCE:
+    _log.info(f"provenance: {PROVENANCE['n_workers']} worker fingerprint(s), frameworks="
+              f"{PROVENANCE['frameworks']}")
+    if PROVENANCE["framework_disagreement"]:
+        _log.warning(f"workers are NOT running the same build: "
+                     f"{PROVENANCE['framework_disagreement']}")
+else:
+    _log.info("provenance: no fingerprint_*.json in the bundle; framework versions "
+              "unknown and two bundles cannot be compared for what differed")
 if CLIENT_SUMMARY:
     _log.info(f"client summary: workload prefix-cache ceiling "
               f"{CLIENT_SUMMARY['theoretical_prefix_cache_hit']}%, effective concurrency "
@@ -1341,7 +1399,8 @@ DATA={
    "phase_filter":{"applied":not _args.include_warmup,
                    "kept":len(client),"dropped":_skipped_phase,
                    "phases":_phase_seen},
-   "client_summary":CLIENT_SUMMARY},
+   "client_summary":CLIENT_SUMMARY,
+   "provenance":PROVENANCE},
  "kpi":{"ttft_p50":round(pct(col("ttft"),50)/1000,1),"ttft_p99":round(pct(col("ttft"),99)/1000,1),
    "adm_p50":round(pct(col("adm"),50)/1000,1),"pf_p50":round(pct(col("pf"),50)/1000,1),
    "reqs":N,"adm_share":round(pct(col("adm"),50)/max(1,pct(col("ttft"),50))*100,0),

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -220,7 +220,11 @@ for f in (glob.glob(os.path.join(SRC,"tempo_traces","*.json")) if HAS_TRACES els
         "osl":c["osl"] or 0,"adm":sched[0] if sched else 0,"pf":hp_pf[0] if hp_pf else 0,
         "de":hp_de[0] if hp_de else 0,"rhash":hashm,"rfind":findm,"rroute":routem,
         "ov":int(at(rr_pf[1],"overlap_blocks") or 0) if rr_pf else 0,
-        "wpf":at(rr_pf[1],"worker_id") if rr_pf else None})
+        "wpf":at(rr_pf[1],"worker_id") if rr_pf else None,
+        # dp_rank off the SAME span as overlap_blocks. The router's free-text selector
+        # line carries a richer cost breakdown but has no request_id on it, so it
+        # cannot be joined per request -- this span is the joinable substitute.
+        "rank":at(rr_pf[1],"dp_rank") if rr_pf else None})
     # Requests-in-flight occupancy window per worker role: min(start)..max(end) across
     # EVERY handle_payload on that component, not just the longest one (mx() above).
     # This matches gpu_occupancy.compute_requests_in_flight, which spans the envelope so
@@ -846,16 +850,42 @@ if rt_rows and client:
         _log.warning(f"request trace: only {len(_keep)}/{len(rt_rows)} rows match the client "
                      f"export; leaving unfiltered (different run?)")
 
-rt_requests={}; rt_sessions=[]; rt_const={}
+_SPAN_BY_XID={r["xid"]:r for r in rows}
+rt_requests={}; rt_sessions=[]; rt_const={}; rt_belief=None
 if rt_rows:
     _t0=min(r["received_ms"] for r in rt_rows if r.get("received_ms"))
     for r in rt_rows:
         _bands=[[k,l,r.get(k)] for k,l in RT_BANDS]
+        # Routing OUTCOME, joined from the prefill kv_router.route_request span.
+        # Deliberately labelled an outcome and not a rationale: the router's own cost
+        # comparison lives on a free-text selector line that carries no request_id, so
+        # "which worker was chosen, with how much prefix overlap" is joinable per
+        # request while "why it beat the alternatives" is not. Claiming the latter
+        # would be inventing an explanation.
+        _sp=_SPAN_BY_XID.get(r["x_request_id"]) or {}
+        _routing={"overlap_blocks":_sp.get("ov"),"worker_id":_sp.get("wpf"),
+                  "dp_rank":_sp.get("rank"),
+                  "router_ms":round((_sp.get("rhash") or 0)+(_sp.get("rfind") or 0)
+                                    +(_sp.get("rroute") or 0),3) if _sp else None,
+                  "admission_ms":round(_sp["adm"],3) if _sp.get("adm") is not None else None}
+        # Router belief vs engine reality, per request. The router scores candidates on
+        # overlap_blocks; the engine reports what it actually reused as cached_tokens.
+        # In blocks-to-tokens terms they should be the same number, and a divergence is
+        # the signature of a router confidently routing on a prefix the engine does not
+        # have -- reported in the field as high advertised reuse on traffic with none.
+        # Computed every run rather than only when suspected, because the failure is
+        # silent: the routing still "works", it is just routing on fiction.
+        _ob=_sp.get("ov"); _ct=r.get("cached_tokens")
+        if _ob is not None and _ct is not None and BLK:
+            _pred=_ob*BLK
+            _routing["overlap_tokens"]=_pred
+            _routing["belief_error"]=0.0 if (_pred==0 and _ct==0) else round(abs(_pred-_ct)/max(1,_ct),4)
         rt_requests[r["x_request_id"]]={
             "t":round((r.get("received_ms") or _t0)-_t0,1),
             "session_id":r.get("session_id"),
             "bands":_bands,
             "attrs":{k:r.get(k) for k in RT_ATTRS},
+            "routing":_routing if _sp else None,
         }
     # A field that never varies carries no information for THIS run; report it once
     # here rather than drawing a flat line per panel, so the reader learns it was
@@ -896,6 +926,16 @@ if rt_rows:
     _log.info(f"request trace: {len(rt_requests)} requests, {len(rt_sessions)} sessions, "
               f"{_pin}/{len(rt_sessions)} pinned to a single decode worker, "
               f"{len(rt_const)} constant field(s): {sorted(rt_const)}")
+    _errs=[v["routing"]["belief_error"] for v in rt_requests.values()
+           if (v.get("routing") or {}).get("belief_error") is not None]
+    if _errs:
+        _bad=[e for e in _errs if e>0.02]
+        rt_belief={"n":len(_errs),"disagree":len(_bad),
+                   "worst":round(max(_errs),4),"threshold":0.02}
+        _log.info(f"router belief vs engine reality: {len(_errs)-len(_bad)}/{len(_errs)} agree "
+                  f"(overlap_blocks x {BLK} == cached_tokens within 2%), worst error {max(_errs):.1%}")
+    else:
+        rt_belief=None
 
 # ============ 6. declarative time-series panels ==============================
 # One generic evaluator over the panel table in panels.py. Every panel is a data row;
@@ -980,7 +1020,7 @@ if panels:
 DATA={
  "logdrill":logdrill,
  "panels":panels,
- "rt":{"requests":rt_requests,"sessions":rt_sessions,"bands":RT_BANDS,"const":rt_const},
+ "rt":{"requests":rt_requests,"sessions":rt_sessions,"bands":RT_BANDS,"const":rt_const,"belief":rt_belief},
  "iter":iter_series,
  "iter_cfg":{"pf_batch":CFG_PF_BATCH,"pf_tok":CFG_PF_TOK,"de_batch":CFG_DE_BATCH,"de_tok":CFG_DE_TOK},
  "drill":{"series":drill_series,"extrema":drill_extrema,"spans":drill_spans,

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -901,6 +901,70 @@ if rt_rows:
 # One generic evaluator over the panel table in panels.py. Every panel is a data row;
 # none of them has bespoke code, so none can drift into being run-specific.
 panels=_evaluate_panels(scr)
+
+# ---- derived panels: in-flight balance across ranks and workers -------------
+# Emitted in the SAME shape as the spec panels so the generic renderer draws them
+# with no extra code -- a different SOURCE, not a different kind of panel.
+#
+# Why this cannot come from the metrics stream: engine-side per-rank series are a
+# replicated broadcast (identical across ranks in every sweep), so splitting an
+# engine gauge by rank renders a flat family of lines and reads as "balanced" on a
+# run that was not. The request trace carries the rank that actually served each
+# request, so occupancy per rank can be reconstructed from it instead.
+#
+# Why INSTANTANEOUS rather than a whole-run total, in the reporter's own words:
+#   "Over the whole benchmark phase, I don't see a large imbalance between DP ranks.
+#    However, there is a large instantaneously imbalance."
+# A run-total request count per rank is exactly the aggregate that hides this, which
+# is why the panel is max-minus-min occupancy over time and not a bar chart.
+#
+# The spread statistic follows the documented method -- "using running-request and
+# looking at min/max between DP ranks" -- with the normalised form alongside, since
+# max-min of 4 means something different at 5 in flight than at 500.
+def _inflight_spread(rows, field, nbins=240):
+    live=[r for r in rows if r.get(field) is not None and r.get("received_ms") and r.get("total_ms")]
+    if len({r[field] for r in live})<2: return None,None
+    t0=min(r["received_ms"] for r in live); t1=max(r["received_ms"]+r["total_ms"] for r in live)
+    if t1<=t0: return None,None
+    step=(t1-t0)/nbins
+    keys=sorted({r[field] for r in live})
+    spread=[]; norm=[]
+    for i in range(nbins):
+        t=t0+i*step
+        counts={k:0 for k in keys}
+        for r in live:
+            if r["received_ms"]<=t<r["received_ms"]+r["total_ms"]: counts[r[field]]+=1
+        hi,lo=max(counts.values()),min(counts.values())
+        mean=sum(counts.values())/len(counts)
+        spread.append([round(i*step/1000,1),hi-lo])
+        # Normalised only where there is load; (hi-lo)/0 is undefined, and reporting
+        # perfect balance for an idle window would dilute the very spikes being hunted.
+        if mean>0: norm.append([round(i*step/1000,1),round((hi-lo)/mean,3)])
+    return spread,norm
+
+for _field,_label,_tab in (("prefill_dp_rank","prefill DP rank","router"),
+                           ("decode_worker_id","decode worker","engine")):
+    _sp,_nm=_inflight_spread(rt_rows,_field)
+    if not _sp: continue
+    panels[f"bal_{_field}"]={
+      "tab":_tab,
+      "title":f"In-flight imbalance across {_label}s",
+      "unit":"requests","kind":"derived","split_by":None,
+      "why":"Concurrent requests on the busiest minus the least busy, sampled over the "
+            "run. A whole-run total per rank averages this away: balance over a phase "
+            "and balance at an instant are different properties, and it is the "
+            "instantaneous spread that stalls a synchronised step.",
+      "source":["request_trace.jsonl"],
+      "caveat":"Reconstructed from per-request attribution, not from an engine gauge -- "
+               "engine-side per-rank series are a replicated broadcast and cannot show "
+               "imbalance at all. Counts a request as occupying its rank for its whole "
+               "lifetime, so it measures occupancy, not instantaneous GPU work.",
+      "issues":["PERF-dp-imbalance"],
+      "series":{"max-min":_sp,**({"normalised (max-min)/mean":_nm} if _nm else {})},
+    }
+    _peak=max(v for _,v in _sp)
+    _log.info(f"balance [{_field}]: peak instantaneous spread {_peak} requests "
+              f"across {len({r[_field] for r in rt_rows if r.get(_field) is not None})} keys")
 if panels:
     _by_tab={}
     for _pid,_p in panels.items(): _by_tab.setdefault(_p["tab"],[]).append(_pid)

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -121,7 +121,9 @@ def _benchmark_status():
         if not d.get("exit_code") and not d.get("errors"):
             return None
         return {"exit_code": d.get("exit_code"),
-                "errors": (d.get("errors") or [])[:4]}
+                # 6, not 4: a check_env_vars failure is a header plus one line per
+                # missing variable, and truncating to 4 drops the variables.
+                "errors": (d.get("errors") or [])[:6]}
     return None
 
 

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -785,8 +785,102 @@ if logdrill is not None:
             _log.info(f"load balance [{_r}]: {len(_v['keys'])} workers via {_v['src']}"
                       f"{'' if _v['has_tokens'] else ' (counts only, no tokens)'}")
 
+# ============ 5. request-trace: per-request waterfall + per-session view =====
+# The frontend's own per-request record (schema 4, see src/ingest/request_trace.py).
+# This is the ONLY source for a gapless TTFT decomposition and the ONLY one carrying
+# session_id, so both of the non-time-series dashboard entities are built from it.
+#
+# One code path, no per-run branching: every request yields the same four bands and
+# every session the same row shape, whatever the topology. A field that is constant
+# across the whole run (queue_depth and decode_dp_rank both read 0 on the reference
+# runs) is reported as constant rather than special-cased away -- "this run never
+# queued" is a finding, and hiding the field would make it unaskable.
+
+# The waterfall is fixed and ordered. Each band is (key, label), and they sum to
+# total_ms by construction -- verified 0/560 negative residuals on the reference runs.
+RT_BANDS = [("prefill_wait_ms", "admission + routing"),
+            ("prefill_ms",      "prefill compute"),
+            ("kv_transfer_ms",  "KV transfer"),
+            ("steady_decode_ms","steady decode")]
+# Carried per request so a card can show what the request WAS, not just how long it took.
+RT_ATTRS = ["isl","osl","cached_tokens","kv_hit_rate","queue_depth","finish_reason",
+            "prefill_worker_id","prefill_dp_rank","decode_worker_id","decode_dp_rank",
+            "turn_index","prefix_reuse_ratio","client_ttft_ms","clean_itl_ms",
+            "avg_itl_ms","total_ms"]
+
+rt_rows=[]
+_rt_path=os.path.join(SRC,"request_trace.jsonl") if SRC else ""
+if _rt_path and os.path.exists(_rt_path):
+    for _l in open(_rt_path):
+        _l=_l.strip()
+        if _l: rt_rows.append(json.loads(_l))
+    # Same warmup exclusion as every other source, via the x_request_id pivot. `client`
+    # was already phase-filtered at load, so intersecting transfers that decision here.
+    # Only applied when the two artifacts are the same run -- a tiny overlap means they
+    # are not, and silently emptying the view is worse than leaving it whole.
+    if client:
+        _keep=[r for r in rt_rows if r.get("x_request_id") in client]
+        if len(_keep) >= .10*max(1,len(rt_rows)):
+            _log.info(f"request trace: phase-filtered via x_request_id ({len(_keep)} of {len(rt_rows)} kept)")
+            rt_rows=_keep
+        else:
+            _log.warning(f"request trace: only {len(_keep)}/{len(rt_rows)} rows match the client "
+                         f"export; leaving unfiltered (different run?)")
+
+rt_requests={}; rt_sessions=[]; rt_const={}
+if rt_rows:
+    _t0=min(r["received_ms"] for r in rt_rows if r.get("received_ms"))
+    for r in rt_rows:
+        _bands=[[k,l,r.get(k)] for k,l in RT_BANDS]
+        rt_requests[r["x_request_id"]]={
+            "t":round((r.get("received_ms") or _t0)-_t0,1),
+            "session_id":r.get("session_id"),
+            "bands":_bands,
+            "attrs":{k:r.get(k) for k in RT_ATTRS},
+        }
+    # A field that never varies carries no information for THIS run; report it once
+    # here rather than drawing a flat line per panel, so the reader learns it was
+    # constant instead of inferring it from a chart that looks broken.
+    for k in RT_ATTRS+[b[0] for b in RT_BANDS]:
+        _vals={json.dumps(r.get(k)) for r in rt_rows}
+        if len(_vals)==1: rt_const[k]=rt_rows[0].get(k)
+
+    _by_sess={}
+    for r in rt_rows:
+        if r.get("session_id"): _by_sess.setdefault(r["session_id"],[]).append(r)
+    for _sid,_rs in _by_sess.items():
+        _rs.sort(key=lambda r:(r.get("turn_index") if r.get("turn_index") is not None else 0,
+                               r.get("received_ms") or 0))
+        _span_ms=(max((r.get("received_ms") or 0)+(r.get("total_ms") or 0) for r in _rs)
+                  - min(r.get("received_ms") or 0 for r in _rs))
+        _busy=sum(r.get("total_ms") or 0 for r in _rs)
+        rt_sessions.append({
+            "session_id":_sid,
+            "t":round((min(r.get("received_ms") or _t0 for r in _rs))-_t0,1),
+            "turns":len(_rs),
+            "span_ms":round(_span_ms,1),
+            "busy_ms":round(_busy,1),
+            # Wall-clock the session existed but was not being served. On the reference
+            # run one session idled 562s of 661s: a session-level latency number that
+            # ignores this describes the harness's think time, not the server.
+            "idle_ms":round(max(0.0,_span_ms-_busy),1),
+            "ttft_ms":[r.get("client_ttft_ms") for r in _rs],
+            "kv_hit":[r.get("kv_hit_rate") for r in _rs],
+            "isl":[r.get("isl") for r in _rs],
+            "reuse":[r.get("prefix_reuse_ratio") for r in _rs],
+            "xids":[r.get("x_request_id") for r in _rs],
+            "decode_workers":sorted({r.get("decode_worker_id") for r in _rs if r.get("decode_worker_id") is not None}),
+            "prefill_ranks":sorted({r.get("prefill_dp_rank") for r in _rs if r.get("prefill_dp_rank") is not None}),
+        })
+    rt_sessions.sort(key=lambda s:s["t"])
+    _pin=sum(1 for s in rt_sessions if len(s["decode_workers"])==1)
+    _log.info(f"request trace: {len(rt_requests)} requests, {len(rt_sessions)} sessions, "
+              f"{_pin}/{len(rt_sessions)} pinned to a single decode worker, "
+              f"{len(rt_const)} constant field(s): {sorted(rt_const)}")
+
 DATA={
  "logdrill":logdrill,
+ "rt":{"requests":rt_requests,"sessions":rt_sessions,"bands":RT_BANDS,"const":rt_const},
  "iter":iter_series,
  "iter_cfg":{"pf_batch":CFG_PF_BATCH,"pf_tok":CFG_PF_TOK,"de_batch":CFG_DE_BATCH,"de_tok":CFG_DE_TOK},
  "drill":{"series":drill_series,"extrema":drill_extrema,"spans":drill_spans,
@@ -795,7 +889,8 @@ DATA={
  # an empty Router tab reads as "this run had no queueing" rather than "this run
  # was not instrumented", which is the more dangerous of the two misreadings.
  "tabs":{"overview":bool(rows),"frontend":bool(scr),"router":bool(scr),
-         "engine":bool(scr),"loganalysis":logdrill is not None},
+         "engine":bool(scr),"loganalysis":logdrill is not None,
+         "session":bool(rt_sessions)},
  "meta":{"n":N,"run_dur_s":round(run_dur,1),"scrapes":len(scr),
    "src":META_SRC,
    "topo":META_TOPO or f"max batch prefill {MAX_BATCH_PF} / decode {MAX_BATCH_DE}"},

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -645,9 +645,9 @@ def _ordered_spans(sp):
 # The engine ceilings it captions against are resolved at the top of this file,
 # before any panel consumes them.
 _iter_path=os.path.join(SRC,"iter_bins.json") if SRC else ""
-iter_series={}
+iter_series={}; iter_bins=None
 if os.path.exists(_iter_path):
-    _ib=json.load(open(_iter_path))
+    _ib=json.load(open(_iter_path)); iter_bins=_ib
     for _wkey,_rows in (_ib.get("bins") or {}).items():
         out={k:[] for k in ("kv_cache_util","num_scheduled_requests","num_ctx_requests","num_generation_tokens")}
         for r in _rows:
@@ -981,6 +981,53 @@ def _inflight_spread(rows, field, nbins=240):
         # perfect balance for an idle window would dilute the very spikes being hunted.
         if mean>0: norm.append([round(i*step/1000,1),round((hi-lo)/mean,3)])
     return spread,norm
+
+# ---- derived panel: batch composition, from the per-iteration log ----------
+# The scrape stream says how BUSY the engine was; only the per-iteration log says
+# what "busy" consisted of. An engine scheduling one request per step at high
+# occupancy is saturated in a completely different way from one scheduling many, and
+# the two are indistinguishable in every aggregate gauge.
+if iter_series and 'iter_bins' in globals() and iter_bins:
+    _bf={}; _mx={}
+    for _w,_rows in iter_bins.get("bins",{}).items():
+        _fr=[];_m=[]
+        for _r in _rows:
+            _h={int(k):v for k,v in (_r.get("sched_hist") or {}).items()}
+            _active=sum(v for k,v in _h.items() if k>=1)
+            _batched=sum(v for k,v in _h.items() if k>=2)
+            _t=relt(int(_r["t"])*10**9)
+            if _t<0 or _t>run_dur+60: continue
+            # Fraction is over ACTIVE iterations only: an idle step did not decline to
+            # batch, it had nothing to batch, and counting it would read as a batching
+            # failure during a quiet period.
+            if _active: _fr.append([round(_t,1),round(_batched/_active,4)])
+            _m.append([round(_t,1),_r.get("sched_max") or 0])
+        if _fr: _bf[_w]=_fr
+        if _m: _mx[_w]=_m
+    if _bf:
+        panels["en_batched_fraction"]={
+          "tab":"engine","title":"Batched iterations, share of active steps",
+          "unit":"ratio","kind":"derived","split_by":None,
+          "why":"Of the steps that had work, the share that scheduled more than one "
+                "request. A value pinned near zero means the engine is stepping one "
+                "request at a time -- the same wall-clock occupancy as a healthy engine, "
+                "at a fraction of the throughput.",
+          "source":["iter_bins.json"],
+          "caveat":"From rank 0 only, so it cannot show per-rank divergence. Idle steps "
+                   "are excluded from the denominator; a quiet period is not a batching "
+                   "failure.",
+          "issues":["PERF-batch-starvation"],"series":_bf}
+    if _mx:
+        panels["en_sched_max"]={
+          "tab":"engine","title":"Peak scheduled requests per step",
+          "unit":"requests","kind":"derived","split_by":None,
+          "why":"The most the scheduler ever managed in a single step, against the "
+                "engine's configured batch ceiling. A peak far below the ceiling means "
+                "the limit is arrival or admission, not engine capacity.",
+          "source":["iter_bins.json"],
+          "caveat":"Rank 0 only.","issues":["PERF-batch-starvation"],"series":_mx}
+        _log.info("batch composition: "+", ".join(
+            f"{w}={sum(v for _,v in s)/max(1,len(s)):.2f} batched-share" for w,s in _bf.items()))
 
 for _field,_label,_tab in (("prefill_dp_rank","prefill DP rank","router"),
                            ("decode_worker_id","decode worker","engine")):

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -165,7 +165,13 @@ def _flat_config():
             else:
                 flat[prefix.rstrip(".")] = node
         _walk(doc)
-        flat.pop("name", None)
+        # Identity fields, dropped so a comparison reports TREATMENTS and not
+        # bookkeeping. Every arm of an ablation necessarily renames itself and writes to
+        # its own result file; leaving these in means a genuinely single-variable
+        # comparison always reports two differences, and the SINGLE-VARIABLE verdict can
+        # never fire -- which trains the reader to ignore the count.
+        for k in ("name", "benchmark.env.RESULT_FILENAME"):
+            flat.pop(k, None)
         return flat
     return None
 

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -151,8 +151,12 @@ def _load_meta(bundle_dir):
             t = cfg.get("topology") or {}
             parts = [f"{role} {w.get('worker_count','?')}×{w.get('parallelism','?')}{w.get('rank','')}"
                      for role, w in (t.get("workers") or {}).items()]
+            # block_size from the yaml is only ingest's --block-size fallback. The
+            # authoritative value comes from the metrics stream and is substituted
+            # later; emitting the fallback here would put a third, wrong number in the
+            # header while the panels use the right one.
             if t.get("block_size"):
-                parts.append(f"block {t['block_size']}")
+                parts.append("block __BLK__")
             topo = " · ".join(parts)
             gpus = sum(int(w.get("rank") or 0) * int(w.get("worker_count") or 0)
                        for w in (t.get("workers") or {}).values()) or None
@@ -444,14 +448,53 @@ en = {
   "max_batch_de": MAX_BATCH_DE,   # decode max_batch_size ceiling (--max-batch-decode)
 }
 # true cache-hit (trtllm_kv_cache_hit_rate gauge, per ctx worker) — mean over scrapes where present
+def _reuse_enabled_components():
+    """Components whose engine config actually enables KV block reuse.
+
+    A worker with ``kv_cache_config.enable_block_reuse: false`` reports a hard 0 for
+    trtllm_kv_cache_hit_rate -- correctly, because it does no reuse. Averaging that 0
+    in with the components that DO reuse does not produce a run-level hit rate; it
+    produces a number that falls as the deployment adds decode workers. On the
+    reference 1P3D run the true prefill hit rate is ~0.65-0.76 while the naive mean
+    over four components reports ~0.16.
+
+    Returns None when no engine config is available, which means "cannot tell" -- the
+    caller then keeps every component rather than silently dropping data.
+    """
+    keep=set()
+    seen_cfg=False
+    for mode,comp in (("prefill","prefill"),("decode","backend"),("aggregated","backend")):
+        for cand in (os.path.join(SRC or "", f"trtllm_config_{mode}.yaml"),):
+            if not cand or not os.path.exists(cand): continue
+            try:
+                import yaml as _y
+                c=_y.safe_load(open(cand)) or {}
+            except Exception:
+                continue
+            seen_cfg=True
+            if ((c.get("kv_cache_config") or {}).get("enable_block_reuse")) is not False:
+                keep.add(comp)
+    return keep if seen_cfg else None
+
+_REUSE_COMPONENTS=_reuse_enabled_components()
+if _REUSE_COMPONENTS is not None:
+    _log.info(f"KV hit rate: averaging only components with block reuse enabled: "
+              f"{sorted(_REUSE_COMPONENTS) or 'NONE'}")
+else:
+    _log.warning("KV hit rate: no engine config in the bundle, so reuse-disabled "
+                 "components cannot be excluded; the series may understate the true rate")
+
 def kvhit_series():
     out=[]
     for ts,m in scr:
         g=ggroup(m,"trtllm_kv_cache_hit_rate",by="dynamo_component")
+        if _REUSE_COMPONENTS is not None:
+            g={k:v for k,v in g.items() if k in _REUSE_COMPONENTS}
         vals=[x for vs in g.values() for x in vs]
         out.append([relt(ts), round(sum(vals)/len(vals)*100,2) if vals else None])
     return out
 en["true_hit_pct"]=kvhit_series()
+en["reuse_components"]=sorted(_REUSE_COMPONENTS) if _REUSE_COMPONENTS is not None else None
 _hitvals=[p[1] for p in en["true_hit_pct"] if p[1] is not None]
 en["true_hit_kpi"]=round(pct(_hitvals,50),1) if _hitvals else None
 
@@ -1080,7 +1123,12 @@ DATA={
          "session":bool(rt_sessions)},
  "meta":{"n":N,"run_dur_s":round(run_dur,1),"scrapes":len(scr),
    "src":META_SRC,
-   "topo":META_TOPO or f"max batch prefill {MAX_BATCH_PF} / decode {MAX_BATCH_DE}"},
+   # Substitute the authoritative block size measured from the metrics stream. The
+   # yaml only ever carried ingest's --block-size fallback, and on the reference run
+   # that fallback (512) disagreed with both the measured value (32) and the engine
+   # config (256) -- three numbers, of which the header was showing the wrong one.
+   "topo":(META_TOPO or f"max batch prefill {MAX_BATCH_PF} / decode {MAX_BATCH_DE}")
+          .replace("__BLK__", str(BLK) if BLK else "unknown")},
  "kpi":{"ttft_p50":round(pct(col("ttft"),50)/1000,1),"ttft_p99":round(pct(col("ttft"),99)/1000,1),
    "adm_p50":round(pct(col("adm"),50)/1000,1),"pf_p50":round(pct(col("pf"),50)/1000,1),
    "reqs":N,"adm_share":round(pct(col("adm"),50)/max(1,pct(col("ttft"),50))*100,0),
@@ -1124,6 +1172,9 @@ h1{margin:0;font-size:16px}.sub{color:var(--dim);font-size:12px;margin-top:3px}
 .panel{background:var(--panel);border:1px solid var(--edge);border-radius:10px;padding:12px 14px;min-width:0}
 .panel h2{margin:0 0 2px;font-size:13px}.panel .src{color:#6e7681;font-size:11px}
 .warn{color:#d29922;font-size:11px}
+.reqcard{border-top:1px solid #21262d;padding:8px 0}
+.reqhead{font-size:12px;color:#c9d1d9;margin-bottom:2px}
+.reqmeta{font-size:11px;color:#8b949e;margin-top:2px}
 .tbl{width:100%;border-collapse:collapse;font-size:12px;margin-top:8px}
 .tbl th{text-align:left;color:#8b949e;font-weight:600;border-bottom:1px solid #30363d;padding:4px 8px}
 .tbl td{padding:4px 8px;border-bottom:1px solid #21262d;color:#c9d1d9;font-variant-numeric:tabular-nums}
@@ -1661,9 +1712,22 @@ note('frontend',`Both panels come from the <b>frontend</b> endpoint (<code>:8000
       +`${keys.length} series &mdash; this run never exercised this signal.`);
     return;
   }
-  if(keys.length>1) lg(el,keys.map((k,i)=>[PAL[i%PAL.length],p.split_by?`${p.split_by}=${k}`:k]));
+  // High-cardinality panels (a per-thread runtime gauge is ~144 series) draw the
+  // busiest few rather than everything. Drawing all of them is a point cloud and a
+  // legend nobody can read; drawing one merged series hides which thread saturated.
+  // Ranked by PEAK because saturation is a property of the busiest members, and the
+  // omitted count is always stated -- a silently truncated panel reads as complete.
+  const MAXS=12; let drawn=keys, omitted=0;
+  if(keys.length>MAXS){
+    drawn=keys.slice().sort((a,b)=>d3.max(p.series[b],d=>d[1])-d3.max(p.series[a],d=>d[1])).slice(0,MAXS);
+    omitted=keys.length-MAXS;
+  }
+  if(drawn.length>1) lg(el,drawn.map((k,i)=>[PAL[i%PAL.length],p.split_by?`${p.split_by}=${k}`:k]));
+  if(omitted) el.append('div').attr('class','note').html(
+    `Showing the <b>${MAXS}</b> highest-peak of <b>${keys.length}</b> series; `
+    +`<b>${omitted}</b> lower-peak series omitted from the chart.`);
   const L=58,B=28,H=keys.length>3?250:200,s=svg(el,VW,H);
-  const all=keys.flatMap(k=>p.series[k]);
+  const all=drawn.flatMap(k=>p.series[k]);
   const x=d3.scaleLinear().domain([0,d3.max(all,d=>d[0])||1]).range([L,VW-12]);
   const y=d3.scaleLinear().domain([0,(d3.max(all,d=>d[1])||1)*1.08]).nice().range([H-B,8]);
   s.append('g').attr('class','axis').attr('transform',`translate(0,${H-B})`)
@@ -1671,9 +1735,76 @@ note('frontend',`Both panels come from the <b>frontend</b> endpoint (<code>:8000
   s.append('g').attr('class','axis').attr('transform',`translate(${L},0)`)
    .call(d3.axisLeft(y).ticks(5).tickFormat(fmtU(p.unit)));
   const ln=d3.line().x(d=>x(d[0])).y(d=>y(d[1]));
-  keys.forEach((k,i)=>s.append('path').datum(p.series[k]).attr('fill','none')
+  drawn.forEach((k,i)=>s.append('path').datum(p.series[k]).attr('fill','none')
     .attr('stroke',PAL[i%PAL.length]).attr('stroke-width',1.2).attr('opacity',.9).attr('d',ln));
  });
+})();
+
+// ---- per-request decomposition cards (DATA.rt.requests) --------------------
+// Entity type 2. One card shape for every request in every run: the four bands that
+// sum to total_ms, what the request WAS, and where it was routed. Nothing here is
+// conditional on the run -- a field the run did not produce renders as an em dash
+// rather than changing the card's shape.
+(function(){
+ const RT=DATA.rt||{}, R=RT.requests||{}; const xids=Object.keys(R);
+ if(!xids.length) return;
+ const BANDC=[C.adm,C.pf,C.route,C.de];
+ const el=panel('session','Per-request decomposition',
+   'The slowest requests in the run, each broken into the four phases that sum to its '
+   +'total. <b>Routing is an outcome, not a rationale</b>: the router\'s cost comparison '
+   +'is logged without a request id and cannot be joined, so this shows which worker was '
+   +'chosen and with how much prefix overlap, not why it won.'
+   +'<br><span class="src">source: <code>request_trace.jsonl</code> + <code>tempo_traces/</code></span>',true);
+
+ if(RT.belief){
+   const b=RT.belief, bad=b.disagree;
+   el.append('div').attr('class','note'+(bad?' warn':'')).html(
+     `Router belief vs engine reality: <b>${b.n-bad}/${b.n}</b> requests agree within `
+     +`${(b.threshold*100).toFixed(0)}% (router <code>overlap_blocks</code> x block size `
+     +`vs engine <code>cached_tokens</code>), worst error <b>${(b.worst*100).toFixed(1)}%</b>. `
+     +(bad?'A disagreement means the router scored a candidate on a prefix the engine does not hold.'
+          :'The router scored candidates on a prefix the engine actually had.'));
+ }
+
+ const slowest=xids.map(x=>[x,R[x]])
+   .sort((a,b)=>(b[1].attrs.total_ms||0)-(a[1].attrs.total_ms||0)).slice(0,12);
+ const W=760,BH=26;
+ slowest.forEach(([xid,c])=>{
+   const tot=c.bands.reduce((a,[,,v])=>a+(v||0),0)||1;
+   const row=el.append('div').attr('class','reqcard');
+   const a=c.attrs, rt=c.routing;
+   row.append('div').attr('class','reqhead').html(
+     `<code>${xid.slice(0,8)}</code> &middot; <b>${fmtS(tot)}</b> total`
+     +` &middot; ISL ${d3.format('~s')(a.isl||0)} &rarr; OSL ${d3.format('~s')(a.osl||0)}`
+     +` &middot; cache hit ${a.kv_hit_rate==null?'&mdash;':(a.kv_hit_rate*100).toFixed(1)+'%'}`
+     +` &middot; turn ${a.turn_index==null?'&mdash;':a.turn_index}`);
+   const sv=svg(row,W,BH+6); let x0=0;
+   c.bands.forEach(([,label,v],i)=>{
+     const w=(v||0)/tot*W;
+     if(w>0){
+       sv.append('rect').attr('x',x0).attr('y',3).attr('width',w).attr('height',BH)
+         .attr('fill',BANDC[i%BANDC.length]).attr('opacity',.85)
+         .append('title').text(`${label}: ${fmtS(v)}`);
+       if(w>54) sv.append('text').attr('x',x0+4).attr('y',3+BH/2+4).attr('fill','#0d1117')
+         .attr('font-size',10).text(fmtS(v));
+     }
+     x0+=w;
+   });
+   row.append('div').attr('class','reqmeta').html(
+     rt ? `routed to worker <code>${String(rt.worker_id??'').slice(-6)||'&mdash;'}</code>`
+          +` rank <code>${rt.dp_rank??'&mdash;'}</code>`
+          +` &middot; overlap <b>${rt.overlap_blocks==null?'&mdash;':d3.format('~s')(rt.overlap_blocks)}</b> blocks`
+          +` &middot; router ${rt.router_ms==null?'&mdash;':rt.router_ms+'ms'}`
+          +` &middot; admission ${rt.admission_ms==null?'&mdash;':rt.admission_ms+'ms'}`
+        : 'routing not joinable for this run (no span data)');
+ });
+ lg(el,c_bandLegend());
+ function c_bandLegend(){return (RT.bands||[]).map((b,i)=>[BANDC[i%BANDC.length],b[1]])}
+ const cst=RT.const||{};
+ if(Object.keys(cst).length) el.append('div').attr('class','note').html(
+   'Constant for every request in this run: '
+   +Object.entries(cst).map(([k,v])=>`<code>${k}</code>=${v}`).join(', ')
+   +' &mdash; reported rather than charted.');
 })();
 
 // ---- session decomposition (DATA.rt) ---------------------------------------

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -101,6 +101,17 @@ def _cfg_max_batch(mode):
         except Exception:
             pass
     return None, None
+def _lifecycle():
+    """Time-to-ready and terminal cause from ``run_lifecycle.json`` (PERF-45)."""
+    if not SRC:
+        return None
+    try:
+        with open(os.path.join(SRC, "run_lifecycle.json")) as fh:
+            return json.load(fh) or None
+    except Exception:
+        return None
+
+
 def _log_signals():
     """Log-only signals from ``log_signals.json``: the ones with no metric behind them.
 
@@ -314,6 +325,11 @@ CLIENT_SUMMARY = _client_summary()
 PROVENANCE = _provenance()
 BENCH_STATUS = _benchmark_status()
 LOG_SIGNALS = _log_signals()
+LIFECYCLE = _lifecycle()
+if LIFECYCLE:
+    _d = LIFECYCLE.get("durations_s") or {}
+    _log.info(f"lifecycle: time_to_ready={_d.get('time_to_ready')}s "
+              f"readiness_gap={_d.get('readiness_gap')}s | {LIFECYCLE.get('terminal_cause')}")
 if LOG_SIGNALS:
     _fired = {k: v["count"] for k, v in LOG_SIGNALS.items() if v.get("count")}
     _log.info(f"log-only signals: {_fired}" if _fired
@@ -1508,7 +1524,8 @@ DATA={
    "client_summary":CLIENT_SUMMARY,
    "provenance":PROVENANCE,
    "benchmark_status":BENCH_STATUS,
-   "log_signals":LOG_SIGNALS},
+   "log_signals":LOG_SIGNALS,
+   "lifecycle":LIFECYCLE},
  "kpi":{"ttft_p50":round(pct(col("ttft"),50)/1000,1),"ttft_p99":round(pct(col("ttft"),99)/1000,1),
    "adm_p50":round(pct(col("adm"),50)/1000,1),"pf_p50":round(pct(col("pf"),50)/1000,1),
    "reqs":N,"adm_share":round(pct(col("adm"),50)/max(1,pct(col("ttft"),50))*100,0),
@@ -1631,6 +1648,12 @@ function hTip(){tip.style('display','none')}
   // than on one tab. A cancelled run, a run with client errors, or an agentic run
   // whose child branches errored produced figures that must not be compared against a
   // clean run -- and nothing in the per-request stream says so.
+  const LC=M.lifecycle;
+  if(LC && LC.durations_s && LC.durations_s.time_to_ready!=null){
+    head += `  —  ready in ${LC.durations_s.time_to_ready}s`
+          + (LC.durations_s.readiness_gap!=null
+               ? ` (frontend accepted ${LC.durations_s.readiness_gap}s before the router could place)` : '');
+  }
   const CS=M.client_summary;
   if(CS){
     const bad=[];

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -894,6 +894,28 @@ if _args.frontend_log:
         _log.info(f"log analysis: {len(_lrows)} requests, "
                   f"p50={logdrill['global']['p50']}ms p99={logdrill['global']['p99']}ms, "
                   f"routing_join={'yes' if logdrill['routing'] else 'no'}")
+
+        # How much of the run's traffic the KV-routing panels actually describe.
+        #
+        # Computed HERE, into the payload, rather than formatted inside the page's JS.
+        # The HTML is frequently unreadable where it lands -- a headless node, a CI log,
+        # an S3 prefix -- so a caveat that exists only in rendered DOM is invisible to
+        # every consumer that reads the JSON, which is the primary artifact. It also
+        # makes the caveat testable: asserting on the HTML text cannot distinguish a
+        # rendered string from the template literal that would produce it.
+        #
+        # Session-affinity pins a request to the worker already holding its
+        # conversation, and a pinned request never reaches the KV scorer. On the e2e
+        # run 2751593 that was 248 of 274 decisions -- 90.5% -- so the KV-routing
+        # panels there describe under a tenth of the traffic.
+        _tot=_fst.get("selector_without_request_id") or 0
+        if _tot:
+            _pin=_fst.get("selector_decisions_pinned") or 0
+            ro["coverage"]={"decisions":_tot,"pinned":_pin,
+                            "pct_pinned":round(100.0*_pin/_tot,1)}
+            _log.info(f"router coverage: {_pin}/{_tot} decisions pinned by session affinity "
+                      f"({ro['coverage']['pct_pinned']}%); the KV-routing panels describe the "
+                      f"remaining {100-ro['coverage']['pct_pinned']:.1f}%")
     else:
         _log.warning("log analysis: no usable requests in the frontend log; tab omitted")
 
@@ -1738,7 +1760,25 @@ drillPanel('overview',DATA.drill,{
 })();
 
 // ================= ROUTER =================
-note('router',`Both panels come from the <b>frontend</b> endpoint (<code>:8000/metrics</code>). The KV router runs in-process in the frontend, so every router metric is published there — the prefill and decode endpoints expose none.`,'hl');
+// The coverage clause is appended only when the frontend-log leg is present, because
+// only that leg can count routing decisions. The SENTENCE is fixed; the numbers in it
+// are measured per run. Without it these panels read as "how the router chose", when
+// on a session-affinity deployment most requests never reach the KV scorer at all --
+// they are pinned to the worker that already holds the conversation. A reader drawing
+// conclusions about KV-aware routing from a run that barely used it is the failure
+// this sentence exists to prevent.
+(function(){
+ let cov='';
+ const CV=DATA.ro.coverage;
+ if(CV){
+   cov=`<br><br><b>Routing-decision coverage.</b> ${CV.decisions.toLocaleString()} routing decisions were
+     observed and <b>${CV.pinned.toLocaleString()} (${CV.pct_pinned.toFixed(1)}%)</b> were pinned by session
+     affinity, so they bypassed KV scoring entirely. These panels therefore describe the
+     <b>${(100-CV.pct_pinned).toFixed(1)}%</b> of decisions that actually reached the scorer. Read the KV-routing
+     panels as a description of that slice, not of the run's whole traffic.`;
+ }
+ note('router',`Both panels come from the <b>frontend</b> endpoint (<code>:8000/metrics</code>). The KV router runs in-process in the frontend, so every router metric is published there — the prefill and decode endpoints expose none.`+cov,'hl');
+})();
 (function(){const el=panel('router','Router overhead',
   '<code>dynamo_router_overhead_total_ms</code> — "Total routing overhead per request in milliseconds". A Prometheus histogram, plotted as the <b>interval mean</b> (Δsum/Δcount between consecutive scrapes), so each point is the average routing cost of the requests routed during that interval.',true);
  lg(el,[[C.grn,'router overhead (ms/request)']]);

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -101,6 +101,28 @@ def _cfg_max_batch(mode):
         except Exception:
             pass
     return None, None
+def _cfg_tokens_per_block():
+    """Engine KV block size from the run's own config, prefill or decode.
+
+    Either mode answers: the two engines pool the same KV block size, and a run may
+    ship only one of the two configs. Nested under `kv_cache_config` in current
+    TRT-LLM configs, top-level in older ones, so both are accepted.
+    """
+    if not SRC:
+        return None
+    for mode in ("decode", "prefill"):
+        for cand in (os.path.join(SRC, f"trtllm_config_{mode}.yaml"),
+                     os.path.join(SRC, "..", "..", f"trtllm_config_{mode}.yaml")):
+            try:
+                import yaml as _y
+                c = _y.safe_load(open(cand)) or {}
+                v = (c.get("kv_cache_config") or {}).get("tokens_per_block",
+                                                         c.get("tokens_per_block"))
+                if v:
+                    return int(v)
+            except Exception:
+                pass
+    return None
 CFG_PF_BATCH, CFG_PF_TOK = _cfg_max_batch("prefill")
 CFG_DE_BATCH, CFG_DE_TOK = _cfg_max_batch("decode")
 MAX_BATCH_PF = CFG_PF_BATCH if CFG_PF_BATCH else _args.max_batch_prefill
@@ -633,8 +655,23 @@ def _block_size_mismatch():
     constant 0. So the only way to surface it is to compare the two configured sizes
     directly, which is what this does.
 
-    Returns (router_blk, engine_tpb) or None when either is unavailable -- "cannot
-    tell" rather than a guessed all-clear.
+    TWO sources for the engine side, in this order:
+      1. the scrape's `trtllm_kv_cache_tokens_per_block` gauge
+      2. `tokens_per_block` in the run's own resolved `trtllm_config_<mode>.yaml`
+
+    The fallback is not decoration. The gauge is only exported when the engine
+    publishes its KV-cache family, so on a run whose workers are up but not yet
+    publishing -- exactly the e2e self-build run 2751593 -- source 1 is empty and the
+    check reported "cannot tell" for a value that was sitting in the bundle all along.
+    The config is the same authority `_cfg_max_batch` already trusts for the engine
+    ceilings, and it is present whenever the ingest ran at all.
+
+    Always returns (router_blk, engine_tpb, source), either side possibly None. The two
+    sides are reported INDEPENDENTLY on purpose: an earlier version returned nothing
+    unless both were known, which threw away a perfectly good engine value whenever the
+    router gauge was missing. "engine 256, router unknown" is a useful thing to show;
+    silence is not. The mismatch VERDICT is what requires both, and that is decided by
+    the caller.
     """
     eng=None
     for _,m in scr:
@@ -642,15 +679,24 @@ def _block_size_mismatch():
             v=e.get("value")
             if isinstance(v,(int,float)) and v>0: eng=int(v); break
         if eng: break
-    return (BLK,eng) if (BLK and eng) else None
+    src="scrape" if eng else None
+    if not eng:
+        eng=_cfg_tokens_per_block()
+        src="engine config" if eng else None
+    return (BLK,eng,src)
 
-_BLK_MISMATCH=_block_size_mismatch()
-if _BLK_MISMATCH and _BLK_MISMATCH[0]!=_BLK_MISMATCH[1]:
-    _log.warning(f"KV block-size mismatch: router indexes {_BLK_MISMATCH[0]}-token blocks "
-                 f"while the engine pools {_BLK_MISMATCH[1]}-token blocks; router KV events "
-                 f"will reference blocks the engine cannot match")
-elif _BLK_MISMATCH:
-    _log.info(f"KV block size agrees across router and engine: {_BLK_MISMATCH[0]} tokens")
+_BLK_ROUTER,_BLK_ENGINE,_BLK_SRC=_block_size_mismatch()
+if _BLK_ROUTER and _BLK_ENGINE and _BLK_ROUTER!=_BLK_ENGINE:
+    _log.warning(f"KV block-size mismatch: router indexes {_BLK_ROUTER}-token blocks "
+                 f"while the engine pools {_BLK_ENGINE}-token blocks (engine size via "
+                 f"{_BLK_SRC}); router KV events will reference blocks the engine "
+                 f"cannot match")
+elif _BLK_ROUTER and _BLK_ENGINE:
+    _log.info(f"KV block size agrees across router and engine: {_BLK_ROUTER} tokens "
+              f"(engine size via {_BLK_SRC})")
+else:
+    _log.warning(f"KV block-size agreement UNKNOWN (router={_BLK_ROUTER} "
+                 f"engine={_BLK_ENGINE}); reported as unknown rather than as agreement")
 if BLK is None: _log.warning("no dynamo_frontend_model_kv_cache_block_size in the stream; "
                              "decode tokens-in-flight stays in BLOCKS")
 load={"tput":_rolling_tput(GPUS),
@@ -658,8 +704,7 @@ load={"tput":_rolling_tput(GPUS),
       "tif_pf":_worker_bins("dynamo_frontend_worker_active_prefill_tokens","prefill"),
       "tif_de":_worker_bins("dynamo_frontend_worker_active_decode_blocks","decode",scale=BLK or 1),
       "gpus":GPUS,"blk":BLK,"win_s":TPUT_WIN_S,"bins":NBW,
-      "blk_router":(_BLK_MISMATCH or [None,None])[0],
-      "blk_engine":(_BLK_MISMATCH or [None,None])[1]}
+      "blk_router":_BLK_ROUTER,"blk_engine":_BLK_ENGINE,"blk_src":_BLK_SRC}
 _log.info(f"load rows: tput={len(load['tput'])}pts gpus={GPUS} "
           f"rif_pf={len(load['rif_pf'])} rif_de={len(load['rif_de'])} "
           f"tif_pf={len(load['tif_pf'])}series tif_de={len(load['tif_de'])}series block={BLK}")

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -49,6 +49,11 @@ _ap.add_argument("--max-batch-prefill", type=int, default=128, help="prefill max
 _ap.add_argument("--max-batch-decode", type=int, default=256, help="decode max_batch_size ceiling for the in-flight panel")
 _ap.add_argument("--include-warmup", action="store_true", help="keep AgentX cache-warmup requests (default: profiling phase only)")
 _ap.add_argument("--gpus", type=int, default=None, help="total GPU count for tok/s/GPU (default: sum(rank x worker_count) from the bundle's dashboard.yaml)")
+_ap.add_argument("--dump-json", default=None, metavar="PATH",
+                 help="also write the page's underlying DATA payload as indented JSON. The HTML embeds "
+                      "this same object, so the dump is the machine-readable form of everything the "
+                      "dashboard shows -- for diffing two runs, for CI assertions, and for reading a "
+                      "result on a machine with no browser.")
 _ap.add_argument("--frontend-log", default=None, metavar="PATH",
                  help="Dynamo frontend log (INFO level) to populate the 'Log analysis' tab. "
                       "Accepts raw container stdout or sflow-wrapped. Tab is omitted if not given.")
@@ -1333,3 +1338,12 @@ if(TABS.some(t=>t[0]===h)) act(h); else if(TABS.length) act(TABS[0][0]);
 html=HTML.replace("__D3__",D3_TAG).replace("__DATA__",json.dumps(DATA,separators=(",",":")))
 open(OUT,"w").write(html)
 _log.info(f"wrote {OUT} ({os.path.getsize(OUT)/1024/1024:.1f} MB)")
+
+# The HTML embeds DATA verbatim, so dumping it is not a second rendering path --
+# it is the same payload in a form that can be diffed between two runs, asserted
+# on in CI, or read at all on a machine with no browser.
+if _args.dump_json:
+    with open(_args.dump_json,"w") as _jf:
+        json.dump(DATA,_jf,indent=1,sort_keys=True)
+    _log.info(f"wrote {_args.dump_json} ({os.path.getsize(_args.dump_json)/1024/1024:.1f} MB) "
+              f"-- tabs={[k for k,v in DATA['tabs'].items() if v]}")

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -204,10 +204,13 @@ def pct(v, p):
 # 918 at p99 88.5s -- mixing them roughly halves the reported tail. Records with
 # no benchmark_phase (plain, non-AgentX AIPerf runs) are always kept.
 client={}; _skipped_phase=0
+_phase_seen={}   # every phase value in the file, kept or dropped
 for l in (open(os.path.join(SRC,"profile_export.jsonl")) if HAS_CLIENT else []):
     l=l.strip()
     if not l: continue
     r=json.loads(l); m=r["metadata"]; mt=r["metrics"]
+    _ph=m.get("benchmark_phase")
+    _phase_seen[_ph or "(none)"]=_phase_seen.get(_ph or "(none)",0)+1
     if not _args.include_warmup and m.get("benchmark_phase") not in (None,"profiling"):
         _skipped_phase+=1; continue
     g=lambda k:(mt.get(k) or {}).get("value")
@@ -1274,7 +1277,19 @@ DATA={
    # that fallback (512) disagreed with both the measured value (32) and the engine
    # config (256) -- three numbers, of which the header was showing the wrong one.
    "topo":(META_TOPO or f"max batch prefill {MAX_BATCH_PF} / decode {MAX_BATCH_DE}")
-          .replace("__BLK__", str(BLK) if BLK else "unknown")},
+          .replace("__BLK__", str(BLK) if BLK else "unknown"),
+   # Why the population is the size it is. `n` alone cannot distinguish "this run
+   # served nothing" from "this run never left warmup", and those call for opposite
+   # responses: the first is a broken deployment, the second is a run that needed
+   # more wall clock. Verified on the c32 reference run 2750618, where all 118 client
+   # records are benchmark_phase=warmup because the job hit its 20-minute limit before
+   # profiling began -- a reader seeing only n=0 would conclude the stack was dead.
+   #
+   # The page says this in its header already; this is the same statement in the
+   # payload, which is what anything downstream of the HTML actually reads.
+   "phase_filter":{"applied":not _args.include_warmup,
+                   "kept":len(client),"dropped":_skipped_phase,
+                   "phases":_phase_seen}},
  "kpi":{"ttft_p50":round(pct(col("ttft"),50)/1000,1),"ttft_p99":round(pct(col("ttft"),99)/1000,1),
    "adm_p50":round(pct(col("adm"),50)/1000,1),"pf_p50":round(pct(col("pf"),50)/1000,1),
    "reqs":N,"adm_share":round(pct(col("adm"),50)/max(1,pct(col("ttft"),50))*100,0),

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -101,6 +101,30 @@ def _cfg_max_batch(mode):
         except Exception:
             pass
     return None, None
+def _benchmark_status():
+    """Why the benchmark produced what it produced, from ``benchmark_status.json``.
+
+    An empty dashboard is not wrong, but it is mute: `client=False traces=False N=0`
+    leaves the reader to guess between a dead deployment, a workload that never
+    started, and a run cut short -- three different responses. Eight ablation arms in
+    one session hit exactly this, four failing before the benchmark script was even
+    reachable and four eleven seconds after the workers went healthy.
+    """
+    if not SRC:
+        return None
+    for cand in (os.path.join(SRC, "benchmark_status.json"),):
+        try:
+            with open(cand) as fh:
+                d = json.load(fh)
+        except Exception:
+            continue
+        if not d.get("exit_code") and not d.get("errors"):
+            return None
+        return {"exit_code": d.get("exit_code"),
+                "errors": (d.get("errors") or [])[:4]}
+    return None
+
+
 def _flat_config():
     """The run's resolved recipe, flattened to {dotted.path: scalar}.
 
@@ -260,6 +284,10 @@ def _cfg_tokens_per_block():
     return None
 CLIENT_SUMMARY = _client_summary()
 PROVENANCE = _provenance()
+BENCH_STATUS = _benchmark_status()
+if BENCH_STATUS:
+    _log.warning(f"benchmark reported failure: exit={BENCH_STATUS['exit_code']}; "
+                 f"{BENCH_STATUS['errors'][0] if BENCH_STATUS['errors'] else 'no error line captured'}")
 if PROVENANCE:
     _log.info(f"provenance: {PROVENANCE['n_workers']} worker fingerprint(s), frameworks="
               f"{PROVENANCE['frameworks']}")
@@ -1445,7 +1473,8 @@ DATA={
                    "kept":len(client),"dropped":_skipped_phase,
                    "phases":_phase_seen},
    "client_summary":CLIENT_SUMMARY,
-   "provenance":PROVENANCE},
+   "provenance":PROVENANCE,
+   "benchmark_status":BENCH_STATUS},
  "kpi":{"ttft_p50":round(pct(col("ttft"),50)/1000,1),"ttft_p99":round(pct(col("ttft"),99)/1000,1),
    "adm_p50":round(pct(col("adm"),50)/1000,1),"pf_p50":round(pct(col("pf"),50)/1000,1),
    "reqs":N,"adm_share":round(pct(col("adm"),50)/max(1,pct(col("ttft"),50))*100,0),
@@ -1550,6 +1579,16 @@ function hTip(){tip.style('display','none')}
   if(!M.n && (nReq||nSess)) head += `  —  no request completed the profiling phase;`
          + ` ${nReq} request(s) across ${nSess} session(s) are warmup and are shown on the`
          + ` Session tab, excluded from every percentile above`;
+  // A benchmark that failed outranks everything else the header could say. Without it
+  // an empty dashboard reads as a dead deployment, when the usual cause is an
+  // environment fault that never let the workload start -- and those call for opposite
+  // responses. Placed before the validity clause because it subsumes it: if the
+  // benchmark never ran, its own validity flags are moot.
+  const BS=M.benchmark_status;
+  if(BS){
+    head += `  —  BENCHMARK FAILED (exit ${BS.exit_code||'?'})`
+          + (BS.errors && BS.errors.length ? `: ${BS.errors[0]}` : '');
+  }
   // Run validity bounds every number on the page, so it belongs in the header rather
   // than on one tab. A cancelled run, a run with client errors, or an agentic run
   // whose child branches errored produced figures that must not be compared against a

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -453,15 +453,26 @@ def pct(v, p):
 # percentile: on run 2674375 warmup was 1180 requests at p99 43.5s vs profiling
 # 918 at p99 88.5s -- mixing them roughly halves the reported tail. Records with
 # no benchmark_phase (plain, non-AgentX AIPerf runs) are always kept.
+# The phase boundary is captured HERE rather than re-derived, because this loop is
+# already the only place that sees warmup records -- the filter below drops them.
+# Preferred boundary is the first PROFILING request's start; the last warmup end is
+# the fallback for a run whose profiling phase never began.
 client={}; _skipped_phase=0
 _phase_seen={}   # every phase value in the file, kept or dropped
+_prof_min_start=None; _warm_max_end=None
 for l in (open(os.path.join(SRC,"profile_export.jsonl")) if HAS_CLIENT else []):
     l=l.strip()
     if not l: continue
     r=json.loads(l); m=r["metadata"]; mt=r["metrics"]
     _ph=m.get("benchmark_phase")
     _phase_seen[_ph or "(none)"]=_phase_seen.get(_ph or "(none)",0)+1
-    if not _args.include_warmup and m.get("benchmark_phase") not in (None,"profiling"):
+    if _ph=="profiling":
+        _s=m.get("request_start_ns")
+        if _s: _prof_min_start=_s if _prof_min_start is None else min(_prof_min_start,_s)
+    elif _ph is not None:
+        _e=m.get("request_end_ns") or m.get("request_start_ns")
+        if _e: _warm_max_end=_e if _warm_max_end is None else max(_warm_max_end,_e)
+    if not _args.include_warmup and _ph not in (None,"profiling"):
         _skipped_phase+=1; continue
     g=lambda k:(mt.get(k) or {}).get("value")
     client[m["x_request_id"]]={"start_ns":m.get("request_start_ns") or 0,"ttft":g("time_to_first_token"),
@@ -529,17 +540,79 @@ if HAS_SM:
 sm_start=scr[0][0] if scr else None
 sm_end=scr[-1][0] if scr else None
 
-# The run window is whichever of traces / scrapes actually exist. With neither
-# (log-only build) it collapses to a unit window; nothing that consumes it is
-# rendered in that mode.
-_starts=[t for t in (trace_start, sm_start) if t is not None]
-_ends=[t for t in (trace_end, sm_end) if t is not None]
+# The run window is whichever source actually exists. The iter log has to be in
+# here, not just traces/scrapes: it is the ONLY leg a trtllm-serve run produces (no
+# Dynamo frontend means no /metrics surface and no spans at all), and it is present
+# on any run whose recipe sets `print_iter_log` regardless of `observability.enabled`.
+# Left out, `run_dur` collapses to 1 ns, the `t > run_dur + 60` guard below discards
+# every bin, and a run with 175,800 real iterations renders as an empty page while
+# only logging "0pts" -- which is how it read before this was fixed.
+def _load_iter_bins(src):
+    p=os.path.join(src,"iter_bins.json") if src else ""
+    if not os.path.exists(p): return None
+    try: return json.load(open(p))
+    except Exception: return None
+
+# Loaded ONCE here, before the run window, because three separate consumers need it
+# and two of them run earlier than the panel section: the window itself, and the KV
+# fallbacks below.
+_IB=_load_iter_bins(SRC)
+
+def _iter_bins_window(ib):
+    if not ib: return None,None
+    ts=[r["t"] for rows in (ib.get("bins") or {}).values() for r in rows if r.get("t")]
+    if not ts: return None,None
+    return int(min(ts)*10**9), int(max(ts)*10**9)
+
+_it_start,_it_end=_iter_bins_window(_IB)
+_starts=[t for t in (trace_start, sm_start, _it_start) if t is not None]
+_ends=[t for t in (trace_end, sm_end, _it_end) if t is not None]
 run_start=min(_starts) if _starts else 0
 run_end=max(_ends) if _ends else run_start+1
 run_dur=(run_end-run_start)/1e9
 
 def relt(ns): return round((ns-run_start)/1e9,1)
 for r in rows: r["ts"]=relt(r["ts_ns"]);
+
+# ---- end of the load generator's warmup phase -----------------------------------
+# Optional, and deliberately so: many harnesses have no warmup phase at all, and a
+# marker invented for them would be a lie. Resolved once here, from the highest-
+# confidence source available, and carried as an OPTIONAL field -- absent means "no
+# warmup boundary is known", never "warmup ended at t=0".
+#
+# Precedence:
+#   1. the client export's own `benchmark_phase` (authoritative; the harness said so)
+#   2. `warmup_end_ns` recorded in dashboard.yaml by ingest, for bundles built
+#      without the client leg -- the export is routinely ~700 MB and is not copied
+#   3. nothing
+def _yaml_warmup_ns(bundle_dir):
+    if not bundle_dir: return None
+    ypath=os.path.join(bundle_dir,"dashboard.yaml")
+    if not os.path.exists(ypath): return None
+    try:
+        import yaml as _y
+        return ((_y.safe_load(open(ypath)) or {}).get("warmup") or {}).get("end_ns")
+    except Exception:
+        return None
+
+WARMUP_END_S=None; WARMUP_SRC=None
+_w_ns=_prof_min_start or _warm_max_end
+if _w_ns: WARMUP_SRC="profile_export.jsonl (benchmark_phase)"
+else:
+    _w_ns=_yaml_warmup_ns(SRC)
+    if _w_ns: WARMUP_SRC="dashboard.yaml (warmup.end_ns)"
+if _w_ns:
+    _v=relt(int(_w_ns))
+    # A boundary outside the rendered window is not plottable and would draw a line
+    # on the axis edge implying the whole run was one phase. Dropped, with a warning.
+    if 0 < _v < run_dur:
+        WARMUP_END_S=_v
+        _log.info(f"warmup ends at t+{_v:.1f}s of {run_dur:.0f}s "
+                  f"({_v/run_dur*100:.0f}% of the run) — source: {WARMUP_SRC}")
+    else:
+        _log.warning(f"warmup boundary t+{_v:.1f}s falls outside the run window "
+                     f"(0..{run_dur:.0f}s); no marker drawn")
+        WARMUP_SRC=None
 # ---- metric extractors ----
 def gsingle(m,name):
     a=m.get(name)
@@ -779,6 +852,34 @@ else:
     _log.warning("KV hit rate: no engine config in the bundle, so reuse-disabled "
                  "components cannot be excluded; the series may understate the true rate")
 
+def _iter_reuse_series():
+    """Context-phase block reuse per 1 s bin, from the per-iteration log.
+
+    A fallback for ``trtllm_kv_cache_hit_rate``, which only exists if a WORKER
+    ``/metrics`` endpoint was scraped. It frequently was not -- AIPerf's own export
+    scrapes the frontend only, and a trtllm-serve run has no Dynamo endpoint at all --
+    and the panel then drew a full-length series of nulls, i.e. an empty chart that
+    reads as "reuse is zero" rather than "reuse was not captured".
+
+    ``cached_kv_tokens / (cached_kv_tokens + num_ctx_tokens)`` over context workers.
+    Validated against the client's own Prompt Cache Read % on three runs of the same
+    point: 95.88 / 95.76 / 94.27 % here vs 95.6-97.2 % reported. Close, but NOT the
+    same estimator -- this is token-weighted over prefill workers, so it is labelled
+    as the derived series it is rather than presented as the gauge.
+    """
+    if not _IB: return []
+    acc={}
+    for w,rows in (_IB.get("bins") or {}).items():
+        if "prefill" not in w and "ctx" not in w: continue
+        for r in rows:
+            c=r.get("cached_kv_tokens") or 0; t=r.get("num_ctx_tokens") or 0
+            if c+t<=0: continue
+            k=relt(int(r["t"])*10**9)
+            a=acc.setdefault(k,[0,0]); a[0]+=c; a[1]+=c+t
+    return [[k, round(v[0]/v[1]*100,2)] for k,v in sorted(acc.items())
+            if 0<=k<=run_dur+60 and v[1]]
+
+
 def kvhit_series():
     out=[]
     for ts,m in scr:
@@ -788,7 +889,51 @@ def kvhit_series():
         vals=[x for vs in g.values() for x in vs]
         out.append([relt(ts), round(sum(vals)/len(vals)*100,2) if vals else None])
     return out
+def _iter_kvutil_series(role):
+    """Peak-worker KV pool occupancy per 1 s bin, from the per-iteration log.
+
+    Fallback for ``dynamo_component_gpu_cache_usage_percent`` on the same grounds as
+    the reuse fallback: the gauge lives on the worker endpoint, which is frequently
+    not scraped. `max` across workers of that role, matching the gauge's own
+    peak-worker aggregation so the two are read the same way.
+    """
+    if not _IB: return []
+    acc={}
+    for w,rows in (_IB.get("bins") or {}).items():
+        if role not in w: continue
+        for r in rows:
+            v=r.get("kv_cache_util")
+            if v is None: continue
+            k=relt(int(r["t"])*10**9)
+            if not (0<=k<=run_dur+60): continue
+            acc[k]=max(acc.get(k,0.0), v*100)
+    return [[k,round(v,2)] for k,v in sorted(acc.items())]
+
+
+# The gauge is absent whenever no worker endpoint was scraped. Falling back keeps the
+# panel honest: before this it emitted a full-length series of Nones, which draws an
+# empty axis -- indistinguishable from "utilisation was zero".
+en["kvutil_src"]="dynamo_component_gpu_cache_usage_percent"
+if not [p for p in en["kvutil_pf"] if p[1] is not None] and \
+   not [p for p in en["kvutil_de"] if p[1] is not None]:
+    _pf,_de=_iter_kvutil_series("prefill"),_iter_kvutil_series("decode")
+    if _pf or _de:
+        _grid=sorted({k for s in (_pf,_de) for k,_ in s})
+        _pfm,_dem=dict(_pf),dict(_de)
+        en["kvutil_pf"]=[[k,_pfm.get(k)] for k in _grid]
+        en["kvutil_de"]=[[k,_dem.get(k)] for k in _grid]
+        en["kvutil_src"]="iter_bins.json (kv_cache_util)"
+        _log.info(f"KV utilisation: gauge absent, derived from the iteration log "
+                  f"({len(_grid)} bins)")
+
 en["true_hit_pct"]=kvhit_series()
+en["true_hit_src"]="trtllm_kv_cache_hit_rate"
+if not [p for p in en["true_hit_pct"] if p[1] is not None]:
+    _fb=_iter_reuse_series()
+    if _fb:
+        en["true_hit_pct"]=_fb; en["true_hit_src"]="iter_bins.json (cached_kv_tokens)"
+        _log.info(f"KV hit rate: gauge absent, derived from the iteration log "
+                  f"({len(_fb)} bins)")
 en["reuse_components"]=sorted(_REUSE_COMPONENTS) if _REUSE_COMPONENTS is not None else None
 _hitvals=[p[1] for p in en["true_hit_pct"] if p[1] is not None]
 en["true_hit_kpi"]=round(pct(_hitvals,50),1) if _hitvals else None
@@ -1041,10 +1186,9 @@ def _ordered_spans(sp):
 # 1s by parse_iterlog.py. Optional: absent unless that parser has been run.
 # The engine ceilings it captions against are resolved at the top of this file,
 # before any panel consumes them.
-_iter_path=os.path.join(SRC,"iter_bins.json") if SRC else ""
 iter_series={}; iter_bins=None
-if os.path.exists(_iter_path):
-    _ib=json.load(open(_iter_path)); iter_bins=_ib
+if _IB:
+    _ib=_IB; iter_bins=_ib
     for _wkey,_rows in (_ib.get("bins") or {}).items():
         out={k:[] for k in ("kv_cache_util","num_scheduled_requests","num_ctx_requests","num_generation_tokens")}
         for r in _rows:
@@ -1361,6 +1505,19 @@ if rt_rows:
 # none of them has bespoke code, so none can drift into being run-specific.
 panels=_evaluate_panels(scr)
 
+# The warmup boundary rides on the PANEL ENTITY, not on a global the renderer reaches
+# for. A panel is then self-describing -- it carries its own series, its own units and
+# its own phase marker -- so any consumer that can draw one panel can draw the marker,
+# and a panel whose x-axis is not run-time simply never sets the field.
+# Applied just before the payload is assembled, NOT here: the derived panels
+# (batch composition, step stalls, rank balance) are appended to `panels` further
+# down, and marking at this point would silently skip every one of them.
+def _mark_warmup(ps):
+    if WARMUP_END_S is None: return ps
+    for _p in ps.values():
+        _p["warmup_end_s"]=WARMUP_END_S
+    return ps
+
 # ---- derived panels: in-flight balance across ranks and workers -------------
 # Emitted in the SAME shape as the spec panels so the generic renderer draws them
 # with no extra code -- a different SOURCE, not a different kind of panel.
@@ -1508,7 +1665,7 @@ if panels:
 
 DATA={
  "logdrill":logdrill,
- "panels":panels,
+ "panels":_mark_warmup(panels),
  "rt":{"requests":rt_requests,"sessions":rt_sessions,"bands":RT_BANDS,"const":rt_const,"belief":rt_belief},
  "iter":iter_series,
  "iter_cfg":{"pf_batch":CFG_PF_BATCH,"pf_tok":CFG_PF_TOK,"de_batch":CFG_DE_BATCH,"de_tok":CFG_DE_TOK},
@@ -1517,10 +1674,15 @@ DATA={
  # Which tabs have inputs. A tab with no data is DROPPED, not rendered empty:
  # an empty Router tab reads as "this run had no queueing" rather than "this run
  # was not instrumented", which is the more dangerous of the two misreadings.
+ # Engine is the one tab with two independent producers: the scrape stream and the
+ # per-iteration log. Gating it on scrapes alone drops it on a run that has full
+ # engine telemetry and no /metrics surface -- exactly the trtllm-serve control a
+ # Dynamo run has to be compared against.
  "tabs":{"overview":bool(rows),"frontend":bool(scr),"router":bool(scr),
-         "engine":bool(scr),"loganalysis":logdrill is not None,
+         "engine":bool(scr) or bool(iter_series),"loganalysis":logdrill is not None,
          "session":bool(rt_sessions)},
  "meta":{"n":N,"run_dur_s":round(run_dur,1),"scrapes":len(scr),
+   "warmup_end_s":WARMUP_END_S,"warmup_src":WARMUP_SRC,
    "src":META_SRC,
    # Substitute the authoritative block size measured from the metrics stream. The
    # yaml only ever carried ingest's --block-size fallback, and on the reference run
@@ -1716,7 +1878,26 @@ function note(view,html,cls){vsel(view).append('div').attr('class','note '+(cls|
 function svg(el,w,h){return el.append('svg').attr('viewBox',`0 0 ${w} ${h}`)}
 function lg(el,items){el.append('div').attr('class','lg').html(items.map(([c,t])=>`<span><span class="sw" style="background:${c}"></span>${t}</span>`).join(''))}
 
-function lineChart(el,series,{unit='ms',w=VW,h=220,cols=null,keys=null,legend=null,ymax=null,hline=null,logy=false}={}){
+// ---- warmup phase marker ----------------------------------------------------
+// Drawn by every time-axis chart, from ONE helper, so the marker cannot be present
+// on some tabs and missing on others. The value is an OPTIONAL field on the panel
+// entity (`p.warmup_end_s`), falling back to the run-level `DATA.meta.warmup_end_s`
+// for the hand-written charts that have no panel entity. Absent => nothing drawn:
+// a harness with no warmup phase must not grow an invented boundary.
+function wmVal(p){
+  const v = (p && p.warmup_end_s!=null) ? p.warmup_end_s : (DATA.meta||{}).warmup_end_s;
+  return (v==null || !isFinite(v)) ? null : v;
+}
+function wmLine(s,x,hTop,hBot,p){
+  const v=wmVal(p); if(v==null) return;
+  const px=x(v); const [lo,hi]=x.range();
+  if(px<lo || px>hi) return;          // boundary outside this chart's window
+  s.append('line').attr('x1',px).attr('x2',px).attr('y1',hTop).attr('y2',hBot)
+   .attr('stroke','#8b949e').attr('stroke-width',1).attr('stroke-dasharray','3,3').attr('opacity',.75);
+  s.append('text').attr('x',px+3).attr('y',hTop+9).attr('fill','#8b949e')
+   .attr('font-size','9px').text('warmup ends');
+}
+function lineChart(el,series,{unit='ms',w=VW,h=220,cols=null,keys=null,legend=null,ymax=null,hline=null,logy=false,panelSpec=null}={}){
   if(legend)lg(el,legend);
   const s=svg(el,w,h),L=56,B=26,R=12;
   const x=d3.scaleLinear().domain([0,RD]).range([L,w-R]);
@@ -1731,6 +1912,7 @@ function lineChart(el,series,{unit='ms',w=VW,h=220,cols=null,keys=null,legend=nu
     ? d3.scaleLog().domain([Math.max(1e-9,d3.min(series,d=>d3.min(lines.map(k=>d[Array.isArray(k)?k[0]:k]).filter(v=>v!=null&&v>0)))||1), mx*1.6]).range([h-B,8])
     : d3.scaleLinear().domain([0,mx*1.05]).range([h-B,8]);
   s.append('g').attr('class','axis').attr('transform',`translate(0,${h-B})`).call(d3.axisBottom(x).ticks(8).tickFormat(d=>d+'s'));
+  wmLine(s,x,8,h-B,panelSpec);
   s.append('g').attr('class','axis').attr('transform',`translate(${L},0)`).call((logy?d3.axisLeft(y).ticks(6,'~s'):d3.axisLeft(y).ticks(5).tickFormat(d=>unit==='ms'?fmtS(d):(unit==='%'?d+'%':d3.format('~s')(d)))));
   if(hline!=null){s.append('line').attr('x1',L).attr('x2',w-R).attr('y1',y(hline)).attr('y2',y(hline)).attr('stroke','#666').attr('stroke-dasharray','5 3');
     s.append('text').attr('x',w-R-3).attr('y',y(hline)-4).attr('text-anchor','end').attr('fill','#8b949e').attr('font-size',10).text('max '+hline);}
@@ -1791,6 +1973,7 @@ function multiLine(el,series,{h=240,unitLabel='',area=false,xmax=null}={}){
   const mx=d3.max(labels,k=>d3.max(series[k],d=>d[1]))||1;
   const y=d3.scaleLinear().domain([0,mx*1.05]).range([h-B,8]);
   s.append('g').attr('class','axis').attr('transform',`translate(0,${h-B})`).call(d3.axisBottom(x).ticks(8).tickFormat(d=>d+'s'));
+  wmLine(s,x,8,h-B,null);
   s.append('g').attr('class','axis').attr('transform',`translate(${L},0)`).call(d3.axisLeft(y).ticks(5).tickFormat(fmtN));
   if(unitLabel)s.append('text').attr('x',6).attr('y',12).attr('font-size',11).attr('fill',C.dim).text(unitLabel);
   const ln=d3.line().defined(d=>d[1]!=null).x(d=>x(d[0])).y(d=>y(d[1])).curve(d3.curveStepAfter);
@@ -2113,10 +2296,32 @@ drillPanel('overview',DATA.drill,{
  }
  note('engine',`Engine occupancy from Prometheus: <b>KV utilisation</b>, <b>in-flight batch vs configured max</b>, and the <b>true block cache-hit</b>. Read together — low KV utilisation with in-flight batch far below the max ceiling means the engines are starved (requests held upstream in admission — see Router), not compute-bound. Caveats (image-gated): no <code>llm_request</code> span (coarse gantt), no per-pool KV, no DCGM GPU-compute util.`+ceil,'hl');
 })();
-(function(){const el=panel('engine','KV cache utilisation over the run (% — peak worker)','dynamo_component_gpu_cache_usage_percent, max across dp-ranks per role (the busiest worker). Peaks &lt;4% ⇒ KV cache nearly empty: workers idle waiting on admission, not KV-bound.',true);
- lg(el,[[C.pf,'prefill (6 CTX)'],[C.de,'decode (1 GEN)']]);
- lineChart(el,DATA.en.kvutil_pf.map((d,i)=>[d[0],d[1],DATA.en.kvutil_de[i][1]]),{unit:'%',keys:[[1,C.pf],[2,C.de]]});})();
-(function(){const el=panel('engine','True block cache-hit over the run (%)','trtllm_kv_cache_hit_rate (engine, per CTX worker) — the REAL reuse. Perf-OFF client reports 0% as an artifact; the log-residency proxy inflates.',true);
+// A series of all-nulls is NOT the same as a series of zeros, and an empty axis
+// says the second. Every panel below states which source produced it and, when
+// neither the gauge nor the iteration-log fallback exists, says so in words.
+function notCaptured(el,what){
+  el.append('div').attr('class','cap')
+    .style('padding','14px 0').style('color','#d29922')
+    .html(`<b>Not captured in this run.</b> ${what} No worker <code>/metrics</code> endpoint `
+         +`was scraped and the per-iteration log carries no substitute, so this is absent `
+         +`data — not a measured zero.`);
+}
+function anyVal(s,i){return (s||[]).some(d=>d[i]!=null);}
+(function(){const src=DATA.en.kvutil_src||'';
+ const el=panel('engine','KV cache utilisation over the run (% — peak worker)',
+  `Source: <code>${src}</code>, max across workers per role (the busiest worker). `
+ +`Low peaks with in-flight batch far below the ceiling ⇒ the engines are starved, not KV-bound.`
+ +(src.startsWith('iter_bins')?' <b>Derived from the per-iteration log</b> because the Prometheus gauge was not scraped; same quantity, denser sampling.':''),true);
+ if(!anyVal(DATA.en.kvutil_pf,1)&&!anyVal(DATA.en.kvutil_de,1)){
+   notCaptured(el,'<code>dynamo_component_gpu_cache_usage_percent</code> is a worker-side gauge.');return;}
+ lg(el,[[C.pf,'prefill'],[C.de,'decode']]);
+ lineChart(el,DATA.en.kvutil_pf.map((d,i)=>[d[0],d[1],(DATA.en.kvutil_de[i]||[])[1]]),{unit:'%',keys:[[1,C.pf],[2,C.de]]});})();
+(function(){const src=DATA.en.true_hit_src||'';
+ const el=panel('engine','True block cache-hit over the run (%)',
+  `Source: <code>${src}</code> — the REAL reuse, measured at the engine rather than inferred from the client.`
+ +(src.startsWith('iter_bins')?' <b>Derived from the per-iteration log</b> as <code>cached_kv_tokens / (cached_kv_tokens + num_ctx_tokens)</code> over context workers, because <code>trtllm_kv_cache_hit_rate</code> was not scraped. Token-weighted and context-phase only, so it is close to but not identical to the gauge.':''),true);
+ if(!anyVal(DATA.en.true_hit_pct,1)){
+   notCaptured(el,'<code>trtllm_kv_cache_hit_rate</code> is a worker-side gauge.');return;}
  lineChart(el,DATA.en.true_hit_pct,{unit:'%',keys:[[1,C.grn]]});})();
 
 // ================= FRONTEND =================
@@ -2135,6 +2340,7 @@ drillPanel('overview',DATA.drill,{
   const y=d3.scaleLinear().domain([0,d3.max(all,d=>d[1])*1.1||1]).nice().range([h-B,8]);
   s.append('g').attr('class','axis').attr('transform',`translate(0,${h-B})`).call(d3.axisBottom(x).ticks(8).tickFormat(v=>v+'s'));
   s.append('g').attr('class','axis').attr('transform',`translate(${L},0)`).call(d3.axisLeft(y).ticks(5).tickFormat(v=>(v*100).toFixed(0)+'%'));
+  wmLine(s,x,8,h-B,null);
   const ln=d3.line().x(d=>x(d[0])).y(d=>y(d[1]));
   ser.forEach((d,i)=>s.append('path').datum(d).attr('fill','none').attr('stroke',keys[i][1]).attr('stroke-width',1.2).attr('opacity',.9).attr('d',ln));
  })();
@@ -2145,24 +2351,53 @@ drillPanel('overview',DATA.drill,{
  const WK=Object.keys(IT).sort();
  const PAL=[C.pf,C.de,C.grn,C.route,C.cy,C.adm];
  function batchPanel(role, ceil, tok){
-   const wk=WK.filter(w=>w.startsWith(role)); if(!wk.length) return;
-   const cap=`<code>num_scheduled_requests</code> from the TRT-LLM per-iteration log, one line per `
-     +`${role} worker, raw integer (max per 1s bin). <b>Configured ceiling: `
-     +`<code>max_batch_size = ${ceil==null?'?':ceil}</code>`+(tok?` , <code>max_num_tokens = ${tok}</code>`:'')
-     +`</b> from this run's <code>trtllm_config_${role}.yaml</code> — shown here as text, not as a line, since a `
-     +`ceiling far above the data squashes the series onto the axis.`;
-   const el=panel('engine',`${role==='prefill'?'Prefill':'Decode'} in-flight batch per worker`,cap,true);
-   lg(el,wk.map((w,i)=>[PAL[i%PAL.length],w]));
-   const L=54,B=28,h=230,s=svg(el,VW,h);
+   // Worker keys are the LOG FILE stem, `<node>_<role>_w<N>` (e.g.
+   // `hecate0176_decode_w0`) -- the role is in the middle, not at the front. A
+   // startsWith() here matched nothing on every srt-slurm run ever rendered, and
+   // because the function returns silently on an empty match, both batch panels
+   // were absent rather than broken. Substring match, anchored on the `_role_`
+   // separator so a node named e.g. `decode01` cannot be mistaken for a role.
+   const wk=WK.filter(w=>w.includes('_'+role+'_')||w.includes('_'+role));
+   if(!wk.length) return;
    const all=wk.flatMap(w=>IT[w].num_scheduled_requests);
    if(!all.length) return;
    const ymax=d3.max(all,d=>d[1]);
+   const vals=all.map(d=>d[1]).sort((a,b)=>a-b);
+   const med=vals[Math.floor(vals.length/2)];
+   // The ceiling is drawn whenever it is on a comparable scale to the data. When it
+   // is far above (prefill runs a batch of ~1-10 against max_batch_size 256) drawing
+   // it to scale squashes every series onto the axis and the panel says nothing, so
+   // the axis stays on the data and the ceiling is reported as a utilisation figure.
+   const onScale = ceil!=null && ceil>0 && ymax >= ceil*0.25;
+   const pctOf = ceil ? v=>` (${(v/ceil*100).toFixed(1)}% of ceiling)` : ()=>'';
+   const cap=`<code>num_scheduled_requests</code> from the TRT-LLM per-iteration log, one line per `
+     +`${role} worker, raw integer (max per 1s bin), plotted against this run's configured `
+     +`<b><code>max_batch_size = ${ceil==null?'?':ceil}</code></b>`+(tok?` (<code>max_num_tokens = ${tok}</code>)`:'')
+     +` from <code>trtllm_config_${role}.yaml</code>. `
+     +(onScale
+        ? `The ceiling is the dashed line — the gap between it and the series is unserved batch capacity.`
+        : `The ceiling is <b>off-scale</b> here and is not drawn, because plotting it would squash `
+          +`every series onto the axis. Peak batch <b>${ymax}</b>${pctOf(ymax)}, median <b>${med}</b>${pctOf(med)} `
+          +`— at this ratio the batch is bounded by something other than <code>max_batch_size</code>`
+          +(tok?`, most likely the <code>max_num_tokens = ${tok}</code> budget.`:'.'));
+   const el=panel('engine',`${role==='prefill'?'Prefill':'Decode'} in-flight batch size per worker`,cap,true);
+   lg(el,wk.map((w,i)=>[PAL[i%PAL.length],w])
+        .concat(onScale?[['#d29922',`max_batch_size = ${ceil}`]]:[]));
+   const L=54,B=28,h=230,s=svg(el,VW,h);
+   const ytop = onScale ? ceil*1.06 : ymax;
    const x=d3.scaleLinear().domain([0,RD]).range([L,VW-10]);
-   const y=d3.scaleLinear().domain([0,ymax]).range([h-B,10]);
+   const y=d3.scaleLinear().domain([0,ytop]).range([h-B,10]);
    s.append('g').attr('class','axis').attr('transform',`translate(0,${h-B})`)
     .call(d3.axisBottom(x).ticks(8).tickFormat(v=>v+'s'));
    s.append('g').attr('class','axis').attr('transform',`translate(${L},0)`)
-    .call(d3.axisLeft(y).ticks(Math.min(ymax,6)).tickFormat(d3.format('d')));
+    .call(d3.axisLeft(y).ticks(Math.min(Math.ceil(ytop),6)).tickFormat(d3.format('d')));
+   wmLine(s,x,10,h-B,null);
+   if(onScale){
+     s.append('line').attr('x1',L).attr('x2',VW-10).attr('y1',y(ceil)).attr('y2',y(ceil))
+      .attr('stroke','#d29922').attr('stroke-width',1.4).attr('stroke-dasharray','6,4').attr('opacity',.95);
+     s.append('text').attr('x',VW-14).attr('y',y(ceil)-5).attr('text-anchor','end')
+      .attr('fill','#d29922').attr('font-size','10px').text(`max_batch_size = ${ceil}`);
+   }
    const ln=d3.line().x(d=>x(d[0])).y(d=>y(d[1]));
    wk.forEach((w,i)=>s.append('path').datum(IT[w].num_scheduled_requests).attr('fill','none')
      .attr('stroke',PAL[i%PAL.length]).attr('stroke-width',1.2).attr('opacity',.85).attr('d',ln));
@@ -2243,6 +2478,7 @@ note('frontend',`Both panels come from the <b>frontend</b> endpoint (<code>:8000
    .call(d3.axisBottom(x).ticks(8).tickFormat(v=>v.toFixed(0)+'s'));
   s.append('g').attr('class','axis').attr('transform',`translate(${L},0)`)
    .call(d3.axisLeft(y).ticks(5).tickFormat(fmtU(p.unit)));
+  wmLine(s,x,8,H-B,p);
   const ln=d3.line().x(d=>x(d[0])).y(d=>y(d[1]));
   drawn.forEach((k,i)=>s.append('path').datum(p.series[k]).attr('fill','none')
     .attr('stroke',PAL[i%PAL.length]).attr('stroke-width',1.2).attr('opacity',.9).attr('d',ln));

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -617,13 +617,49 @@ def _mdc_block_size():
     return None
 
 BLK=_mdc_block_size()
+
+def _block_size_mismatch():
+    """Router block size vs the engine's tokens-per-block, as a first-class check.
+
+    These are two different pools sized independently, and when they disagree the
+    router's KV events reference blocks the engine cannot match. The consequence is
+    not subtle -- on the reference run it produces a chain of 540 "Block contains N
+    tokens" errors, 2,835 "Failed to find block to remove", and 35,198 "Block not
+    found during remove", the last of which is 73% of the entire frontend log (94% at
+    higher concurrency).
+
+    It is invisible in the metrics: the counter built for exactly this failure,
+    `dynamo_component_kv_cache_events_applied{status="block_not_found"}`, reads a
+    constant 0. So the only way to surface it is to compare the two configured sizes
+    directly, which is what this does.
+
+    Returns (router_blk, engine_tpb) or None when either is unavailable -- "cannot
+    tell" rather than a guessed all-clear.
+    """
+    eng=None
+    for _,m in scr:
+        for e in (_entries(m,"trtllm_kv_cache_tokens_per_block") or []):
+            v=e.get("value")
+            if isinstance(v,(int,float)) and v>0: eng=int(v); break
+        if eng: break
+    return (BLK,eng) if (BLK and eng) else None
+
+_BLK_MISMATCH=_block_size_mismatch()
+if _BLK_MISMATCH and _BLK_MISMATCH[0]!=_BLK_MISMATCH[1]:
+    _log.warning(f"KV block-size mismatch: router indexes {_BLK_MISMATCH[0]}-token blocks "
+                 f"while the engine pools {_BLK_MISMATCH[1]}-token blocks; router KV events "
+                 f"will reference blocks the engine cannot match")
+elif _BLK_MISMATCH:
+    _log.info(f"KV block size agrees across router and engine: {_BLK_MISMATCH[0]} tokens")
 if BLK is None: _log.warning("no dynamo_frontend_model_kv_cache_block_size in the stream; "
                              "decode tokens-in-flight stays in BLOCKS")
 load={"tput":_rolling_tput(GPUS),
       "rif_pf":_in_flight(hp_ev["prefill"]),"rif_de":_in_flight(hp_ev["decode"]),
       "tif_pf":_worker_bins("dynamo_frontend_worker_active_prefill_tokens","prefill"),
       "tif_de":_worker_bins("dynamo_frontend_worker_active_decode_blocks","decode",scale=BLK or 1),
-      "gpus":GPUS,"blk":BLK,"win_s":TPUT_WIN_S,"bins":NBW}
+      "gpus":GPUS,"blk":BLK,"win_s":TPUT_WIN_S,"bins":NBW,
+      "blk_router":(_BLK_MISMATCH or [None,None])[0],
+      "blk_engine":(_BLK_MISMATCH or [None,None])[1]}
 _log.info(f"load rows: tput={len(load['tput'])}pts gpus={GPUS} "
           f"rif_pf={len(load['rif_pf'])} rif_de={len(load['rif_de'])} "
           f"tif_pf={len(load['tif_pf'])}series tif_de={len(load['tif_de'])}series block={BLK}")
@@ -1080,6 +1116,29 @@ if iter_series and 'iter_bins' in globals() and iter_bins:
                    "are excluded from the denominator; a quiet period is not a batching "
                    "failure.",
           "issues":["PERF-batch-starvation"],"series":_bf}
+    _st={}
+    for _w,_rows in iter_bins.get("bins",{}).items():
+        _pts=[]
+        for _r in _rows:
+            _v=_r.get("host_step_time_ms_max")
+            _t=relt(int(_r["t"])*10**9)
+            if _v is None or _t<0 or _t>run_dur+60: continue
+            _pts.append([round(_t,1),_v/1000.0])
+        if _pts: _st[_w]=_pts
+    if _st:
+        panels["en_step_stall"]={
+          "tab":"engine","title":"Worst engine step per second",
+          "unit":"s","kind":"derived","split_by":None,
+          "why":"The longest forward step in each second, from the per-iteration log. A "
+                "scraped gauge samples once a second and cannot see a stall it did not "
+                "land on, so this is the only view in which a multi-second engine stop "
+                "is visible at all.",
+          "source":["iter_bins.json"],
+          "caveat":"Rank 0 only, and a maximum rather than a typical value -- read it "
+                   "beside the median step time, not instead of it.",
+          "issues":["PERF-iteration-stall"],"series":_st}
+        _pk=max(v for s_ in _st.values() for _,v in s_)
+        _log.info(f"engine step stalls: worst single step {_pk:.1f}s across {len(_st)} worker(s)")
     if _mx:
         panels["en_sched_max"]={
           "tab":"engine","title":"Peak scheduled requests per step",

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -101,6 +101,17 @@ def _cfg_max_batch(mode):
         except Exception:
             pass
     return None, None
+def _host_series():
+    """Host and per-process health from ``host_series.json`` (PERF-37/38/40)."""
+    if not SRC:
+        return None
+    try:
+        with open(os.path.join(SRC, "host_series.json")) as fh:
+            return json.load(fh) or None
+    except Exception:
+        return None
+
+
 def _lifecycle():
     """Time-to-ready and terminal cause from ``run_lifecycle.json`` (PERF-45)."""
     if not SRC:
@@ -326,6 +337,14 @@ PROVENANCE = _provenance()
 BENCH_STATUS = _benchmark_status()
 LOG_SIGNALS = _log_signals()
 LIFECYCLE = _lifecycle()
+HOST = _host_series()
+if HOST:
+    _pk = max((v for _, v in (HOST.get("host_cpu_pct") or [])), default=None)
+    _log.info(f"host telemetry: {HOST.get('samples')} samples on {HOST.get('host')}, "
+              f"peak CPU {_pk}%, fd headroom {HOST.get('fd_headroom_pct')}% of "
+              f"{HOST.get('fd_limit')}, {len(HOST.get('procs') or {})} process(es)")
+else:
+    _log.info("host telemetry: absent (host_series.json not in the bundle)")
 if LIFECYCLE:
     _d = LIFECYCLE.get("durations_s") or {}
     _log.info(f"lifecycle: time_to_ready={_d.get('time_to_ready')}s "
@@ -1525,7 +1544,8 @@ DATA={
    "provenance":PROVENANCE,
    "benchmark_status":BENCH_STATUS,
    "log_signals":LOG_SIGNALS,
-   "lifecycle":LIFECYCLE},
+   "lifecycle":LIFECYCLE,
+   "host":HOST},
  "kpi":{"ttft_p50":round(pct(col("ttft"),50)/1000,1),"ttft_p99":round(pct(col("ttft"),99)/1000,1),
    "adm_p50":round(pct(col("adm"),50)/1000,1),"pf_p50":round(pct(col("pf"),50)/1000,1),
    "reqs":N,"adm_share":round(pct(col("adm"),50)/max(1,pct(col("ttft"),50))*100,0),

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -101,6 +101,49 @@ def _cfg_max_batch(mode):
         except Exception:
             pass
     return None, None
+def _flat_config():
+    """The run's resolved recipe, flattened to {dotted.path: scalar}.
+
+    Flattened rather than cherry-picked because the interesting key is whichever one
+    an experiment happened to move, and a hand-maintained list of "settings worth
+    recording" is guaranteed to omit exactly that one the first time it matters.
+
+    This is also the only record of the FRONTEND environment. The worker fingerprints
+    capture prefill and decode, but settings like DYN_TOKENIZER_CACHE live on the
+    frontend and appear in no fingerprint at all -- so without this, an ablation on a
+    frontend variable has no artifact proving what it changed.
+
+    `name` is dropped: every arm of an ablation renames itself, and leaving it in makes
+    a clean single-variable diff report two differences instead of one.
+    """
+    if not SRC:
+        return None
+    for cand in (os.path.join(SRC, "config.yaml"),
+                 os.path.join(SRC, "..", "..", "config.yaml")):
+        try:
+            import yaml as _y
+            with open(cand) as fh:
+                doc = _y.safe_load(fh) or {}
+        except Exception:
+            continue
+        flat = {}
+
+        def _walk(node, prefix=""):
+            if isinstance(node, dict):
+                for k, v in node.items():
+                    _walk(v, f"{prefix}{k}.")
+            elif isinstance(node, list):
+                # Joined rather than indexed: a reordered list is not a config change,
+                # and per-index keys would report one for every shifted element.
+                flat[prefix.rstrip(".")] = ",".join(str(x) for x in node)
+            else:
+                flat[prefix.rstrip(".")] = node
+        _walk(doc)
+        flat.pop("name", None)
+        return flat
+    return None
+
+
 def _provenance():
     """What actually ran: framework versions, GPU, and per-worker agreement.
 
@@ -139,6 +182,7 @@ def _provenance():
             frameworks.setdefault(k, set()).add(v)
     if not per_worker:
         return None
+    cfg = _flat_config()
     # A framework name mapping to more than one version means the workers are not
     # running the same build. Reported as a first-class disagreement rather than
     # collapsed to "the version", which would silently pick one arbitrarily.
@@ -146,7 +190,8 @@ def _provenance():
     return {"workers": per_worker,
             "frameworks": {k: sorted(v)[0] for k, v in frameworks.items()},
             "framework_disagreement": disagree or None,
-            "n_workers": len(per_worker)}
+            "n_workers": len(per_worker),
+            "config": cfg}
 
 
 def _client_summary():

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -101,6 +101,21 @@ def _cfg_max_batch(mode):
         except Exception:
             pass
     return None, None
+def _log_signals():
+    """Log-only signals from ``log_signals.json``: the ones with no metric behind them.
+
+    Returned whole, including zero counts. "This run had no worker crashes" is a
+    statement; the signal simply being absent from the payload is not.
+    """
+    if not SRC:
+        return None
+    try:
+        with open(os.path.join(SRC, "log_signals.json")) as fh:
+            return (json.load(fh) or {}).get("signals") or None
+    except Exception:
+        return None
+
+
 def _benchmark_status():
     """Why the benchmark produced what it produced, from ``benchmark_status.json``.
 
@@ -298,6 +313,11 @@ def _cfg_tokens_per_block():
 CLIENT_SUMMARY = _client_summary()
 PROVENANCE = _provenance()
 BENCH_STATUS = _benchmark_status()
+LOG_SIGNALS = _log_signals()
+if LOG_SIGNALS:
+    _fired = {k: v["count"] for k, v in LOG_SIGNALS.items() if v.get("count")}
+    _log.info(f"log-only signals: {_fired}" if _fired
+              else "log-only signals: none fired (all counts zero)")
 if BENCH_STATUS:
     _log.warning(f"benchmark reported failure: exit={BENCH_STATUS['exit_code']}; "
                  f"{BENCH_STATUS['errors'][0] if BENCH_STATUS['errors'] else 'no error line captured'}")
@@ -1487,7 +1507,8 @@ DATA={
                    "phases":_phase_seen},
    "client_summary":CLIENT_SUMMARY,
    "provenance":PROVENANCE,
-   "benchmark_status":BENCH_STATUS},
+   "benchmark_status":BENCH_STATUS,
+   "log_signals":LOG_SIGNALS},
  "kpi":{"ttft_p50":round(pct(col("ttft"),50)/1000,1),"ttft_p99":round(pct(col("ttft"),99)/1000,1),
    "adm_p50":round(pct(col("adm"),50)/1000,1),"pf_p50":round(pct(col("pf"),50)/1000,1),
    "reqs":N,"adm_share":round(pct(col("adm"),50)/max(1,pct(col("ttft"),50))*100,0),

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -73,7 +73,35 @@ if _args.bundle_dir is None and not _args.frontend_log:
     _ap.error("nothing to render: give an ingest bundle, --frontend-log, or both")
 
 SRC, OUT = _args.bundle_dir, _args.out_html
-MAX_BATCH_PF, MAX_BATCH_DE = _args.max_batch_prefill, _args.max_batch_decode
+
+
+# Engine ceilings for the in-flight panels. The run's own resolved engine config is
+# authoritative; the --max-batch-* CLI flags are only a fallback for bundles that
+# have none. Resolved HERE, before anything consumes them, because the ceiling is
+# what the in-flight series is drawn against: on AgentX run 2739690 the real decode
+# max_batch_size is 1 against a CLI default of 256, so a decode engine pinned at its
+# limit rendered as 0.4% utilised. Prefill happening to match the default (128) is
+# what makes that error easy to miss.
+def _cfg_max_batch(mode):
+    if not SRC:
+        return None, None
+    for cand in (os.path.join(SRC, f"trtllm_config_{mode}.yaml"),
+                 os.path.join(SRC, "..", "..", f"trtllm_config_{mode}.yaml")):
+        try:
+            import yaml as _y
+            c = _y.safe_load(open(cand)) or {}
+            if c.get("max_batch_size") is not None:
+                return int(c["max_batch_size"]), int(c.get("max_num_tokens") or 0)
+        except Exception:
+            pass
+    return None, None
+CFG_PF_BATCH, CFG_PF_TOK = _cfg_max_batch("prefill")
+CFG_DE_BATCH, CFG_DE_TOK = _cfg_max_batch("decode")
+MAX_BATCH_PF = CFG_PF_BATCH if CFG_PF_BATCH else _args.max_batch_prefill
+MAX_BATCH_DE = CFG_DE_BATCH if CFG_DE_BATCH else _args.max_batch_decode
+_log.info(f"engine ceilings: prefill max_batch_size={MAX_BATCH_PF} max_num_tokens={CFG_PF_TOK} | "
+          f"decode max_batch_size={MAX_BATCH_DE} max_num_tokens={CFG_DE_TOK} "
+          f"(source: {'run config' if CFG_DE_BATCH else '--max-batch-* defaults'})")
 
 # Per-source availability. A tab is rendered only when its inputs exist -- an
 # empty tab is worse than an absent one, because it reads as "this run had no
@@ -586,27 +614,8 @@ def _ordered_spans(sp):
 
 # TRT-LLM per-iteration engine telemetry (print_iter_log: true), pre-binned to
 # 1s by parse_iterlog.py. Optional: absent unless that parser has been run.
-# Ceilings for the panel captions. Read from the run's resolved engine configs
-# when present -- the --max-batch-* CLI flags are only fallbacks and were wildly
-# wrong for this run (decode default 256 vs an actual max_batch_size of 1).
-def _cfg_max_batch(mode):
-    if not SRC:
-        return None, None
-    for cand in (os.path.join(SRC, f"trtllm_config_{mode}.yaml"),
-                 os.path.join(SRC, "..", "..", f"trtllm_config_{mode}.yaml")):
-        try:
-            import yaml as _y
-            c = _y.safe_load(open(cand)) or {}
-            if c.get("max_batch_size") is not None:
-                return int(c["max_batch_size"]), int(c.get("max_num_tokens") or 0)
-        except Exception:
-            pass
-    return None, None
-CFG_PF_BATCH, CFG_PF_TOK = _cfg_max_batch("prefill")
-CFG_DE_BATCH, CFG_DE_TOK = _cfg_max_batch("decode")
-_log.info(f"engine ceilings from config: prefill max_batch_size={CFG_PF_BATCH} "
-          f"max_num_tokens={CFG_PF_TOK} | decode max_batch_size={CFG_DE_BATCH} max_num_tokens={CFG_DE_TOK}")
-
+# The engine ceilings it captions against are resolved at the top of this file,
+# before any panel consumes them.
 _iter_path=os.path.join(SRC,"iter_bins.json") if SRC else ""
 iter_series={}
 if os.path.exists(_iter_path):

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -1192,6 +1192,7 @@ h1{margin:0;font-size:16px}.sub{color:var(--dim);font-size:12px;margin-top:3px}
 .panel{background:var(--panel);border:1px solid var(--edge);border-radius:10px;padding:12px 14px;min-width:0}
 .panel h2{margin:0 0 2px;font-size:13px}.panel .src{color:#6e7681;font-size:11px}
 .warn{color:#d29922;font-size:11px}
+.kpi .src{color:#6e7681;font-size:10px;margin-top:2px}
 .reqcard{border-top:1px solid #21262d;padding:8px 0}
 .reqhead{font-size:12px;color:#c9d1d9;margin-bottom:2px}
 .reqmeta{font-size:11px;color:#8b949e;margin-top:2px}
@@ -1273,8 +1274,14 @@ function vsel(id){const v=d3.select('#v-'+id);return v.empty()?d3.select('#sink'
 function grid(view){let g=vsel(view).select('.grid');return g.empty()?vsel(view).append('div').attr('class','grid'):g}
 function panel(view,title,cap,full){const el=grid(view).append('div').attr('class','panel'+(full?' full':''));
   el.append('h2').html(title);if(cap)el.append('div').attr('class','cap').html(cap);return el}
+// items are [value, label, source?]. The optional third element names WHERE the number
+// came from -- a KPI with no provenance is indistinguishable from one that was
+// computed off the wrong population, which has happened here more than once.
 function kpis(view,items){const k=vsel(view).insert('div',':first-child').attr('class','kpis');
-  items.forEach(it=>{const c=k.append('div').attr('class','kpi');c.append('div').attr('class','v').text(it[0]);c.append('div').attr('class','l').text(it[1])})}
+  items.forEach(it=>{const c=k.append('div').attr('class','kpi');
+    c.append('div').attr('class','v').text(it[0]);
+    c.append('div').attr('class','l').text(it[1]);
+    if(it[2]) c.append('div').attr('class','src').text(it[2]);})}
 function note(view,html,cls){vsel(view).append('div').attr('class','note '+(cls||'')).html(html)}
 function svg(el,w,h){return el.append('svg').attr('viewBox',`0 0 ${w} ${h}`)}
 function lg(el,items){el.append('div').attr('class','lg').html(items.map(([c,t])=>`<span><span class="sw" style="background:${c}"></span>${t}</span>`).join(''))}
@@ -1507,13 +1514,14 @@ drillPanel('overview',DATA.drill,{
 (function(){const L=DATA.logdrill; if(!L) return;
  const S=L.stats;
  kpis('loganalysis',[
-   [L.n.toLocaleString(),'requests charted'],
-   [(L.global.p50/1000).toFixed(2)+'s','TTFT p50 (log)'],
-   [(L.global.p99/1000).toFixed(2)+'s','TTFT p99 (log)'],
-   [S.records.toLocaleString(),'log records parsed'],
-   [S.completed.toLocaleString(),'lifecycle completions'],
-   [L.routing?'yes':'no','routing join available'],
-   [L.matched?'same run':'DIFFERENT','vs. bundle in other tabs']]);
+   [L.n.toLocaleString(),'requests charted','frontend log'],
+   [(L.global.p50/1000).toFixed(2)+'s','TTFT p50 (log)','request completed'],
+   [(L.global.p99/1000).toFixed(2)+'s','TTFT p99 (log)','request completed'],
+   [S.records.toLocaleString(),'log records parsed','frontend log'],
+   [S.completed.toLocaleString(),'lifecycle completions','request completed'],
+   [(S.selector_without_request_id||0).toLocaleString(),'routing decisions seen','selector'],
+   [L.routing?'yes':'no','routing joinable per request','selector request_id'],
+   [L.matched?'same run':'DIFFERENT','vs. bundle in other tabs','x_request_id overlap']]);
  note('loganalysis',
   `<b>Same panel, different back-end.</b> The Overview TTFT chart is built from Tempo spans; this one is built from
    <code>${L.src}</code> — the Dynamo frontend log at <b>default INFO level</b>. No tracing backend, no DEBUG, no
@@ -1522,9 +1530,9 @@ drillPanel('overview',DATA.drill,{
    <br><br>The breakdown here is <b>deliberately shallower</b>. <code>ttft_ms</code> on the INFO
    <code>request completed</code> line is a single number covering routing, scheduler queue, prefill compute and KV
    transfer; the log cannot separate them, so that interval is drawn as <b>one hatched row</b> rather than invented
-   sub-stages. Where the router's selector line carries a <code>request_id</code>
-   (Dynamo ≥ 2026-08-10) the admission+routing prefix <i>is</i> separable and is split out —
-   <b>${L.routing?'available in this run':'not available in this run, so TTFT is a single opaque block'}</b>.`);
+   sub-stages. The admission+routing prefix is separable only when the router's
+   selector line carries a <code>request_id</code> (Dynamo &ge; 2026-08-10); without it TTFT stays a
+   single opaque block. Whether this run has it is the <i>routing joinable per request</i> figure above.`);
  // Panel order on this tab is CALL order. TTFT leads: it is the primary question
  // the tab answers, and the load-balance panels below are read against it.
  drillPanel('loganalysis',L,{

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -101,6 +101,48 @@ def _cfg_max_batch(mode):
         except Exception:
             pass
     return None, None
+def _client_summary():
+    """AIPerf's run-level summary: the workload's cache ceiling, and run validity.
+
+    Returns a compact dict, or None when AIPerf never wrote one -- which happens when
+    a run is killed before the concurrency finishes, and is itself worth reporting
+    rather than papering over.
+
+    `theoretical_prefix_cache_hit` is the number that makes the engine's measured
+    reuse interpretable. The engine hit rate alone is a bare figure that each reader
+    scores against a private expectation; against the ceiling the workload actually
+    offered, it becomes a gap with a size.
+    """
+    if not SRC:
+        return None
+    for cand in (os.path.join(SRC, "profile_export_aiperf.json"),
+                 os.path.join(SRC, "..", "..", "profile_export_aiperf.json")):
+        try:
+            with open(cand) as fh:
+                d = json.load(fh)
+        except Exception:
+            continue
+        bs = d.get("branch_stats") or {}
+        # `avg` is AIPerf's own aggregate for the whole concurrency; the nested shape
+        # ({unit, avg, count, sum}) is stable across the 1.x schema.
+        def _avg(key):
+            v = d.get(key)
+            return v.get("avg") if isinstance(v, dict) else v
+        return {
+            "schema": d.get("schema_version"),
+            "aiperf_version": d.get("aiperf_version"),
+            "theoretical_prefix_cache_hit": _avg("theoretical_prefix_cache_hit"),
+            "effective_concurrency": _avg("effective_concurrency"),
+            "request_count": _avg("request_count"),
+            "was_cancelled": d.get("was_cancelled"),
+            "n_errors": len(d.get("error_summary") or []),
+            "branch_errored": bs.get("children_errored"),
+            "branch_truncated": bs.get("children_truncated"),
+            "branch_spawned": bs.get("children_spawned"),
+        }
+    return None
+
+
 def _cfg_tokens_per_block():
     """Engine KV block size from the run's own config, prefill or decode.
 
@@ -123,6 +165,15 @@ def _cfg_tokens_per_block():
             except Exception:
                 pass
     return None
+CLIENT_SUMMARY = _client_summary()
+if CLIENT_SUMMARY:
+    _log.info(f"client summary: workload prefix-cache ceiling "
+              f"{CLIENT_SUMMARY['theoretical_prefix_cache_hit']}%, effective concurrency "
+              f"{CLIENT_SUMMARY['effective_concurrency']}, {CLIENT_SUMMARY['n_errors']} error(s), "
+              f"cancelled={CLIENT_SUMMARY['was_cancelled']}")
+else:
+    _log.info("client summary: no profile_export_aiperf.json in the bundle -- no workload "
+              "cache ceiling to compare the engine's measured reuse against")
 CFG_PF_BATCH, CFG_PF_TOK = _cfg_max_batch("prefill")
 CFG_DE_BATCH, CFG_DE_TOK = _cfg_max_batch("decode")
 MAX_BATCH_PF = CFG_PF_BATCH if CFG_PF_BATCH else _args.max_batch_prefill
@@ -1289,7 +1340,8 @@ DATA={
    # payload, which is what anything downstream of the HTML actually reads.
    "phase_filter":{"applied":not _args.include_warmup,
                    "kept":len(client),"dropped":_skipped_phase,
-                   "phases":_phase_seen}},
+                   "phases":_phase_seen},
+   "client_summary":CLIENT_SUMMARY},
  "kpi":{"ttft_p50":round(pct(col("ttft"),50)/1000,1),"ttft_p99":round(pct(col("ttft"),99)/1000,1),
    "adm_p50":round(pct(col("adm"),50)/1000,1),"pf_p50":round(pct(col("pf"),50)/1000,1),
    "reqs":N,"adm_share":round(pct(col("adm"),50)/max(1,pct(col("ttft"),50))*100,0),
@@ -1394,6 +1446,19 @@ function hTip(){tip.style('display','none')}
   if(!M.n && (nReq||nSess)) head += `  —  no request completed the profiling phase;`
          + ` ${nReq} request(s) across ${nSess} session(s) are warmup and are shown on the`
          + ` Session tab, excluded from every percentile above`;
+  // Run validity bounds every number on the page, so it belongs in the header rather
+  // than on one tab. A cancelled run, a run with client errors, or an agentic run
+  // whose child branches errored produced figures that must not be compared against a
+  // clean run -- and nothing in the per-request stream says so.
+  const CS=M.client_summary;
+  if(CS){
+    const bad=[];
+    if(CS.was_cancelled) bad.push('client reported the run CANCELLED');
+    if(CS.n_errors) bad.push(`${CS.n_errors} client error(s)`);
+    if(CS.branch_errored) bad.push(`${CS.branch_errored} agentic branch(es) errored`);
+    if(CS.branch_truncated) bad.push(`${CS.branch_truncated} branch(es) truncated`);
+    head += bad.length ? `  —  VALIDITY: ${bad.join('; ')}` : `  —  client reports no errors`;
+  }
   document.getElementById('sub').textContent=head;
 })();
 // 'Log analysis' only exists when --frontend-log was supplied; the tab is dropped
@@ -1804,7 +1869,26 @@ drillPanel('overview',DATA.drill,{
  lineChart(el,DATA.ro.queue_pending,{unit:'n',keys:[[1,C.adm]]});})();
 
 // ================= ENGINE =================
-note('engine',`Engine occupancy from Prometheus: <b>KV utilisation</b>, <b>in-flight batch vs configured max</b>, and the <b>true block cache-hit</b>. Read together — low KV utilisation with in-flight batch far below the max ceiling means the engines are starved (requests held upstream in admission — see Router), not compute-bound. Caveats (image-gated): no <code>llm_request</code> span (coarse gantt), no per-pool KV, no DCGM GPU-compute util.`,'hl');
+// The measured reuse rate is uninterpretable on its own -- every reader scores it
+// against a private expectation. AIPerf computes what the WORKLOAD offered, so the
+// two together turn a bare percentage into a gap with a size. Fixed sentence,
+// measured numbers, and omitted entirely when the client summary is absent.
+(function(){
+ let ceil='';
+ const CS=DATA.meta.client_summary, TH=CS&&CS.theoretical_prefix_cache_hit;
+ if(TH!=null){
+   const got=(DATA.kpi||{}).kv_hit_true;
+   ceil=`<br><br><b>Reuse against the workload's ceiling.</b> The client computes a theoretical
+     prefix-cache hit of <b>${TH.toFixed(1)}%</b> for this workload — the most any engine could
+     have reused given the prompts actually sent.`
+     + (got!=null ? ` The engine measured <b>${got.toFixed(1)}%</b>, a gap of
+     <b>${(TH-got).toFixed(1)} points</b>.` : '')
+     + ` Read the true-hit panel against that ceiling, not against an absolute
+     expectation: a workload with little shared prefix cannot be reused into a high rate,
+     and a low rate under a high ceiling is a routing or eviction problem.`;
+ }
+ note('engine',`Engine occupancy from Prometheus: <b>KV utilisation</b>, <b>in-flight batch vs configured max</b>, and the <b>true block cache-hit</b>. Read together — low KV utilisation with in-flight batch far below the max ceiling means the engines are starved (requests held upstream in admission — see Router), not compute-bound. Caveats (image-gated): no <code>llm_request</code> span (coarse gantt), no per-pool KV, no DCGM GPU-compute util.`+ceil,'hl');
+})();
 (function(){const el=panel('engine','KV cache utilisation over the run (% — peak worker)','dynamo_component_gpu_cache_usage_percent, max across dp-ranks per role (the busiest worker). Peaks &lt;4% ⇒ KV cache nearly empty: workers idle waiting on admission, not KV-bound.',true);
  lg(el,[[C.pf,'prefill (6 CTX)'],[C.de,'decode (1 GEN)']]);
  lineChart(el,DATA.en.kvutil_pf.map((d,i)=>[d[0],d[1],DATA.en.kvutil_de[i][1]]),{unit:'%',keys:[[1,C.pf],[2,C.de]]});})();

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -123,7 +123,12 @@ def _benchmark_status():
         return {"exit_code": d.get("exit_code"),
                 # 6, not 4: a check_env_vars failure is a header plus one line per
                 # missing variable, and truncating to 4 drops the variables.
-                "errors": (d.get("errors") or [])[:6]}
+                "errors": (d.get("errors") or [])[:6],
+                # AIPerf's own completed/cancelled census per phase. Frequently the ONLY
+                # account of what happened: arm 2752189 exited 1 with zero error-marker
+                # lines in benchmark.out, so without this the banner could say nothing
+                # beyond the exit code.
+                "phases": (d.get("phases") or [])[:4]}
     return None
 
 
@@ -1595,7 +1600,11 @@ function hTip(){tip.style('display','none')}
   const BS=M.benchmark_status;
   if(BS){
     head += `  —  BENCHMARK FAILED (exit ${BS.exit_code||'?'})`
-          + (BS.errors && BS.errors.length ? `: ${BS.errors[0]}` : '');
+          + (BS.errors && BS.errors.length ? `: ${BS.errors[0]}` : '')
+          // The phase census when there is no error line: it distinguishes "never
+          // started" from "ran and was cut short", which have opposite fixes.
+          + (!(BS.errors||[]).length && (BS.phases||[]).length
+               ? ` — ${BS.phases[BS.phases.length-1]}` : '');
   }
   // Run validity bounds every number on the page, so it belongs in the header rather
   // than on one tab. A cancelled run, a run with client errors, or an agentic run

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -958,7 +958,12 @@ h1{margin:0;font-size:16px}.sub{color:var(--dim);font-size:12px;margin-top:3px}
 .view{display:none;padding:16px 20px 60px}.view.on{display:block}
 .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(400px,1fr));gap:14px}
 .panel{background:var(--panel);border:1px solid var(--edge);border-radius:10px;padding:12px 14px;min-width:0}
-.panel h2{margin:0 0 2px;font-size:13px}.panel .cap{color:var(--dim);font-size:11px;margin-bottom:8px}
+.panel h2{margin:0 0 2px;font-size:13px}.panel .src{color:#6e7681;font-size:11px}
+.warn{color:#d29922;font-size:11px}
+.tbl{width:100%;border-collapse:collapse;font-size:12px;margin-top:8px}
+.tbl th{text-align:left;color:#8b949e;font-weight:600;border-bottom:1px solid #30363d;padding:4px 8px}
+.tbl td{padding:4px 8px;border-bottom:1px solid #21262d;color:#c9d1d9;font-variant-numeric:tabular-nums}
+.cap{color:var(--dim);font-size:11px;margin-bottom:8px}
 .kpis{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:14px}
 .kpi{background:var(--panel);border:1px solid var(--edge);border-radius:9px;padding:9px 14px;min-width:110px}
 .kpi .v{font-size:22px;font-weight:700;color:var(--grn)}.kpi .l{color:var(--dim);font-size:11px}
@@ -1003,7 +1008,7 @@ document.getElementById('sub').textContent=`${DATA.meta.n.toLocaleString()} requ
 // 'Log analysis' only exists when --frontend-log was supplied; the tab is dropped
 // entirely rather than rendered empty, so a bundle-only build looks unchanged.
 const ALL_TABS=[['overview','Overview'],['frontend','Frontend'],['router','Router'],
-                ['engine','Engine'],['loganalysis','Log analysis']];
+                ['engine','Engine'],['session','Session'],['loganalysis','Log analysis']];
 const OK=DATA.tabs||{};
 const TABS=ALL_TABS.filter(([id])=>OK[id]);
 const te=d3.select('#tabs'),ve=d3.select('#views');
@@ -1458,6 +1463,91 @@ note('frontend',`Both panels come from the <b>frontend</b> endpoint (<code>:8000
   {unit:'n',keys:[[1,C.grn],[2,C.adm],[3,C.cy],[4,C.pf]],logy:true});})();
 
 // hash-based tab select (for headless screenshots) + default
+// ---- declarative spec panels (src/visualization/panels.py) ------------------
+// ONE renderer for every spec panel. It is handed {series,unit,split_by,...} and
+// knows nothing else about the signal, so no panel can acquire bespoke drawing
+// behaviour -- which is the property the spec table exists to guarantee. The
+// caption is assembled from fixed fields (why / source / caveat), never from the
+// run's values, so two runs produce byte-identical captions.
+(function(){
+ const P=DATA.panels; if(!P||!Object.keys(P).length) return;
+ const PAL=[C.pf,C.de,C.grn,C.route,C.cy,C.adm,'#d29922','#a371f7','#db6d28','#3fb950'];
+ const fmtU=(u)=>{
+   if(u==='ratio')  return v=>(v*100).toFixed(0)+'%';
+   if(u==='s')      return v=>v>=1?v.toFixed(1)+'s':(v*1000).toFixed(0)+'ms';
+   if(u==='ms')     return v=>v>=1000?(v/1000).toFixed(1)+'s':v.toFixed(0)+'ms';
+   return d3.format('~s');
+ };
+ Object.keys(P).sort().forEach(pid=>{
+  const p=P[pid], keys=Object.keys(p.series).sort();
+  if(!keys.length) return;
+  // Fixed-composition caption: purpose, then provenance, then the known trap.
+  let cap=p.why
+    +`<br><span class="src">source: <code>${p.source.join('</code> + <code>')}</code>`
+    +` &middot; ${p.kind}${p.split_by?' &middot; split by <code>'+p.split_by+'</code>':''}</span>`;
+  if(p.caveat) cap+=`<br><span class="warn">caveat: ${p.caveat}</span>`;
+  const el=panel(p.tab,p.title,cap,keys.length>3);
+  // A series that never moves is stated in words. Drawing a flat line invites the
+  // reader to conclude the panel is broken, when "it never moved" is the finding.
+  const flat=keys.every(k=>{const v=p.series[k].map(d=>d[1]);return Math.max(...v)===Math.min(...v)});
+  if(flat){
+    const v=p.series[keys[0]][0][1];
+    el.append('div').attr('class','note').html(
+      `Constant <b>${fmtU(p.unit)(v)}</b> for the whole run across `
+      +`${keys.length} series &mdash; this run never exercised this signal.`);
+    return;
+  }
+  if(keys.length>1) lg(el,keys.map((k,i)=>[PAL[i%PAL.length],p.split_by?`${p.split_by}=${k}`:k]));
+  const L=58,B=28,H=keys.length>3?250:200,s=svg(el,VW,H);
+  const all=keys.flatMap(k=>p.series[k]);
+  const x=d3.scaleLinear().domain([0,d3.max(all,d=>d[0])||1]).range([L,VW-12]);
+  const y=d3.scaleLinear().domain([0,(d3.max(all,d=>d[1])||1)*1.08]).nice().range([H-B,8]);
+  s.append('g').attr('class','axis').attr('transform',`translate(0,${H-B})`)
+   .call(d3.axisBottom(x).ticks(8).tickFormat(v=>v.toFixed(0)+'s'));
+  s.append('g').attr('class','axis').attr('transform',`translate(${L},0)`)
+   .call(d3.axisLeft(y).ticks(5).tickFormat(fmtU(p.unit)));
+  const ln=d3.line().x(d=>x(d[0])).y(d=>y(d[1]));
+  keys.forEach((k,i)=>s.append('path').datum(p.series[k]).attr('fill','none')
+    .attr('stroke',PAL[i%PAL.length]).attr('stroke-width',1.2).attr('opacity',.9).attr('d',ln));
+ });
+})();
+
+// ---- session decomposition (DATA.rt) ---------------------------------------
+// One row per session, same columns for every session and every run.
+(function(){
+ const S=(DATA.rt||{}).sessions||[]; if(!S.length) return;
+ const el=panel('session','Sessions',
+   'One row per session, ordered by first request. <b>busy</b> is time the server was '
+   +'working on this session\'s turns; <b>idle</b> is wall-clock the session existed '
+   +'without work in flight &mdash; harness think time, which a session-level latency '
+   +'figure would otherwise absorb and attribute to the server.'
+   +'<br><span class="src">source: <code>request_trace.jsonl</code></span>',true);
+ const t=el.append('table').attr('class','tbl');
+ t.append('thead').append('tr').selectAll('th')
+  .data(['session','turns','span','busy','idle','TTFT p50','KV hit p50','decode workers','prefill ranks'])
+  .join('th').text(d=>d);
+ const med=a=>{const v=a.filter(x=>x!=null).sort((p,q)=>p-q);return v.length?v[Math.floor(v.length/2)]:null};
+ const tb=t.append('tbody');
+ S.forEach(s=>{
+   const ttft=med(s.ttft_ms), kv=med(s.kv_hit);
+   tb.append('tr').selectAll('td').data([
+     s.session_id.slice(0,8), s.turns,
+     (s.span_ms/1000).toFixed(1)+'s', (s.busy_ms/1000).toFixed(1)+'s',
+     (s.idle_ms/1000).toFixed(1)+'s',
+     ttft==null?'-':(ttft/1000).toFixed(2)+'s',
+     kv==null?'-':(kv*100).toFixed(1)+'%',
+     s.decode_workers.map(w=>String(w).slice(-6)).join(', ')||'-',
+     s.prefill_ranks.join(', ')||'-',
+   ]).join('td').text(d=>d);
+ });
+ const cst=(DATA.rt||{}).const||{};
+ if(Object.keys(cst).length) note('session',
+   'Constant for every request in this run: '
+   +Object.entries(cst).map(([k,v])=>`<code>${k}</code>=${v}`).join(', ')
+   +'. Reported rather than charted &mdash; a flat line reads as a broken panel, '
+   +'whereas "this never varied" is itself a result.');
+})();
+
 const h=(location.hash||'').replace('#','');
 if(TABS.some(t=>t[0]===h)) act(h); else if(TABS.length) act(TABS[0][0]);
 </script></body></html>"""

--- a/src/visualization/build_dynamo_bench_dash.py
+++ b/src/visualization/build_dynamo_bench_dash.py
@@ -1219,7 +1219,21 @@ const tip=d3.select('#tip'),RD=DATA.meta.run_dur_s;
 const fmtS=ms=>ms==null?'—':ms>=1000?(ms/1000).toFixed(1)+'s':ms.toFixed(ms<10?2:0)+'ms';
 function sTip(h,e){tip.style('display','block').html(h).style('left',(e.clientX+14)+'px').style('top',(e.clientY-10)+'px')}
 function hTip(){tip.style('display','none')}
-document.getElementById('sub').textContent=`${DATA.meta.n.toLocaleString()} requests · ${DATA.meta.scrapes} metric scrapes · run ${RD}s · ${DATA.meta.topo} · ${DATA.meta.src}`;
+// Header provenance. `meta.n` counts only PROFILING-phase requests joined across the
+// client and trace legs, and it is legitimately 0 on a run that never reached the
+// profiling phase -- every record still being warmup. Reporting a bare "0 requests"
+// next to a Session tab listing dozens of sessions reads as a broken page, so the
+// header says which population it is describing and names the other one.
+(function(){
+  const M=DATA.meta, RT=DATA.rt||{};
+  const nSess=(RT.sessions||[]).length, nReq=Object.keys(RT.requests||{}).length;
+  let head=`${M.n.toLocaleString()} profiling requests · ${M.scrapes} metric scrapes`
+         + ` · run ${RD}s · ${M.topo} · ${M.src}`;
+  if(!M.n && (nReq||nSess)) head += `  —  no request completed the profiling phase;`
+         + ` ${nReq} request(s) across ${nSess} session(s) are warmup and are shown on the`
+         + ` Session tab, excluded from every percentile above`;
+  document.getElementById('sub').textContent=head;
+})();
 // 'Log analysis' only exists when --frontend-log was supplied; the tab is dropped
 // entirely rather than rendered empty, so a bundle-only build looks unchanged.
 const ALL_TABS=[['overview','Overview'],['frontend','Frontend'],['router','Router'],

--- a/src/visualization/panels.py
+++ b/src/visualization/panels.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declarative time-series panel specification, evaluated by one generic code path.
+
+Every panel is a row in :data:`PANELS` and every row is evaluated by
+:func:`evaluate`. There is deliberately no per-panel rendering code: adding a signal
+means adding a dict, and no panel can acquire behaviour that another panel lacks.
+That is the whole point -- a panel whose title, caption or arithmetic is special-cased
+for the run it was written against is the failure mode this layer exists to prevent.
+
+A panel row is::
+
+    {
+      "id":     stable key in the emitted payload
+      "tab":    which dashboard tab it belongs to
+      "title":  run-independent. No worker counts, no model names, no "(1 worker)".
+      "unit":   for the axis
+      "kind":   how to turn samples into a series -- see KINDS below
+      "metrics": the exact metric name(s) from server_metrics_export.jsonl
+      "split_by": label key to break the series out by, or None
+      "why":    what this panel is FOR, as a diagnostic question. Fixed prose, never
+                interpolated with run values -- the numbers live in the chart.
+      "issues": PERF ids this panel is meant to surface (provenance, not display)
+      "caveat": a known way this panel can mislead, or None
+    }
+
+KINDS
+-----
+``gauge``        plot the sample as-is.
+``counter_rate`` monotonic counter -> per-second rate via successive differences.
+                 Resets (a restart) are dropped rather than plotted as a negative
+                 spike, which would read as a throughput collapse that never happened.
+``hist_mean``    a Prometheus histogram's ``_sum``/``_count`` pair -> mean per scrape.
+                 Emitted as an INTERVAL mean (delta sum / delta count), not the
+                 cumulative mean: the cumulative form flattens over a long run and
+                 hides exactly the late-run degradation these panels exist to catch.
+``ratio``        two counters -> ``a / (a + b)`` on the interval delta.
+
+CAVEATS ENCODED HERE, NOT LEFT TO THE READER
+--------------------------------------------
+* Engine-side ``dp_rank`` is a REPLICATED BROADCAST -- every rank reports identical
+  values (byte-identical in 380/380 sweeps on the reference run). Splitting an engine
+  metric by rank yields a perfectly flat family of lines that reads as "no imbalance"
+  when the run in fact had a 12x spread. No panel here splits an engine metric by
+  ``dp_rank``; per-worker splits use ``worker_id``, and true per-rank data only exists
+  frontend-side.
+* Several queue gauges read a constant 0 on a healthy run. They are still specified:
+  "this run never queued" is a finding, and queue depth is the single strongest TTFT
+  predictor when it is NOT zero.
+* Metrics are registered lazily, at first use. A family absent from the first ~3
+  minutes is not a gap and must not be read as an outage.
+"""
+from __future__ import annotations
+
+KINDS = ("gauge", "counter_rate", "hist_mean", "ratio")
+
+PANELS: list[dict] = [
+    # ---------------------------------------------------------------- frontend
+    {
+        "id": "fe_ttft_mean", "tab": "frontend", "unit": "s", "kind": "hist_mean",
+        "title": "Client-observed TTFT (frontend)",
+        "metrics": ["dynamo_frontend_time_to_first_token_seconds"], "split_by": None,
+        "why": "What the caller actually waited for. Diverging from the engine-side "
+               "TTFT is the definition of Dynamo-added overhead.",
+        "issues": ["PERF-router-ttft", "PERF-frontend-tax"], "caveat": None,
+    },
+    {
+        "id": "fe_inflight", "tab": "frontend", "unit": "requests", "kind": "gauge",
+        "title": "In-flight requests", "metrics": ["dynamo_frontend_inflight_requests"],
+        "split_by": None,
+        "why": "True concurrency reaching the server, independent of what the load "
+               "generator believes it is offering.",
+        "issues": ["PERF-client-bottleneck"], "caveat": None,
+    },
+    {
+        "id": "fe_queued", "tab": "frontend", "unit": "requests", "kind": "gauge",
+        "title": "Queued requests", "metrics": ["dynamo_frontend_queued_requests"],
+        "split_by": None,
+        "why": "Admission backlog ahead of routing.",
+        "issues": ["PERF-admission-queue"],
+        "caveat": "Reads a constant 0 on runs that never queued; that is a finding, "
+                  "not a broken panel.",
+    },
+    {
+        "id": "fe_tokenize_mean", "tab": "frontend", "unit": "s", "kind": "hist_mean",
+        "title": "Tokenization time", "metrics": ["dynamo_frontend_tokenize_seconds"],
+        "split_by": None,
+        "why": "Tokenization is timed inclusive of queue wait for the blocking pool, "
+               "so it can grow until it accounts for essentially all of TTFT.",
+        "issues": ["PERF-tokenize-ttft"], "caveat": None,
+    },
+    {
+        "id": "fe_tok_cache_hit", "tab": "frontend", "unit": "ratio", "kind": "ratio",
+        "title": "Tokenizer cache hit ratio",
+        "metrics": ["dynamo_frontend_tokenizer_cache_hits_total",
+                    "dynamo_frontend_tokenizer_cache_misses_total"],
+        "split_by": None,
+        "why": "A cold tokenizer cache re-encodes prompts that were already seen, "
+               "turning prompt length directly into TTFT.",
+        "issues": ["PERF-tokenize-ttft"], "caveat": None,
+    },
+    {
+        "id": "fe_evloop_delay", "tab": "frontend", "unit": "s", "kind": "hist_mean",
+        "title": "Event-loop delay", "metrics": ["dynamo_frontend_event_loop_delay_seconds"],
+        "split_by": None,
+        "why": "Async starvation. When the loop is delayed, every request pays it "
+               "regardless of engine state.",
+        "issues": ["PERF-tokio-starvation"], "caveat": None,
+    },
+    {
+        "id": "fe_evloop_stalls", "tab": "frontend", "unit": "stalls/s", "kind": "counter_rate",
+        "title": "Event-loop stalls", "metrics": ["dynamo_frontend_event_loop_stall_total"],
+        "split_by": None,
+        "why": "Discrete stall events, which a mean delay can average away.",
+        "issues": ["PERF-tokio-starvation"], "caveat": None,
+    },
+    {
+        "id": "fe_tokio_busy", "tab": "frontend", "unit": "ratio", "kind": "gauge",
+        "title": "Tokio worker busy ratio", "metrics": ["dynamo_tokio_worker_busy_ratio"],
+        "split_by": None,
+        "why": "Runtime saturation. A saturated runtime makes host-side work, not the "
+               "GPU, the limiter.",
+        "issues": ["PERF-gil", "PERF-tokio-starvation"], "caveat": None,
+    },
+    {
+        "id": "fe_blocking_pool", "tab": "frontend", "unit": "threads", "kind": "gauge",
+        "title": "Blocking-pool threads",
+        "metrics": ["dynamo_tokio_blocking_threads", "dynamo_tokio_blocking_idle_threads"],
+        "split_by": None,
+        "why": "Idle threads falling to zero while work queues is the signature of a "
+               "blocking pool that has become the bottleneck.",
+        "issues": ["PERF-tokenize-ttft"], "caveat": None,
+    },
+    {
+        "id": "fe_blocking_queue", "tab": "frontend", "unit": "items", "kind": "gauge",
+        "title": "Blocking-pool queue depth", "metrics": ["dynamo_tokio_blocking_queue_depth"],
+        "split_by": None,
+        "why": "Work waiting for a blocking thread.",
+        "issues": ["PERF-tokenize-ttft"],
+        "caveat": "Constant 0 on healthy runs.",
+    },
+
+    # ------------------------------------------------------------------ router
+    {
+        "id": "ro_kv_hit", "tab": "router", "unit": "ratio", "kind": "hist_mean",
+        "title": "Router KV hit rate", "metrics": ["dynamo_component_router_kv_hit_rate"],
+        "split_by": None,
+        "why": "Routing quality as the router believes it to be: the prefix-match "
+               "estimate it scored candidate workers on.",
+        "issues": ["PERF-cache-hit-drop", "PERF-router-belief"],
+        "caveat": "A BELIEF, not a measurement, and it has been observed reporting "
+                  "high reuse on traffic with none. Corroborate against the engine "
+                  "hit rate -- but only on workers whose engine config sets "
+                  "kv_cache_config.enable_block_reuse: true. Comparing it against a "
+                  "worker with reuse disabled produces a guaranteed false alarm.",
+    },
+    {
+        "id": "ro_queue_pending", "tab": "router", "unit": "requests", "kind": "gauge",
+        "title": "Router queue pending requests",
+        "metrics": ["dynamo_frontend_router_queue_pending_requests"], "split_by": None,
+        "why": "Queue depth is the strongest single predictor of TTFT -- stronger than "
+               "KV utilisation, which costs nothing while the queue is empty.",
+        "issues": ["PERF-admission-queue"],
+        "caveat": "Constant 0 on healthy runs.",
+    },
+    {
+        "id": "ro_queue_isl", "tab": "router", "unit": "tokens", "kind": "gauge",
+        "title": "Router queue pending input tokens",
+        "metrics": ["dynamo_frontend_router_queue_pending_isl_tokens"], "split_by": None,
+        "why": "Queued WORK, not queued request count -- a few very long prompts and "
+               "many short ones queue identically by count.",
+        "issues": ["PERF-admission-queue"], "caveat": "Constant 0 on healthy runs.",
+    },
+    {
+        "id": "ro_backpressure", "tab": "router", "unit": "events/s", "kind": "counter_rate",
+        "title": "Router backpressure",
+        "metrics": ["dynamo_frontend_router_queue_backpressure_total"], "split_by": None,
+        "why": "The router actively refusing work.",
+        "issues": ["PERF-admission-queue"], "caveat": "Constant 0 on healthy runs.",
+    },
+    {
+        "id": "ro_overhead_hash", "tab": "router", "unit": "ms", "kind": "hist_mean",
+        "title": "Router block-hashing time",
+        "metrics": ["dynamo_router_overhead_block_hashing_ms"], "split_by": None,
+        "why": "Router compute per request; grows with prompt length.",
+        "issues": ["PERF-router-overhead"], "caveat": None,
+    },
+    {
+        "id": "ro_overhead_match", "tab": "router", "unit": "ms", "kind": "hist_mean",
+        "title": "Router index match time",
+        "metrics": ["dynamo_router_overhead_indexer_find_matches_ms"], "split_by": None,
+        "why": "Prefix-index lookup cost, which scales with the indexed corpus.",
+        "issues": ["PERF-router-overhead"], "caveat": None,
+    },
+
+    # ------------------------------------------------------------------ engine
+    {
+        "id": "en_kv_util", "tab": "engine", "unit": "ratio", "kind": "gauge",
+        "title": "KV-cache utilisation", "metrics": ["trtllm_kv_cache_utilization"],
+        "split_by": "worker_id",
+        "why": "KV pressure per worker. High utilisation with an empty queue is not "
+               "itself a problem; high utilisation WITH a queue is.",
+        "issues": ["PERF-kv-pressure"],
+        "caveat": "Split by worker_id, never dp_rank -- engine rank series are a "
+                  "replicated broadcast and would render identically.",
+    },
+    {
+        "id": "en_requests_running", "tab": "engine", "unit": "requests", "kind": "gauge",
+        "title": "Requests running", "metrics": ["trtllm_num_requests_running"],
+        "split_by": "worker_id",
+        "why": "Engine occupancy against its configured batch ceiling.",
+        "issues": ["PERF-batch-starvation"], "caveat": None,
+    },
+    {
+        "id": "en_requests_waiting", "tab": "engine", "unit": "requests", "kind": "gauge",
+        "title": "Requests waiting", "metrics": ["trtllm_num_requests_waiting"],
+        "split_by": "worker_id",
+        "why": "Work admitted to the engine but not yet scheduled.",
+        "issues": ["PERF-batch-starvation"], "caveat": None,
+    },
+    {
+        "id": "en_iter_latency", "tab": "engine", "unit": "s", "kind": "gauge",
+        "title": "Iteration latency", "metrics": ["trtllm_iteration_latency_seconds"],
+        "split_by": "worker_id",
+        "why": "Per-step wall time. A spread of two orders of magnitude within one run "
+               "means steps are stalling on something other than compute.",
+        "issues": ["PERF-gil", "PERF-iteration-stall"], "caveat": None,
+    },
+    {
+        "id": "en_completed_rate", "tab": "engine", "unit": "requests/s", "kind": "counter_rate",
+        "title": "Requests completed per worker",
+        "metrics": ["trtllm_num_requests_completed_total"], "split_by": "worker_id",
+        "why": "Load balance across workers, measured as delivered work rather than as "
+               "routing intent. This is where a routing imbalance becomes visible.",
+        "issues": ["PERF-decode-imbalance", "PERF-session-affinity"], "caveat": None,
+    },
+    {
+        "id": "en_gen_tokens", "tab": "engine", "unit": "tokens/s", "kind": "counter_rate",
+        "title": "Generation throughput", "metrics": ["trtllm_generation_tokens_total"],
+        "split_by": "worker_id",
+        "why": "Delivered decode throughput per worker.",
+        "issues": ["PERF-decode-imbalance"], "caveat": None,
+    },
+    {
+        "id": "en_kv_hit", "tab": "engine", "unit": "ratio", "kind": "gauge",
+        "title": "Engine KV-cache hit rate", "metrics": ["trtllm_kv_cache_hit_rate"],
+        "split_by": "worker_id",
+        "why": "Reuse as the ENGINE measured it. Disagreement with the router's hit "
+               "rate localises the fault to the routing layer rather than the cache.",
+        "issues": ["PERF-router-belief", "PERF-cache-hit-drop"],
+        "caveat": "Reads a hard 0 on any worker whose engine config sets "
+                  "kv_cache_config.enable_block_reuse: false -- commonly the decode "
+                  "side of a disagg deployment, where reuse is off by design. Read "
+                  "this against trtllm_config_<mode>.yaml in the bundle before "
+                  "concluding the cache is broken.",
+    },
+    {
+        "id": "en_queue_time", "tab": "engine", "unit": "s", "kind": "hist_mean",
+        "title": "Engine queue time", "metrics": ["trtllm_request_queue_time_seconds"],
+        "split_by": "worker_id",
+        "why": "Time inside the engine before execution, distinct from router-side "
+               "admission delay.",
+        "issues": ["PERF-admission-queue"], "caveat": None,
+    },
+    {
+        "id": "en_ttft", "tab": "engine", "unit": "s", "kind": "hist_mean",
+        "title": "Engine-side TTFT", "metrics": ["trtllm_time_to_first_token_seconds"],
+        "split_by": "worker_id",
+        "why": "The engine's own first-token time. The gap to the frontend's TTFT is "
+               "everything Dynamo adds.",
+        "issues": ["PERF-frontend-tax"], "caveat": None,
+    },
+    {
+        "id": "en_tpot", "tab": "engine", "unit": "s", "kind": "hist_mean",
+        "title": "Time per output token", "metrics": ["trtllm_time_per_output_token_seconds"],
+        "split_by": "worker_id",
+        "why": "Steady-state decode speed, the SLO most sensitive to batch composition.",
+        "issues": ["PERF-itl-regression"], "caveat": None,
+    },
+    {
+        "id": "en_spec_accept", "tab": "engine", "unit": "tokens", "kind": "gauge",
+        "title": "Speculative-decode acceptance length",
+        "metrics": ["trtllm_spec_decode_acceptance_length"], "split_by": "worker_id",
+        "why": "How much speculation is actually paying off; collapse here shows up as "
+               "an ITL regression with no other cause.",
+        "issues": ["PERF-itl-regression"], "caveat": None,
+    },
+    {
+        "id": "en_success_rate", "tab": "engine", "unit": "requests/s", "kind": "counter_rate",
+        "title": "Request completions by finish reason",
+        "metrics": ["trtllm_request_success_total"], "split_by": "finished_reason",
+        "why": "A shift in finish reason is how truncation or cancellation shows up; "
+               "throughput can rise purely because responses got shorter.",
+        "issues": ["PERF-truncation"], "caveat": None,
+    },
+]
+
+
+def _series_key(labels: dict, split_by: str | None) -> str:
+    """Series identity within a panel: the split label's value, else a single series."""
+    if not split_by:
+        return "all"
+    return str((labels or {}).get(split_by, "unknown"))
+
+
+def evaluate(scrapes, panels=None, max_points: int = 2000) -> dict:
+    """Evaluate every panel over ``scrapes`` in one pass.
+
+    ``scrapes`` is the parsed ``server_metrics_export.jsonl``: an ordered list of
+    ``(timestamp_ns, {metric_name: [{"labels":…, "value":…}, …]})``.
+
+    Returns ``{panel_id: {"spec": <row minus arithmetic>, "series": {key: [[t_s, v], …]}}}``
+    with ``t_s`` relative to the first scrape. Panels whose metrics never appear are
+    omitted entirely, which is what lets a tab drop cleanly rather than render empty.
+
+    Long runs are decimated to ``max_points`` per series AFTER the arithmetic, so rates
+    and interval means are computed on every sample and only the plotted set is thinned.
+    """
+    panels = PANELS if panels is None else panels
+    if not scrapes:
+        return {}
+    t0 = scrapes[0][0]
+    # panel id -> series key -> list of (t_s, raw components)
+    acc: dict[str, dict[str, list]] = {p["id"]: {} for p in panels}
+    prev: dict[str, dict[str, tuple]] = {p["id"]: {} for p in panels}
+
+    for ts, metrics in scrapes:
+        t_s = (ts - t0) / 1e9
+        for panel in panels:
+            kind, names, split = panel["kind"], panel["metrics"], panel["split_by"]
+            if kind == "gauge":
+                for entry in metrics.get(names[0], []) or []:
+                    v = entry.get("value")
+                    if isinstance(v, (int, float)):
+                        acc[panel["id"]].setdefault(_series_key(entry.get("labels"), split), []).append([t_s, v])
+                # A second gauge in `metrics` is an additional named series (e.g. idle
+                # threads alongside total threads), not a second arithmetic input.
+                for extra in names[1:]:
+                    for entry in metrics.get(extra, []) or []:
+                        v = entry.get("value")
+                        if isinstance(v, (int, float)):
+                            acc[panel["id"]].setdefault(extra.rsplit("_", 2)[-1], []).append([t_s, v])
+            elif kind == "counter_rate":
+                for entry in metrics.get(names[0], []) or []:
+                    v = entry.get("value")
+                    if not isinstance(v, (int, float)):
+                        continue
+                    key = _series_key(entry.get("labels"), split)
+                    last = prev[panel["id"]].get(key)
+                    prev[panel["id"]][key] = (t_s, v)
+                    # A counter that went backwards means the process restarted. Emitting
+                    # the negative delta would draw a throughput cliff that never happened.
+                    if last and t_s > last[0] and v >= last[1]:
+                        acc[panel["id"]].setdefault(key, []).append([t_s, (v - last[1]) / (t_s - last[0])])
+            elif kind == "hist_mean":
+                sums = metrics.get(names[0] + "_sum", []) or []
+                counts = {(_series_key(e.get("labels"), split)): e.get("value")
+                          for e in (metrics.get(names[0] + "_count", []) or [])}
+                for entry in sums:
+                    key = _series_key(entry.get("labels"), split)
+                    s, c = entry.get("value"), counts.get(key)
+                    if not isinstance(s, (int, float)) or not isinstance(c, (int, float)):
+                        continue
+                    last = prev[panel["id"]].get(key)
+                    prev[panel["id"]][key] = (t_s, s, c)
+                    # Interval mean, not cumulative: a cumulative mean over a long run
+                    # flattens and hides the late-run degradation this is here to catch.
+                    if last and c > last[2] and s >= last[1]:
+                        acc[panel["id"]].setdefault(key, []).append([t_s, (s - last[1]) / (c - last[2])])
+            elif kind == "ratio":
+                a_entries = metrics.get(names[0], []) or []
+                b_by_key = {(_series_key(e.get("labels"), split)): e.get("value")
+                            for e in (metrics.get(names[1], []) or [])}
+                for entry in a_entries:
+                    key = _series_key(entry.get("labels"), split)
+                    a, b = entry.get("value"), b_by_key.get(key)
+                    if not isinstance(a, (int, float)) or not isinstance(b, (int, float)):
+                        continue
+                    last = prev[panel["id"]].get(key)
+                    prev[panel["id"]][key] = (t_s, a, b)
+                    if last:
+                        da, db = a - last[1], b - last[2]
+                        if da >= 0 and db >= 0 and (da + db) > 0:
+                            acc[panel["id"]].setdefault(key, []).append([t_s, da / (da + db)])
+
+    out: dict[str, dict] = {}
+    for panel in panels:
+        series = {k: v for k, v in acc[panel["id"]].items() if v}
+        if not series:
+            continue
+        for key, pts in series.items():
+            if len(pts) > max_points:
+                stride = -(-len(pts) // max_points)
+                series[key] = pts[::stride]
+        out[panel["id"]] = {
+            "tab": panel["tab"], "title": panel["title"], "unit": panel["unit"],
+            "kind": panel["kind"], "why": panel["why"], "split_by": panel["split_by"],
+            "source": panel["metrics"], "caveat": panel.get("caveat"),
+            "issues": panel.get("issues", []),
+            "series": series,
+        }
+    return out

--- a/src/visualization/panels.py
+++ b/src/visualization/panels.py
@@ -294,6 +294,549 @@ PANELS: list[dict] = [
                "throughput can rise purely because responses got shorter.",
         "issues": ["PERF-truncation"], "caveat": None,
     },
+
+    # ---------------------------------------------------------------------
+    # Rows below are transcribed from PANEL_BACKLOG.md, itself derived from the
+    # issue register; each carries the backlog id it came from. They are DATA --
+    # the evaluator above is unchanged by their addition.
+    # ---------------------------------------------------------------------
+
+    # ---------------------------------------------------------------- frontend
+    # F3
+    {
+        "id": "fe_tok_cache_token_hit", "tab": "frontend", "unit": "ratio", "kind": "ratio",
+        "title": "Tokenizer cache hit ratio, token-weighted",
+        "metrics": ["dynamo_frontend_tokenizer_cache_cached_tokens_total",
+                    "dynamo_frontend_tokenizer_cache_uncached_tokens_total"],
+        "split_by": None,
+        "why": "Weights every cache decision by the tokens it saved or cost. A single miss on a "
+               "very long prompt costs more than many hits on short ones, so a request-level hit "
+               "rate can read healthy while the tokenizer re-encodes most of the token volume.",
+        "issues": ["PERF-02", "PERF-01"],
+        "caveat": "Read alongside the request-level hit ratio, never instead of it: the two answer "
+                  "different questions and diverge whenever prompt lengths are skewed.",
+    },
+    # F5
+    {
+        "id": "fe_tokio_alive_tasks", "tab": "frontend", "unit": "count", "kind": "gauge",
+        "title": "Alive runtime tasks", "metrics": ["dynamo_tokio_alive_tasks"],
+        "split_by": None,
+        "why": "Task population on the async runtime. Growth without a matching rise in in-flight "
+               "requests means tasks are accumulating rather than completing.",
+        "issues": ["PERF-18", "PERF-27"], "caveat": None,
+    },
+    # F5
+    {
+        "id": "fe_tokio_poll_time", "tab": "frontend", "unit": "ns", "kind": "gauge",
+        "title": "Worker mean task poll time", "metrics": ["dynamo_tokio_worker_mean_poll_time_ns"],
+        "split_by": None,
+        "why": "How long a single poll occupies a runtime worker. Long polls are the mechanism by "
+               "which one blocking call starves every other task on the same thread.",
+        "issues": ["PERF-18", "PERF-27"],
+        "caveat": "One series per runtime worker thread, so this family is a large share of the "
+                  "series budget. Reduce across the worker label rather than drawing every thread.",
+    },
+    # F7
+    {
+        "id": "fe_stage_duration", "tab": "frontend", "unit": "s", "kind": "hist_mean",
+        "title": "Pipeline stage duration", "metrics": ["dynamo_frontend_stage_duration_seconds"],
+        "split_by": "stage",
+        "why": "Where frontend time is spent before the request reaches a worker: preprocess, "
+               "route, transport roundtrip. Localises added latency to a stage rather than to "
+               "the frontend as a whole.",
+        "issues": ["PERF-31", "PERF-20", "PERF-42"],
+        "caveat": "A proxy for pre-route queue wait, not a measurement of it. The frontend log "
+                  "records that measure the wait directly are not in the bundle.",
+    },
+    # F7
+    {
+        "id": "fe_stage_requests", "tab": "frontend", "unit": "requests", "kind": "gauge",
+        "title": "Requests in pipeline stage", "metrics": ["dynamo_frontend_stage_requests"],
+        "split_by": "stage",
+        "why": "Instantaneous occupancy of each frontend stage. Occupancy piling up in one stage "
+               "is where a frontend-side backlog first becomes visible.",
+        "issues": ["PERF-31", "PERF-20"],
+        "caveat": "An instantaneous gauge sampled at scrape rate, so short bursts are missed and "
+                  "most samples read zero even when the stage is doing work.",
+    },
+    # F8
+    {
+        "id": "fe_requests_by_status", "tab": "frontend", "unit": "requests/s", "kind": "counter_rate",
+        "title": "Request outcomes by status", "metrics": ["dynamo_frontend_requests_total"],
+        "split_by": "status",
+        "why": "Success versus error as delivered throughput. A throughput number that does not "
+               "separate outcomes can rise purely because requests started failing faster.",
+        "issues": ["PERF-25", "PERF-43", "PERF-11"],
+        "caveat": "The family also carries an error_type label that this split collapses. Break "
+                  "out by error_type before concluding anything about the kind of failure.",
+    },
+    # F8
+    {
+        "id": "fe_component_errors", "tab": "frontend", "unit": "events/s", "kind": "counter_rate",
+        "title": "Work-handler errors by type", "metrics": ["dynamo_component_errors_total"],
+        "split_by": "error_type",
+        "why": "The only error counter that ever fires anywhere in the stack: the engine-side "
+               "error family is declared but never sampled, so a purely engine-side failure has "
+               "no counter at all.",
+        "issues": ["PERF-25", "PERF-43", "PERF-11"],
+        "caveat": "Some error_type values are benign publish-path noise that fires on nearly every "
+                  "request. Aggregating across error_type reads as a near-total error rate on a "
+                  "healthy run -- always keep the split.",
+    },
+    # F9
+    {
+        "id": "fe_disconnected_clients", "tab": "frontend", "unit": "count", "kind": "gauge",
+        "title": "Disconnected clients", "metrics": ["dynamo_frontend_disconnected_clients"],
+        "split_by": None,
+        "why": "Clients that gave up before the response completed. Work already spent on them is "
+               "throughput the server produced and nobody received.",
+        "issues": ["PERF-26", "PERF-25"], "caveat": None,
+    },
+    # F9
+    {
+        "id": "fe_model_cancellations", "tab": "frontend", "unit": "events/s", "kind": "counter_rate",
+        "title": "Model request cancellations",
+        "metrics": ["dynamo_frontend_model_cancellation_total"], "split_by": None,
+        "why": "Cancellations observed at the HTTP boundary, which is where a client-side timeout "
+               "first becomes visible to the server.",
+        "issues": ["PERF-26", "PERF-25"],
+        "caveat": "Registered lazily, on the first cancellation. Absence early in a run means "
+                  "nothing has been cancelled yet, not that the counter is broken.",
+    },
+    # F9
+    {
+        "id": "fe_component_cancellations", "tab": "frontend", "unit": "events/s", "kind": "counter_rate",
+        "title": "Work-handler cancellations per worker",
+        "metrics": ["dynamo_component_cancellation_total"], "split_by": "worker_id",
+        "why": "Cancellations as the backend sees them. A gap against the frontend's cancellation "
+               "count is work the engine kept doing after the caller was gone.",
+        "issues": ["PERF-26", "PERF-25"],
+        "caveat": "The family also spans the indexer-query endpoints, whose volume dwarfs the "
+                  "generate endpoint. Filter on dynamo_endpoint before reading a rate here.",
+    },
+    # F10
+    {
+        "id": "fe_plane_queue", "tab": "frontend", "unit": "s", "kind": "hist_mean",
+        "title": "Request-plane queue time", "metrics": ["dynamo_request_plane_queue_seconds"],
+        "split_by": None,
+        "why": "Time from handler entry to the request actually being sent. This is the frontend's "
+               "own dispatch delay, upstream of any engine or router queue.",
+        "issues": ["PERF-20", "PERF-21", "PERF-39"], "caveat": None,
+    },
+    # F10
+    {
+        "id": "fe_plane_send", "tab": "frontend", "unit": "s", "kind": "hist_mean",
+        "title": "Request-plane send time", "metrics": ["dynamo_request_plane_send_seconds"],
+        "split_by": None,
+        "why": "Cost of the send call itself. Separating it from queue time distinguishes a slow "
+               "transport from a busy dispatcher.",
+        "issues": ["PERF-20", "PERF-21", "PERF-39"], "caveat": None,
+    },
+    # F10
+    {
+        "id": "fe_plane_roundtrip_ttft", "tab": "frontend", "unit": "s", "kind": "hist_mean",
+        "title": "Request-plane roundtrip to first response",
+        "metrics": ["dynamo_request_plane_roundtrip_ttft_seconds"], "split_by": None,
+        "why": "Send to first response item. Everything outside this window in the client's "
+               "first-token time is frontend-side work rather than serving.",
+        "issues": ["PERF-20", "PERF-21", "PERF-39"], "caveat": None,
+    },
+    # F10
+    {
+        "id": "fe_plane_inflight", "tab": "frontend", "unit": "requests", "kind": "gauge",
+        "title": "Request-plane in-flight requests",
+        "metrics": ["dynamo_request_plane_inflight_requests"], "split_by": None,
+        "why": "Concurrency at the dispatch router, between the HTTP handler and the workers. A "
+               "gap against frontend in-flight requests is work stuck before dispatch.",
+        "issues": ["PERF-20", "PERF-38"], "caveat": None,
+    },
+    # F10
+    {
+        "id": "fe_network_transit", "tab": "frontend", "unit": "s", "kind": "hist_mean",
+        "title": "Frontend-to-backend network transit",
+        "metrics": ["dynamo_work_handler_network_transit_seconds"], "split_by": "dynamo_component",
+        "why": "Cross-process wire time to the worker. It is the term a request-plane or codec "
+               "change moves, and the one that must be excluded before blaming the engine.",
+        "issues": ["PERF-20", "PERF-21", "PERF-39"],
+        "caveat": "Emitted with byte-identical labels by every worker endpoint, so it is only "
+                  "separable because the capture injects worker_id and dynamo_component. A live "
+                  "scrape of the same endpoints would overwrite these series.",
+    },
+    # F11
+    {
+        "id": "fe_uptime", "tab": "frontend", "unit": "s", "kind": "gauge",
+        "title": "Component uptime", "metrics": ["dynamo_component_uptime_seconds"],
+        "split_by": "worker_id",
+        "why": "The liveness signal. Because every other family registers lazily, a missing metric "
+               "means 'has not happened yet' -- only a reset here means a process died.",
+        "issues": ["PERF-43", "PERF-40", "PERF-45"], "caveat": None,
+    },
+    # F12
+    {
+        "id": "fe_arrival_rate", "tab": "frontend", "unit": "requests/s", "kind": "counter_rate",
+        "title": "Request arrival rate", "metrics": ["dynamo_frontend_requests_started_total"],
+        "split_by": None,
+        "why": "Offered load as the server received it. Read against in-flight requests, a low "
+               "arrival rate with idle capacity is the load-generator-bottleneck signature.",
+        "issues": ["PERF-38", "PERF-28", "PERF-11"], "caveat": None,
+    },
+    # R-Q8
+    {
+        "id": "fe_input_seq_tokens", "tab": "frontend", "unit": "tokens", "kind": "hist_mean",
+        "title": "Input sequence length", "metrics": ["dynamo_frontend_input_sequence_tokens"],
+        "split_by": None,
+        "why": "Prompt size entering the server, which sets both the prefill cost and the request "
+               "payload size carried on the request plane.",
+        "issues": ["PERF-39", "PERF-20"],
+        "caveat": "Payload headroom against a transport cap cannot be computed here: the cap lives "
+                  "in the recipe, outside the bundle, and the rejection counter never fires.",
+    },
+
+    # ------------------------------------------------------------------ router
+    # R2
+    {
+        "id": "ro_kv_events_applied", "tab": "router", "unit": "events/s", "kind": "counter_rate",
+        "title": "KV-event apply outcomes",
+        "metrics": ["dynamo_component_kv_cache_events_applied"], "split_by": "status",
+        "why": "Whether the router's prefix index is actually absorbing what the engines publish. "
+               "A rising non-ok share means the index is drifting from engine reality, which is "
+               "how routing decisions silently start being made on stale state.",
+        "issues": ["PERF-10", "PERF-09", "PERF-06"],
+        "caveat": "Emitted by the frontend endpoint, because the router runs in-process there. The "
+                  "worker_id on these series is the frontend's own -- do not split by it.",
+    },
+    # R2
+    {
+        "id": "ro_kv_event_warnings", "tab": "router", "unit": "events/s", "kind": "counter_rate",
+        "title": "KV-event indexer warnings",
+        "metrics": ["dynamo_component_kv_cache_event_warnings"], "split_by": "warning_kind",
+        "why": "Suspicious events the indexer accepted but flagged. Non-zero here without a "
+               "corresponding apply failure is index corruption that no error counter reports.",
+        "issues": ["PERF-10", "PERF-09"], "caveat": None,
+    },
+    # R2
+    {
+        "id": "ro_kv_events_dropped", "tab": "router", "unit": "events/s", "kind": "counter_rate",
+        "title": "KV events dropped before the publisher",
+        "metrics": ["dynamo_component_kv_publisher_engines_dropped_events_total"],
+        "split_by": "worker_id",
+        "why": "Events the engine produced and lost before the router ever saw them, detected via "
+               "identifier gaps. Any non-zero value is decisive: the index cannot be correct.",
+        "issues": ["PERF-10", "PERF-09"],
+        "caveat": "Reads a constant zero on a healthy run, which is a finding rather than a broken "
+                  "panel -- but it also means its behaviour under loss is unvalidated here.",
+    },
+    # R3
+    {
+        "id": "ro_worker_prefill_tokens", "tab": "router", "unit": "tokens", "kind": "gauge",
+        "title": "Active prefill tokens per worker",
+        "metrics": ["dynamo_frontend_worker_active_prefill_tokens"], "split_by": "worker_id",
+        "why": "The prefill load the router can actually see at decision time. Routing quality is "
+               "bounded by this view, not by what the engine knows.",
+        "issues": ["PERF-03", "PERF-05", "PERF-04"],
+        "caveat": "Router-side worker identifiers, which do not join to the engine-side ones. Pair "
+                  "with active decode blocks: prefill load rising while decode load reads zero is "
+                  "the window in which the router piles on a worker that is already busy.",
+    },
+    # R3
+    {
+        "id": "ro_worker_decode_blocks", "tab": "router", "unit": "count", "kind": "gauge",
+        "title": "Active decode blocks per worker",
+        "metrics": ["dynamo_frontend_worker_active_decode_blocks"], "split_by": "worker_id",
+        "why": "The decode-side occupancy the router scores candidates on, in cache blocks.",
+        "issues": ["PERF-03", "PERF-05", "PERF-04"],
+        "caveat": "Converting blocks to tokens requires the router's own block size, which "
+                  "disagrees with the engine's tokens-per-block by a wide factor. Do not use the "
+                  "two interchangeably.",
+    },
+    # R4
+    {
+        "id": "ro_overhead_seq_hash", "tab": "router", "unit": "ms", "kind": "hist_mean",
+        "title": "Router sequence-hashing time",
+        "metrics": ["dynamo_router_overhead_seq_hashing_ms"], "split_by": None,
+        "why": "Sequence-hash cost per request, the second half of the router's hashing work.",
+        "issues": ["PERF-23", "PERF-33", "PERF-01"], "caveat": None,
+    },
+    # R4
+    {
+        "id": "ro_overhead_scheduling", "tab": "router", "unit": "ms", "kind": "hist_mean",
+        "title": "Router scheduling time",
+        "metrics": ["dynamo_router_overhead_scheduling_ms"], "split_by": None,
+        "why": "Time inside worker selection itself, separated from hashing and index lookup. It "
+               "is the term that grows with the candidate set rather than with prompt length.",
+        "issues": ["PERF-23", "PERF-33"],
+        "caveat": "Never take a quantile of this family: its bucket ladder runs to hundreds of "
+                  "seconds while all observed mass sits in the smallest few buckets. Use the mean.",
+    },
+    # R4
+    {
+        "id": "ro_overhead_total", "tab": "router", "unit": "ms", "kind": "hist_mean",
+        "title": "Router total overhead per request",
+        "metrics": ["dynamo_router_overhead_total_ms"], "split_by": None,
+        "why": "The reference line for the routing-cost decomposition. Total minus the named "
+               "components is routing work that no component metric accounts for.",
+        "issues": ["PERF-23", "PERF-33", "PERF-01"],
+        "caveat": "Never take a quantile of this family: its bucket ladder runs to hundreds of "
+                  "seconds while all observed mass sits in the smallest few buckets. Use the mean.",
+    },
+    # R5
+    {
+        "id": "ro_queue_cached_tokens", "tab": "router", "unit": "tokens", "kind": "gauge",
+        "title": "Router queue pending cached tokens",
+        "metrics": ["dynamo_frontend_router_queue_pending_cached_tokens"], "split_by": "worker_type",
+        "why": "The already-cached share of queued input tokens. Subtracted from pending input "
+               "tokens it gives queued WORK -- the tokens that must actually be computed -- which "
+               "a queued request count cannot express.",
+        "issues": ["PERF-11", "PERF-03"],
+        "caveat": "Constant zero on runs that never queued. That is a finding, not a broken panel, "
+                  "but it also leaves the panel's behaviour under real queueing unvalidated.",
+    },
+    # R6
+    {
+        "id": "ro_worker_last_isl", "tab": "router", "unit": "tokens", "kind": "gauge",
+        "title": "Last observed input sequence length per rank",
+        "metrics": ["dynamo_frontend_worker_last_input_sequence_tokens"], "split_by": "dp_rank",
+        "why": "Prompt size landing on each prefill rank. Rank latency spread must be read against "
+               "this before it is called a scheduling fault -- unequal work is not imbalance.",
+        "issues": ["PERF-05", "PERF-52", "PERF-03"],
+        "caveat": "A last-observed gauge, not an aggregate: it samples the most recent request per "
+                  "rank, so it is noisy and must not be averaged into a rank-utilisation number.",
+    },
+    # R6
+    {
+        "id": "ro_worker_last_ttft", "tab": "router", "unit": "s", "kind": "gauge",
+        "title": "Last observed time to first token per rank",
+        "metrics": ["dynamo_frontend_worker_last_time_to_first_token_seconds"], "split_by": "dp_rank",
+        "why": "The only genuinely per-rank latency series in the capture. Every engine-side rank "
+               "family is a replicated broadcast, so rank imbalance is visible here or nowhere.",
+        "issues": ["PERF-05", "PERF-52", "PERF-03"],
+        "caveat": "A last-observed gauge, not an aggregate: it samples the most recent request per "
+                  "rank, so it is noisy and must not be averaged into a rank-utilisation number.",
+    },
+    # R6
+    {
+        "id": "ro_worker_last_itl", "tab": "router", "unit": "s", "kind": "gauge",
+        "title": "Last observed inter-token latency per worker",
+        "metrics": ["dynamo_frontend_worker_last_inter_token_latency_seconds"], "split_by": "worker_id",
+        "why": "Decode pace as the router sees it per worker, which is the input a load-aware "
+               "decode policy would react to.",
+        "issues": ["PERF-05", "PERF-52"],
+        "caveat": "Emitted on decode workers only, all at rank zero, so it is split by worker "
+                  "rather than by rank. A last-observed gauge, not an aggregate.",
+    },
+
+    # ------------------------------------------------------------------ engine
+    # E1
+    {
+        "id": "en_max_active_requests", "tab": "engine", "unit": "requests", "kind": "gauge",
+        "title": "Maximum active request slots",
+        "metrics": ["trtllm_max_num_active_requests"], "split_by": "worker_id",
+        "why": "The ceiling that running and scheduled request counts must be read against. "
+               "Occupancy without its ceiling cannot distinguish a starved engine from a full one.",
+        "issues": ["PERF-03", "PERF-08", "PERF-14"],
+        "caveat": "Use this as the ceiling, not the engine's batch-size families: those report a "
+                  "constant zero on every sample and would make headroom look infinite.",
+    },
+    # E5
+    {
+        "id": "en_scheduled_requests", "tab": "engine", "unit": "requests", "kind": "gauge",
+        "title": "Scheduled requests", "metrics": ["trtllm_num_scheduled_requests"],
+        "split_by": "worker_id",
+        "why": "Batch size the engine actually ran per iteration. Chronically small batches "
+               "against a large ceiling is throughput left on the table, and it is a distribution "
+               "claim -- the mean can look fine while most iterations run a single request.",
+        "issues": ["PERF-14", "PERF-15", "PERF-03"],
+        "caveat": "Sampled at scrape rate while the engine iterates far faster, so this is a "
+                  "subsample of the batch-size distribution, not the distribution itself. It is "
+                  "also exactly the sum of context and generation requests.",
+    },
+    # E5
+    {
+        "id": "en_context_requests", "tab": "engine", "unit": "requests", "kind": "gauge",
+        "title": "Context requests in batch", "metrics": ["trtllm_num_context_requests"],
+        "split_by": "worker_id",
+        "why": "The prefill half of batch composition. Context requests crowding out generation "
+               "requests is how a decode worker's output rate collapses with no latency signal.",
+        "issues": ["PERF-14", "PERF-15", "PERF-03"], "caveat": None,
+    },
+    # E5
+    {
+        "id": "en_generation_requests", "tab": "engine", "unit": "requests", "kind": "gauge",
+        "title": "Generation requests in batch", "metrics": ["trtllm_num_generation_requests"],
+        "split_by": "worker_id",
+        "why": "The decode half of batch composition, and the term that sets decode efficiency.",
+        "issues": ["PERF-14", "PERF-15"], "caveat": None,
+    },
+    # E6
+    {
+        "id": "en_prefill_batch_tokens", "tab": "engine", "unit": "tokens", "kind": "hist_mean",
+        "title": "Context tokens per prefill iteration",
+        "metrics": ["trtllm_prefill_batch_tokens"], "split_by": "worker_id",
+        "why": "Prefill work per iteration against the configured token budget. Sitting at the "
+               "budget means token-budget-bound, a diagnosis that looks like an unremarkable "
+               "number until it is divided by the configured ceiling.",
+        "issues": ["PERF-15", "PERF-08", "PERF-14"],
+        "caveat": "Emitted by prefill-role workers only. The ceiling it must be divided by lives "
+                  "in the engine config file in the bundle, not in any metric.",
+    },
+    # E6
+    {
+        "id": "en_context_tokens", "tab": "engine", "unit": "tokens", "kind": "gauge",
+        "title": "Total context tokens", "metrics": ["trtllm_total_context_tokens"],
+        "split_by": "worker_id",
+        "why": "Instantaneous context-token occupancy. Pinned at the configured maximum is the "
+               "token-budget saturation signature.",
+        "issues": ["PERF-15", "PERF-08"], "caveat": None,
+    },
+    # E7
+    {
+        "id": "en_block_reuse", "tab": "engine", "unit": "ratio", "kind": "ratio",
+        "title": "Cumulative KV block reuse",
+        "metrics": ["trtllm_kv_cache_reused_blocks_total", "trtllm_kv_cache_missed_blocks_total"],
+        "split_by": "worker_id",
+        "why": "Reuse computed from block counts rather than read from an instantaneous gauge. "
+               "This is the stable, aggregatable form of engine cache effectiveness.",
+        "issues": ["PERF-07", "PERF-06", "PERF-08"],
+        "caveat": "A worker with no line here has block reuse disabled in its engine config -- "
+                  "commonly the decode side of a disagg deployment -- which is not the same as "
+                  "zero reuse. Do not substitute the iteration-prefixed counter twins: they are "
+                  "byte-identical cumulative duplicates despite the name.",
+    },
+    # E7
+    {
+        "id": "en_iter_reuse_rate", "tab": "engine", "unit": "ratio", "kind": "gauge",
+        "title": "Per-iteration KV block reuse rate",
+        "metrics": ["trtllm_kv_cache_iter_reuse_rate"], "split_by": "worker_id",
+        "why": "The instantaneous companion to the cumulative reuse ratio. Divergence between the "
+               "two localises a reuse collapse to a window rather than to the whole run.",
+        "issues": ["PERF-07", "PERF-06"],
+        "caveat": "Instantaneous and un-aggregatable: averaging it across workers is not a hit "
+                  "rate. Reads zero on workers whose engine config disables block reuse.",
+    },
+    # E8
+    {
+        "id": "en_spec_drafted", "tab": "engine", "unit": "tokens/s", "kind": "counter_rate",
+        "title": "Draft tokens by position",
+        "metrics": ["trtllm_spec_decode_drafted_tokens_total"], "split_by": "token_position",
+        "why": "Speculation offered, broken out by draft position. Read against accepted tokens "
+               "at the same position, this shows which position is being rejected -- the "
+               "actionable part of an acceptance collapse.",
+        "issues": ["PERF-16", "PERF-14"],
+        "caveat": "The acceptance rate is accepted divided by drafted, which is not the same as "
+                  "the ratio arithmetic this layer supports; read the two rate panels together "
+                  "rather than expecting a single ratio series.",
+    },
+    # E8
+    {
+        "id": "en_spec_accepted", "tab": "engine", "unit": "tokens/s", "kind": "counter_rate",
+        "title": "Accepted tokens by position",
+        "metrics": ["trtllm_spec_decode_accepted_tokens_total"], "split_by": "token_position",
+        "why": "Speculation that paid off, broken out by draft position. Its collapse shows up as "
+               "an inter-token latency regression with no other visible cause.",
+        "issues": ["PERF-16", "PERF-14"],
+        "caveat": "A forced-acceptance environment override makes this report policy rather than "
+                  "model behaviour. That setting lives outside the bundle, so check the run "
+                  "config before reading the value as a model property.",
+    },
+    # E9 (also E3, prefill-side delivered work)
+    {
+        "id": "en_prompt_tokens", "tab": "engine", "unit": "tokens/s", "kind": "counter_rate",
+        "title": "Prompt token throughput", "metrics": ["trtllm_prompt_tokens_total"],
+        "split_by": "worker_id",
+        "why": "Prefill work delivered per worker. Read against generation throughput it answers "
+               "whether the engine is mostly prefilling -- a diagnosis no single metric states, "
+               "and the prefill-side counterpart to a completed-request count.",
+        "issues": ["PERF-08", "PERF-15", "PERF-06"],
+        "caveat": "Emitted by prefill-role workers only, so there is no decode line to compare "
+                  "against within this panel.",
+    },
+    # E9
+    {
+        "id": "en_prompt_cached_tokens", "tab": "engine", "unit": "tokens/s", "kind": "counter_rate",
+        "title": "Cached prompt tokens", "metrics": ["trtllm_prompt_cached_tokens_total"],
+        "split_by": "worker_id",
+        "why": "Prompt tokens served from cache. Subtracted from prompt throughput it gives the "
+               "tokens actually recomputed, which is how a reuse regression is told apart from a "
+               "genuinely lighter workload.",
+        "issues": ["PERF-08", "PERF-06", "PERF-07"], "caveat": None,
+    },
+    # E10
+    {
+        "id": "en_kv_offload_bytes", "tab": "engine", "unit": "bytes/s", "kind": "counter_rate",
+        "title": "KV offload throughput",
+        "metrics": ["trtllm_kv_cache_offload_bytes_total"], "split_by": "worker_id",
+        "why": "Bytes evicted from GPU to the host pool. Sustained offload is cache pressure "
+               "being paid in interconnect bandwidth rather than in visible latency.",
+        "issues": ["PERF-24", "PERF-07"],
+        "caveat": "Host-pool occupancy cannot be read alongside this: the host utilisation gauge "
+                  "is a constant zero on every sample.",
+    },
+    # E10
+    {
+        "id": "en_kv_onboard_bytes", "tab": "engine", "unit": "bytes/s", "kind": "counter_rate",
+        "title": "KV onboard throughput",
+        "metrics": ["trtllm_kv_cache_onboard_bytes_total"], "split_by": "worker_id",
+        "why": "Bytes pulled back from host to GPU. This traffic is prefill work that the reuse "
+               "metrics count as a hit, so a high hit rate can still be paying transfer cost.",
+        "issues": ["PERF-24", "PERF-07"],
+        "caveat": "Registered lazily, on the first host-to-device onboard. Its absence early in a "
+                  "run is not a gap.",
+    },
+    # E10
+    {
+        "id": "en_kv_intra_device_bytes", "tab": "engine", "unit": "bytes/s", "kind": "counter_rate",
+        "title": "Intra-device KV copy throughput",
+        "metrics": ["trtllm_kv_cache_intra_device_copy_bytes_total"], "split_by": "worker_id",
+        "why": "Block copies within the GPU. It is cache bookkeeping that consumes bandwidth "
+               "without appearing in any latency or reuse number.",
+        "issues": ["PERF-24", "PERF-07"], "caveat": None,
+    },
+    # E12
+    {
+        "id": "en_prefill_time", "tab": "engine", "unit": "s", "kind": "hist_mean",
+        "title": "Prefill phase duration",
+        "metrics": ["trtllm_request_prefill_time_seconds"], "split_by": "worker_id",
+        "why": "Context-phase duration per worker, separated from queueing and from decode.",
+        "issues": ["PERF-17", "PERF-13", "PERF-04"],
+        "caveat": "On prefill-role workers this coincides exactly with the inference-time family "
+                  "because the request ends at the first token there. That coincidence is the "
+                  "structural signature of disaggregation, not a duplicate to remove.",
+    },
+    # E12
+    {
+        "id": "en_decode_time", "tab": "engine", "unit": "s", "kind": "hist_mean",
+        "title": "Decode phase duration",
+        "metrics": ["trtllm_request_decode_time_seconds"], "split_by": "worker_id",
+        "why": "Generation-phase duration per worker: first token to last token, which is the "
+               "span an inter-token latency regression lengthens.",
+        "issues": ["PERF-17", "PERF-13", "PERF-04"],
+        "caveat": "Decode-role only, and registered lazily on the first decode completion. Its "
+                  "absence early in a run is not a gap.",
+    },
+    # E12
+    {
+        "id": "en_e2e_latency", "tab": "engine", "unit": "s", "kind": "hist_mean",
+        "title": "End-to-end request latency",
+        "metrics": ["trtllm_e2e_request_latency_seconds"], "split_by": "worker_id",
+        "why": "Whole-request time as the engine measured it. Its divergence from engine-side "
+               "first-token time on decode workers is where the decode span actually lives.",
+        "issues": ["PERF-17", "PERF-13"],
+        "caveat": "Its bucket ladder differs from the first-token families, so cross-family "
+                  "quantile comparison is meaningless. Compare means.",
+    },
+    # E13
+    {
+        "id": "en_gpu_memory", "tab": "engine", "unit": "bytes", "kind": "gauge",
+        "title": "GPU memory usage", "metrics": ["trtllm_gpu_memory_usage_bytes"],
+        "split_by": "worker_id",
+        "why": "The only GPU-side signal in the whole metric surface. A leak or an approach to "
+               "the device limit is visible here and nowhere else.",
+        "issues": ["PERF-36", "PERF-34"],
+        "caveat": "A leak and out-of-memory canary, nothing more: there is no utilisation, "
+                  "occupancy, power or temperature signal anywhere in the capture. Host and "
+                  "pinned memory gauges exist but read a constant zero.",
+    },
+
 ]
 
 

--- a/src/visualization/panels.py
+++ b/src/visualization/panels.py
@@ -680,8 +680,12 @@ PANELS: list[dict] = [
                "budget means token-budget-bound, a diagnosis that looks like an unremarkable "
                "number until it is divided by the configured ceiling.",
         "issues": ["PERF-15", "PERF-08", "PERF-14"],
-        "caveat": "Emitted by prefill-role workers only. The ceiling it must be divided by lives "
-                  "in the engine config file in the bundle, not in any metric.",
+        "caveat": "Emitted by prefill-role workers only. The ceiling it must be divided by "
+                  "lives in the engine config file in the bundle, not in any metric. Read it "
+                  "as a distribution and not only as this interval mean -- the share of "
+                  "iterations that actually REACH the ceiling and the average fraction of it "
+                  "are different quantities, and a run can look budget-bound on one while "
+                  "being far from it on the other.",
     },
     # E6
     {
@@ -839,6 +843,29 @@ PANELS: list[dict] = [
         "caveat": "A leak and out-of-memory canary, nothing more: there is no utilisation, "
                   "occupancy, power or temperature signal anywhere in the capture. Host and "
                   "pinned memory gauges exist but read a constant zero.",
+    },
+
+    # --- closing the remaining AVAILABLE issues from the coverage audit ---------
+    {
+        # PERF-21
+        "id": "ro_work_ttfr", "tab": "router", "unit": "s", "kind": "hist_mean",
+        "title": "Work-handler time to first response",
+        "metrics": ["dynamo_work_handler_time_to_first_response_seconds"],
+        "split_by": "dynamo_component",
+        "why": "How long the request plane took to get anything back from a component. "
+               "It separates a component that is slow to start responding from one that "
+               "is slow to finish, which end-to-end latency alone cannot.",
+        "issues": ["PERF-21"], "caveat": None,
+    },
+    {
+        # PERF-22
+        "id": "ro_component_requests", "tab": "router", "unit": "requests/s",
+        "kind": "counter_rate", "title": "Component request rate",
+        "metrics": ["dynamo_component_requests_total"], "split_by": "worker_id",
+        "why": "Delivered request rate per worker as the request plane saw it. Read "
+               "against the engine's own completion rate, a persistent gap means work "
+               "is being accepted faster than it is finished.",
+        "issues": ["PERF-22"], "caveat": None,
     },
 
 ]

--- a/src/visualization/panels.py
+++ b/src/visualization/panels.py
@@ -118,7 +118,11 @@ PANELS: list[dict] = [
     {
         "id": "fe_tokio_busy", "tab": "frontend", "unit": "ratio", "kind": "gauge",
         "title": "Tokio worker busy ratio", "metrics": ["dynamo_tokio_worker_busy_ratio"],
-        "split_by": None,
+        # One series PER WORKER THREAD. Collapsing them into a single unsplit series
+        # interleaves every thread's samples at the same timestamps and draws a point
+        # cloud, not a trend -- and a runtime is saturated when its BUSIEST threads
+        # are, which an undifferentiated blob cannot show.
+        "split_by": "worker",
         "why": "Runtime saturation. A saturated runtime makes host-side work, not the "
                "GPU, the limiter.",
         "issues": ["PERF-gil", "PERF-tokio-starvation"], "caveat": None,

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1955,3 +1955,65 @@ class TestRunLifecycle:
             f.write("2026-08-21 04:00:00 [INFO] Model is ready. Have 1 prefills and 3 decodes.\n")
         lc = self._lc(run_dir, tmp_path)
         assert lc["milestones"]["model_ready"] == "2026-08-21 02:34:09"
+
+
+class TestHostTelemetry:
+    """Host and per-process health (PERF-37/38/40).
+
+    The Prometheus scrape describes what Dynamo publishes; it says nothing about the
+    machine underneath. A frontend pinned at 100% of one core is indistinguishable, in
+    every published metric, from an idle one -- both report low queue depth and low
+    in-flight. Host CPU plus INVOLUNTARY context switches is the discriminator, and
+    open-fd-vs-limit is the only warning an accept loop ever gets.
+    """
+
+    @staticmethod
+    def _samples(run_dir: Path, rows: list[dict]) -> None:
+        (run_dir / "host_samples.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n")
+
+    @staticmethod
+    def _row(t, busy, total, fds, ctx_invol, cpu_j):
+        return {"t": t, "host": "theia0163",
+                "cpu_busy_jiffies": busy, "cpu_total_jiffies": total,
+                "mem": {"MemTotal": 1000, "MemAvailable": 400},
+                "fd_limit": 1024, "established_conns": 12,
+                "procs": [{"pid": 7, "name": "dynamo-frontend", "rss_kb": 2048,
+                           "threads": 8, "ctx_invol": ctx_invol, "open_fds": fds,
+                           "cpu_jiffies": cpu_j}]}
+
+    def _host(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "d.json"
+        proc = _render(bundle, tmp_path / "d.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())["meta"]["host"] or {}
+
+    def test_cpu_percent_is_derived_from_cumulative_counters(self, run_dir: Path, tmp_path: Path):
+        """The sampler stores jiffies, not percentages, so the capture interval never
+        gets baked into the stored number. 50 busy of 100 total = 50%."""
+        self._samples(run_dir, [self._row(100.0, 0, 0, 10, 0, 0),
+                                self._row(101.0, 50, 100, 10, 0, 0)])
+        h = self._host(run_dir, tmp_path)
+        assert h["host_cpu_pct"][0][1] == 50.0
+
+    def test_involuntary_ctx_switch_rate_is_exposed(self, run_dir: Path, tmp_path: Path):
+        """The lock-convoy signal: descheduled against its will, not yielding."""
+        self._samples(run_dir, [self._row(100.0, 0, 0, 10, 1000, 0),
+                                self._row(102.0, 10, 100, 10, 1400, 0)])
+        h = self._host(run_dir, tmp_path)
+        proc = next(iter(h["procs"].values()))
+        assert proc["ctx_invol_rate"][0][1] == 200.0, "(1400-1000)/2s"
+
+    def test_fd_headroom_against_the_limit(self, run_dir: Path, tmp_path: Path):
+        """Reported even when comfortable: 'we were at 2%' is the answer that RULES OUT
+        fd exhaustion, which is as useful as confirming it."""
+        self._samples(run_dir, [self._row(100.0, 0, 0, 20, 0, 0),
+                                self._row(101.0, 10, 100, 20, 0, 0)])
+        h = self._host(run_dir, tmp_path)
+        assert h["fd_limit"] == 1024
+        assert h["fd_headroom_pct"] == round(100.0 * 20 / 1024, 2)
+
+    def test_absent_sampler_yields_no_host_block(self, run_dir: Path, tmp_path: Path):
+        assert self._host(run_dir, tmp_path) == {}

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -762,3 +762,98 @@ class TestRequestAndSessionEntities:
         data = json.loads(payload.read_text())
         assert data["tabs"]["session"] is False
         assert data["rt"]["sessions"] == []
+
+
+class TestPanelSpec:
+    """The declarative panel layer: one evaluator, no per-panel code."""
+
+    def test_every_panel_row_is_well_formed(self):
+        """A malformed row would fail at render time on a cluster, hours after the
+        run it was meant to explain."""
+        from src.visualization.panels import KINDS, PANELS
+
+        ids = [p["id"] for p in PANELS]
+        assert len(ids) == len(set(ids)), "panel ids must be unique"
+        for p in PANELS:
+            assert p["kind"] in KINDS, f"{p['id']}: bad kind"
+            assert p["metrics"], f"{p['id']}: no source metric"
+            assert p["title"] and p["why"], f"{p['id']}: missing title/why"
+            if p["kind"] == "ratio":
+                assert len(p["metrics"]) == 2, f"{p['id']}: ratio needs exactly two counters"
+
+    def test_titles_are_run_independent(self):
+        """Principle: no panel title may encode the run it was written against."""
+        import re
+
+        from src.visualization.panels import PANELS
+
+        for p in PANELS:
+            assert not re.search(r"\d", p["title"]), f"{p['id']}: digit in title suggests a hardcoded count"
+            for banned in ("agentx", "2739690", "deepseek", "lyris", "gb200", "gb300"):
+                assert banned not in p["title"].lower(), f"{p['id']}: run-specific title"
+
+    def test_no_engine_metric_is_split_by_dp_rank(self):
+        """Engine-side dp_rank is a replicated broadcast -- every rank reports
+        identical values. Splitting on it renders a flat family of lines that reads as
+        'no imbalance' on a run that had a 12x spread."""
+        from src.visualization.panels import PANELS
+
+        for p in PANELS:
+            if any(m.startswith("trtllm_") for m in p["metrics"]):
+                assert p["split_by"] != "dp_rank", f"{p['id']}: would render a false flat"
+
+    def test_counter_rate_ignores_a_counter_reset(self):
+        """A restart makes a counter go backwards. Emitting the negative delta draws a
+        throughput cliff that never happened."""
+        from src.visualization.panels import evaluate
+
+        spec = [{"id": "c", "tab": "t", "title": "T", "unit": "u", "kind": "counter_rate",
+                 "metrics": ["m"], "split_by": None, "why": "w", "issues": [], "caveat": None}]
+        scrapes = [(i * 1_000_000_000, {"m": [{"labels": {}, "value": v}]})
+                   for i, v in enumerate([10, 20, 5, 15])]
+        series = evaluate(scrapes, spec)["c"]["series"]["all"]
+        assert [v for _, v in series] == [10.0, 10.0], "the reset must be dropped, not plotted"
+
+    def test_hist_mean_is_an_interval_mean(self):
+        """A cumulative mean flattens over a long run and hides the late degradation
+        these panels exist to catch."""
+        from src.visualization.panels import evaluate
+
+        spec = [{"id": "h", "tab": "t", "title": "T", "unit": "s", "kind": "hist_mean",
+                 "metrics": ["lat"], "split_by": None, "why": "w", "issues": [], "caveat": None}]
+        # interval 1: 10 events / 10s -> 1.0 ; interval 2: 10 events / 100s -> 10.0
+        scrapes = [
+            (0, {"lat_sum": [{"labels": {}, "value": 0.0}], "lat_count": [{"labels": {}, "value": 0}]}),
+            (1_000_000_000, {"lat_sum": [{"labels": {}, "value": 10.0}], "lat_count": [{"labels": {}, "value": 10}]}),
+            (2_000_000_000, {"lat_sum": [{"labels": {}, "value": 110.0}], "lat_count": [{"labels": {}, "value": 20}]}),
+        ]
+        assert [v for _, v in evaluate(scrapes, spec)["h"]["series"]["all"]] == [1.0, 10.0]
+
+    def test_split_by_produces_one_series_per_worker(self):
+        from src.visualization.panels import evaluate
+
+        spec = [{"id": "g", "tab": "t", "title": "T", "unit": "u", "kind": "gauge",
+                 "metrics": ["m"], "split_by": "worker_id", "why": "w", "issues": [], "caveat": None}]
+        scrapes = [(0, {"m": [{"labels": {"worker_id": "a"}, "value": 1},
+                              {"labels": {"worker_id": "b"}, "value": 2}]})]
+        assert set(evaluate(scrapes, spec)["g"]["series"]) == {"a", "b"}
+
+    def test_panels_with_no_data_are_omitted(self):
+        """Omission is what lets a tab drop cleanly instead of rendering empty."""
+        from src.visualization.panels import evaluate
+
+        spec = [{"id": "absent", "tab": "t", "title": "T", "unit": "u", "kind": "gauge",
+                 "metrics": ["never_emitted"], "split_by": None, "why": "w", "issues": [], "caveat": None}]
+        assert evaluate([(0, {"other": [{"labels": {}, "value": 1}]})], spec) == {}
+
+    def test_panels_reach_the_payload(self, run_dir: Path, tmp_path: Path):
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+
+        panels = json.loads(payload.read_text())["panels"]
+        assert panels, "the fixture emits KV-cache metrics, so panels must be present"
+        for p in panels.values():
+            assert {"tab", "title", "unit", "kind", "why", "source", "series"} <= set(p)

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1208,6 +1208,54 @@ class TestKvHitRateGating:
         assert "block 512" not in topo
 
 
+class TestBlockSizeMismatch:
+    """Router block size vs engine tokens-per-block.
+
+    The e2e self-build run 2751593 reported blk_router=None blk_engine=None -- "cannot
+    tell" -- on a run whose engine config plainly said 256. The gauge the check read
+    (`trtllm_kv_cache_tokens_per_block`) is only exported once the engine publishes its
+    KV-cache family, so a run without it lost a check whose whole purpose is a failure
+    mode that is invisible in the metrics.
+    """
+
+    def test_engine_block_size_falls_back_to_the_run_config(self, run_dir: Path, tmp_path: Path):
+        """No gauge in the scrape, but tokens_per_block in the config -> still decided."""
+        (run_dir / "trtllm_config_decode.yaml").write_text(
+            "max_batch_size: 1\nmax_num_tokens: 4\nkv_cache_config:\n  tokens_per_block: 256\n")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+        load = json.loads(payload.read_text())["load"]
+        assert load["blk_engine"] == 256, "engine size must come from the config when the gauge is absent"
+        assert load["blk_src"] == "engine config"
+
+    def test_a_mismatch_is_reported_not_averaged_away(self, run_dir: Path, tmp_path: Path):
+        """Router 32 vs engine 256 is the reference run's real configuration."""
+        (run_dir / "trtllm_config_decode.yaml").write_text(
+            "max_batch_size: 1\nkv_cache_config:\n  tokens_per_block: 256\n")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        load = json.loads(payload.read_text())["load"]
+        if load["blk_router"] is not None:
+            assert load["blk_router"] != load["blk_engine"], "the fixture encodes a mismatch"
+
+    def test_no_config_and_no_gauge_stays_unknown(self, run_dir: Path, tmp_path: Path):
+        """A guessed all-clear is worse than an admitted unknown: the consequence of a
+        mismatch is a silent router index, so 'no mismatch' must never be inferred from
+        missing data."""
+        for f in run_dir.glob("trtllm_config_*.yaml"):
+            f.unlink()
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert json.loads(payload.read_text())["load"]["blk_engine"] is None
+
+
 class TestHeaderProvenance:
     def test_header_explains_an_empty_profiling_population(self, run_dir: Path, tmp_path: Path):
         """A run can end before the profiling phase, leaving every client record marked

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1206,3 +1206,19 @@ class TestKvHitRateGating:
         topo = json.loads(payload.read_text())["meta"]["topo"]
         assert "__BLK__" not in topo
         assert "block 512" not in topo
+
+
+class TestHeaderProvenance:
+    def test_header_explains_an_empty_profiling_population(self, run_dir: Path, tmp_path: Path):
+        """A run can end before the profiling phase, leaving every client record marked
+        warmup. meta.n is then legitimately 0 -- but a bare "0 requests" beside a
+        Session tab listing dozens of sessions reads as a broken page. Observed for
+        real: 118 warmup records, 0 profiling, 65 sessions."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.html"
+        assert _render(bundle, out, "--d3-cdn").returncode == 0
+
+        html = out.read_text()
+        assert "profiling requests" in html, "the header must name which population it counts"
+        assert "are warmup and are shown on the" in html, "and name the other one"

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -2061,3 +2061,422 @@ class TestHostSamplerProcessSelection:
         got = hs._interesting_pids(limit=5)
         assert 12 in got, "the one real worker must survive a budget full of wrappers"
         assert len(got) == 5
+
+
+class TestAiperfJsonMetrics:
+    """AIPerf's own server-metrics export as a second metrics source.
+
+    This is the only server-metrics leg a run predating ``observability.enabled`` has,
+    which makes it the difference between a landed fix being demonstrable against its
+    own baseline and not. Two behaviours are load-bearing and both fail *silently*:
+    picking up ``summary``'s children as if they were metrics families, and reading
+    interval slices as if they were cumulative.
+    """
+
+    @staticmethod
+    def _export(path: Path) -> Path:
+        def sl(i, **kw):
+            return dict(start_ns=T0 + i * 10**9, end_ns=T0 + (i + 1) * 10**9, **kw)
+
+        doc = {
+            "schema_version": "1",
+            # `summary` is a sibling object, so its children sit at the same indent
+            # as a metrics family. Anything that scans on indent alone merges them.
+            "summary": {
+                "decoy_family": {
+                    "type": "counter",
+                    "series": [
+                        {
+                            "endpoint_url": "x",
+                            "labels": {},
+                            "stats": {"total": 999.0},
+                            "timeslices": [sl(0, total=999.0)],
+                        }
+                    ],
+                }
+            },
+            "metrics_phase": "profiling",
+            "metrics": {
+                "dynamo_frontend_tokenize_seconds": {
+                    "type": "histogram",
+                    "series": [
+                        {
+                            "endpoint_url": "http://f:8000/metrics",
+                            "labels": {"model": "m"},
+                            "stats": {"count": 6, "sum": 12.0},
+                            "timeslices": [
+                                sl(0, count=1, sum=2.0),
+                                sl(1, count=2, sum=4.0),
+                                sl(2, count=3, sum=6.0),
+                            ],
+                        }
+                    ],
+                },
+                "dynamo_frontend_requests": {
+                    "type": "counter",
+                    "series": [
+                        {
+                            "endpoint_url": "http://f:8000/metrics",
+                            "labels": {"status": "ok"},
+                            "stats": {"total": 30.0},
+                            "timeslices": [sl(0, total=10.0), sl(1, total=20.0)],
+                        }
+                    ],
+                },
+                "dynamo_tokio_blocking_queue_depth": {
+                    "type": "gauge",
+                    "series": [
+                        {
+                            "endpoint_url": "http://f:8000/metrics",
+                            "labels": {"worker": "3"},
+                            "stats": {"avg": 5.0},
+                            "timeslices": [
+                                sl(0, avg=4.0, min=0, max=9),
+                                sl(1, avg=6.0, min=1, max=646),
+                            ],
+                        }
+                    ],
+                },
+            },
+        }
+        path.write_text(json.dumps(doc, indent=2))
+        return path
+
+    @staticmethod
+    def _convert(tmp_path: Path):
+        sys.path.insert(0, str(REPO_ROOT))
+        from src.ingest.metrics_aiperf_json import process
+
+        src = TestAiperfJsonMetrics._export(tmp_path / "server_metrics_export.json")
+        out = tmp_path / "server_metrics_export.jsonl"
+        process(str(src), str(out))
+        return [json.loads(line) for line in out.read_text().splitlines()]
+
+    def test_summary_section_is_not_mistaken_for_metrics(self, tmp_path: Path):
+        recs = self._convert(tmp_path)
+        names = {k for r in recs for k in r["metrics"]}
+        assert "decoy_family" not in names
+
+    def test_interval_slices_are_accumulated_into_cumulative_series(self, tmp_path: Path):
+        """`hist_mean` and `counter_rate` both differentiate. Feed them interval slices
+        unchanged and the panel shows a jagged line around zero instead of a trend."""
+        recs = self._convert(tmp_path)
+        counts = [
+            r["metrics"]["dynamo_frontend_tokenize_seconds_count"][0]["value"]
+            for r in recs
+            if "dynamo_frontend_tokenize_seconds_count" in r["metrics"]
+        ]
+        assert counts == [1.0, 3.0, 6.0]
+        assert counts[-1] == 6, "the cumulative end value must reproduce stats.count"
+
+        totals = [
+            r["metrics"]["dynamo_frontend_requests_total"][0]["value"]
+            for r in recs
+            if "dynamo_frontend_requests_total" in r["metrics"]
+        ]
+        assert totals == [10.0, 30.0]
+
+    def test_counter_is_emitted_under_both_names(self, tmp_path: Path):
+        """AIPerf keys a counter by its base name, exposition adds `_total`; a panel may
+        name either, so both resolve."""
+        names = {k for r in self._convert(tmp_path) for k in r["metrics"]}
+        assert {"dynamo_frontend_requests", "dynamo_frontend_requests_total"} <= names
+
+    def test_gauge_uses_the_per_slice_average(self, tmp_path: Path):
+        recs = self._convert(tmp_path)
+        vals = [
+            r["metrics"]["dynamo_tokio_blocking_queue_depth"][0]["value"]
+            for r in recs
+            if "dynamo_tokio_blocking_queue_depth" in r["metrics"]
+        ]
+        assert vals == [4.0, 6.0]
+
+    def test_schema_matches_the_prometheus_processor(self, tmp_path: Path):
+        """Both metrics sources must be interchangeable at the panel layer."""
+        for rec in self._convert(tmp_path):
+            assert set(rec) == {"timestamp_ns", "metrics"}
+            assert isinstance(rec["timestamp_ns"], int)
+            for entries in rec["metrics"].values():
+                for e in entries:
+                    assert set(e) == {"labels", "value"}
+                    assert isinstance(e["labels"], dict)
+                    assert isinstance(e["value"], float)
+
+
+class TestIterLogOnlyBuild:
+    """A bundle whose ONLY leg is the per-iteration log must still render.
+
+    This is the trtllm-serve shape: no Dynamo frontend means no ``/metrics`` surface
+    and no spans, so `iter_bins.json` is the whole bundle. It is also every run whose
+    recipe sets ``print_iter_log`` without ``observability.enabled``.
+
+    Two things used to drop it on the floor, both silently:
+      * the run window was built from traces + scrapes only, so with neither it
+        collapsed to 1 ns and the ``t > run_dur + 60`` guard discarded every bin;
+      * the Engine tab was gated on the scrape stream alone.
+    The failure mode was an empty page and one INFO line reading ``0pts`` -- on a run
+    with 175,800 real iterations.
+    """
+
+    @staticmethod
+    def _iter_only_bundle(tmp_path: Path) -> Path:
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+        t0 = T0 // 10**9
+        bins = {
+            "node0_prefill_w0": [
+                {"t": t0 + i, "n_iters": 3, "kv_cache_util": 0.4 + i * 0.01,
+                 "num_scheduled_requests": 1, "num_ctx_requests": 1,
+                 "num_ctx_tokens": 8192, "num_generation_tokens": 0,
+                 "host_step_time_ms": 340.0 + i, "device_step_time_ms": 335.0 + i,
+                 "sched_max": 1, "host_step_time_ms_max": 340.0 + i,
+                 "device_step_time_ms_max": 335.0 + i, "sched_hist": {"1": 3}}
+                for i in range(120)
+            ],
+            "node9_decode_w0": [
+                {"t": t0 + i, "n_iters": 28, "kv_cache_util": 0.40,
+                 "num_scheduled_requests": 64, "num_ctx_requests": 0,
+                 "num_ctx_tokens": 0, "num_generation_tokens": 64,
+                 "host_step_time_ms": 36.1, "device_step_time_ms": 35.7,
+                 "sched_max": 64, "host_step_time_ms_max": 36.1,
+                 "device_step_time_ms_max": 35.7, "sched_hist": {"64": 28}}
+                for i in range(120)
+            ],
+        }
+        (bundle / "iter_bins.json").write_text(json.dumps(
+            {"meta": {"bin_seconds": 1.0, "offset_hours_applied": 0,
+                      "iterations": 3720, "workers": sorted(bins)},
+             "bins": bins}))
+        return bundle
+
+    def test_engine_tab_survives_without_a_scrape_stream(self, tmp_path: Path):
+        bundle = self._iter_only_bundle(tmp_path)
+        out = tmp_path / "d.html"
+        proc = _render(bundle, out, "--d3-cdn")
+        assert proc.returncode == 0, proc.stderr
+        tabs = _tabs(out.read_text())
+        assert tabs.get("engine") is True, f"engine tab dropped on an iter-log-only bundle: {tabs}"
+        assert tabs.get("frontend") is False and tabs.get("router") is False
+
+    def test_the_run_window_comes_from_the_iter_log_when_nothing_else_exists(
+        self, tmp_path: Path
+    ):
+        """`run_dur` of ~0 is what silently discarded every bin."""
+        bundle = self._iter_only_bundle(tmp_path)
+        out = tmp_path / "d.html"
+        dump = tmp_path / "d.json"
+        proc = _render(bundle, out, "--d3-cdn", "--dump-json", str(dump))
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(dump.read_text())
+        assert payload["meta"]["run_dur_s"] >= 110, payload["meta"]["run_dur_s"]
+
+    def test_every_iteration_bin_reaches_the_payload(self, tmp_path: Path):
+        bundle = self._iter_only_bundle(tmp_path)
+        out = tmp_path / "d.html"
+        dump = tmp_path / "d.json"
+        _render(bundle, out, "--d3-cdn", "--dump-json", str(dump))
+        it = json.loads(dump.read_text())["iter"]
+        assert set(it) == {"node0_prefill_w0", "node9_decode_w0"}
+        for worker, series in it.items():
+            pts = series["kv_cache_util"]
+            assert len(pts) == 120, f"{worker}: {len(pts)} of 120 bins survived"
+
+    def test_both_batch_panels_render_with_srtslurm_worker_names(self, tmp_path: Path):
+        """srt-slurm names a worker `<node>_<role>_w<N>`, so the role is in the MIDDLE.
+
+        A `startsWith(role)` filter matched nothing on every srt-slurm run, and the
+        panel builder returns silently on an empty match -- so both in-flight batch
+        panels were simply absent, with no warning anywhere.
+        """
+        bundle = self._iter_only_bundle(tmp_path)
+        out = tmp_path / "d.html"
+        _render(bundle, out, "--d3-cdn")
+        html = out.read_text()
+        # The Prefill/Decode prefix is interpolated at runtime, so only the invariant
+        # tail of the title template is literal in the HTML. Asserting the full string
+        # would fail against a page that renders perfectly.
+        assert "in-flight batch size per worker" in html
+        # The regression itself: the role sits in the MIDDLE of `<node>_<role>_w<N>`.
+        assert "startsWith(role)" not in html, "role filter reverted to a prefix match"
+        # And the filter must actually select this fixture's worker names.
+        workers = list(json.loads((bundle / "iter_bins.json").read_text())["bins"])
+        for role in ("prefill", "decode"):
+            assert [w for w in workers if f"_{role}_" in w or f"_{role}" in w], role
+
+    def test_kv_panels_fall_back_to_the_iteration_log(self, tmp_path: Path):
+        """Both KV gauges live on the WORKER endpoint. When it was never scraped the
+        panels emitted a full-length series of nulls -- an empty chart, which reads as
+        a measured zero rather than as absent data."""
+        bundle = self._iter_only_bundle(tmp_path)
+        out = tmp_path / "d.html"
+        dump = tmp_path / "d.json"
+        _render(bundle, out, "--d3-cdn", "--dump-json", str(dump))
+        en = json.loads(dump.read_text())["en"]
+        assert en["kvutil_src"].startswith("iter_bins"), en["kvutil_src"]
+        assert en["true_hit_src"].startswith("iter_bins"), en["true_hit_src"]
+        assert [p for p in en["kvutil_pf"] if p[1] is not None], "kvutil still all-null"
+        assert en["true_hit_kpi"] is not None, "true-hit KPI still None"
+
+    def test_derived_reuse_matches_the_hand_computed_ratio(self, tmp_path: Path):
+        """cached_kv_tokens/(cached+num_ctx_tokens); the fixture is 0 cached, so 0%."""
+        bundle = self._iter_only_bundle(tmp_path)
+        src = json.loads((bundle / "iter_bins.json").read_text())
+        for r in src["bins"]["node0_prefill_w0"]:
+            r["cached_kv_tokens"] = 9000          # 9000 / (9000 + 8192)
+        (bundle / "iter_bins.json").write_text(json.dumps(src))
+        out = tmp_path / "d.html"; dump = tmp_path / "d.json"
+        _render(bundle, out, "--d3-cdn", "--dump-json", str(dump))
+        en = json.loads(dump.read_text())["en"]
+        expected = 9000 / (9000 + 8192) * 100
+        vals = [p[1] for p in en["true_hit_pct"] if p[1] is not None]
+        assert vals, "no reuse series produced"
+        assert abs(vals[0] - expected) < 0.05, (vals[0], expected)
+
+
+class TestWarmupMarker:
+    """The load generator's warmup phase, marked on every time-axis chart.
+
+    Carried as an OPTIONAL field on the panel entity. Optional is the design: many
+    harnesses have no warmup phase, and a marker invented for them would assert a
+    boundary that does not exist. Absent must mean "unknown", never "t=0".
+    """
+
+    @staticmethod
+    def _client(run_dir: Path, *, warmup: int, profiling: int) -> None:
+        """AgentX-shaped export: a warmup phase, then the measured phase."""
+        # The scrape window defines the rendered axis, and a boundary outside it is
+        # correctly refused -- so widen the capture to cover the phases being written.
+        _write_raw_prometheus(run_dir, sweeps=warmup + profiling + 2)
+        art = run_dir / "artifacts" / "run"
+        art.mkdir(parents=True, exist_ok=True)
+        recs = []
+        for i in range(warmup):
+            recs.append({"metadata": {"x_request_id": f"w{i}", "benchmark_phase": "warmup",
+                                      "request_start_ns": T0 + i * 10**9,
+                                      "request_end_ns": T0 + (i + 1) * 10**9},
+                         "metrics": {"time_to_first_token": {"value": 100.0},
+                                     "request_latency": {"value": 200.0}}})
+        for i in range(profiling):
+            t = T0 + (warmup + i) * 10**9
+            recs.append({"metadata": {"x_request_id": XIDS[i % len(XIDS)],
+                                      "benchmark_phase": "profiling",
+                                      "request_start_ns": t, "request_end_ns": t + 10**9},
+                         "metrics": {"time_to_first_token": {"value": 100.0},
+                                     "request_latency": {"value": 200.0}}})
+        (art / "profile_export.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def test_boundary_is_the_first_profiling_request(self, run_dir: Path, tmp_path: Path):
+        self._client(run_dir, warmup=20, profiling=40)
+        bundle = tmp_path / "b"
+        _run_ingest(run_dir, bundle)
+        dump = tmp_path / "d.json"
+        _render(bundle, tmp_path / "d.html", "--d3-cdn", "--dump-json", str(dump))
+        meta = json.loads(dump.read_text())["meta"]
+        assert meta["warmup_end_s"] is not None
+        assert "benchmark_phase" in (meta["warmup_src"] or "")
+
+    def test_absent_when_the_harness_tags_no_phase(self, run_dir: Path, tmp_path: Path):
+        """A plain AIPerf run has no benchmark_phase. It must not acquire a boundary."""
+        bundle = tmp_path / "b"
+        _run_ingest(run_dir, bundle)
+        dump = tmp_path / "d.json"
+        _render(bundle, tmp_path / "d.html", "--d3-cdn", "--dump-json", str(dump))
+        meta = json.loads(dump.read_text())["meta"]
+        assert meta["warmup_end_s"] is None, meta["warmup_end_s"]
+        assert meta["warmup_src"] is None
+
+    def test_every_panel_entity_carries_the_field(self, run_dir: Path, tmp_path: Path):
+        """One marker source, so it cannot appear on some tabs and not others."""
+        self._client(run_dir, warmup=20, profiling=40)
+        bundle = tmp_path / "b"
+        _run_ingest(run_dir, bundle)
+        dump = tmp_path / "d.json"
+        _render(bundle, tmp_path / "d.html", "--d3-cdn", "--dump-json", str(dump))
+        payload = json.loads(dump.read_text())
+        panels = payload["panels"]
+        assert panels, "no panels to check"
+        missing = [k for k, p in panels.items() if p.get("warmup_end_s") is None]
+        assert not missing, f"panels without the marker: {missing[:5]}"
+        assert all(p["warmup_end_s"] == payload["meta"]["warmup_end_s"] for p in panels.values())
+
+    def test_the_page_draws_it(self, run_dir: Path, tmp_path: Path):
+        self._client(run_dir, warmup=20, profiling=40)
+        bundle = tmp_path / "b"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "d.html"
+        _render(bundle, out, "--d3-cdn")
+        html = out.read_text()
+        assert "warmup ends" in html, "marker label absent from the page"
+        assert "function wmLine" in html
+
+
+class TestMetricsSourceAutoSelect:
+    """`--metrics auto` picks the source the run actually captured.
+
+    A run with `observability.enabled` has `raw_prometheus.jsonl`. A run without it
+    usually still has AIPerf's own export, because the frontend's `/metrics` surface
+    exists regardless of that knob. Selecting per-run is what lets ONE ingest command
+    -- in particular the in-job postprocess hook, which takes no source flag -- work
+    on both.
+    """
+
+    @staticmethod
+    def _aiperf_export(run_dir: Path, nested: bool = False) -> None:
+        # Two layouts in the wild, and the deeper one is NOT a superset of the other:
+        # some harness builds write `agentic/<conc>/aiperf_artifacts/...`, others
+        # `agentic/<conc>/...`, and stock AIPerf `artifacts/<run>/...`.
+        art = (run_dir / "agentic" / "conc_4" / "aiperf_artifacts") if nested \
+            else (run_dir / "artifacts" / "run")
+        art.mkdir(parents=True, exist_ok=True)
+        t0 = T0
+        doc = {"metrics": {"dynamo_frontend_requests": {"type": "counter", "series": [
+            {"endpoint_url": "http://f:8000/metrics", "labels": {},
+             "stats": {"total": 30.0},
+             "timeslices": [
+                 {"start_ns": t0 + i * 10**9, "end_ns": t0 + (i + 1) * 10**9, "total": 10.0}
+                 for i in range(3)]}]}}}
+        (art / "server_metrics_export.json").write_text(json.dumps(doc, indent=2))
+
+    def test_prefers_the_in_job_scraper_when_present(self, run_dir: Path, tmp_path: Path):
+        self._aiperf_export(run_dir)          # both sources available
+        bundle = tmp_path / "b"
+        _run_ingest(run_dir, bundle)          # no --metrics flag => auto
+        rec = json.loads((bundle / "server_metrics_export.jsonl").read_text().splitlines()[0])
+        # the raw-prometheus fixture carries this family; the aiperf fixture does not
+        assert "dynamo_frontend_queued_requests" in rec["metrics"]
+
+    def test_falls_back_to_the_aiperf_export_without_observability(
+        self, run_dir: Path, tmp_path: Path
+    ):
+        """The `observability.enabled: false` shape: no raw scrape, AIPerf export only."""
+        (run_dir / "raw_prometheus.jsonl").unlink()
+        self._aiperf_export(run_dir)
+        bundle = tmp_path / "b"
+        _run_ingest(run_dir, bundle)
+        out = bundle / "server_metrics_export.jsonl"
+        assert out.exists(), "auto did not fall back to the AIPerf export"
+        rec = json.loads(out.read_text().splitlines()[0])
+        assert "dynamo_frontend_requests_total" in rec["metrics"]
+
+    def test_the_server_metrics_tabs_survive_that_fallback(self, run_dir: Path, tmp_path: Path):
+        """This is the property that matters: a run without observability still gets
+        the Frontend / Router / Engine tabs rather than a log-only page."""
+        (run_dir / "raw_prometheus.jsonl").unlink()
+        self._aiperf_export(run_dir)
+        bundle = tmp_path / "b"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "d.html"
+        _render(bundle, out, "--d3-cdn")
+        tabs = _tabs(out.read_text())
+        assert tabs.get("frontend") and tabs.get("router"), tabs
+
+    def test_finds_the_nested_aiperf_artifacts_layout(self, run_dir: Path, tmp_path: Path):
+        """`agentic/<conc>/aiperf_artifacts/server_metrics_export.json` -- the layout an
+        srt-slurm AgentX run on lyris writes. Missing it silently costs three tabs."""
+        (run_dir / "raw_prometheus.jsonl").unlink()
+        self._aiperf_export(run_dir, nested=True)
+        bundle = tmp_path / "b"
+        _run_ingest(run_dir, bundle)
+        assert (bundle / "server_metrics_export.jsonl").exists(), \
+            "auto did not find the nested aiperf_artifacts layout"

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1208,6 +1208,60 @@ class TestKvHitRateGating:
         assert "block 512" not in topo
 
 
+class TestRouterCoverageCaveat:
+    """The KV-routing panels must say how much of the traffic they describe.
+
+    On a session-affinity deployment most requests never reach the KV scorer: they are
+    pinned to the worker already holding the conversation. On the e2e run 2751593, 248
+    of 274 routing decisions (90.5%) were pinned. Without the caveat these panels read
+    as "how the router chose" for the whole run, when they describe under a tenth of it.
+    """
+
+    @staticmethod
+    def _with_selector(run_dir: Path, n_pinned: int, n_fresh: int) -> None:
+        """Append selector decisions in the JSONL flavour the frontend emits."""
+        log = run_dir / "node0_frontend_0.out"
+        out = [log.read_text()]
+        for i in range(n_pinned + n_fresh):
+            pinned = "pinned " if i < n_pinned else ""
+            out.append(json.dumps({
+                "time": f"2026-08-20T10:00:{i % 60:02d}.000000Z",
+                "target": "dynamo_llm::kv_router::scheduling::selector",
+                "message": f"Selected {pinned}worker: worker_type=decode, worker_id=1 dp_rank=0, logit=0.5",
+            }))
+        log.write_text("\n".join(out) + "\n")
+
+    def test_coverage_is_measured_into_the_payload(self, run_dir: Path, tmp_path: Path):
+        """Asserted on the JSON, not the HTML.
+
+        The HTML always contains the template literal that WOULD render the caveat, so
+        a text search cannot tell a rendered string from its source. The payload is
+        also the artifact most consumers actually read.
+        """
+        self._with_selector(run_dir, n_pinned=90, n_fresh=10)
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload),
+                       "--frontend-log", str(run_dir / "node0_frontend_0.out"))
+        assert proc.returncode == 0, proc.stderr
+        cov = json.loads(payload.read_text())["ro"]["coverage"]
+        assert cov["decisions"] == 100
+        assert cov["pinned"] == 90
+        assert cov["pct_pinned"] == 90.0
+
+    def test_absent_without_the_log_leg(self, run_dir: Path, tmp_path: Path):
+        """No frontend log means no decision count. A coverage claim with no
+        measurement behind it is worse than no claim at all, so the key must be
+        absent rather than defaulted to zero -- zero pinned would read as
+        'every request reached the scorer', the opposite of not knowing."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert "coverage" not in json.loads(payload.read_text())["ro"]
+
+
 class TestBlockSizeMismatch:
     """Router block size vs engine tokens-per-block.
 

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -928,3 +928,37 @@ class TestDoubleMetricPollingWarning:
 
         with caplog.at_level(logging.WARNING):
             self._mixin("no-such-benchmark", True)._warn_on_double_metric_polling()
+
+
+class TestWaterfallKvTransferBand:
+    def test_run_level_waterfall_has_the_kv_transfer_band(self, run_dir: Path, tmp_path: Path):
+        """The decode `handle_payload` span starts AFTER the KV cache has transferred,
+        so a spans-only waterfall butts prefill compute against decode compute and
+        silently absorbs the wait between them. On the reference run that gap is 83%
+        of TTFT at p90 -- the single largest phase, invisible."""
+        src = run_dir / "dynamo-request-trace"
+        src.write_text("\n".join(
+            json.dumps(_trace_record(xid, "s1", 1_787_174_000_000 + i * 1000,
+                                     prefill_wait=2.0, prefill=500.0, kv_transfer=250.0,
+                                     total=1000.0, avg_itl=20.0, osl=11, hashes=[1, 2]))
+            for i, xid in enumerate(XIDS)) + "\n")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+
+        wf = json.loads(payload.read_text())["waterfall"]
+        assert wf, "fixture has no spans, so the waterfall may be empty; guard the assert"
+        for band in wf.values():
+            assert "kvt" in band, "the run-level waterfall must carry the KV-transfer band"
+
+    def test_kvt_band_is_zero_without_a_request_trace(self, run_dir: Path, tmp_path: Path):
+        """Aggregated runs have no transfer, and older captures have no trace file.
+        The band must still exist so the waterfall's shape is run-independent."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)  # no dynamo-request-trace in the fixture
+        payload = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        for band in json.loads(payload.read_text())["waterfall"].values():
+            assert band["kvt"] == 0

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1222,3 +1222,79 @@ class TestHeaderProvenance:
         html = out.read_text()
         assert "profiling requests" in html, "the header must name which population it counts"
         assert "are warmup and are shown on the" in html, "and name the other one"
+
+
+class TestJsonlSelectorRecovery:
+    """On a DYN_LOGGING_JSONL=true run every record is JSON, and the parser used to
+    discard every non-SPAN_CLOSED JSON line. That silently threw away the entire
+    router family: 597 real selector records on the reference log counted as 0."""
+
+    @staticmethod
+    def _log(tmp_path: Path, msgs) -> Path:
+        p = tmp_path / "node_frontend_0.out"
+        p.write_text("\n".join(json.dumps({
+            "time": "2026-08-19T21:15:34.05374%dZ" % (i % 10),
+            "level": "DEBUG",
+            "target": "dynamo_kv_router::scheduling::selector",
+            "message": m,
+        }) for i, m in enumerate(msgs)) + "\n")
+        return p
+
+    def test_jsonl_selector_decisions_are_counted(self, tmp_path: Path):
+        from src.ingest.frontend_infolog_parser import parse_frontend_log
+
+        log = self._log(tmp_path, [
+            "Selected pinned worker: worker_type=prefill, worker_id=7587 dp_rank=1, logit=0.5",
+            "Selected pinned worker: worker_type=decode, worker_id=7588 dp_rank=0, logit=0.5",
+            "Selected worker",
+        ])
+        s = parse_frontend_log(str(log))["stats"]
+        assert s["selector_without_request_id"] == 3, "JSON selector records must be seen"
+        assert s["selector_decisions_pinned"] == 2
+
+    def test_candidate_scores_are_not_counted_as_decisions(self, tmp_path: Path):
+        """A per-candidate score is not a choice. Conflating them would inflate the
+        decision count by the number of workers considered."""
+        from src.ingest.frontend_infolog_parser import parse_frontend_log
+
+        log = self._log(tmp_path, [
+            "Formula for worker_id=7587 dp_rank=0 with 0.00 effective cached blocks: 8094.094 = a * b",
+            "Pinned formula for worker_id=7588 dp_rank=1 with 12.00 effective cached blocks: 42.0 = a * b",
+            "Selected pinned worker: worker_type=prefill, worker_id=7588 dp_rank=1, logit=0.5",
+        ])
+        s = parse_frontend_log(str(log))["stats"]
+        assert s["selector_candidate_scores"] == 2
+        assert s["selector_without_request_id"] == 1
+
+    def test_span_closed_records_still_parse(self, tmp_path: Path):
+        """The fix must not disturb the SPAN_CLOSED path it sits next to."""
+        from src.ingest.frontend_infolog_parser import parse_frontend_log
+
+        p = tmp_path / "node_frontend_0.out"
+        p.write_text(json.dumps({
+            "time": "2026-08-19T21:15:34.053746Z", "level": "DEBUG",
+            "target": "request_span", "message": "SPAN_CLOSED",
+            "request_id": "r1", "x_request_id": "xid0", "time.duration_us": 1_000_000,
+            "ttft_ms": 120.0, "input_tokens": 10, "output_tokens": 5,
+        }) + "\n")
+        parsed = parse_frontend_log(str(p))
+        assert "xid0" in parsed["requests"]
+
+
+class TestSpanBusyIdleRetained:
+    def test_busy_and_idle_survive_as_attributes(self, tmp_path: Path):
+        """time.busy_us / time.idle_us split a span's wall time into work vs waiting --
+        the difference between a span that is slow because it computed and one that is
+        slow because it blocked. They were being dropped as envelope metadata."""
+        from src.ingest.traces_spanlog import parse_line
+
+        span = parse_line(json.dumps({
+            "time": "2026-08-19T21:15:34.053746Z", "message": "SPAN_CLOSED",
+            "span_name": "handle_payload", "span_id": "a", "parent_id": "b",
+            "trace_id": "t", "request_id": "r", "x_request_id": "x",
+            "time.duration_us": 1000, "time.busy_us": 200, "time.idle_us": 800,
+            "component": "prefill",
+        }))
+        assert span["attrs"]["time.busy_us"] == 200
+        assert span["attrs"]["time.idle_us"] == 800
+        assert "time.duration_us" not in span["attrs"], "duration is the span length, not an attr"

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -962,3 +962,57 @@ class TestWaterfallKvTransferBand:
         _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
         for band in json.loads(payload.read_text())["waterfall"].values():
             assert band["kvt"] == 0
+
+
+class TestInstantaneousImbalancePanels:
+    """Balance over a phase and balance at an instant are different properties.
+
+    Reported in the field as: "Over the whole benchmark phase, I don't see a large
+    imbalance between DP ranks. However, there is a large instantaneously imbalance."
+    A run-total per rank is exactly the aggregate that hides it.
+    """
+
+    @staticmethod
+    def _trace(run_dir: Path, ranks_by_turn):
+        recs = []
+        for i, rank in enumerate(ranks_by_turn):
+            r = _trace_record(f"x{i}", "s1", 1_787_174_000_000 + i * 10,
+                              prefill_wait=1.0, prefill=10.0, kv_transfer=1.0,
+                              total=1000.0, avg_itl=2.0, osl=11, hashes=[1])
+            r["event"]["request"]["worker"]["prefill_dp_rank"] = rank
+            recs.append(r)
+        (run_dir / "dynamo-request-trace").write_text(
+            "\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def _panels(self, run_dir: Path, tmp_path: Path):
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(payload.read_text())["panels"]
+
+    def test_concurrent_skew_is_detected(self, run_dir: Path, tmp_path: Path):
+        """Every request lands on rank 0 while ranks 1-3 idle."""
+        self._trace(run_dir, [0, 0, 0, 0, 0, 1])
+        p = self._panels(run_dir, tmp_path)["bal_prefill_dp_rank"]
+        assert max(v for _, v in p["series"]["max-min"]) >= 4
+
+    def test_balanced_load_shows_no_spread(self, run_dir: Path, tmp_path: Path):
+        """Overlapping requests spread evenly across ranks must not raise an alarm."""
+        self._trace(run_dir, [0, 1, 2, 3])
+        p = self._panels(run_dir, tmp_path)["bal_prefill_dp_rank"]
+        assert max(v for _, v in p["series"]["max-min"]) <= 1
+
+    def test_single_rank_run_emits_no_panel(self, run_dir: Path, tmp_path: Path):
+        """With one rank there is no imbalance to express; a flat zero line would
+        imply the run was checked and found balanced."""
+        self._trace(run_dir, [0, 0, 0])
+        assert "bal_prefill_dp_rank" not in self._panels(run_dir, tmp_path)
+
+    def test_derived_panel_matches_the_spec_panel_shape(self, run_dir: Path, tmp_path: Path):
+        """It must be indistinguishable from a spec panel to the renderer -- a
+        different source, not a different kind of panel."""
+        self._trace(run_dir, [0, 0, 1, 2])
+        p = self._panels(run_dir, tmp_path)["bal_prefill_dp_rank"]
+        assert {"tab", "title", "unit", "kind", "why", "source", "caveat", "series"} <= set(p)

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1047,3 +1048,89 @@ class TestRoutingOutcomeAndBeliefCheck:
         """No overlap_blocks means the belief check has nothing to compare; it must
         report nothing rather than a vacuous 100% agreement."""
         assert self._bundle(run_dir, tmp_path)["rt"]["belief"] is None
+
+
+_ITER_LINE = (
+    "[08/19/2026-14:11:49] [TRT-LLM] [I] [_torch][RANK 0] iter = {i}, global_rank = 0, "
+    "rank = 0, num_scheduled_requests = {sched}, kv_cache_util = {kv}, "
+    "currank_total_requests = 0/1, host_step_time = {host}ms, "
+    "prev_device_step_time = {dev}, timestamp = 2026-08-19 14:11:{sec:02d}, "
+    "states = {{'num_ctx_requests': 1, 'num_ctx_tokens': 4, "
+    "'num_generation_tokens': {gen}, 'cached_kv_tokens': 0}}"
+)
+
+
+class TestIterLogProcessor:
+    """TRT-LLM print_iter_log -> iter_bins.json. The only source for batch composition."""
+
+    def test_parses_a_real_line(self):
+        from src.ingest.iter_log import parse_line
+
+        r = parse_line(_ITER_LINE.format(i=2, sched=3, kv="0.112", host="4.08",
+                                         dev="243.13ms", sec=49, gen=7))
+        assert r["iter"] == 2 and r["num_scheduled_requests"] == 3
+        assert r["kv_cache_util"] == 0.112
+        assert r["host_step_time_ms"] == 4.08 and r["device_step_time_ms"] == 243.13
+        assert r["num_generation_tokens"] == 7
+
+    def test_na_device_time_is_none_not_zero(self):
+        """N/A on the first iteration of a lifecycle. Zero would be a real measurement
+        and would drag any aggregate toward it."""
+        from src.ingest.iter_log import parse_line
+
+        assert parse_line(_ITER_LINE.format(i=1, sched=1, kv="0.001", host="243.17",
+                                            dev="N/A", sec=49, gen=0))["device_step_time_ms"] is None
+
+    def test_non_iter_lines_are_ignored(self):
+        from src.ingest.iter_log import parse_line
+
+        assert parse_line("[TRT-LLM] [I] some other log line entirely") is None
+
+    def test_timezone_offset_is_derived_not_hardcoded(self, tmp_path: Path):
+        """TRT-LLM stamps worker-LOCAL time while every other bundle source is UTC.
+        Reading it naively puts engine events hours from the frontend events they
+        belong to. The offset is derived from the run window, so it follows the
+        cluster and DST instead of assuming one zone."""
+        from src.ingest.iter_log import derive_offset_hours
+
+        recs = [{"local_ts": "2026-08-19 14:11:49"}]
+        # Log says 14:11 local; the run window is centred 7h later in UTC.
+        base = int(datetime(2026, 8, 19, 21, 11, 49, tzinfo=timezone.utc).timestamp() * 1e9)
+        assert derive_offset_hours(recs, base - 10**11, base + 10**11) == 7
+        # A window centred on the log time itself needs no shift.
+        base0 = int(datetime(2026, 8, 19, 14, 11, 49, tzinfo=timezone.utc).timestamp() * 1e9)
+        assert derive_offset_hours(recs, base0 - 10**11, base0 + 10**11) == 0
+
+    def test_no_window_means_no_guess(self):
+        """An underived offset beats an invented one."""
+        from src.ingest.iter_log import derive_offset_hours
+
+        assert derive_offset_hours([{"local_ts": "2026-08-19 14:11:49"}], None, None) == 0
+
+    def test_bins_carry_the_scheduled_distribution(self, tmp_path: Path):
+        """A median alone cannot answer "did it ever batch" -- the distribution can."""
+        from src.ingest.iter_log import process
+
+        log = tmp_path / "node_decode_w0.out"
+        lines = [_ITER_LINE.format(i=i, sched=s, kv="0.01", host="13.0", dev="12.0ms",
+                                   sec=49, gen=1)
+                 for i, s in enumerate([0, 1, 1, 4], start=1)]
+        log.write_text("\n".join(lines) + "\n")
+        out = tmp_path / "iter_bins.json"
+        assert process(str(out), [str(log)]) >= 1
+
+        d = json.loads(out.read_text())
+        rows = d["bins"]["node_decode_w0"]
+        hist = {}
+        for r in rows:
+            for k, v in r["sched_hist"].items():
+                hist[k] = hist.get(k, 0) + v
+        assert hist == {"0": 1, "1": 2, "4": 1}
+        assert max(r["sched_max"] for r in rows) == 4
+
+    def test_no_iter_lines_is_not_an_error(self, tmp_path: Path):
+        from src.ingest.iter_log import process
+
+        log = tmp_path / "node_decode_w0.out"
+        log.write_text("nothing of interest here\n")
+        assert process(str(tmp_path / "iter_bins.json"), [str(log)]) == 0

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1604,3 +1604,55 @@ class TestClientSummaryLeg:
         read as absent, never as 0%, which would imply the workload offered no reuse."""
         payload = self._payload(run_dir, tmp_path)
         assert payload["meta"]["client_summary"] is None
+
+
+class TestProvenanceLeg:
+    """What actually ran, from the workers' own fingerprints.
+
+    Container tags routinely disagree with the wheels they bundle, so the versions
+    found INSIDE a running worker are the only trustworthy answer. They are also
+    per-worker: a deployment whose prefill and decode landed on different builds is
+    visible here and nowhere else, because both halves run and only the meaning of the
+    numbers changes. PERF-49.
+    """
+
+    @staticmethod
+    def _fingerprint(run_dir: Path, worker: str, trtllm: str = "1.3.0rc21") -> None:
+        (run_dir / f"fingerprint_{worker}.json").write_text(json.dumps({
+            "frameworks": {"tensorrt_llm": trtllm, "dynamo": "1.3.0.dev2026071601"},
+            "cuda_version": "13.0", "nccl_version": "2.28", "python_version": "3.12.3",
+            "gpu": "GB300", "hostname": f"theia-{worker}",
+        }))
+
+    def _payload(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())
+
+    def test_fingerprints_reach_the_bundle_and_payload(self, run_dir: Path, tmp_path: Path):
+        self._fingerprint(run_dir, "prefill_w0")
+        self._fingerprint(run_dir, "decode_w0")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        assert (bundle / "fingerprint_prefill_w0.json").is_file()
+        assert (bundle / "config.yaml").is_file() or True  # config.yaml is optional in the fixture
+        out = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(out))
+        pv = json.loads(out.read_text())["meta"]["provenance"]
+        assert pv["n_workers"] == 2
+        assert pv["frameworks"]["tensorrt_llm"] == "1.3.0rc21"
+        assert pv["framework_disagreement"] is None
+
+    def test_workers_on_different_builds_are_flagged(self, run_dir: Path, tmp_path: Path):
+        """Silent in every other panel: both halves run, and only the meaning of the
+        numbers changes."""
+        self._fingerprint(run_dir, "prefill_w0", trtllm="1.3.0rc21")
+        self._fingerprint(run_dir, "decode_w0", trtllm="1.2.0rc4")
+        pv = self._payload(run_dir, tmp_path)["meta"]["provenance"]
+        assert pv["framework_disagreement"] == {"tensorrt_llm": ["1.2.0rc4", "1.3.0rc21"]}
+
+    def test_absent_fingerprints_report_none_not_agreement(self, run_dir: Path, tmp_path: Path):
+        assert self._payload(run_dir, tmp_path)["meta"]["provenance"] is None

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1016,3 +1016,34 @@ class TestInstantaneousImbalancePanels:
         self._trace(run_dir, [0, 0, 1, 2])
         p = self._panels(run_dir, tmp_path)["bal_prefill_dp_rank"]
         assert {"tab", "title", "unit", "kind", "why", "source", "caveat", "series"} <= set(p)
+
+
+class TestRoutingOutcomeAndBeliefCheck:
+    """Entity type 2 asks the card to explain the routing decision, not just the timing."""
+
+    @staticmethod
+    def _bundle(run_dir: Path, tmp_path: Path):
+        src = run_dir / "dynamo-request-trace"
+        src.write_text("\n".join(
+            json.dumps(_trace_record(xid, "s1", 1_787_174_000_000 + i * 1000,
+                                     prefill_wait=2.0, prefill=500.0, kv_transfer=50.0,
+                                     total=1000.0, avg_itl=20.0, osl=11, hashes=[1, 2]))
+            for i, xid in enumerate(XIDS)) + "\n")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(payload.read_text())
+
+    def test_cards_exist_without_spans(self, run_dir: Path, tmp_path: Path):
+        """The fixture has no SPAN_CLOSED logs, so routing is unjoinable. The card must
+        still be produced with routing None rather than fabricating a decision."""
+        rt = self._bundle(run_dir, tmp_path)["rt"]
+        assert rt["requests"]
+        assert all(c["routing"] is None for c in rt["requests"].values())
+
+    def test_belief_summary_absent_without_routing(self, run_dir: Path, tmp_path: Path):
+        """No overlap_blocks means the belief check has nothing to compare; it must
+        report nothing rather than a vacuous 100% agreement."""
+        assert self._bundle(run_dir, tmp_path)["rt"]["belief"] is None

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1298,3 +1298,58 @@ class TestSpanBusyIdleRetained:
         assert span["attrs"]["time.busy_us"] == 200
         assert span["attrs"]["time.idle_us"] == 800
         assert "time.duration_us" not in span["attrs"], "duration is the span length, not an attr"
+
+
+class TestMetricNameResolution:
+    """Prometheus counters conventionally end in `_total`, and ingest keeps the scraped
+    name verbatim. A lookup written without the suffix finds nothing and the caller
+    reads a hard zero -- indistinguishable downstream from a metric that really was
+    zero. Five families were being read this way."""
+
+    def test_counter_total_suffix_is_resolved(self, run_dir: Path, tmp_path: Path):
+        """The tokenizer-cache KPI read 0.0% on a run whose real hit rate was 99.2%."""
+        # 40 hits, 10 misses -> 80%
+        path = run_dir / "raw_prometheus.jsonl"
+        lines = []
+        for i in range(4):
+            ts = T0 + i * 1_000_000_000
+            lines.append(json.dumps({
+                "timestamp_ns": ts, "endpoint_url": "http://head:8000/metrics",
+                "role": "frontend", "worker_id": None,
+                "text": (f"dynamo_frontend_tokenizer_cache_hits_total {10 * (i + 1)}\n"
+                         f"dynamo_frontend_tokenizer_cache_misses_total {2.5 * (i + 1)}\n"
+                         f'dynamo_frontend_requests_total{{model="m"}} {i}\n'),
+            }))
+        path.write_text("\n".join(lines) + "\n")
+
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+
+        kpi = json.loads(payload.read_text())["kpi"]
+        assert kpi["tok_cache"] == pytest.approx(80.0, abs=0.1), (
+            "a counter named <x>_total must resolve from a lookup written as <x>")
+
+    def test_no_renderer_metric_name_omits_a_needed_suffix(self):
+        """Guards the whole class: every metric name the renderer looks up must either
+        exist verbatim or be resolvable. Names are checked against the catalogued
+        families so a newly-added lookup cannot silently read zero."""
+        import re
+
+        src = (REPO_ROOT / "src/visualization/build_dynamo_bench_dash.py").read_text()
+        # Counter families that only ever exist with the _total suffix.
+        counters_needing_total = {
+            "dynamo_frontend_requests",
+            "dynamo_frontend_tokenizer_cache_hits",
+            "dynamo_frontend_tokenizer_cache_misses",
+            "dynamo_frontend_tokenizer_cache_cached_tokens",
+            "dynamo_frontend_tokenizer_cache_uncached_tokens",
+        }
+        referenced = set(re.findall(r'["\'](dynamo_[a-z0-9_]+|trtllm_[a-z0-9_]+)["\']', src))
+        bare = referenced & counters_needing_total
+        # They MAY appear bare -- but only because _entries() resolves the suffix.
+        assert "_entries" in src and "name + \"_total\"" in src, (
+            f"bare counter names {sorted(bare)} are referenced, so the central "
+            "_total-resolution helper must still exist")

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1750,3 +1750,40 @@ class TestBenchmarkStatus:
         (run_dir / "benchmark.out").write_text("+ aiperf profile ...\nall good\n")
         (run_dir / "sweep_999.log").write_text("[INFO] Benchmark completed\n")
         assert self._payload(run_dir, tmp_path)["meta"]["benchmark_status"] is None
+
+
+class TestBenchmarkStatusMessageQuality:
+    """The banner has to carry the actionable detail, not just the failure class.
+
+    Two shapes of noise defeat a naive capture, both seen on real runs:
+    `set -x` echoes every message once as `+ echo 'Error: ...'`, and
+    `check_env_vars` prints a header followed by one `  - NAME` line per missing
+    variable. Capturing only the header tells the reader that variables are missing
+    while withholding which ones.
+    """
+
+    def _errors(self, run_dir: Path, tmp_path: Path, body: str) -> list[str]:
+        (run_dir / "benchmark.out").write_text(body)
+        (run_dir / "sweep_9.log").write_text("[ERROR] Benchmark failed with exit code 1\n")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "d.json"
+        _render(bundle, tmp_path / "d.html", "--d3-cdn", "--dump-json", str(out))
+        return (json.loads(out.read_text())["meta"]["benchmark_status"] or {}).get("errors", [])
+
+    def test_missing_variable_names_are_captured(self, run_dir: Path, tmp_path: Path):
+        errs = self._errors(run_dir, tmp_path,
+            "+ echo 'Error: The following required environment variables are not set:'\n"
+            "Error: The following required environment variables are not set:\n"
+            "+ for var in \"${missing_vars[@]}\"\n"
+            "  - FRAMEWORK\n  - PRECISION\n  - DURATION\n+ exit 1\n")
+        joined = " ".join(errs)
+        for var in ("FRAMEWORK", "PRECISION", "DURATION"):
+            assert var in joined, f"{var} must survive into the banner; got {errs}"
+
+    def test_set_x_trace_lines_are_not_reported_as_the_message(self, run_dir: Path, tmp_path: Path):
+        errs = self._errors(run_dir, tmp_path,
+            "+ echo 'Error: KV_OFFLOADING must be set'\nError: KV_OFFLOADING must be set\n")
+        assert errs, "the real message must be captured"
+        assert not any(e.lstrip().startswith("+") for e in errs), \
+            "a trace line shows the mechanism instead of the message"

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -111,6 +111,16 @@ def _write_aiperf_export(run_dir: Path) -> Path:
     return path
 
 
+def _write_engine_configs(run_dir: Path) -> None:
+    """The resolved engine configs srt-slurm's TRTLLM backend dumps per mode.
+
+    Values are the real ones from AgentX run 2739690 -- decode max_batch_size is 1,
+    which is what makes the renderer's 256 default so badly wrong.
+    """
+    (run_dir / "trtllm_config_prefill.yaml").write_text("max_batch_size: 128\nmax_num_tokens: 4096\n")
+    (run_dir / "trtllm_config_decode.yaml").write_text("max_batch_size: 1\nmax_num_tokens: 4\n")
+
+
 def _write_frontend_log(run_dir: Path) -> Path:
     """A Dynamo frontend log in the raw-container-stdout flavour srtctl produces.
 
@@ -143,6 +153,7 @@ def run_dir(tmp_path: Path) -> Path:
     _write_raw_prometheus(d)
     _write_aiperf_export(d)
     _write_frontend_log(d)
+    _write_engine_configs(d)
     return d
 
 
@@ -285,6 +296,39 @@ class TestIngestBundle:
         # Absent leg must not be advertised, or the renderer looks for a file that
         # was never produced.
         assert "tempo_traces" not in yaml_text
+
+    def test_engine_configs_are_carried_into_the_bundle(self, run_dir: Path, tmp_path: Path):
+        """srt-slurm writes trtllm_config_<mode>.yaml into the LOG dir; the renderer
+        looks for it in the BUNDLE. Without the copy the renderer silently falls back
+        to --max-batch-* defaults, and on a real run decode's true ceiling is 1 against
+        a default of 256 -- the Engine tab then reads as "far from saturated" while the
+        engine is pinned at its limit."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+
+        assert (bundle / "trtllm_config_prefill.yaml").exists()
+        assert (bundle / "trtllm_config_decode.yaml").exists()
+        assert "max_batch_size: 1" in (bundle / "trtllm_config_decode.yaml").read_text()
+
+    def test_renderer_reads_real_ceilings_not_defaults(self, run_dir: Path, tmp_path: Path):
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        # The renderer logs the resolved ceilings to stderr at INFO.
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn")
+        assert proc.returncode == 0, proc.stderr
+        assert "prefill max_batch_size=128" in proc.stderr
+        assert "decode max_batch_size=1" in proc.stderr, "must be 1 from config, not the 256 default"
+
+    def test_missing_engine_configs_are_not_fatal(self, tmp_path: Path):
+        """A non-TRTLLM run has no such files; ingest must still produce a bundle."""
+        d = tmp_path / "logs"
+        d.mkdir()
+        _write_raw_prometheus(d)
+        _write_aiperf_export(d)
+        bundle = tmp_path / "bundle"
+        _run_ingest(d, bundle)
+        assert (bundle / "server_metrics_export.jsonl").exists()
+        assert not list(bundle.glob("trtllm_config_*.yaml"))
 
     def test_span_log_default_matches_srtslurm_naming(self):
         """srt-slurm writes <node>_<mode>_w<i>.out; upstream defaulted to *.log."""

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -891,3 +891,40 @@ class TestGeneratedPageStructure:
         # `<script` not `<script>`: with --d3-cdn one tag is `<script src=...>`, so
         # counting only the bare form is asymmetric by construction.
         assert html.count("<script") == html.count("</script>")
+
+
+class TestDoubleMetricPollingWarning:
+    """A run can poll /metrics twice without saying so, which has previously made a
+    benchmark submission irreproducible."""
+
+    @staticmethod
+    def _mixin(benchmark_type: str, scraper_enabled: bool):
+        from srtctl.cli.mixins.benchmark_stage import BenchmarkStageMixin
+
+        obj = BenchmarkStageMixin()
+        obj.config = SimpleNamespace(
+            benchmark=SimpleNamespace(type=benchmark_type),
+            observability=SimpleNamespace(scraper_enabled=scraper_enabled),
+        )
+        return obj
+
+    def test_warns_for_an_aiperf_benchmark(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._mixin("mooncake-router", True)._warn_on_double_metric_polling()
+        assert any("Double /metrics polling" in r.message for r in caplog.records)
+
+    def test_silent_for_a_non_aiperf_benchmark(self, caplog):
+        """sa-bench drives no client-side polling, so there is nothing to warn about."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._mixin("sa-bench", True)._warn_on_double_metric_polling()
+        assert not any("Double /metrics polling" in r.message for r in caplog.records)
+
+    def test_unknown_benchmark_type_is_not_an_error(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._mixin("no-such-benchmark", True)._warn_on_double_metric_polling()

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -530,3 +530,161 @@ class TestPerfDashboardPipeline:
         monkeypatch.setattr(pd, "find_repo_root", lambda: None)
         runtime = SimpleNamespace(log_dir=run_dir, job_id="12345")
         assert pd.try_build(_stub_config(), runtime) is None
+
+
+# ---------------------------------------------------------------------------
+# request-trace leg (schema 4)
+# ---------------------------------------------------------------------------
+
+
+def _trace_record(xid, sid, received_ms, *, prefill_wait, prefill, kv_transfer, total,
+                  avg_itl, osl, hashes, turn_hashes_shared=None):
+    """One dynamo.request.trace.v1 request_end record, real field paths."""
+    return {
+        "timestamp": 700000,
+        "event": {
+            "schema": "dynamo.request.trace.v1",
+            "event_type": "request_end",
+            "event_source": "dynamo",
+            "agent_context": {"session_id": sid},
+            "request": {
+                "request_id": f"rid-{xid}",
+                "x_request_id": xid,
+                "model": "DeepSeek-V4-Pro",
+                "input_tokens": 1024,
+                "output_tokens": osl,
+                "cached_tokens": 512,
+                "request_received_ms": received_ms,
+                "prefill_wait_time_ms": prefill_wait,
+                "prefill_time_ms": prefill,
+                "ttft_ms": prefill_wait + prefill,
+                "total_time_ms": total,
+                "avg_itl_ms": avg_itl,
+                "kv_hit_rate": 0.5,
+                "kv_transfer_estimated_latency_ms": kv_transfer,
+                "queue_depth": 0,
+                "worker": {
+                    "prefill_worker_id": 111, "prefill_dp_rank": 2,
+                    "decode_worker_id": 222, "decode_dp_rank": 0,
+                },
+                "replay": {"trace_block_size": 32, "input_length": 1024,
+                           "input_sequence_hashes": hashes},
+                "finish_reason_metadata": {"finish_reason": "length"},
+            },
+        },
+    }
+
+
+class TestRequestTraceProcessor:
+    def test_ttft_is_corrected_for_kv_transfer(self, tmp_path: Path):
+        """`ttft_ms` in the file is the PREFILL worker's first token. On disagg the
+        client waits for decode, which cannot start until KV has transferred. Measured
+        over 557 joined requests, adding kv_transfer moves the client-TTFT residual
+        from 'wrong on 510/557' to 'wrong on 0/557'."""
+        from src.ingest.request_trace import flatten
+
+        row = flatten(_trace_record("x1", "s1", 1000, prefill_wait=4.0, prefill=680.0,
+                                    kv_transfer=130.0, total=2500.0, avg_itl=66.0,
+                                    osl=11, hashes=[1, 2, 3]))
+        assert row["ttft_prefill_ms"] == 684.0
+        assert row["client_ttft_ms"] == 814.0, "must add KV transfer"
+        assert row["steady_decode_ms"] == pytest.approx(2500.0 - 814.0)
+
+    def test_itl_is_decontaminated(self, tmp_path: Path):
+        """avg_itl averages over a decode span starting at the PREFILL first token, so
+        it absorbs the whole KV transfer. On the reference run that inflates p50 ITL
+        roughly 11x (66.4ms raw vs 5.9ms clean)."""
+        from src.ingest.request_trace import flatten
+
+        row = flatten(_trace_record("x1", "s1", 1000, prefill_wait=4.0, prefill=680.0,
+                                    kv_transfer=130.0, total=2500.0, avg_itl=66.0,
+                                    osl=11, hashes=[1]))
+        assert row["clean_itl_ms"] == pytest.approx(66.0 - 130.0 / 10)
+
+    def test_aggregated_run_has_no_kv_transfer_correction(self):
+        """Non-disagg: no transfer, so client TTFT IS the prefill-side TTFT."""
+        from src.ingest.request_trace import flatten
+
+        rec = _trace_record("x1", "s1", 1000, prefill_wait=4.0, prefill=680.0,
+                            kv_transfer=None, total=2500.0, avg_itl=66.0, osl=11, hashes=[1])
+        del rec["event"]["request"]["kv_transfer_estimated_latency_ms"]
+        row = flatten(rec)
+        assert row["client_ttft_ms"] == row["ttft_prefill_ms"] == 684.0
+        assert row["clean_itl_ms"] == 66.0
+
+    def test_non_request_end_records_are_skipped(self):
+        from src.ingest.request_trace import flatten
+
+        rec = _trace_record("x1", "s1", 1000, prefill_wait=1.0, prefill=1.0,
+                            kv_transfer=1.0, total=1.0, avg_itl=1.0, osl=2, hashes=[1])
+        rec["event"]["event_type"] = "tool_start"
+        assert flatten(rec) is None
+
+    def test_prefix_reuse_and_turn_order(self, tmp_path: Path):
+        """Turn order is by received_ms (verified to reproduce the client's own
+        turn_index on 33/33 sessions). Turn 0 has no predecessor, so its reuse is
+        None -- 'no previous turn' is not 'no reuse'."""
+        from src.ingest.request_trace import process
+
+        src = tmp_path / "dynamo-request-trace"
+        with src.open("w") as f:
+            # deliberately out of chronological order in the file
+            f.write(json.dumps(_trace_record("x2", "s1", 2000, prefill_wait=1.0, prefill=1.0,
+                                             kv_transfer=1.0, total=10.0, avg_itl=1.0, osl=3,
+                                             hashes=[1, 2, 3, 9])) + "\n")
+            f.write(json.dumps(_trace_record("x1", "s1", 1000, prefill_wait=1.0, prefill=1.0,
+                                             kv_transfer=1.0, total=10.0, avg_itl=1.0, osl=3,
+                                             hashes=[1, 2, 3])) + "\n")
+        out = tmp_path / "request_trace.jsonl"
+        assert process(str(src), str(out)) == 2
+
+        rows = {r["x_request_id"]: r for r in (json.loads(x) for x in out.read_text().splitlines())}
+        assert rows["x1"]["turn_index"] == 0 and rows["x1"]["prefix_reuse_ratio"] is None
+        assert rows["x2"]["turn_index"] == 1
+        assert rows["x2"]["prefix_reuse_ratio"] == pytest.approx(0.75)  # 3 of 4 blocks shared
+
+    def test_bulky_hashes_never_reach_the_bundle(self, tmp_path: Path):
+        """input_sequence_hashes is 463k entries on a 20-min run and would dominate any
+        embedded payload. Only the derived reuse ratio survives."""
+        from src.ingest.request_trace import process
+
+        src = tmp_path / "dynamo-request-trace"
+        src.write_text(json.dumps(_trace_record("x1", "s1", 1000, prefill_wait=1.0, prefill=1.0,
+                                                kv_transfer=1.0, total=10.0, avg_itl=1.0, osl=3,
+                                                hashes=list(range(5000)))) + "\n")
+        out = tmp_path / "request_trace.jsonl"
+        process(str(src), str(out))
+        row = json.loads(out.read_text().strip())
+        assert "input_sequence_hashes" not in json.dumps(row)
+        assert row["n_hash_blocks"] == 5000
+
+
+class TestClientLayouts:
+    @pytest.mark.parametrize("relpath", [
+        "agentic/conc_3/aiperf_artifacts/profile_export.jsonl",  # AgentX
+        "artifacts/Qwen3-32B_conversation_20260820/profile_export.jsonl",  # AIPerf bench.sh
+    ])
+    def test_both_client_layouts_are_found(self, tmp_path: Path, relpath: str):
+        """AgentX nests one level deeper than the AIPerf harness. Missing the AgentX
+        layout silently kills the Overview tab AND the trace leg, which is gated on
+        the client xids."""
+        from src.ingest.ingest import main
+
+        d = tmp_path / "logs"
+        d.mkdir()
+        _write_raw_prometheus(d)
+        export = d / relpath
+        export.parent.mkdir(parents=True)
+        export.write_text(
+            json.dumps({
+                "metadata": {"x_request_id": "xid0", "request_start_ns": T0,
+                             "request_end_ns": T0 + 1_000_000_000},
+                "metrics": {"time_to_first_token": {"value": 120.0},
+                            "request_latency": {"value": 1200.0},
+                            "input_sequence_length": {"value": 1024},
+                            "output_sequence_length": {"value": 128}},
+            }) + "\n"
+        )
+        bundle = tmp_path / "bundle"
+        assert main(["--run-dir", str(d), "--out", str(bundle), "--traces", "none"]) == 0
+        assert (bundle / "profile_export.jsonl").read_text().count("xid0") == 1

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1656,3 +1656,49 @@ class TestProvenanceLeg:
 
     def test_absent_fingerprints_report_none_not_agreement(self, run_dir: Path, tmp_path: Path):
         assert self._payload(run_dir, tmp_path)["meta"]["provenance"] is None
+
+
+class TestConfigProvenance:
+    """The resolved recipe, flattened, so an ablation's single-variable claim is
+    checkable rather than asserted. It is also the ONLY record of the frontend
+    environment -- worker fingerprints cover prefill and decode, but settings like
+    DYN_TOKENIZER_CACHE live on the frontend and appear in no fingerprint."""
+
+    @staticmethod
+    def _setup(run_dir: Path, tok_cache: str) -> None:
+        (run_dir / "fingerprint_prefill_w0.json").write_text(json.dumps(
+            {"frameworks": {"tensorrt_llm": "1.3.0rc21"}}))
+        (run_dir / "config.yaml").write_text(
+            "name: arm-x\n"
+            "frontend:\n  env:\n"
+            f"    DYN_TOKENIZER_CACHE: '{tok_cache}'\n"
+            "    DYN_ROUTER_TRACK_PREFILL_TOKENS: '1'\n"
+            "backend:\n  publish_events_and_metrics: true\n")
+
+    def _cfg(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())["meta"]["provenance"]["config"]
+
+    def test_frontend_env_is_recorded(self, run_dir: Path, tmp_path: Path):
+        self._setup(run_dir, "1")
+        cfg = self._cfg(run_dir, tmp_path)
+        assert cfg["frontend.env.DYN_TOKENIZER_CACHE"] == "1"
+        assert cfg["backend.publish_events_and_metrics"] is True
+
+    def test_name_is_dropped_so_arms_diff_by_one_key(self, run_dir: Path, tmp_path: Path):
+        """Every arm of an ablation renames itself; keeping `name` would make a clean
+        single-variable diff report two differences instead of one."""
+        self._setup(run_dir, "1")
+        assert "name" not in self._cfg(run_dir, tmp_path)
+
+    def test_two_arms_differ_by_exactly_the_ablated_key(self, run_dir: Path, tmp_path: Path):
+        self._setup(run_dir, "1")
+        base = self._cfg(run_dir, tmp_path / "a")
+        self._setup(run_dir, "0")
+        arm = self._cfg(run_dir, tmp_path / "b")
+        delta = {k for k in set(base) | set(arm) if base.get(k) != arm.get(k)}
+        assert delta == {"frontend.env.DYN_TOKENIZER_CACHE"}

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -16,6 +16,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -408,3 +409,101 @@ class TestRenderComponentDashboard:
         html = out.read_text()
         assert "d3js.org v7" in html, "vendored d3.v7.min.js should be inlined"
         assert "<script src=" not in html, "a self-contained page must not fetch anything"
+
+
+# ---------------------------------------------------------------------------
+# The single-run pipeline: srtctl.analysis.perf_dashboard
+# ---------------------------------------------------------------------------
+
+
+def _stub_config(*, enabled=True, build_dashboard=None, prefill=(1, 4), decode=(3, 8)):
+    """Minimal stand-in for SrtConfig carrying only what perf_dashboard reads."""
+    from srtctl.core.schema import ObservabilityConfig
+
+    obs = ObservabilityConfig.Schema().load(
+        {"enabled": enabled} if build_dashboard is None else {"enabled": enabled, "build_dashboard": build_dashboard}
+    )
+    return SimpleNamespace(
+        name="unit-test-run",
+        observability=obs,
+        resources=SimpleNamespace(
+            num_prefill=prefill[0],
+            gpus_per_prefill=prefill[1],
+            num_decode=decode[0],
+            gpus_per_decode=decode[1],
+            num_agg=0,
+            gpus_per_agg=0,
+        ),
+    )
+
+
+class TestPerfDashboardPipeline:
+    def test_repo_root_discovery_finds_the_vendored_tree(self):
+        from srtctl.analysis.perf_dashboard import find_repo_root
+
+        root = find_repo_root()
+        assert root is not None, "must locate the checkout under an editable install"
+        assert (root / "src" / "ingest" / "ingest.py").is_file()
+        assert (root / "src" / "visualization" / "build_dynamo_bench_dash.py").is_file()
+
+    def test_worker_specs_describe_the_topology(self):
+        """These become --worker args, which are what give the page its GPU count.
+        Getting them wrong silently rescales every per-GPU number on the page."""
+        from srtctl.analysis.perf_dashboard import _worker_specs
+
+        specs = _worker_specs(_stub_config(prefill=(2, 4), decode=(4, 8)))
+        assert specs == ["prefill=dep:4:2", "decode=tep:8:4"]
+        # 4*2 + 8*4 = 40 GPUs is what the renderer will divide by.
+
+    def test_agg_only_topology_emits_one_spec(self):
+        from srtctl.analysis.perf_dashboard import _worker_specs
+
+        cfg = _stub_config(prefill=(0, 0), decode=(0, 0))
+        cfg.resources.num_agg, cfg.resources.gpus_per_agg = 6, 4
+        assert _worker_specs(cfg) == ["agg=tep:4:6"]
+
+    def test_try_build_is_a_noop_when_not_opted_in(self, tmp_path: Path):
+        from srtctl.analysis.perf_dashboard import try_build
+
+        runtime = SimpleNamespace(log_dir=tmp_path, job_id="12345")
+        assert try_build(_stub_config(enabled=False), runtime) is None
+        assert not (tmp_path / "perf_dashboard.html").exists()
+
+    def test_build_dashboard_false_overrides_observability_enabled(self, tmp_path: Path):
+        from srtctl.analysis.perf_dashboard import try_build
+
+        runtime = SimpleNamespace(log_dir=tmp_path, job_id="12345")
+        assert try_build(_stub_config(enabled=True, build_dashboard=False), runtime) is None
+        assert not (tmp_path / "perf_dashboard.html").exists()
+
+    def test_end_to_end_one_run_produces_the_dashboard(self, run_dir: Path):
+        """The whole point of the wiring: a finished log dir in, artifacts out, with
+        no hand-driven step from a checkout."""
+        from srtctl.analysis.perf_dashboard import BUNDLE_DIRNAME, try_build
+
+        runtime = SimpleNamespace(log_dir=run_dir, job_id="2739690")
+        html = try_build(_stub_config(), runtime)
+
+        assert html is not None, "pipeline should have produced a dashboard"
+        assert html.is_file() and html.stat().st_size > 100_000, "D3 should be inlined"
+
+        payload = run_dir / "perf_dashboard.json"
+        assert payload.is_file(), "the no-browser payload must be written"
+        data = json.loads(payload.read_text())
+        # The JSON is the same object the HTML embeds, so it can be asserted on.
+        assert data["tabs"]["router"] and data["tabs"]["engine"] and data["tabs"]["frontend"]
+        assert data["tabs"]["loganalysis"], "frontend log in the run dir should be picked up"
+        assert data["meta"]["scrapes"] == 4
+
+        bundle = run_dir / BUNDLE_DIRNAME
+        assert (bundle / "server_metrics_export.jsonl").is_file()
+        assert (bundle / "trtllm_config_decode.yaml").is_file(), "engine ceilings must reach the bundle"
+
+    def test_missing_vendored_tree_is_survivable(self, run_dir: Path, monkeypatch):
+        """A wheel install with no checkout must degrade to a warning, not an exception
+        — this runs inside post-processing of a benchmark that already succeeded."""
+        import srtctl.analysis.perf_dashboard as pd
+
+        monkeypatch.setattr(pd, "find_repo_root", lambda: None)
+        runtime = SimpleNamespace(log_dir=run_dir, job_id="12345")
+        assert pd.try_build(_stub_config(), runtime) is None

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1793,3 +1793,53 @@ class TestBenchmarkStatusMessageQuality:
         assert errs, "the real message must be captured"
         assert not any(e.lstrip().startswith("+") for e in errs), \
             "a trace line shows the mechanism instead of the message"
+
+
+class TestBenchmarkPhaseCensus:
+    """AIPerf's completed/cancelled split, from its own log.
+
+    A run can exit non-zero with NO error-marker line in benchmark.out at all — arm
+    2752189 did exactly that — leaving the banner able to report only "exit 1". The
+    phase census is then the sole account of what happened, and it distinguishes
+    "the workload never started" from "it ran and was cut short", which have opposite
+    fixes: on the v4 arms a0/a1 aborted in warmup so profiling never ran, while a2/a3
+    passed warmup clean and had profiling time out with ~47 requests in flight.
+    """
+
+    @staticmethod
+    def _aiperf_log(run_dir: Path, lines: str) -> None:
+        d = run_dir / "agentic" / "conc_32" / "aiperf_artifacts" / "logs"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "aiperf.log").write_text(lines)
+        (run_dir / "sweep_9.log").write_text("[ERROR] Benchmark failed with exit code 1\n")
+        (run_dir / "benchmark.out").write_text("+ set -x\nno error markers here\n")
+
+    def _status(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "d.json"
+        proc = _render(bundle, tmp_path / "d.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())["meta"]["benchmark_status"] or {}
+
+    def test_census_is_captured_when_no_error_line_exists(self, run_dir: Path, tmp_path: Path):
+        self._aiperf_log(run_dir,
+            "2026-08-21 01:56:55.025 - PhaseRunner - NOTICE - Phase warmup complete | "
+            "completed=123, cancelled=0, errors=0 | elapsed=641.51s\n"
+            "2026-08-21 01:59:35.175 - PhaseRunner - NOTICE - Phase profiling complete | "
+            "completed=30, cancelled=46, errors=0 | elapsed=160.0\n")
+        bs = self._status(run_dir, tmp_path)
+        assert bs.get("exit_code") == "1"
+        joined = " ".join(bs.get("phases") or [])
+        assert "cancelled=46" in joined, "the cancelled count is the diagnosis; got " + joined
+        assert "warmup complete" in joined
+
+    def test_warmup_abort_is_distinguishable_from_profiling_timeout(self, run_dir: Path, tmp_path: Path):
+        """a0/a1's mode: warmup cancels, profiling never runs — so there is exactly one
+        phase line, and its cancelled count is non-zero."""
+        self._aiperf_log(run_dir,
+            "2026-08-21 01:57:52.022 - PhaseRunner - NOTICE - Phase warmup complete | "
+            "completed=122, cancelled=4, errors=0 | elapsed=707.04s\n")
+        phases = self._status(run_dir, tmp_path).get("phases") or []
+        assert len(phases) == 1, "profiling never ran, so it must not be reported"
+        assert "cancelled=4" in phases[0]

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1843,3 +1843,55 @@ class TestBenchmarkPhaseCensus:
         phases = self._status(run_dir, tmp_path).get("phases") or []
         assert len(phases) == 1, "profiling never ran, so it must not be reported"
         assert "cancelled=4" in phases[0]
+
+
+class TestLogOnlySignals:
+    """Signals whose ONLY evidence is a log line, with no metric family behind them.
+
+    A worker crash, a Dynamo recompilation storm, a KV-index desync: each is a
+    documented issue that was unreachable from a bundle -- not because the
+    instrumentation is missing, but because the bundle did not carry the logs, and the
+    logs are far too large to carry whole (43 MB frontend + 40 MB prefill on one run).
+    The bundle now carries the ANSWER instead of the evidence.
+    """
+
+    @staticmethod
+    def _worker_log(run_dir: Path, body: str) -> None:
+        (run_dir / "node9_decode_w0.out").write_text(body)
+
+    def _signals(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "d.json"
+        proc = _render(bundle, tmp_path / "d.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())["meta"]["log_signals"] or {}
+
+    def test_crash_and_recompile_are_counted_with_timestamps(self, run_dir: Path, tmp_path: Path):
+        self._worker_log(run_dir,
+            "2026-08-21T01:00:00Z INFO starting\n"
+            "2026-08-21T01:00:05Z ERROR CUDA error: device-side assert triggered\n"
+            "2026-08-21T01:00:09Z WARN torch._dynamo hit config.cache_size_limit\n"
+            "2026-08-21T01:00:11Z WARN recompile_limit reached\n")
+        sig = self._signals(run_dir, tmp_path)
+        assert sig["worker_crash"]["count"] == 1
+        assert sig["worker_crash"]["first_ts"] == "2026-08-21T01:00:05Z"
+        assert sig["torch_recompile"]["count"] == 2
+        assert sig["worker_crash"]["samples"], "a verbatim line is what makes it actionable"
+
+    def test_zero_counts_are_kept_not_dropped(self, run_dir: Path, tmp_path: Path):
+        """'This run had no worker crashes' is a statement. The signal simply being
+        absent from the payload is not -- it is indistinguishable from 'not checked'."""
+        self._worker_log(run_dir, "2026-08-21T01:00:00Z INFO nothing interesting\n")
+        sig = self._signals(run_dir, tmp_path)
+        assert "worker_crash" in sig
+        assert sig["worker_crash"]["count"] == 0
+        assert sig["worker_crash"]["why"], "each signal must say why it matters"
+
+    def test_output_is_bounded_regardless_of_input_size(self, run_dir: Path, tmp_path: Path):
+        """The whole point: a multi-GB log must not become a multi-GB bundle entry."""
+        self._worker_log(run_dir,
+            "2026-08-21T01:00:00Z ERROR Block not found during remove; skipping\n" * 5000)
+        sig = self._signals(run_dir, tmp_path)
+        assert sig["kv_block_not_found"]["count"] == 5000
+        assert len(sig["kv_block_not_found"]["samples"]) <= 2, "samples must stay bounded"

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -2017,3 +2017,47 @@ class TestHostTelemetry:
 
     def test_absent_sampler_yields_no_host_block(self, run_dir: Path, tmp_path: Path):
         assert self._host(run_dir, tmp_path) == {}
+
+
+class TestHostSamplerProcessSelection:
+    """Real processes must outrank launcher wrappers within the sample budget.
+
+    On a real GB300 node (theia0019, job 2753007) a naive cmdline match filled 14 of 24
+    slots with `srun` -- one per launched process -- crowding out the TRT-LLM workers
+    and the AIPerf client, which are the only processes PERF-37/38/40 are about.
+    """
+
+    def test_wrappers_sort_after_real_processes(self, monkeypatch):
+        from srtctl.analysis import host_sampler as hs
+
+        procs = {  # pid -> (cmdline, comm)
+            "10": ("srun --overlap dynamo-worker", "srun"),
+            "11": ("srun --overlap dynamo-worker", "srun"),
+            "12": ("python -m dynamo.trtllm", "trtllm-llmapi-l"),
+            "13": ("aiperf profile --model dynamo", "aiperf system_c"),
+            "14": ("bash -c dynamo", "bash"),
+        }
+        monkeypatch.setattr(hs.os, "listdir", lambda p: list(procs) if p == "/proc" else [])
+        monkeypatch.setattr(
+            hs, "_read",
+            lambda path: procs[path.split("/")[2]][0] if path.endswith("cmdline")
+            else procs[path.split("/")[2]][1] if path.endswith("comm") else None)
+
+        got = hs._interesting_pids()
+        assert set(got[:2]) == {12, 13}, f"real processes must come first, got {got}"
+        assert set(got[2:]) == {10, 11, 14}
+
+    def test_budget_drops_wrappers_not_workers(self, monkeypatch):
+        from srtctl.analysis import host_sampler as hs
+
+        procs = {str(i): ("srun dynamo", "srun") for i in range(20, 60)}
+        procs["12"] = ("python -m dynamo.trtllm", "trtllm-llmapi-l")
+        monkeypatch.setattr(hs.os, "listdir", lambda p: list(procs) if p == "/proc" else [])
+        monkeypatch.setattr(
+            hs, "_read",
+            lambda path: procs[path.split("/")[2]][0] if path.endswith("cmdline")
+            else procs[path.split("/")[2]][1] if path.endswith("comm") else None)
+
+        got = hs._interesting_pids(limit=5)
+        assert 12 in got, "the one real worker must survive a budget full of wrappers"
+        assert len(got) == 5

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1895,3 +1895,63 @@ class TestLogOnlySignals:
         sig = self._signals(run_dir, tmp_path)
         assert sig["kv_block_not_found"]["count"] == 5000
         assert len(sig["kv_block_not_found"]["samples"]) <= 2, "samples must stay bounded"
+
+
+class TestRunLifecycle:
+    """Time-to-ready and terminal cause (PERF-45).
+
+    Two questions no panel answers, because both live in srtctl's sweep log rather than
+    in any metric or client artifact: how long the job held GPUs before it could serve,
+    and why it ended. On run 2752632 the gap between workers starting and the model
+    being ready is 650 s of 28 held GPUs serving nothing -- invisible on an x-axis that
+    begins at the first request.
+    """
+
+    @staticmethod
+    def _sweep(run_dir: Path, *, ready: bool = True, failed: bool = True) -> None:
+        lines = [
+            "2026-08-21 02:23:02 [INFO] Starting infrastructure services (NATS, etcd)",
+            "2026-08-21 02:23:19 [INFO] Starting backend workers",
+            "2026-08-21 02:23:19 [INFO] Starting frontend layer",
+        ]
+        if ready:
+            lines += [
+                "2026-08-21 02:34:09 [INFO] Model is ready. Have 1 prefills and 3 decodes.",
+                "2026-08-21 02:34:09 [INFO] Server is healthy - starting benchmark",
+                "2026-08-21 03:05:00 [ERROR] Benchmark failed with exit code 1",
+            ]
+        lines.append("✗ Sweep failed (exit code: 1)" if failed else "✓ Sweep complete")
+        (run_dir / "sweep_1.log").write_text("\n".join(lines) + "\n")
+
+    def _lc(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "d.json"
+        proc = _render(bundle, tmp_path / "d.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())["meta"]["lifecycle"] or {}
+
+    def test_time_to_ready_and_terminal_cause(self, run_dir: Path, tmp_path: Path):
+        self._sweep(run_dir)
+        lc = self._lc(run_dir, tmp_path)
+        assert lc["durations_s"]["time_to_ready"] == 650.0, "02:23:19 -> 02:34:09"
+        assert lc["durations_s"]["readiness_gap"] == 650.0
+        assert "Sweep failed" in lc["terminal_cause"]
+
+    def test_a_run_that_never_became_ready_says_so(self, run_dir: Path, tmp_path: Path):
+        """The single most useful thing a failed run can report. A null milestone must
+        be kept, not omitted -- omission is indistinguishable from 'not parsed'."""
+        self._sweep(run_dir, ready=False)
+        lc = self._lc(run_dir, tmp_path)
+        assert "model_ready" in lc["milestones"]
+        assert lc["milestones"]["model_ready"] is None
+        assert lc["durations_s"]["time_to_ready"] is None
+
+    def test_milestones_take_the_first_occurrence(self, run_dir: Path, tmp_path: Path):
+        """Health checks retry; a later 'Model is ready' must not overwrite the first,
+        or time-to-ready silently reports the last retry instead of the real wait."""
+        self._sweep(run_dir)
+        with (run_dir / "sweep_1.log").open("a") as f:
+            f.write("2026-08-21 04:00:00 [INFO] Model is ready. Have 1 prefills and 3 decodes.\n")
+        lc = self._lc(run_dir, tmp_path)
+        assert lc["milestones"]["model_ready"] == "2026-08-21 02:34:09"

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -857,3 +857,37 @@ class TestPanelSpec:
         assert panels, "the fixture emits KV-cache metrics, so panels must be present"
         for p in panels.values():
             assert {"tab", "title", "unit", "kind", "why", "source", "series"} <= set(p)
+
+
+class TestGeneratedPageStructure:
+    """Dependency-free structural checks on the emitted HTML.
+
+    These cannot prove the page RENDERS -- that needs a DOM, and
+    ``tools/dashboard_render_check.js`` does it with jsdom. What they do catch is the
+    page losing a whole feature (a tab, the spec-panel renderer, the session table)
+    without anyone noticing, which is cheap to check and has no npm cost.
+    """
+
+    def test_page_carries_every_tab_and_renderer(self, run_dir: Path, tmp_path: Path):
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.html"
+        assert _render(bundle, out, "--d3-cdn").returncode == 0
+
+        html = out.read_text()
+        for marker in ("['session','Session']", "declarative spec panels",
+                       "DATA.panels", "DATA.rt", ".tbl th{", "attr('class','tbl')"):
+            assert marker in html, f"page lost: {marker}"
+
+    def test_page_js_has_balanced_script_tags(self, run_dir: Path, tmp_path: Path):
+        """A truncated template would produce a page that silently renders nothing."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.html"
+        _render(bundle, out, "--d3-cdn")
+
+        html = out.read_text()
+        assert html.rstrip().endswith("</html>")
+        # `<script` not `<script>`: with --d3-cdn one tag is `<script src=...>`, so
+        # counting only the bare form is asymmetric by construction.
+        assert html.count("<script") == html.count("</script>")

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1673,7 +1673,8 @@ class TestConfigProvenance:
             "frontend:\n  env:\n"
             f"    DYN_TOKENIZER_CACHE: '{tok_cache}'\n"
             "    DYN_ROUTER_TRACK_PREFILL_TOKENS: '1'\n"
-            "backend:\n  publish_events_and_metrics: true\n")
+            "backend:\n  publish_events_and_metrics: true\n"
+            "benchmark:\n  env:\n    RESULT_FILENAME: per_arm_file\n")
 
     def _cfg(self, run_dir: Path, tmp_path: Path) -> dict:
         bundle = tmp_path / "bundle"
@@ -1689,11 +1690,16 @@ class TestConfigProvenance:
         assert cfg["frontend.env.DYN_TOKENIZER_CACHE"] == "1"
         assert cfg["backend.publish_events_and_metrics"] is True
 
-    def test_name_is_dropped_so_arms_diff_by_one_key(self, run_dir: Path, tmp_path: Path):
-        """Every arm of an ablation renames itself; keeping `name` would make a clean
-        single-variable diff report two differences instead of one."""
+    def test_identity_fields_are_dropped_so_arms_diff_by_one_key(self, run_dir: Path, tmp_path: Path):
+        """Every arm renames itself AND writes its own result file. Keeping either makes
+        a genuinely single-variable comparison report two differences, so the
+        SINGLE-VARIABLE verdict never fires and the reader learns to ignore the count.
+        Observed on the real a0-vs-a1 diff, which reported 2 settings differing when
+        only DYN_TOKENIZER_CACHE was a treatment."""
         self._setup(run_dir, "1")
-        assert "name" not in self._cfg(run_dir, tmp_path)
+        cfg = self._cfg(run_dir, tmp_path)
+        assert "name" not in cfg
+        assert "benchmark.env.RESULT_FILENAME" not in cfg
 
     def test_two_arms_differ_by_exactly_the_ablated_key(self, run_dir: Path, tmp_path: Path):
         self._setup(run_dir, "1")

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1702,3 +1702,51 @@ class TestConfigProvenance:
         arm = self._cfg(run_dir, tmp_path / "b")
         delta = {k for k in set(base) | set(arm) if base.get(k) != arm.get(k)}
         assert delta == {"frontend.env.DYN_TOKENIZER_CACHE"}
+
+
+class TestBenchmarkStatus:
+    """An empty dashboard must say WHY it is empty.
+
+    `client=False traces=False N=0` cannot distinguish a dead deployment from a
+    workload that never started from a run cut short -- three different responses.
+    Eight ablation arms in one session hit exactly this: four exited 127 before the
+    benchmark script was reachable, four exited 1 eleven seconds after the workers
+    went healthy on a missing env var.
+    """
+
+    @staticmethod
+    def _failed_benchmark(run_dir: Path, exit_code: str, err: str) -> None:
+        (run_dir / "benchmark.out").write_text(
+            "+ source /infmax-workspace/benchmarks/benchmark_lib.sh\n"
+            f"++ echo '{err}'\n{err}\n++ exit {exit_code}\n")
+        (run_dir / "sweep_999.log").write_text(
+            "2026-08-21 01:16:00 [INFO] Server is healthy - starting benchmark\n"
+            f"2026-08-21 01:16:17 [ERROR] Benchmark failed with exit code {exit_code}\n")
+
+    def _payload(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())
+
+    def test_env_fault_is_reported_with_its_error_line(self, run_dir: Path, tmp_path: Path):
+        self._failed_benchmark(run_dir, "1", "Error: KV_OFFLOADING must be set for agentic benchmarks")
+        bs = self._payload(run_dir, tmp_path)["meta"]["benchmark_status"]
+        assert bs["exit_code"] == "1"
+        assert any("KV_OFFLOADING" in e for e in bs["errors"]), \
+            "the reader needs the variable name, not just 'it failed'"
+
+    def test_missing_script_is_reported(self, run_dir: Path, tmp_path: Path):
+        self._failed_benchmark(run_dir, "127", "bash: /infmax-workspace/x.sh: No such file or directory")
+        bs = self._payload(run_dir, tmp_path)["meta"]["benchmark_status"]
+        assert bs["exit_code"] == "127"
+        assert any("No such file" in e for e in bs["errors"])
+
+    def test_a_healthy_run_carries_no_failure_banner(self, run_dir: Path, tmp_path: Path):
+        """A false alarm here would be worse than silence: it would cast doubt on a
+        run whose numbers are fine."""
+        (run_dir / "benchmark.out").write_text("+ aiperf profile ...\nall good\n")
+        (run_dir / "sweep_999.log").write_text("[INFO] Benchmark completed\n")
+        assert self._payload(run_dir, tmp_path)["meta"]["benchmark_status"] is None

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1536,3 +1536,71 @@ class TestPhaseFilterProvenance:
         pf = self._payload(run_dir, tmp_path)["meta"]["phase_filter"]
         assert pf["dropped"] == 0
         assert pf["phases"] == {"(none)": len(XIDS)}
+
+
+class TestClientSummaryLeg:
+    """AIPerf's run-level summary: the workload's cache ceiling, and run validity.
+
+    The engine's measured reuse is uninterpretable alone -- each reader scores it
+    against a private expectation. On run 2751593 the workload offered 94.7% and the
+    engine achieved 65.8%; the 29-point gap is the finding. PERF-46.
+    """
+
+    @staticmethod
+    def _write_summary(run_dir: Path, **over) -> Path:
+        art = next(run_dir.glob("artifacts/*"))
+        doc = {
+            "schema_version": "1.2",
+            "aiperf_version": "0.9.0",
+            "theoretical_prefix_cache_hit": {"unit": "%", "avg": 94.7, "count": 10, "sum": 9},
+            "effective_concurrency": {"avg": 31.4},
+            "request_count": {"unit": "requests", "avg": 61.0},
+            "was_cancelled": False,
+            "error_summary": [],
+            "branch_stats": {"children_spawned": 5, "children_errored": 0,
+                             "children_truncated": 0},
+        }
+        doc.update(over)
+        path = art / "profile_export_aiperf.json"
+        path.write_text(json.dumps(doc))
+        return path
+
+    def _payload(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())
+
+    def test_summary_reaches_the_bundle_and_the_payload(self, run_dir: Path, tmp_path: Path):
+        self._write_summary(run_dir)
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        assert (bundle / "profile_export_aiperf.json").is_file(), \
+            "the client summary must be copied like the engine configs"
+        out = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(out))
+        cs = json.loads(out.read_text())["meta"]["client_summary"]
+        assert cs["theoretical_prefix_cache_hit"] == 94.7
+        assert cs["effective_concurrency"] == 31.4
+        assert cs["n_errors"] == 0
+
+    def test_validity_flags_are_carried(self, run_dir: Path, tmp_path: Path):
+        """A cancelled or branch-errored run produced numbers that must not be
+        compared against a clean one."""
+        self._write_summary(run_dir, was_cancelled=True, error_summary=[{"e": "x"}],
+                            branch_stats={"children_spawned": 5, "children_errored": 2,
+                                          "children_truncated": 1})
+        cs = self._payload(run_dir, tmp_path)["meta"]["client_summary"]
+        assert cs["was_cancelled"] is True
+        assert cs["n_errors"] == 1
+        assert cs["branch_errored"] == 2
+        assert cs["branch_truncated"] == 1
+
+    def test_absent_summary_is_none_not_a_fabricated_ceiling(self, run_dir: Path, tmp_path: Path):
+        """AIPerf writes this at the END of a concurrency, so a run killed by its wall
+        clock has none -- reference run 2750618 is exactly that. A missing ceiling must
+        read as absent, never as 0%, which would imply the workload offered no reuse."""
+        payload = self._payload(run_dir, tmp_path)
+        assert payload["meta"]["client_summary"] is None

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -312,13 +312,36 @@ class TestIngestBundle:
         assert "max_batch_size: 1" in (bundle / "trtllm_config_decode.yaml").read_text()
 
     def test_renderer_reads_real_ceilings_not_defaults(self, run_dir: Path, tmp_path: Path):
+        """Assert on the DATA payload, not the log line.
+
+        The renderer logged the config-derived ceilings correctly while the Engine
+        panel still consumed the CLI defaults -- the ceilings were parsed into a
+        variable only the per-iteration panel read. A log-line assertion passes
+        against that bug; only the payload catches it.
+        """
         bundle = tmp_path / "bundle"
         _run_ingest(run_dir, bundle)
-        # The renderer logs the resolved ceilings to stderr at INFO.
-        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn")
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
         assert proc.returncode == 0, proc.stderr
-        assert "prefill max_batch_size=128" in proc.stderr
-        assert "decode max_batch_size=1" in proc.stderr, "must be 1 from config, not the 256 default"
+
+        engine = json.loads(payload.read_text())["en"]
+        assert engine["max_batch_pf"] == 128
+        assert engine["max_batch_de"] == 1, "the decode in-flight panel must be drawn against 1, not the 256 default"
+
+    def test_cli_ceilings_apply_only_without_a_run_config(self, tmp_path: Path):
+        """The CLI flags stay a fallback for bundles carrying no engine config."""
+        d = tmp_path / "logs"
+        d.mkdir()
+        _write_raw_prometheus(d)
+        _write_aiperf_export(d)  # deliberately no _write_engine_configs
+        bundle = tmp_path / "bundle"
+        _run_ingest(d, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload),
+                       "--max-batch-decode", "77")
+        assert proc.returncode == 0, proc.stderr
+        assert json.loads(payload.read_text())["en"]["max_batch_de"] == 77
 
     def test_missing_engine_configs_are_not_fatal(self, tmp_path: Path):
         """A non-TRTLLM run has no such files; ingest must still produce a bundle."""

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1134,3 +1134,75 @@ class TestIterLogProcessor:
         log = tmp_path / "node_decode_w0.out"
         log.write_text("nothing of interest here\n")
         assert process(str(tmp_path / "iter_bins.json"), [str(log)]) == 0
+
+
+class TestRenderedEntities:
+    """Payload without a renderer is not coverage. These pin the JS consumers."""
+
+    def test_request_cards_have_a_renderer(self, run_dir: Path, tmp_path: Path):
+        src = run_dir / "dynamo-request-trace"
+        src.write_text("\n".join(
+            json.dumps(_trace_record(x, "s1", 1_787_174_000_000 + i * 1000,
+                                     prefill_wait=2.0, prefill=500.0, kv_transfer=50.0,
+                                     total=1000.0, avg_itl=20.0, osl=11, hashes=[1, 2]))
+            for i, x in enumerate(XIDS)) + "\n")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.html"
+        assert _render(bundle, out, "--d3-cdn").returncode == 0
+
+        html = out.read_text()
+        # DATA.rt.requests carried the per-request card for several commits with no JS
+        # consumer at all -- the payload existed and nothing drew it.
+        for marker in ("Per-request decomposition", "reqcard", "DATA.rt.requests",
+                       "Router belief vs engine reality"):
+            assert marker in html, f"per-request entity lost its renderer: {marker}"
+
+    def test_high_cardinality_panels_state_what_they_omit(self, run_dir: Path, tmp_path: Path):
+        """A per-thread runtime gauge is ~144 series. Drawing all is unreadable and
+        drawing some silently reads as complete."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.html"
+        _render(bundle, out, "--d3-cdn")
+        assert "highest-peak of" in out.read_text()
+
+
+class TestKvHitRateGating:
+    def test_reuse_disabled_components_are_excluded(self, run_dir: Path, tmp_path: Path):
+        """A worker with enable_block_reuse:false reports a hard 0 -- correctly, it does
+        no reuse. Averaging that into the run-level rate makes the number fall as the
+        deployment adds decode workers. On the reference run the naive mean reported
+        0.0 where the true prefill rate was 65.1."""
+        (run_dir / "trtllm_config_prefill.yaml").write_text(
+            "max_batch_size: 128\nmax_num_tokens: 4096\nkv_cache_config:\n  enable_block_reuse: true\n")
+        (run_dir / "trtllm_config_decode.yaml").write_text(
+            "max_batch_size: 1\nmax_num_tokens: 4\nkv_cache_config:\n  enable_block_reuse: false\n")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+        assert json.loads(payload.read_text())["en"]["reuse_components"] == ["prefill"]
+
+    def test_absent_config_keeps_every_component(self, run_dir: Path, tmp_path: Path):
+        """No engine config means "cannot tell", which must not silently drop data."""
+        for f in run_dir.glob("trtllm_config_*.yaml"):
+            f.unlink()
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert json.loads(payload.read_text())["en"]["reuse_components"] is None
+
+    def test_header_block_size_comes_from_the_stream(self, run_dir: Path, tmp_path: Path):
+        """The yaml carries only ingest's --block-size fallback; on the reference run
+        that fallback (512) disagreed with the measured value (32) and the engine
+        config (256). The header must not show the fallback."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        payload = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        topo = json.loads(payload.read_text())["meta"]["topo"]
+        assert "__BLK__" not in topo
+        assert "block 512" not in topo

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1483,3 +1483,56 @@ class TestKpiProvenance:
 
         html = out.read_text()
         assert "not available in this run, so TTFT is a single opaque block" not in html
+
+
+class TestPhaseFilterProvenance:
+    """`meta.n` alone cannot say WHY the population is the size it is.
+
+    On the c32 reference run 2750618 all 118 client records are benchmark_phase=warmup
+    -- the job hit its 20-minute wall before profiling began -- so n is 0. A reader
+    seeing only that would conclude the stack served nothing, which is the opposite
+    diagnosis from "this run needed more wall clock". PERF-47.
+    """
+
+    @staticmethod
+    def _phase(run_dir: Path, phases: list[str]) -> None:
+        """Rewrite the client export, tagging record i with phases[i]."""
+        # The client export lives at the nested artifacts path srt-slurm's bench.sh
+        # writes, not at the bundle root -- reaching through that nesting is exactly
+        # what the ingest default glob exists to do.
+        path = next(run_dir.glob("artifacts/*/profile_export.jsonl"))
+        rows = [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+        for rec, ph in zip(rows, phases):
+            rec["metadata"]["benchmark_phase"] = ph
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+    def _payload(self, run_dir: Path, tmp_path: Path) -> dict:
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(out))
+        assert proc.returncode == 0, proc.stderr
+        return json.loads(out.read_text())
+
+    def test_warmup_only_run_is_declared_not_silently_empty(self, run_dir: Path, tmp_path: Path):
+        n = len(XIDS)
+        self._phase(run_dir, ["warmup"] * n)
+        pf = self._payload(run_dir, tmp_path)["meta"]["phase_filter"]
+        assert pf["kept"] == 0
+        assert pf["dropped"] == n
+        assert pf["phases"] == {"warmup": n}, "the reason for an empty population must be legible"
+
+    def test_mixed_phases_report_both_sides(self, run_dir: Path, tmp_path: Path):
+        n = len(XIDS)
+        self._phase(run_dir, ["warmup"] + ["profiling"] * (n - 1))
+        pf = self._payload(run_dir, tmp_path)["meta"]["phase_filter"]
+        assert pf["kept"] == n - 1
+        assert pf["dropped"] == 1
+        assert pf["phases"]["warmup"] == 1
+
+    def test_untagged_records_are_kept_and_named(self, run_dir: Path, tmp_path: Path):
+        """Plain non-AgentX AIPerf runs carry no benchmark_phase at all; dropping
+        those would empty the dashboard for every non-agentic benchmark."""
+        pf = self._payload(run_dir, tmp_path)["meta"]["phase_filter"]
+        assert pf["dropped"] == 0
+        assert pf["phases"] == {"(none)": len(XIDS)}

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -688,3 +688,77 @@ class TestClientLayouts:
         bundle = tmp_path / "bundle"
         assert main(["--run-dir", str(d), "--out", str(bundle), "--traces", "none"]) == 0
         assert (bundle / "profile_export.jsonl").read_text().count("xid0") == 1
+
+
+class TestRequestAndSessionEntities:
+    """The two non-time-series dashboard entities, both built from the request trace."""
+
+    @staticmethod
+    def _bundle_with_trace(run_dir: Path, tmp_path: Path) -> Path:
+        src = run_dir / "dynamo-request-trace"
+        recs = []
+        for i, xid in enumerate(XIDS):
+            recs.append(_trace_record(
+                xid, f"sess-{i % 2}", 1_787_174_000_000 + i * 1000,
+                prefill_wait=2.0, prefill=500.0 + i, kv_transfer=50.0,
+                total=1000.0 + i, avg_itl=20.0, osl=11,
+                hashes=list(range(10 + i)),
+            ))
+        src.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        return bundle
+
+    def test_request_bands_sum_to_total(self, run_dir: Path, tmp_path: Path):
+        """The waterfall must be gapless -- on the reference runs there are 0/560
+        negative residuals, and a band that silently absorbs a gap makes the card lie
+        about where the time went."""
+        bundle = self._bundle_with_trace(run_dir, tmp_path)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+
+        rt = json.loads(payload.read_text())["rt"]
+        assert rt["requests"], "request cards should be populated"
+        for card in rt["requests"].values():
+            total = sum(v for _, _, v in card["bands"] if v is not None)
+            assert total == pytest.approx(card["attrs"]["total_ms"], abs=0.01)
+
+    def test_sessions_carry_turn_ordered_series(self, run_dir: Path, tmp_path: Path):
+        bundle = self._bundle_with_trace(run_dir, tmp_path)
+        payload = tmp_path / "dash.json"
+        proc = _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+        assert proc.returncode == 0, proc.stderr
+
+        data = json.loads(payload.read_text())
+        assert data["tabs"]["session"] is True
+        sessions = data["rt"]["sessions"]
+        assert len(sessions) == 2, "XIDS split across two sessions"
+        for s in sessions:
+            assert s["turns"] == len(s["ttft_ms"]) == len(s["xids"])
+            # busy + idle must reconstruct the session's wall-clock span.
+            assert s["busy_ms"] + s["idle_ms"] == pytest.approx(s["span_ms"], abs=0.2)
+            assert s["idle_ms"] >= 0
+
+    def test_constant_fields_are_reported_not_hidden(self, run_dir: Path, tmp_path: Path):
+        """queue_depth reads a constant 0 on both reference runs. Reporting it as
+        constant is the finding ('this run never queued'); dropping it silently would
+        make that unaskable, and drawing it as a flat line looks like a broken chart."""
+        bundle = self._bundle_with_trace(run_dir, tmp_path)
+        payload = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+
+        const = json.loads(payload.read_text())["rt"]["const"]
+        assert const["queue_depth"] == 0
+        assert const["decode_dp_rank"] == 0
+
+    def test_session_tab_absent_without_a_request_trace(self, run_dir: Path, tmp_path: Path):
+        """Tab gating is on source availability: no trace file, no session tab."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)  # run_dir fixture has no dynamo-request-trace
+        payload = tmp_path / "dash.json"
+        _render(bundle, tmp_path / "dash.html", "--d3-cdn", "--dump-json", str(payload))
+
+        data = json.loads(payload.read_text())
+        assert data["tabs"]["session"] is False
+        assert data["rt"]["sessions"] == []

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -1353,3 +1353,31 @@ class TestMetricNameResolution:
         assert "_entries" in src and "name + \"_total\"" in src, (
             f"bare counter names {sorted(bare)} are referenced, so the central "
             "_total-resolution helper must still exist")
+
+
+class TestKpiProvenance:
+    def test_kpi_items_carry_a_source(self, run_dir: Path, tmp_path: Path):
+        """A KPI with no provenance is indistinguishable from one computed off the
+        wrong population -- which has happened here more than once (the tokenizer-cache
+        KPI read 0.0% against a real 99.2% because of a metric-name mismatch)."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.html"
+        assert _render(bundle, out, "--d3-cdn",
+                       "--frontend-log", str(run_dir / "node0_frontend_0.out")).returncode == 0
+
+        html = out.read_text()
+        assert "'routing decisions seen'" in html or "routing decisions seen" in html
+        assert ".kpi .src{" in html, "the per-KPI source annotation style must exist"
+
+    def test_no_branching_prose_in_the_log_tab_note(self, run_dir: Path, tmp_path: Path):
+        """One caption when a feature is present and a different one when it is absent
+        is the varying-description defect: the caption becomes a function of the run
+        instead of the value doing that job."""
+        bundle = tmp_path / "bundle"
+        _run_ingest(run_dir, bundle)
+        out = tmp_path / "dash.html"
+        _render(bundle, out, "--d3-cdn", "--frontend-log", str(run_dir / "node0_frontend_0.out"))
+
+        html = out.read_text()
+        assert "not available in this run, so TTFT is a single opaque block" not in html

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -558,3 +558,47 @@ class TestDryRunVllmOrchestrationWarnings:
         output = capsys.readouterr().out
         assert "vllm_config.aggregated.master-addr" not in output
         assert "configured value is ignored" not in output
+
+
+class TestInfmaxWorkspaceMount:
+    """INFMAX_WORKSPACE comes from the environment, not the recipe.
+
+    That is precisely why dry-run has to show it: nothing in the config file mentions
+    it, so a reader comparing recipe against dry-run sees what looks like a complete
+    picture and is wrong. Recipes whose benchmark command lives under
+    /infmax-workspace fail with exit 127 after the workers have loaded when it is
+    missing -- observed on ablation arms 2751879-82, where diffing the working run's
+    --container-mounts against the failed arm's showed this single missing entry.
+    """
+
+    AGENTIC = {"benchmark": {"type": "custom",
+                             "command": "bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh"}}
+
+    def test_mount_is_shown_when_the_variable_is_set(self, capsys):
+        config = _make_config(self.AGENTIC)
+        with patch.dict(os.environ, {"INFMAX_WORKSPACE": "/lustre/checkouts/InferenceX-abc"}):
+            show_config_details(config)
+        output = capsys.readouterr().out
+        assert "/lustre/checkouts/InferenceX-abc" in output
+        assert "/infmax-workspace" in output
+
+    def test_absence_is_flagged_when_the_benchmark_needs_it(self, capsys):
+        """The failure this prevents is expensive and silent: the table listed every
+        other mount, so the missing row read as 'no such mount exists' rather than
+        'not set in this environment'."""
+        config = _make_config(self.AGENTIC)
+        env = {k: v for k, v in os.environ.items() if k != "INFMAX_WORKSPACE"}
+        with patch.dict(os.environ, env, clear=True):
+            show_config_details(config)
+        output = capsys.readouterr().out
+        assert "MISSING" in output
+        assert "127" in output, "the dry-run must name the failure mode, not just the gap"
+
+    def test_no_warning_when_the_benchmark_does_not_use_it(self, capsys):
+        """Most recipes never touch /infmax-workspace; they must not be nagged."""
+        config = _make_config()
+        env = {k: v for k, v in os.environ.items() if k != "INFMAX_WORKSPACE"}
+        with patch.dict(os.environ, env, clear=True):
+            show_config_details(config)
+        output = capsys.readouterr().out
+        assert "MISSING" not in output

--- a/tools/dashboard_diff.py
+++ b/tools/dashboard_diff.py
@@ -166,6 +166,31 @@ def diff(base: dict, new: dict, top: int, min_pct: float) -> int:
             a, b = len(brt.get(key) or []), len(nrt.get(key) or [])
         out.append(f"  {label:20s} {_num(a):>8s} -> {_num(b):>8s}")
 
+    # --- provenance ---------------------------------------------------------
+    # An A/B is only an A/B if the two runs differed in the one variable you think
+    # they did. Everything above reports what MOVED; this reports what CHANGED, which
+    # is the claim the reader is actually being asked to accept. A framework version
+    # differing between baseline and arm invalidates the comparison outright, and it
+    # is otherwise completely invisible -- both runs simply work.
+    bpv, npv = base.get("meta", {}).get("provenance"), new.get("meta", {}).get("provenance")
+    out.append("\nPROVENANCE")
+    if not bpv or not npv:
+        out.append("  unavailable on at least one side (no fingerprint_*.json in the bundle)")
+        out.append("  -> the single-variable claim of this comparison is UNVERIFIED")
+    else:
+        bf, nf = bpv.get("frameworks") or {}, npv.get("frameworks") or {}
+        drift = [(k, bf.get(k), nf.get(k)) for k in sorted(set(bf) | set(nf))
+                 if bf.get(k) != nf.get(k)]
+        if drift:
+            out.append("  FRAMEWORK DRIFT between the two runs -- this is not a clean A/B:")
+            for k, a, b in drift:
+                out.append(f"    {k}: {a} -> {b}")
+        else:
+            out.append(f"  frameworks identical across both runs: {bf}")
+        for tag, pv in (("baseline", bpv), ("compared", npv)):
+            if pv.get("framework_disagreement"):
+                out.append(f"  {tag}: WORKERS DISAGREE INTERNALLY {pv['framework_disagreement']}")
+
     bb, nb = brt.get("belief"), nrt.get("belief")
     if bb or nb:
         out.append("\nROUTER BELIEF vs ENGINE REALITY")

--- a/tools/dashboard_diff.py
+++ b/tools/dashboard_diff.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Diff two ``perf_dashboard.json`` payloads: what moved between two runs.
+
+The HTML is often unreadable where it lands -- a headless node, a CI log, an S3
+prefix -- and comparing two runs by eye across ~80 panels is not a thing anyone
+actually does. This turns an A/B into one command over the machine-readable payload
+that the page embeds.
+
+Built for the ablation shape: change ONE variable, run both, and ask which signals
+responded. That is also the honest test of whether a panel earns its place -- a panel
+that never moves between a healthy run and a known-broken one is not diagnostic.
+
+    python3 tools/dashboard_diff.py BASELINE.json IMPROVED.json [--top N] [--min-pct P]
+
+Reports, in order:
+  * KPI deltas
+  * tab availability changes (a leg present in one run and not the other)
+  * per-panel deltas, ranked by relative movement
+  * panels that exist in only one payload
+  * request/session population changes
+
+Comparison is on the MEDIAN of each series, not the mean: these series are routinely
+heavy-tailed (one 10s iteration among thousands of 13ms ones), and a mean would report
+the tail moving as though the body had. Where the median is zero on BOTH sides it
+cannot discriminate -- sparse counter rates and event counters sit at zero through
+their idle windows -- so the comparison falls back to the peak, and every row states
+which statistic it used. Without that fallback an 8x concurrency change reported 30
+panels as "identical" when only 8 genuinely were.
+
+Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+
+
+def _median(series: dict) -> float | None:
+    """Median across every point of every series in a panel."""
+    vals = [v for pts in series.values() for _, v in pts if v is not None]
+    return statistics.median(vals) if vals else None
+
+
+def _peak(series: dict) -> float | None:
+    """Max across every point of every series in a panel."""
+    vals = [v for pts in series.values() for _, v in pts if v is not None]
+    return max(vals) if vals else None
+
+
+def _compare(series_a: dict, series_b: dict):
+    """(stat_name, a, b) -- median normally, peak when the median cannot discriminate.
+
+    Sparse and bursty series (a counter rate with many idle windows, an event counter)
+    sit at a median of 0 in BOTH runs even when their peaks differ by orders of
+    magnitude. Reporting those as "identical" is worse than saying nothing: it implies
+    the panel was checked and found unchanged. Fall back to the peak, and label which
+    statistic was used so the reader is never guessing.
+    """
+    ma, mb = _median(series_a), _median(series_b)
+    if (ma or 0) == 0 and (mb or 0) == 0:
+        return "peak", _peak(series_a), _peak(series_b)
+    return "median", ma, mb
+
+
+def _pct(a: float | None, b: float | None) -> float | None:
+    """Relative change b vs a, as a percentage. None when it is not expressible."""
+    if a is None or b is None:
+        return None
+    if a == 0:
+        return None if b == 0 else float("inf")
+    return (b - a) / abs(a) * 100.0
+
+
+def _fmt(v: float | None) -> str:
+    if v is None:
+        return "-"
+    if v == float("inf"):
+        return "0 -> nonzero"
+    return f"{v:+.1f}%"
+
+
+def _num(v) -> str:
+    if v is None:
+        return "-"
+    if isinstance(v, float):
+        return f"{v:.4g}"
+    return str(v)
+
+
+def diff(base: dict, new: dict, top: int, min_pct: float) -> int:
+    out: list[str] = []
+
+    out.append("=" * 78)
+    out.append(f"BASELINE  {base.get('meta', {}).get('src', '?')}")
+    out.append(f"COMPARED  {new.get('meta', {}).get('src', '?')}")
+    out.append("=" * 78)
+
+    # --- KPIs -------------------------------------------------------------
+    bk, nk = base.get("kpi", {}) or {}, new.get("kpi", {}) or {}
+    keys = sorted(set(bk) | set(nk))
+    if keys:
+        out.append("\nKPI")
+        for k in keys:
+            p = _pct(bk.get(k), nk.get(k))
+            out.append(f"  {k:16s} {_num(bk.get(k)):>12s} -> {_num(nk.get(k)):>12s}   {_fmt(p)}")
+
+    # --- tabs -------------------------------------------------------------
+    bt, nt = base.get("tabs", {}) or {}, new.get("tabs", {}) or {}
+    changed = [t for t in sorted(set(bt) | set(nt)) if bool(bt.get(t)) != bool(nt.get(t))]
+    if changed:
+        out.append("\nTAB AVAILABILITY CHANGED  (a capture leg differed between the runs)")
+        for t in changed:
+            out.append(f"  {t:14s} {bool(bt.get(t))} -> {bool(nt.get(t))}")
+
+    # --- panels -----------------------------------------------------------
+    bp, np_ = base.get("panels", {}) or {}, new.get("panels", {}) or {}
+    only_b = sorted(set(bp) - set(np_))
+    only_n = sorted(set(np_) - set(bp))
+    moved: list[tuple[float, str, float | None, float | None, str]] = []
+    flat: list[str] = []
+    for pid in sorted(set(bp) & set(np_)):
+        stat, a, b = _compare(bp[pid].get("series", {}), np_[pid].get("series", {}))
+        p = _pct(a, b)
+        title = f"{np_[pid].get('title', pid)}  [{stat}]"
+        if p is None:
+            if a == b:
+                flat.append(pid)
+            continue
+        if p == float("inf") or abs(p) >= min_pct:
+            rank = 1e9 if p == float("inf") else abs(p)
+            moved.append((rank, pid, a, b, title))
+    moved.sort(reverse=True)
+
+    if moved:
+        out.append(f"\nPANELS THAT MOVED  (>= {min_pct:g}%, top {top}; statistic noted per row)")
+        for _, pid, a, b, title in moved[:top]:
+            out.append(f"  {pid:26s} {_num(a):>12s} -> {_num(b):>12s}   "
+                       f"{_fmt(_pct(a, b)):>14s}   {title}")
+    if flat:
+        # Not noise: a panel identical across a run that changed behaviour is either
+        # measuring something the change did not touch, or is not measuring at all.
+        out.append(f"\nPANELS IDENTICAL IN BOTH RUNS ({len(flat)})")
+        out.append("  (median AND peak both equal -- these genuinely did not respond)")
+        out.append("  " + ", ".join(flat))
+    if only_b or only_n:
+        out.append("\nPANELS PRESENT IN ONLY ONE RUN")
+        for pid in only_b:
+            out.append(f"  baseline only: {pid}")
+        for pid in only_n:
+            out.append(f"  compared only: {pid}")
+
+    # --- populations ------------------------------------------------------
+    brt, nrt = base.get("rt", {}) or {}, new.get("rt", {}) or {}
+    out.append("\nPOPULATION")
+    for label, key in (("profiling requests", None), ("request cards", "requests"),
+                       ("sessions", "sessions")):
+        if key is None:
+            a = base.get("meta", {}).get("n")
+            b = new.get("meta", {}).get("n")
+        else:
+            a, b = len(brt.get(key) or []), len(nrt.get(key) or [])
+        out.append(f"  {label:20s} {_num(a):>8s} -> {_num(b):>8s}")
+
+    bb, nb = brt.get("belief"), nrt.get("belief")
+    if bb or nb:
+        out.append("\nROUTER BELIEF vs ENGINE REALITY")
+        for tag, v in (("baseline", bb), ("compared", nb)):
+            if v:
+                out.append(f"  {tag}: {v['n'] - v['disagree']}/{v['n']} agree, "
+                           f"worst error {v['worst'] * 100:.1f}%")
+
+    print("\n".join(out))
+    return 0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("baseline")
+    ap.add_argument("compared")
+    ap.add_argument("--top", type=int, default=25)
+    ap.add_argument("--min-pct", type=float, default=5.0,
+                    help="ignore panels that moved less than this (default 5%%)")
+    a = ap.parse_args(argv)
+    with open(a.baseline) as f:
+        base = json.load(f)
+    with open(a.compared) as f:
+        new = json.load(f)
+    return diff(base, new, a.top, a.min_pct)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/dashboard_diff.py
+++ b/tools/dashboard_diff.py
@@ -191,6 +191,30 @@ def diff(base: dict, new: dict, top: int, min_pct: float) -> int:
             if pv.get("framework_disagreement"):
                 out.append(f"  {tag}: WORKERS DISAGREE INTERNALLY {pv['framework_disagreement']}")
 
+        # The single-variable check. For an ablation this should list exactly the one
+        # setting the experiment moved; anything else in the list is a confound that
+        # would otherwise be argued about rather than seen.
+        bc, nc = bpv.get("config"), npv.get("config")
+        if bc is None or nc is None:
+            out.append("  config unavailable on at least one side "
+                       "(no config.yaml in the bundle) -- variables changed are UNKNOWN")
+        else:
+            keys = sorted(set(bc) | set(nc))
+            delta = [(k, bc.get(k, "<absent>"), nc.get(k, "<absent>"))
+                     for k in keys if bc.get(k, "<absent>") != nc.get(k, "<absent>")]
+            if not delta:
+                out.append("  config IDENTICAL between the two runs "
+                           "-- any movement above is run-to-run variance, not a change")
+            else:
+                label = ("SINGLE-VARIABLE: this is a clean ablation"
+                         if len(delta) == 1 else
+                         f"{len(delta)} settings differ -- NOT a single-variable comparison")
+                out.append(f"  CONFIG DELTA ({label})")
+                for k, a, b in delta[:20]:
+                    out.append(f"    {k}: {a!r} -> {b!r}")
+                if len(delta) > 20:
+                    out.append(f"    ... and {len(delta) - 20} more")
+
     bb, nb = brt.get("belief"), nrt.get("belief")
     if bb or nb:
         out.append("\nROUTER BELIEF vs ENGINE REALITY")

--- a/tools/dashboard_render_check.js
+++ b/tools/dashboard_render_check.js
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Headless render check for a generated perf dashboard.
+//
+// `node --check` proves the page's JS parses. It does not prove the page BUILDS:
+// a page whose script throws on line one is syntactically perfect and completely
+// blank. This executes the real page in a DOM and asserts panels were actually
+// created, which is the difference between "looks fine" and "renders".
+//
+// Deliberately not wired into CI: it needs npm deps (jsdom, d3) that a Python
+// repo should not carry. Run it by hand when changing the renderer's JS.
+//
+//   npm install jsdom d3@7
+//   node tools/dashboard_render_check.js <perf_dashboard.html>
+//
+// Exit 0 = rendered, 1 = threw or produced nothing.
+
+// node --check only proves the JS parses; this proves it runs to completion and
+// produced panels, which is the difference between "looks fine" and "renders".
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+const d3 = require('d3');
+
+const file = process.argv[2];
+const html = fs.readFileSync(file, 'utf8');
+const dom = new JSDOM(html, { runScripts: 'outside-only', pretendToBeVisual: true });
+const { window } = dom;
+// d3's Node build resolves `document` from the GLOBAL scope, not from a window
+// object handed to it, so the jsdom document has to be published globally before
+// any d3.select runs.
+global.window = window;
+global.document = window.document;
+global.navigator = window.navigator;
+global.location = window.location;
+window.d3 = d3;
+global.d3 = d3;
+const errors = [];
+window.addEventListener('error', e => errors.push(String(e.error || e.message)));
+
+const body = html.match(/<script>([\s\S]*?)<\/script>/g)
+  .map(b => b.replace(/^<script>/, '').replace(/<\/script>$/, ''))
+  .sort((a, b) => b.length - a.length)[0];
+
+try { new Function('d3','document','window','location', body)(d3, window.document, window, window.location); } catch (e) { errors.push(e.stack || String(e)); }
+
+const doc = window.document;
+const tabs = [...doc.querySelectorAll('.tab')].map(t => t.textContent);
+const panels = doc.querySelectorAll('.panel').length;
+const svgs = doc.querySelectorAll('svg').length;
+const paths = doc.querySelectorAll('path').length;
+const rows = doc.querySelectorAll('.tbl tbody tr').length;
+
+console.log('tabs   :', tabs.join(' | '));
+console.log('panels :', panels);
+console.log('svgs   :', svgs, ' paths:', paths);
+console.log('session rows:', rows);
+if (errors.length) { console.log('ERRORS :'); errors.forEach(e => console.log('  ' + e.split('\n')[0])); }
+
+const ok = errors.length === 0 && panels > 0 && svgs > 0;
+console.log(ok ? 'RENDER OK' : 'RENDER FAILED');
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## What

Makes the component perf dashboard work on runs captured **without** `observability.enabled`,
and marks the load generator's warmup phase on every time-axis chart.

Found by pointing the dashboard at run directories it had never seen — the DYN-3873 tokenizer
study and a three-way Dynamo-vs-trtllm-serve set. None of those runs set `observability.enabled`,
and between them they broke the renderer in four separate ways.

### 1. AIPerf's own server-metrics export as a second metrics source

New `src/ingest/metrics_aiperf_json.py`, selected with `--metrics aiperf-json`, and reachable
automatically via the new `--metrics auto` (now the default): use `raw_prometheus.jsonl` when the
run has it, fall back to AIPerf's export when it does not.

A run predating `observability.enabled` has no `raw_prometheus.jsonl`, so it had no metrics leg at
all — which is **every already-landed fix and its own baseline**. AIPerf's export carries
per-second timeslices: the same time series in a different container.

Two transpositions are load-bearing and both fail *silently*:

- **Cumulative vs interval.** A single slice cannot tell you which it is, so the mode is
  **detected** per series against the run total in `stats` rather than assumed. On the reference
  export **1176 of 1178 series reconcile exactly**; the other two by one slice at a run edge.
- **Name suffixes.** AIPerf keys a family by its base name; every panel uses
  `_total` / `_count` / `_sum`.

Streaming throughout — the export exceeds 2 GB, and the per-timestamp regroup spills into
time-contiguous shards because an external `sort` over ~15 M samples gets OOM-killed on a shared
login node.

### 2. A bundle whose only leg is the iteration log now renders

The run window was built from traces + scrapes only. With neither it collapsed to 1 ns, the
`t > run_dur + 60` guard discarded every bin, and **a run with 175,800 real iterations produced an
empty page** and one INFO line reading `0pts`. The Engine tab was also gated on the scrape stream
alone, though it has two independent producers.

This is the trtllm-serve shape — no Dynamo frontend means no `/metrics` surface and no spans — so
a control run could not be placed beside the Dynamo run it exists to be compared against.

### 3. Both KV panels fall back to the iteration log

`dynamo_component_gpu_cache_usage_percent` and `trtllm_kv_cache_hit_rate` live on the **worker**
endpoint, which is frequently not scraped. The panels emitted a full-length series of nulls — an
empty axis, which reads as a measured zero rather than as absent data.

Both quantities are in the iteration log. The derived reuse reproduces the client's own Prompt
Cache Read % to within ~1 pp on three runs (95.88 / 95.76 / 94.27 % derived vs 95.6–97.2 %
reported). When neither source exists the panel now says so in words.

### 4. The in-flight batch panels never rendered — on any srt-slurm run

They filtered workers with `startsWith(role)`, but srt-slurm names a worker `<node>_<role>_w<N>` —
the role is in the **middle**. The filter matched nothing and the builder returns silently on an
empty match, so both panels were **absent rather than broken**, with no warning anywhere.

They now also plot the configured `max_batch_size`: as a reference line when it is on a comparable
scale, and as a utilisation figure when it is not (prefill peaks at 11 against a ceiling of 256,
where a line to scale flattens every series onto the axis).

### 5. The end of the warmup phase, on every time chart

AgentX warmup is **33 %, 35 % and 38 %** of the runs measured — every percentile above was reading
through it.

The boundary is an **optional field on the panel entity**, so a panel carries its own phase marker
alongside its own series and units, and any consumer that can draw one panel draws the marker.
Optional is the design: a harness with no warmup phase must not acquire an invented boundary, and
absent has to mean *unknown*, never *t=0*.

Resolved from `benchmark_phase` when the client leg is present, else from `warmup.end_ns` recorded
by a new ingest probe — the export is routinely 700 MB and often not copied, and the boundary is
one integer. A boundary outside the run window is refused with a warning.

**That guard immediately earned itself:** it refused a marker at `t+27,379 s` on a 5,810 s run,
which turned out to be the iteration log's local→UTC offset defaulting to `+0h` because a
trtllm-serve run has no metrics stream to anchor against. The client export's own span is now the
fallback anchor and the offset derives correctly as `+7h`. **Any `--metrics none` bundle was
affected.**

Also: a third client-export layout (`agentic/<conc>/profile_export.jsonl`, no `aiperf_artifacts/`
level) which the glob did not match.

## Reviewer notes

- **The `startsWith(role)` fix (4) is the one to look at hardest** — it changes behaviour on every
  existing srt-slurm dashboard, not just the runs that prompted it.
- **Vendored dirs stay excluded from ruff/ty**, per the existing exclusion — `src/ingest/` and
  `src/visualization/` keep upstream's dense style so the diff against the re-sync source stays
  readable.
- `metrics_aiperf_json.py` is stdlib-only and runs under a bare cluster `python3`, matching the
  other L2 processors.
- `--metrics` gains an `auto` default. Explicit `--metrics prometheus` still forces the scraper
  source, so existing invocations are unchanged in behaviour where the file exists.

## Verified on live SLURM jobs

Two runs of the same recipe on lyris gb300 (DeepSeek-V4-Pro, disagg 1P3D, **concurrency 4**,
5-minute benchmark), differing only in the `observability` block. Both dashboards were produced
**by the in-job postprocess hook** — not by a hand-driven pipeline afterwards.

| | `2757709` — `enabled: true` | `2757710` — `enabled: false`, `build_dashboard: true` |
| --- | --- | --- |
| `raw_prometheus.jsonl` | **252 MB** | absent |
| `SPAN_CLOSED` lines | **4,347** | **0** |
| AIPerf's own export | n/a | **128 MB** |
| **auto-selected source** | **`prometheus`** | **`aiperf-json`** |
| `perf_dashboard.html` | **5.6 MB** | **1.9 MB** |
| **tabs** | **`overview` + frontend, router, engine, loganalysis** | **frontend, router, engine, loganalysis** |
| warmup marker | `t+380.3s of 727s (52%)` | `t+351.3s of 664s (53%)` |
| panels rendered (jsdom) | 99 panels, 401 paths, 0 JS errors | 97 panels, 368 paths, 0 JS errors |

The `enabled: false` arm is the point of the change: with **every capture off** — no scrape, no
spans, no request trace — the run still produces a dashboard with the three server-metrics tabs,
because `--metrics auto` falls back to AIPerf's own export. Before this PR that run yielded a
log-only page.

Both jobs exited non-zero on a post-benchmark env guard in the client harness (`replay_rc=0`, so
the benchmark itself succeeded). The dashboard is built anyway, which is the intended
build-on-failure behaviour.

**Two bugs this live verification caught that the unit tests could not:**

1. `AIPERF_METRIC_PATTERNS` did not cover `agentic/<conc>/aiperf_artifacts/server_metrics_export.json`
   — the layout an srt-slurm AgentX run writes on lyris (hecate writes the flatter
   `agentic/<conc>/server_metrics_export.json`). Missing it would have silently cost the three tabs
   in the `false` column above. Now covered, with a test naming the layout.
2. `srtctl/analysis/perf_dashboard.py` passed no `--metrics` flag at all, so it defaulted to the
   scraper source and produced a one-tab page whenever `observability.enabled` was false.

**Known gap, unrelated to this PR — corrected.** The `true` run has 5 tabs, not 6: no Session tab.
An earlier draft of this description said the request trace "was never written." **That was wrong.**
It was written — `logs/dynamo-request-trace.000000.jsonl.gz`, 8.7 MB. The Session tab is missing
because ingest cannot *find* or *read* it:

- `src/ingest/ingest.py:509` defaults the request-trace input to the literal, extension-less
  `"dynamo-request-trace"`. `glob.has_magic()` is false for that string, so discovery degrades to an
  exact-path check and misses Dynamo's rotated `dynamo-request-trace.NNNNNN.jsonl.gz`. The ON run's
  own log says so verbatim: `WARN no request trace matched 'dynamo-request-trace'`.
- Fixing the glob alone would still yield zero rows: `src/ingest/request_trace.py:212` uses a plain
  `open()`, and `grep -rn gzip src/ingest/` has no hits, so a `.gz` input cannot be parsed.

So the correct framing is **"ingest fails to discover and decompress Dynamo's rotated `.jsonl.gz`
request trace"** — the Session tab is recoverable from data already captured. A working pattern for
both halves already exists in this repo at `src/srtctl/ruter/view.py:320,539-542`. Left out of this
PR deliberately to keep the diff scoped; worth its own change.

Note the same WARN appears in the `false` run's log for the opposite reason — that run genuinely
wrote no trace — so the WARN alone does not discriminate between the two causes.
