### PR TITLE
fix(trtllm): add numa_cpu_bind to bind worker ranks per NUMA domain

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -87,6 +87,24 @@ class TRTLLMProtocol:
     # gpu_type.
     numa_memory_bind: bool | None = None
 
+    # Whether to bind each worker rank to its own NUMA locality domain via
+    # srun --cpu-bind=rank_ldom. None (default) preserves the existing
+    # unbound behavior. True enables per-rank NUMA binding; False forces it off.
+    #
+    # On hosts with many NUMA domains this matters a great deal. Measured on
+    # b300 (AMD EPYC 9575F, 8 NUMA domains, 8 gen ranks/node) with GLM-5.2
+    # disaggregated decode, binding as the only variable:
+    #     unbound          decode p50 70.4 ms
+    #     rank_ldom bound  decode p50 14.1 ms   (5.0x, matches aggregated 14.0 ms)
+    # The cost is host-side input prep (prepare_for_spec_decode) contending
+    # across NUMA domains when ranks are free to migrate; the tail is also
+    # heavily skewed unbound, which shows up as a rotating straggler.
+    #
+    # Requires the whole node to be allocated -- srun rejects rank_ldom with
+    # "Entire node must be allocated" otherwise -- so enable it together with
+    # use_exclusive_sbatch_directive.
+    numa_cpu_bind: bool | None = None
+
     Schema: ClassVar[builtins.type[Schema]] = Schema
 
     # =========================================================================
@@ -97,11 +115,15 @@ class TRTLLMProtocol:
         """TRTLLM uses MPI-style launching (one srun per endpoint with all nodes)."""
         from srtctl.backends.base import SrunConfig
 
+        # rank_ldom binds task i to NUMA locality domain i. Default (None) keeps
+        # the historical unbound behavior so existing clusters are unaffected.
+        cpu_bind = "verbose,rank_ldom" if self.numa_cpu_bind else "verbose,none"
+
         return SrunConfig(
             mpi="pmix",
             oversubscribe=True,
             launch_per_endpoint=True,
-            cpu_bind="verbose,none",
+            cpu_bind=cpu_bind,
         )
 
     def get_config_for_mode(self, mode: WorkerMode) -> dict[str, Any]:


### PR DESCRIPTION
`TrtllmBackend.get_srun_config()` hardcodes `cpu_bind="verbose,none"` (`src/srtctl/backends/trtllm.py`), which disables CPU binding for every TRT-LLM run. On hosts with many NUMA domains the worker ranks are then free to migrate, and they contend.

## Measurement

b300 (AMD EPYC 9575F, **8 NUMA domains**, 8 gen ranks/node), GLM-5.2 NVFP4 disaggregated decode. Configs byte-identical; binding is the only variable:

| | decode p50 |
|---|---|
| unbound (current behaviour) | **70.4 ms** |
| `--cpu-bind=rank_ldom` | **14.1 ms** (n=826, p99 14.2) |
| aggregated, same hardware | 14.0 ms |
| reference cluster (2 NUMA domains) | 13.9 ms |

**5.0x**, landing on the aggregated figure.

## Root cause

The cost is host-side input prep — `prepare_for_spec_decode` (`dsa.py:1480-1487`), which nsys shows is **99.8% pure CPU Python** (0.4 ms of CUDA runtime in a 256 ms range). A standalone reproducer of those exact statements:

| | |
|---|---|
| 1 rank on an idle node | **0.22 ms** |
| 8 ranks on one node, unbound | **35–56 ms, skewed** (two ranks stay fast) |
| 8 ranks, bound | **0.21 ms, uniform** |

The skew is what presents in production as a rotating straggler: all ranks stall together in the per-iteration MPI collectives waiting on whichever rank is slowest that iteration.

The comparison that isolates it: a 2-NUMA-domain reference host runs the same bench at **1.14–1.40 ms uniform** despite being **2.2x slower single-threaded** (31.2 µs vs 14.1 µs on a fixed CPU loop). It is NUMA topology, not CPU speed — and the b300 host is the faster machine once ranks stop migrating.

NIXL, MPI/UCX transport (15 µs synchronized allgather), GIL contention, request starvation and the disagg path itself were each excluded on measurement.

## Change

Adds `numa_cpu_bind: bool | None = None`, mirroring the existing `numa_memory_bind` option:

- `None` (default) — unchanged behaviour, no existing cluster is affected
- `True` — `--cpu-bind=verbose,rank_ldom` (task *i* → NUMA domain *i*)
- `False` — forces off

## Notes for reviewers

- `rank_ldom` **requires the whole node**; srun rejects it with `Entire node must be allocated` otherwise. Pair with `use_exclusive_sbatch_directive` (schema default is False).
- I also tried wrapping the worker in `numactl --cpunodebind` — **do not**: it breaks MPI startup (7 of 8 `mgmn_worker_node` processes die and rank 0 hangs at `MpiCommSession`). Binding must come from srun.
- `--mem-bind=local` is deliberately not included: it OOM-killed the prefill worker, whose host KV pool exceeds one NUMA domain, and a microbenchmark showed memory binding alone gives no benefit. First-touch already places pages locally once threads are CPU-bound.

