### PR TITLE
trtllm: allow extra trtllm-serve CLI flags; forward srun_options to MPI workers

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -64,6 +64,27 @@ class TRTLLMProtocol:
     decode_environment: dict[str, str] = field(default_factory=dict)
     aggregated_environment: dict[str, str] = field(default_factory=dict)
 
+    # Extra `trtllm-serve` CLI flags per mode, appended verbatim to the worker
+    # command (frontend.type: trtllm_serve only -- dynamo.trtllm takes a
+    # different CLI).
+    #
+    # `trtllm_config` already covers everything that belongs in the engine YAML,
+    # which is nearly everything: trtllm-serve merges that file into LlmArgs. But
+    # a few of its options configure the OpenAI SERVER layer rather than the
+    # engine and have no LlmArgs field, so no YAML key can reach them. The one
+    # that matters in practice is `--tool_parser` (a click.Choice consumed
+    # directly by the server constructor); note that its sibling
+    # `--reasoning_parser` IS forwarded into get_llm_args() and so remains
+    # settable from `trtllm_config`.
+    #
+    #     backend:
+    #       type: trtllm
+    #       prefill_extra_args: ["--tool_parser", "glm47"]
+    #       decode_extra_args:  ["--tool_parser", "glm47"]
+    prefill_extra_args: list[str] = field(default_factory=list)
+    decode_extra_args: list[str] = field(default_factory=list)
+    aggregated_extra_args: list[str] = field(default_factory=list)
+
     trtllm_config: TRTLLMServerConfig | None = None
 
     # Whether dynamo.trtllm workers pass `--publish-events-and-metrics`.
@@ -132,6 +153,15 @@ class TRTLLMProtocol:
         elif mode == "agg":
             return dict(self.trtllm_config.aggregated or {})
         return {}
+
+    def get_extra_args_for_mode(self, mode: WorkerMode) -> list[str]:
+        """Extra trtllm-serve CLI flags for this mode (see the field docs)."""
+        by_mode: dict[WorkerMode, list[str]] = {
+            "prefill": self.prefill_extra_args,
+            "decode": self.decode_extra_args,
+            "agg": self.aggregated_extra_args,
+        }
+        return list(by_mode.get(mode) or [])
 
     def get_environment_for_mode(self, mode: WorkerMode) -> dict[str, str]:
         eplb_prefix = f"moe_shared_{uuid.uuid4().hex}"
@@ -280,6 +310,7 @@ class TRTLLMProtocol:
             # ai-dynamo tensorrtllm-runtime 1.3.0-dev.1 container, which accept --config;
             # some trtllm-serve builds spell this --extra_llm_api_options.
             cmd.extend(["--config", str(container_config_path)])
+            cmd.extend(self.get_extra_args_for_mode(mode))
             return self._wrap_with_numa_cpu_bind(cmd)
 
         # dynamo.trtllm path (default): workers register into etcd/NATS and the dynamo

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -384,6 +384,11 @@ class WorkerStageMixin:
             mpi=srun_config.mpi,
             oversubscribe=srun_config.oversubscribe,
             cpu_bind=srun_config.cpu_bind,
+            # Endpoint (MPI) workers were the only srun path that dropped the
+            # recipe-level srun_options; the per-process worker, benchmark and
+            # telemetry paths all forward it. Needed so a cluster can express
+            # per-rank CPU/NUMA binding, which srun_config.cpu_bind cannot.
+            srun_options=self.runtime.srun_options,
             het_group=leader.het_group,
         )
 


### PR DESCRIPTION
## What

Two small additions to the trtllm backend, both cluster-agnostic — no site paths,
devices or hostnames.

### 1. `prefill/decode/aggregated_extra_args` (`backends/trtllm.py`, +31)

`trtllm_config` already covers everything that belongs in the engine YAML, which is
almost everything: `trtllm-serve` merges that file into `LlmArgs`. But a few
`trtllm-serve` options configure the OpenAI **server** layer and have no `LlmArgs`
field, so no YAML key can reach them. The one that matters in practice is
`--tool_parser`, a `click.Choice` consumed directly by the server constructor. Its
sibling `--reasoning_parser` *is* forwarded into `get_llm_args()` and therefore stays
settable from `trtllm_config`; only `tool_parser` is unreachable.

Shaped like the existing `master_extra_args` on the sglang and vllm backends.

```yaml
backend:
  type: trtllm
  prefill_extra_args: ["--tool_parser", "glm47"]
  decode_extra_args:  ["--tool_parser", "glm47"]
```

Applies to `frontend.type: trtllm_serve` only; the `dynamo.trtllm` path takes a
different CLI and is untouched.

### 2. Forward `srun_options` to endpoint workers (`cli/mixins/worker_stage.py`, +5)

`start_endpoint_worker()` was the only srun path dropping the recipe-level
`srun_options`; the per-process worker, benchmark and telemetry paths all forward it.
Without it a recipe cannot express per-rank CPU/NUMA binding, which
`srun_config.cpu_bind` cannot encode.

## Why

Reproducing a BTK-produced GLM-5.2 NVFP4 disaggregated benchmark under srtctl. The
reference sets `--tool_parser glm47` on both ctx and gen; without change 1 the
reproduction silently drops a flag the reference uses.

## Note for users of change 2

TensorRT-LLM's `configure_cpu_affinity()` **strips** any externally constrained
affinity unless `TLLM_NUMA_AWARE_WORKER_AFFINITY` is set, so masks delivered this way
may not survive into the workers. Verify in the worker logs:

- `CPU affinity set to [...] for optimal NUMA-aware scheduling` — NUMA binding applied
- `Removing CPU affinity constraints` — your mask was discarded

On an 8-NUMA-domain node this was measured over a full benchmark run to change
throughput by nothing, so treat the mask as advisory until verified on your hardware.

## Testing

Both paths verified on a completed 12-GPU disaggregated run (srtctl job 46586):
`--tool_parser glm47` present in the worker command line, and `cpu-bind=MASK` in the
Slurm verbose output. No behaviour change when the new fields are unset.
