### PR TITLE
feat(analysis): build the perf dashboard on every run

### DIFF
--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -21,17 +21,10 @@ from a repo checkout.
 
 ---
 
-## Quick start — one run, built automatically
+## Quick start — nothing to turn on
 
-Set the analytics knob in the recipe and the dashboard is produced by the job itself:
-
-```yaml
-observability:
-  enabled: true          # capture + build the dashboard
-  # build_dashboard: false   # capture only, skip rendering
-```
-
-Post-processing then writes, into the run's log dir:
+**Every job builds its own dashboard.** There is no knob and nothing to remember:
+post-processing writes, into the run's log dir:
 
 ```
 perf_dashboard.html          self-contained page (D3 inlined, no network needed)
@@ -50,6 +43,20 @@ is logged and never changes the outcome of a benchmark that already produced res
 
 Nothing else is required. One `srtctl` submission collects the data, post-processes it
 and renders the page, in that order, inside the job.
+
+What `observability.enabled` changes is **which tabs the page carries**, not whether
+there is a page:
+
+```yaml
+observability:
+  enabled: true          # adds the server-side capture legs — see the table below
+```
+
+Without it the page is built from the client's own metrics export, the per-iteration
+worker logs and the frontend log: **Frontend / Router / Engine / Log-analysis**.
+Turning it on adds the scraped `/metrics` stream and the `SPAN_CLOSED` traces, and
+with them the **Overview** tab. Either way there is a dashboard, because the question
+it answers is asked *after* the run, when opting in is no longer possible.
 
 ### Comparing two runs
 
@@ -148,19 +155,22 @@ network — copy it anywhere.
 
 ## Capturing the inputs
 
-Everything the dashboard reads is produced by **one recipe knob**:
+The dashboard reads whatever the run happens to have. Four of the eight legs below do
+not depend on `observability.enabled` at all; that knob is what adds the other four:
 
 ```yaml
 observability:
   enabled: true
 ```
 
-That expands (see `ObservabilityConfig` in `src/srtctl/core/schema.py`) into the
-capture legs below. Without it you still get the Log-analysis tab, and nothing else.
+It expands (see `ObservabilityConfig` in `src/srtctl/core/schema.py`) into the legs
+marked with it below. Without it the Metrics leg falls back to the client's own
+export, and the page is built without the traces — so it keeps every time-series tab
+and loses Overview.
 
 | Leg | Recipe requirement | Artifact | Bundle output | Feeds |
 | --- | ------------------ | -------- | ------------- | ----- |
-| **Metrics** | `observability.enabled` | `<log_dir>/raw_prometheus.jsonl` | `server_metrics_export.jsonl` | every time-series panel |
+| **Metrics** | `observability.enabled`, else the client's own export | `<log_dir>/raw_prometheus.jsonl`, else `<log_dir>/agentic/*/…/server_metrics_export.json` | `server_metrics_export.jsonl` | every time-series panel |
 | **Request trace** | `observability.enabled` | `<log_dir>/dynamo-request-trace` | `request_trace.jsonl` | per-request card, per-session view, the waterfall's KV-transfer band |
 | **Per-iteration** | `print_iter_log: true` in the engine config | `SPAN`-free lines in `<log_dir>/*_w*.out` | `iter_bins.json` | batch composition, host/device step time |
 | **Traces** | `observability.enabled` **and** an AIPerf benchmark | `SPAN_CLOSED` lines in `<log_dir>/*.out` | `tempo_traces/<xid>.json` | Overview, routing outcome on the card |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1054,10 +1054,11 @@ Set `scrape_metrics: false` beside `enabled` to use Tachometer without also writ
 | `scrape_metrics` | bool/null | `null` | Override raw capture; `null` follows `enabled` |
 | `scrape_interval_seconds` | float | `1.0` | Interval between raw Prometheus scrape sweeps |
 | `scrape_output` | string | `raw_prometheus.jsonl` | Raw capture filename below the run log directory |
-| `build_dashboard` | bool/null | `null` | Build the component perf dashboard in post-processing; `null` follows `enabled`. See [Component Performance Dashboard](component-dashboard.md) |
 | `enable_otel` | bool | `false` | Inject OTEL tracing environment variables |
 | `otel_endpoint` | string/null | `null` | OTEL collector endpoint |
 | `tachometer` | object | `enabled: false` | Native Tachometer collection settings |
+
+The component perf dashboard is **not** configured here. It is built in post-processing on every run; `enabled` decides which capture legs exist and therefore which tabs the page carries. See [Component Performance Dashboard](component-dashboard.md).
 
 Tachometer always collects worker and frontend metrics. DCGM and node exporters are optional additions:
 

--- a/src/srtctl/analysis/perf_dashboard.py
+++ b/src/srtctl/analysis/perf_dashboard.py
@@ -3,12 +3,19 @@
 
 """Post-run bridge: a finished run's log dir -> component perf dashboard.
 
-Closes the loop that ``observability.enabled`` opens. That knob makes a run *emit*
-every signal the offline tooling wants -- ``raw_prometheus.jsonl``, ``SPAN_CLOSED``
-lines on the worker/frontend logs, the frontend's own request-trace records -- but
-nothing consumed them, so reading a run still meant hand-driving two scripts from a
-checkout. This module runs them at the end of the job instead, so one submission
-produces the page.
+Runs on **every** job, with no opt-in. Reading a run used to mean hand-driving two
+scripts from a checkout against a log dir; this module runs them at the end of the
+job instead, so one submission produces the page.
+
+Unconditional because the page is not a special-occasion artifact: the question it
+answers -- where did the time go, which component was the ceiling -- is the one
+asked of every run, and it is asked *after* the run, when opting in is no longer
+possible. A knob would only ever be discovered by the person who already knew.
+
+``observability.enabled`` decides which capture legs exist and therefore which tabs
+the page carries; it never decides whether the page exists. A run with no
+server-side capture at all still renders from the client's own metrics export, the
+per-iteration log and the frontend log -- which is the shape most runs have.
 
 It drives the two vendored layers as SUBPROCESSES:
 
@@ -226,20 +233,21 @@ def build(config: SrtConfig, runtime: RuntimeContext) -> Path | None:
 
 
 def try_build(config: SrtConfig, runtime: RuntimeContext) -> Path | None:
-    """Build the dashboard if the run opted in, else return None.
+    """Build the dashboard for a finished run. Returns the HTML path, or None.
 
     Single entry point for :class:`PostProcessStageMixin`, so the mixin stays free of
     analysis-package internals -- the same contract as
     :func:`srtctl.analysis.metrics_scraper.try_start_raw_scraper`.
 
-    Gated on ``observability.build_dashboard``, which defaults to following
-    ``observability.enabled``: a run instrumented for offline analysis should produce
-    the artifact that analysis is done with, without a second knob to remember.
+    Unconditional: there is no opt-in to check. What differs between runs is which
+    legs :func:`build` finds, and that is the ingest's decision to make from the log
+    dir rather than a recipe's to declare in advance.
+
+    With no gate left, this ``except`` is the only thing standing between a bug in
+    third-party rendering code and the post-processing of a benchmark that has
+    already produced its results -- so it stays broad on purpose.
     """
     try:
-        observability = getattr(config, "observability", None)
-        if observability is None or not getattr(observability, "dashboard_enabled", False):
-            return None
         return build(config, runtime)
     except Exception as e:  # noqa: BLE001 - visualisation is never fatal
         logger.warning("perf dashboard: skipped after error: %s", e)

--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -206,10 +206,10 @@ class PostProcessStageMixin:
         # Keep the prepared bundle inside logs/ so the existing S3 sync below
         # transfers it with the raw benchmark artifacts.
         self._normalize_ruter()
-        # Build the component perf dashboard (optional). Deliberately ordered BEFORE
-        # the S3 sync below: the sync ships the whole log dir, so building here is what
-        # gets perf_dashboard.{html,json} and its bundle off the cluster. Building
-        # after would leave them behind on a node whose /lustre scratch is transient.
+        # Build the component perf dashboard. Deliberately ordered BEFORE the S3 sync
+        # below: the sync ships the whole log dir, so building here is what gets
+        # perf_dashboard.{html,json} and its bundle off the cluster. Building after
+        # would leave them behind on a node whose /lustre scratch is transient.
         self._build_perf_dashboard()
 
         # Run srtlog + S3 upload in single container (if S3 configured)
@@ -252,18 +252,18 @@ class PostProcessStageMixin:
             logger.warning("ruter normalization failed: %s", error)
 
     def _build_perf_dashboard(self) -> None:
-        """Render the component perf dashboard from this run's own capture.
+        """Render the component perf dashboard from this run's own artifacts.
 
-        Closes the loop `observability.enabled` opens: that knob makes the run emit
-        raw_prometheus.jsonl, SPAN_CLOSED lines and the frontend request-trace, and
-        this turns them into `<log_dir>/perf_dashboard.{html,json}` plus the
-        intermediate bundle — so one submission yields the page, with no second
-        hand-driven step from a checkout.
+        Turns whatever the run captured — `raw_prometheus.jsonl` or the client's own
+        metrics export, SPAN_CLOSED lines, the request trace, the per-iteration log —
+        into `<log_dir>/perf_dashboard.{html,json}` plus the intermediate bundle, so
+        one submission yields the page with no second hand-driven step from a
+        checkout.
 
-        Gated on `observability.build_dashboard`, which follows `observability.enabled`
-        by default. Best-effort: `try_build` swallows its own failures, and the extra
-        guard here means even an import error cannot fail a benchmark that has already
-        produced results.
+        Runs on every job; `observability.enabled` changes which tabs the page carries,
+        not whether it is built. Best-effort: `try_build` swallows its own failures,
+        and the extra guard here means even an import error cannot fail a benchmark
+        that has already produced results.
         """
         try:
             from srtctl.analysis.perf_dashboard import try_build

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1083,6 +1083,13 @@ class ObservabilityConfig:
     directly. It never reaches into the benchmark client to ask it to re-export
     what the servers already publish.
 
+    It does **not** decide whether the component perf dashboard is built. That
+    happens on every run (see :mod:`srtctl.analysis.perf_dashboard`); ``enabled``
+    only decides which capture legs exist and therefore which tabs the page
+    carries. Keeping the two separate is deliberate: a run that captured nothing
+    server-side still renders from the client export and the per-iteration log,
+    and that is the shape most runs have.
+
     Attributes:
         enabled: Master analytics knob. Default: False.
         enable_otel: If True, inject OTEL environment variables into all workers
@@ -1096,11 +1103,6 @@ class ObservabilityConfig:
             back-to-back rather than queueing (see the drift-free pacing in
             ``RawMetricsScraper``).
         scrape_output: Filename (under the run's log dir) for the RAW capture.
-        build_dashboard: Build the component perf dashboard during post-processing
-            (``<log_dir>/perf_dashboard.html`` plus a ``.json`` payload and the
-            intermediate bundle). Defaults to the value of ``enabled`` -- a run
-            instrumented for offline analysis should produce the artifact that
-            analysis is done with. Set False to capture without rendering.
         tachometer: Optional native Tachometer capture configuration. It runs
             alongside RAW capture when both are enabled.
     """
@@ -1112,7 +1114,6 @@ class ObservabilityConfig:
     scrape_metrics: bool | None = None
     scrape_interval_seconds: float = 1.0
     scrape_output: str = "raw_prometheus.jsonl"
-    build_dashboard: bool | None = None
     tachometer: TachometerConfig = field(default_factory=TachometerConfig)
 
     Schema: ClassVar[type[Schema]] = Schema
@@ -1121,11 +1122,6 @@ class ObservabilityConfig:
     def scraper_enabled(self) -> bool:
         """Whether the in-job RAW Prometheus scraper should run."""
         return self.enabled if self.scrape_metrics is None else self.scrape_metrics
-
-    @property
-    def dashboard_enabled(self) -> bool:
-        """Whether to build the component perf dashboard during post-processing."""
-        return self.enabled if self.build_dashboard is None else self.build_dashboard
 
 
 @dataclass(frozen=True)

--- a/tests/test_component_dashboard.py
+++ b/tests/test_component_dashboard.py
@@ -440,13 +440,11 @@ class TestRenderComponentDashboard:
 # ---------------------------------------------------------------------------
 
 
-def _stub_config(*, enabled=True, build_dashboard=None, prefill=(1, 4), decode=(3, 8)):
+def _stub_config(*, enabled=True, prefill=(1, 4), decode=(3, 8)):
     """Minimal stand-in for SrtConfig carrying only what perf_dashboard reads."""
     from srtctl.core.schema import ObservabilityConfig
 
-    obs = ObservabilityConfig.Schema().load(
-        {"enabled": enabled} if build_dashboard is None else {"enabled": enabled, "build_dashboard": build_dashboard}
-    )
+    obs = ObservabilityConfig.Schema().load({"enabled": enabled})
     return SimpleNamespace(
         name="unit-test-run",
         observability=obs,
@@ -486,18 +484,40 @@ class TestPerfDashboardPipeline:
         cfg.resources.num_agg, cfg.resources.gpus_per_agg = 6, 4
         assert _worker_specs(cfg) == ["agg=tep:4:6"]
 
-    def test_try_build_is_a_noop_when_not_opted_in(self, tmp_path: Path):
-        from srtctl.analysis.perf_dashboard import try_build
+    def test_build_is_not_gated_on_observability(self, tmp_path: Path, monkeypatch):
+        """The page is built for every run. `observability.enabled` selects which
+        capture legs exist -- which tabs appear -- never whether there is a page:
+        a run with no server-side capture still has a client export and an
+        iteration log to render, and it is the run you cannot re-instrument."""
+        import srtctl.analysis.perf_dashboard as pd
 
+        sentinel = tmp_path / "perf_dashboard.html"
+        seen: list[bool] = []
+
+        def _record(config, runtime):
+            seen.append(config.observability.enabled)
+            return sentinel
+
+        monkeypatch.setattr(pd, "build", _record)
         runtime = SimpleNamespace(log_dir=tmp_path, job_id="12345")
-        assert try_build(_stub_config(enabled=False), runtime) is None
-        assert not (tmp_path / "perf_dashboard.html").exists()
 
-    def test_build_dashboard_false_overrides_observability_enabled(self, tmp_path: Path):
-        from srtctl.analysis.perf_dashboard import try_build
+        assert pd.try_build(_stub_config(enabled=False), runtime) is sentinel
+        assert pd.try_build(_stub_config(enabled=True), runtime) is sentinel
+        assert seen == [False, True], "both arms must reach build()"
 
+    def test_try_build_swallows_a_rendering_failure(self, tmp_path: Path, monkeypatch):
+        """With no opt-in gate left, this guard is the only thing between a bug in
+        third-party rendering code and the post-processing of a benchmark that has
+        already produced its results."""
+        import srtctl.analysis.perf_dashboard as pd
+
+        def _boom(config, runtime):
+            raise RuntimeError("renderer exploded")
+
+        monkeypatch.setattr(pd, "build", _boom)
         runtime = SimpleNamespace(log_dir=tmp_path, job_id="12345")
-        assert try_build(_stub_config(enabled=True, build_dashboard=False), runtime) is None
+
+        assert pd.try_build(_stub_config(), runtime) is None
         assert not (tmp_path / "perf_dashboard.html").exists()
 
     def test_end_to_end_one_run_produces_the_dashboard(self, run_dir: Path):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -203,6 +203,16 @@ class TestExpandObservability:
         with pytest.raises(ValidationError, match="storage_subdir"):
             SrtConfig.Schema().load(cfg)
 
+    def test_retired_build_dashboard_knob_is_rejected(self):
+        """The perf dashboard is built on every run, so the knob that used to gate it
+        is gone. A recipe still carrying it must fail at submit time: silently
+        accepting `build_dashboard: false` would promise a capture-only run and then
+        render one anyway."""
+        cfg = _trtllm_config(enabled=True, build_dashboard=False)
+
+        with pytest.raises(ValidationError, match="build_dashboard"):
+            SrtConfig.Schema().load(cfg)
+
     def test_tachometer_requires_master_observability_knob(self):
         cfg = _trtllm_config(enabled=False, tachometer={"enabled": True})
 


### PR DESCRIPTION
## What

Removes `observability.build_dashboard`. The component perf dashboard is now built in
post-processing on **every** run, instead of following the capture knob.

## Why

The gate and the artifact answer different questions.

`observability.enabled` decides which signals a run *emits*. Whether the page gets
rendered from whatever was emitted is not a second decision a recipe should have to make
in advance — and it is a question asked *after* the run, when opting in is no longer
possible. A gate there is only ever found by someone who already knew about it.

The gate also had a shape that read backwards. `dashboard_enabled` followed `enabled`,
so a run captured **without** observability produced no page at all unless you also knew
to write `build_dashboard: true` — precisely the run that cannot be re-instrumented, and
precisely the run #330 taught the renderer to handle.

And since #330 there is no run shape for which building produces nothing useful:

| | `observability.enabled: false` | `observability.enabled: true` |
| --- | --- | --- |
| metrics source | the client's own `server_metrics_export.json` | scraped `raw_prometheus.jsonl` |
| tabs | Frontend, Router, Engine, Log-analysis | **+ Overview** |

(Measured on lyris `2757710` / `2757709` in #330 — 97 panels / 368 paths and 99 panels /
401 paths respectively, both by the in-job hook, 0 JS errors either side.)

So `observability.enabled` now changes **which tabs the page carries**, never whether the
page exists.

## The change

* `ObservabilityConfig.build_dashboard` and the `dashboard_enabled` property are gone.
* `try_build` drops the opt-in check and keeps its broad `except`. With the gate gone that
  guard is the only thing between a bug in the vendored renderer and the post-processing
  of a benchmark that has already produced results, so its docstring now says that is its
  whole job.
* `PostProcessStageMixin._build_perf_dashboard` is unchanged in behaviour — it already
  called `try_build` unconditionally; only the docstring and the `(optional)` comment on
  the call site were describing a gate that no longer exists.

## Breaking change

A recipe still setting `observability.build_dashboard` now fails schema validation:

```
ValidationError: {'observability': {'build_dashboard': ['Unknown field.']}}
```

**Migration: delete the line.** The dashboard is built either way.

This fails at *submit* time, before any GPU time is spent, which is why it is a hard error
rather than a warn-and-ignore shim: the knob is two days old (#330, merged 2026-08-22),
nothing in-tree ever set it (`git grep build_dashboard -- '*.yaml'` is empty), and silently
accepting `build_dashboard: false` would promise a capture-only run and then render one
anyway. Happy to add a deprecation shim instead if reviewers would rather.

There is deliberately **no replacement escape hatch**. The cost is one ingest + one render
subprocess per job, after results are already produced and written — 16 s and 44 s on the
two runs above. If a "capture only" mode is wanted later it should be a CLI flag on the
run, not a recipe field, since it is an operator's choice and not a property of the recipe.

## Docs

Two claims in `docs/component-dashboard.md` that the unconditional behaviour invalidates,
both corrected:

1. The quick start told you to set `observability.enabled: true` to get a dashboard. There
   is now nothing to set.
2. "Without it you still get the Log-analysis tab, and nothing else." Stale since #330 —
   and it already contradicted its own leg table, four rows of which never depended on
   `observability.enabled`. The Metrics row now names the AIPerf-export fallback that
   `--metrics auto` selects.

`docs/config-reference.md` loses the `build_dashboard` row and gains a line saying the
dashboard is not configured there.

## Tests

`make check` — 1435 passed, 2 skipped. Replacing the two tests that asserted the gate:

* `test_build_is_not_gated_on_observability` — both arms of `observability.enabled` reach
  `build()`.
* `test_try_build_swallows_a_rendering_failure` — a raising `build` still returns `None`
  and writes nothing, since that guard is now load-bearing on its own.
* `test_retired_build_dashboard_knob_is_rejected` — pins the removal, so the field cannot
  come back silently, and documents the migration error.

Not run on a live SLURM job: the code path exercised here is the same `try_build` that
#330 verified in-job on `2757709`/`2757710`, with one branch deleted from it.
