### PR TITLE
feat(vllm): default DP launch mode to per-node

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -405,11 +405,11 @@ The following keys are owned by srtctl and are stripped at runtime if present in
 - `node-rank` / `node_rank`
 
 Existing recipes that still contain these keys generally continue to work
-because the values are ignored. One exception is `headless` combined with
-`dp_launch_mode: per_node` and `data-parallel-size`: backend validation rejects
-that combination before direct-vLLM command construction, so remove `headless`
-from such recipes. `srtctl dry-run` emits a **WARNING** for each accepted key so
-operators can clean up recipes over time.
+because the values are ignored. One exception is `headless` combined with the
+default `dp_launch_mode: per_node` and `data-parallel-size`: backend validation
+rejects that combination before direct-vLLM command construction, so remove
+`headless` from such recipes. `srtctl dry-run` emits a **WARNING** for each
+accepted key so operators can clean up recipes over time.
 
 Health checks, benchmark clients, and `SRT_FRONTEND_HOST` target the **aggregate
 endpoint leader** (the node running the public `vllm serve`), not necessarily the
@@ -523,14 +523,12 @@ Each worker leader gets a globally unique port starting at 5550:
 
 ### vLLM DP launch mode
 
-vLLM data-parallel endpoints use one process per GPU by default. Set
-`dp_launch_mode: per_node` to launch one process per node. srtslurm derives
-whether each TP/PP replica is node-local or spans multiple nodes:
+vLLM data-parallel endpoints use one process per node by default. srtslurm
+derives whether each TP/PP replica is node-local or spans multiple nodes:
 
 ```yaml
 backend:
   type: vllm
-  dp_launch_mode: per_node
   vllm_config:
     prefill:
       data-parallel-size: 8
@@ -540,13 +538,13 @@ backend:
 
 | Value      | Process layout                                                               |
 | ---------- | ---------------------------------------------------------------------------- |
-| `per_gpu`  | One process per DP rank/GPU (default)                                        |
-| `per_node` | One process per node; automatically supports node-local or distributed TP/PP |
+| `per_node` | One process per node (default); supports node-local or distributed TP/PP      |
+| `per_gpu`  | One process per DP rank/GPU (deprecated compatibility mode)                   |
 
-`per_gpu` remains the compatibility default for now, but srtslurm will switch
-the default to `per_node` in a future release. Existing vLLM DP configurations
-should set `backend.dp_launch_mode: per_node` now; srtslurm emits a
-configuration-time migration warning while they still use `per_gpu`.
+Set `backend.dp_launch_mode: per_gpu` only when temporarily preserving the
+legacy process layout. srtslurm emits a configuration-time deprecation warning
+for Dynamo-backed DP configurations that select it. `per_gpu` will be removed
+in a future release.
 
 When `TP x PP` fits on one node, srtslurm derives
 `--data-parallel-size-local` and `--data-parallel-start-rank`, then enables

--- a/src/srtctl/backends/vllm.py
+++ b/src/srtctl/backends/vllm.py
@@ -239,7 +239,6 @@ class VLLMProtocol:
           connector: nixl  # translated to --kv-transfer-config JSON
           allow_prefill_decode_colocation: true  # pack P/D on one node when all workers fit
           allow_prefill_decode_colocation_across_nodes: true  # continue packing on later nodes
-          dp_launch_mode: per_node  # one process manages all local DP ranks
           prefill_environment:
             PYTHONUNBUFFERED: "1"
           vllm_config:
@@ -293,12 +292,11 @@ class VLLMProtocol:
     # node pools. Defaults off to preserve the original one-node-only policy.
     allow_prefill_decode_colocation_across_nodes: bool = False
 
-    # DP process layout. Keep the existing per-GPU behavior by default;
-    # per-node lets vLLM manage the node-local portion of a DP x TP x PP
-    # topology in one CUDA namespace and derives cross-node TP/PP rendezvous
-    # when a replica is larger than the node-local GPU allocation.
-    # TODO: Change the default to per_node after the per_gpu migration window.
-    dp_launch_mode: DPLaunchMode = "per_gpu"
+    # DP process layout. Per-node lets vLLM manage the node-local portion of a
+    # DP x TP x PP topology in one CUDA namespace and derives cross-node TP/PP
+    # rendezvous when a replica is larger than the node-local GPU allocation.
+    # Per-GPU remains available as a deprecated compatibility layout.
+    dp_launch_mode: DPLaunchMode = "per_node"
 
     Schema: ClassVar[builtins.type[Schema]] = Schema
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -63,7 +63,7 @@ def _vllm_health_entries(
 ) -> int:
     """Return expected Dynamo generate registrations for a vLLM worker mode."""
     dp_size = _vllm_data_parallel_size(config, mode)
-    dp_launch_mode = getattr(config.backend, "dp_launch_mode", "per_gpu")
+    dp_launch_mode = getattr(config.backend, "dp_launch_mode", "per_node")
     if dp_size > 1 and dp_launch_mode == "per_node":
         if backend_processes is None:
             raise ValueError("backend_processes are required for per-node DP health expectations")

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1730,7 +1730,7 @@ class SrtConfig:
         self._warn_dp_launch_mode()
 
     def _warn_dp_launch_mode(self):
-        """Nudge vLLM DP recipes toward the per-node launch topology.
+        """Warn when a vLLM DP recipe selects the deprecated per-GPU layout.
 
         Skipped for frontend.type: vllm, where the setting has no effect —
         `vllm serve` owns the local DP ranks, so the layout is one process per
@@ -1746,8 +1746,8 @@ class SrtConfig:
             return
 
         logger.warning(
-            "vLLM DP mode(s) %s use dp_launch_mode=per_gpu. per_node is the recommended topology "
-            "and will become the default in a future release; set backend.dp_launch_mode: per_node now",
+            "vLLM DP mode(s) %s use deprecated dp_launch_mode=per_gpu; "
+            "use backend.dp_launch_mode: per_node instead. per_gpu will be removed in a future release",
             ", ".join(mode_name for mode_name, _ in dp_modes),
         )
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1778,6 +1778,7 @@ class TestVLLMPrefillDecodeColocation:
 
         backend = VLLMProtocol(
             allow_prefill_decode_colocation=True,
+            dp_launch_mode="per_gpu",
             vllm_config=VLLMServerConfig(
                 prefill={"data-parallel-size": 4, "enable-expert-parallel": True},
                 decode={"data-parallel-size": 4, "enable-expert-parallel": True},
@@ -2433,15 +2434,16 @@ class TestVLLMDataParallelMode:
         assert backend_dp._is_dp_mode("decode") is True
         assert backend_dp._get_dp_size("prefill") == 16
 
-    def test_dp_mode_creates_per_gpu_processes(self):
-        """Test that DP mode creates one process per GPU instead of per node."""
+    def test_dp_per_gpu_mode_creates_per_gpu_processes(self):
+        """The deprecated compatibility mode still creates one process per GPU."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
         from srtctl.core.topology import Endpoint
 
         backend = VLLMProtocol(
+            dp_launch_mode="per_gpu",
             vllm_config=VLLMServerConfig(
                 prefill={"data-parallel-size": 16, "enable-expert-parallel": True},
-            )
+            ),
         )
 
         # Create an endpoint spanning 2 nodes with 8 GPUs each = 16 GPUs total
@@ -2478,13 +2480,12 @@ class TestVLLMDataParallelMode:
         dp_ranks = [p.node_rank for p in processes]
         assert dp_ranks == list(range(16))
 
-    def test_dp_per_node_mode_creates_per_node_processes(self):
-        """Per-node DP owns all local GPUs and reserves rank-sized port blocks."""
+    def test_dp_mode_defaults_to_per_node_processes(self):
+        """DP defaults to one process per node with rank-sized port blocks."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
         from srtctl.core.topology import Endpoint
 
         backend = VLLMProtocol(
-            dp_launch_mode="per_node",
             vllm_config=VLLMServerConfig(
                 prefill={"data-parallel-size": 8, "enable-expert-parallel": True},
             ),
@@ -2740,15 +2741,16 @@ class TestVLLMDataParallelMode:
         profiler_config = json.loads(cmd[cmd.index("--profiler-config") + 1])
         assert profiler_config == {"profiler": "cuda", "delay_iterations": 10, "max_iterations": 15}
 
-    def test_dp_mode_allocates_unique_ports_for_multiple_endpoints_per_node(self):
-        """Test DP endpoints sharing a node get non-colliding coordination ports."""
+    def test_dp_per_gpu_mode_allocates_unique_ports_for_multiple_endpoints_per_node(self):
+        """Legacy per-GPU endpoints sharing a node get distinct port ranges."""
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
         from srtctl.core.topology import Endpoint
 
         backend = VLLMProtocol(
+            dp_launch_mode="per_gpu",
             vllm_config=VLLMServerConfig(
                 decode={"data-parallel-size": 4, "enable-expert-parallel": True},
-            )
+            ),
         )
 
         endpoints = [
@@ -2780,8 +2782,8 @@ class TestVLLMDataParallelMode:
         assert [p.node_rank for p in first_endpoint] == list(range(4))
         assert [p.node_rank for p in second_endpoint] == list(range(4))
 
-    def test_dp_mode_command_includes_dp_flags(self):
-        """Test that DP mode command includes correct DP flags instead of TP flags."""
+    def test_dp_per_gpu_mode_command_includes_dp_flags(self):
+        """Legacy per-GPU commands include per-rank DP flags instead of TP flags."""
         from pathlib import Path
         from unittest.mock import MagicMock, patch
 
@@ -2789,13 +2791,14 @@ class TestVLLMDataParallelMode:
         from srtctl.core.topology import Process
 
         backend = VLLMProtocol(
+            dp_launch_mode="per_gpu",
             vllm_config=VLLMServerConfig(
                 prefill={
                     "data-parallel-size": 16,
                     "data-parallel-rpc-port": 13345,
                     "enable-expert-parallel": True,
                 },
-            )
+            ),
         )
 
         # Create a process representing GPU 5 with dp_rank=5
@@ -4237,8 +4240,8 @@ class TestDirectVllmMultiNode:
 
         assert "dp_launch_mode" not in caplog.text
 
-    def test_dp_launch_mode_warning_still_fires_for_dynamo(self, caplog):
-        """The advisory is still useful where the setting picks the process layout."""
+    def test_deprecated_per_gpu_warning_fires_for_dynamo(self, caplog):
+        """Explicit per-GPU compatibility mode warns Dynamo users to migrate."""
         import logging
 
         from srtctl.backends import VLLMProtocol, VLLMServerConfig
@@ -4250,10 +4253,13 @@ class TestDirectVllmMultiNode:
                 model=ModelConfig(path="/m", container="/c.sqsh", precision="fp4"),
                 resources=ResourceConfig(gpu_type="b200", gpus_per_node=8, agg_nodes=2, agg_workers=1),
                 frontend=FrontendConfig(type="dynamo"),
-                backend=VLLMProtocol(vllm_config=VLLMServerConfig(aggregated={"data-parallel-size": 16})),
+                backend=VLLMProtocol(
+                    dp_launch_mode="per_gpu",
+                    vllm_config=VLLMServerConfig(aggregated={"data-parallel-size": 16}),
+                ),
             )
 
-        assert "dp_launch_mode=per_gpu" in caplog.text
+        assert "deprecated dp_launch_mode=per_gpu" in caplog.text
 
     def test_direct_vllm_keeps_api_server_count_on_leader_only(self):
         """vLLM rejects --api-server-count alongside --headless, so only rank 0 keeps it.

--- a/tests/test_health_expectations.py
+++ b/tests/test_health_expectations.py
@@ -16,7 +16,7 @@ def _config(
     num_decode=0,
     num_agg=0,
     vllm_config=None,
-    dp_launch_mode="per_gpu",
+    dp_launch_mode="per_node",
 ):
     """Build a duck-typed stand-in for SrtConfig with only the fields the helpers read."""
     backend = SimpleNamespace(type=backend_type, vllm_config=vllm_config, dp_launch_mode=dp_launch_mode)
@@ -43,14 +43,21 @@ def _processes(*, prefill=0, decode=0, agg=0, gpu_count=None):
     ]
 
 
-def test_dynamo_vllm_disagg_multiplies_by_data_parallel_size():
-    """6xDEP2 + 1xDEP8: Dynamo registers one generate instance per DP rank."""
+def test_dynamo_vllm_per_gpu_disagg_multiplies_by_data_parallel_size():
+    """Legacy per-GPU DP registers one generate instance per DP rank."""
     vllm_config = SimpleNamespace(
         prefill={"data-parallel-size": 2},
         decode={"data-parallel-size": 8},
         aggregated=None,
     )
-    config = _config("dynamo", "vllm", num_prefill=6, num_decode=1, vllm_config=vllm_config)
+    config = _config(
+        "dynamo",
+        "vllm",
+        num_prefill=6,
+        num_decode=1,
+        vllm_config=vllm_config,
+        dp_launch_mode="per_gpu",
+    )
 
     n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(config)
 
@@ -58,10 +65,16 @@ def test_dynamo_vllm_disagg_multiplies_by_data_parallel_size():
     assert count_desc == "12P + 8D Dynamo generate instances; logical workers: 6P + 1D"
 
 
-def test_dynamo_vllm_aggregated_multiplies_by_data_parallel_size():
-    """Aggregated workers register as decode instances, one per DP rank."""
+def test_dynamo_vllm_per_gpu_aggregated_multiplies_by_data_parallel_size():
+    """Legacy per-GPU aggregate workers register once per DP rank."""
     vllm_config = SimpleNamespace(prefill=None, decode=None, aggregated={"data-parallel-size": 8})
-    config = _config("dynamo", "vllm", num_agg=1, vllm_config=vllm_config)
+    config = _config(
+        "dynamo",
+        "vllm",
+        num_agg=1,
+        vllm_config=vllm_config,
+        dp_launch_mode="per_gpu",
+    )
 
     n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(config)
 
@@ -82,7 +95,6 @@ def test_dynamo_vllm_per_node_disagg_counts_node_processes():
         num_prefill=3,
         num_decode=1,
         vllm_config=vllm_config,
-        dp_launch_mode="per_node",
     )
 
     n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(config, _processes(prefill=6, decode=4))


### PR DESCRIPTION
## Summary

- make `backend.dp_launch_mode: per_node` the default for vLLM data-parallel endpoints
- retain explicit `per_gpu` as a deprecated compatibility layout
- emit a configuration-time migration warning when Dynamo-backed DP configs select `per_gpu`
- align health-count fallbacks, documentation, and topology tests with the new default

## Why

PR #277 introduced the migration warning and announced that `per_node` would become the default. Merged PR #327 makes the per-node launcher topology-aware for regular `DP x TP x PP` deployments, including TP/PP replicas that span nodes, so the compatibility default is no longer needed.

This PR completes that migration. Existing configurations can temporarily preserve the old one-process-per-rank layout with:

```yaml
backend:
  dp_launch_mode: per_gpu
```

That setting now warns and will be removed in a future release.

This supersedes the older draft #272, which predated topology-aware TP/PP support and used a different compatibility knob.

## Validation

- full post-rebase test suite: 1,434 passed, 2 skipped, 6 deselected
- focused config and health suite: 203 passed
- Ruff source check and format check passed
- `git diff --check` passed
