### PR TITLE
docs: document direct Docker lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # srtctl
 
-Command-line tool for distributed LLM inference benchmarks on SLURM clusters using TensorRT LLM, SGLang and vLLM. Replace complex shell scripts and 50+ CLI flags with declarative YAML configuration.
+Command-line tool for distributed LLM inference benchmarks on SLURM clusters and direct GPU hosts using TensorRT LLM, SGLang and vLLM. Replace complex shell scripts and 50+ CLI flags with declarative YAML configuration.
 
 ## Quick Start
 
@@ -24,6 +24,7 @@ make setup ARCH=aarch64  # or ARCH=x86_64
 - [Profiling](docs/profiling.md) - Torch/nsys profiling
 - [Analyzing Results](docs/analyzing.md) - Dashboard and visualization
 - [ruter](docs/ruter.md) - Dynamo router post-processing
+- [Direct Host Lifecycle](docs/direct-host.md) - Run the same recipe directly through Docker
 
 ## Commands
 
@@ -40,8 +41,8 @@ srtctl apply -f config.yaml --tags experiment,baseline
 # Dry-run (validate without submitting)
 srtctl dry-run -f config.yaml
 
-# Emit a direct single-node lifecycle script without submitting
-srtctl apply -f config.yaml --bash > job.sh
+# Render and run one single-node recipe through Docker
+srtctl apply -f config.yaml -o /absolute/path/to/runs --bash > job.sh
 chmod +x job.sh
 ./job.sh
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-`srtctl` is a command-line tool for running distributed LLM inference benchmarks on SLURM clusters. It replaces complex shell scripts and 50+ CLI flags with clean, declarative YAML configuration files.
+`srtctl` is a command-line tool for running distributed LLM inference benchmarks on SLURM clusters or a single direct GPU host. It replaces complex shell scripts and 50+ CLI flags with clean, declarative YAML configuration files.
 
 ## Table of Contents
 
@@ -30,6 +30,8 @@ When you run `srtctl apply -f config.yaml`, the tool:
 3. Generates a SLURM batch script and SGLang configuration files
 4. Submits to SLURM
 
+For a single GPU host, render the same recipe with `srtctl apply -f config.yaml --bash`. The resulting launcher owns a Docker serving container on the current host instead of submitting to SLURM. It uses the same topology and lifecycle plan, including worker/router readiness, Tachometer, benchmark execution, and ruter post-processing where configured. See [Direct Host Lifecycle](direct-host.md) for requirements and a complete example.
+
 The `srtctl-mcp` server is different from `srtctl apply`: it is a schema and
 recipe-authoring helper. It does not use host-side `srtslurm.yaml` for cluster
 defaults, aliases, containers, model paths, filesystem checks, or dry-run
@@ -46,11 +48,13 @@ Once allocated, workers launch inside containers, discover each other through ET
 | `srtctl apply -f <config> --setup-script <script>` | Submit with custom setup script         |
 | `srtctl apply -f <config> --tags tag1,tag2`        | Submit with tags for filtering          |
 | `srtctl dry-run -f <config>`                       | Validate and preview without submitting |
+| `srtctl apply -f <config> --bash`                  | Render a one-host Docker lifecycle       |
 | `srtctl validate -f <config>`                      | Alias for dry-run                       |
 
 ## Next Steps
 
 - [Installation](installation.md) - Set up `srtctl` and submit your first job
+- [Direct Host Lifecycle](direct-host.md) - Run a single-node recipe through Docker
 - [Monitoring](monitoring.md) - Understanding job logs and debugging
 - [Parameter Sweeps](sweeps.md) - Run grid searches across configurations
 - [Config Overrides](overrides.md) - Multi-variant jobs from a single file

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Introduction](README.md)
 - [Installation](installation.md)
 - [CLI Reference](cli.md)
+- [Direct Host Lifecycle](direct-host.md)
 
 ## Configuration
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -270,8 +270,8 @@ srtctl apply -f config.yaml:override_tp64
 # Submit only the base config (ignore overrides)
 srtctl apply -f config.yaml:base
 
-# Emit a direct single-node lifecycle script without submitting
-srtctl apply -f config.yaml --bash > job.sh
+# Render and run one single-node recipe through Docker
+srtctl apply -f config.yaml -o /absolute/path/to/runs --bash > job.sh
 chmod +x job.sh
 ./job.sh
 
@@ -279,13 +279,14 @@ chmod +x job.sh
 srtctl apply -f config.yaml --tags "experiment-1,baseline"
 ```
 
-`--bash` renders a self-contained script for one direct host; it is not an sbatch script. It currently
-supports a one-node SGLang backend with a Dynamo or SGLang Model Gateway frontend, with
-`frontend.enable_multiple_frontends: false` and a `benchmark.type: custom` command. The host must already
-provide the configured Python environment and, for Dynamo, the `configs/nats-server` and `configs/etcd`
-binaries. The script creates one process group and log per worker/router, waits for worker and router
-readiness plus a chat-completions smoke request, starts the configured Tachometer scraper, runs the benchmark,
-then stops only its owned process groups and compacts Tachometer artifacts.
+`--bash` renders a small direct-host launcher; it is not an sbatch script. The launcher owns a Docker serving
+container and runs the serving lifecycle inside the selected SGLang image. It currently supports a one-node
+SGLang backend with the Dynamo frontend, `frontend.enable_multiple_frontends: false`, and one
+`benchmark.type: custom` command. It requires Docker with GPU support, an absolute `SRTCTL_SGLANG_SOURCE`,
+`SRTCTL_LOCAL_CONTAINER_IMAGE`, and either `dynamo.hash` or `dynamo.top_of_tree: true`. The run creates
+separate worker, router, Tachometer, and benchmark logs, gates load on worker/router readiness and a
+chat-completions smoke request, then cleans up only containers and process groups it owns. See
+[Direct Host Lifecycle](direct-host.md) for the complete setup and the included 3P2D Dynamo recipe.
 
 ### `srtctl dry-run`
 

--- a/docs/direct-host.md
+++ b/docs/direct-host.md
@@ -1,0 +1,85 @@
+# Direct host lifecycle
+
+Use the direct lifecycle to run one Dynamo + SGLang benchmark on the GPU host you are already logged into. It consumes the same recipe as SLURM; only the execution owner changes.
+
+| Target | Command | Owner |
+| --- | --- | --- |
+| SLURM cluster | `srtctl apply -f recipe.yaml` | Scheduler, `srun`, and the job container |
+| One GPU host | `srtctl apply -f recipe.yaml --bash` | Docker host runner and one serving container |
+
+The direct path is intentionally single-host. It supports the SGLang backend behind the Dynamo frontend, one concrete custom benchmark, optional Mooncake, Tachometer, and ruter. Use the SLURM lifecycle for multi-node runs, sweeps, profiling, or DCGM power telemetry.
+
+```mermaid
+flowchart LR
+    Y["same recipe.yaml"] --> R["srtctl apply --bash"]
+    R --> H["host runner: Docker, mounts, cleanup"]
+    H --> C["serving container"]
+    C --> S["SGLang source + Dynamo source"]
+    S --> W["workers + Dynamo router"]
+    W --> T["Tachometer + benchmark + ruter"]
+    T --> O["run output"]
+```
+
+## Requirements
+
+- A single GPU host with Docker and the NVIDIA Container Toolkit. The host must be able to run `docker run --gpus all ...`.
+- An absolute model path readable by Docker. A Hugging Face snapshot is supported; its repository root is mounted so its `blobs/` symlinks resolve.
+- An absolute checkout of the SGLang source to install inside the serving image.
+- A serving image configured as `environment.SRTCTL_LOCAL_CONTAINER_IMAGE`.
+- `dynamo.hash` or `dynamo.top_of_tree: true`. The first run builds a hash-keyed Dynamo wheel outside the container; later runs reuse it.
+- `make setup ARCH=$(uname -m)` for the bundled Tachometer scraper and infrastructure binaries. For ruter, install its optional dependency with `uv sync --extra ruter`.
+
+The direct runner creates a cached SGLang environment under `<output-base>/.srtctl-runtime/` and Dynamo wheels under `<output-base>/.srtctl-cache/dynamo-wheels/`. Delete those only when you deliberately want a cold rebuild.
+
+## Run the included 3P2D route-observability recipe
+
+This recipe uses three TP1 prefills and two TP1 decodes on one eight-GPU host. It runs a Mooncake trace, scrapes Tachometer, and normalizes the ruter bundle.
+
+```bash
+cd /path/to/srt-slurm
+make setup ARCH="$(uname -m)"
+uv sync --extra ruter
+
+export RUTER_MODEL_PATH=/absolute/path/to/Qwen3-32B-FP8
+export RUTER_SGLANG_SOURCE=/absolute/path/to/sglang
+export RUTER_MOONCAKE_TRACE=/absolute/path/to/mooncake_refined.jsonl
+
+uv run srtctl apply -f recipes/qwen3-32b/ruter-3p2d-dynamo.yaml -o /absolute/path/to/runs --bash > run.sh
+bash -n run.sh
+bash run.sh
+```
+
+`--bash` renders a small host launcher. When it runs, the launcher starts a labeled Docker container, installs the selected SGLang source before plain Dynamo, starts the infrastructure and workers, waits for a smoke request, then runs Tachometer, AIPerf, and ruter. `Ctrl-C` and `SIGTERM` stop only processes and containers owned by this run.
+
+The recipe keeps both `model.container` and `SRTCTL_LOCAL_CONTAINER_IMAGE` so it is also valid for the SLURM lifecycle. The direct lifecycle uses `SRTCTL_LOCAL_CONTAINER_IMAGE`; SLURM uses the normal container setting.
+
+## Inspect the result
+
+Each direct run creates its own timestamped directory below `-o` (or `outputs/` if `-o` is omitted):
+
+```text
+<run>/
+├── direct-host-plan.json       # host ownership, mounts, and runtime inputs
+├── direct-plan.json            # in-container worker/router plan
+├── logs/
+│   ├── worker-*.log            # one log per prefill/decode worker
+│   ├── router.log
+│   ├── tachometer.log
+│   ├── aiperf.log
+│   └── .ruter/
+├── artifacts/
+│   ├── aiperf/
+│   ├── dynamo-request-trace*.jsonl.gz
+│   └── tachometer/local/final.parquet
+└── tachometer.toml
+```
+
+Names vary slightly with the recipe, but workers, router, Tachometer, benchmark, and post-processing never share a log file. Raw logs and Parquet remain unchanged; ruter writes normalized records in `logs/.ruter/`.
+
+Open the route view after the run:
+
+```bash
+uv run srtctl view /absolute/path/to/runs/<run>
+```
+
+See [ruter](ruter.md) for the normalized bundle and viewer behavior.

--- a/docs/ruter.md
+++ b/docs/ruter.md
@@ -14,7 +14,7 @@
        enabled: true
    ```
 
-2. Run the recipe through either lifecycle. The post-process step is the same for SLURM and direct Bash:
+2. Run the recipe through either lifecycle. The post-process step is the same for SLURM and the [direct Docker lifecycle](direct-host.md):
 
    ```bash
    uv run srtctl apply -f recipe.yaml


### PR DESCRIPTION
## Summary
- document the one-host Docker lifecycle alongside the existing Slurm path
- add the runnable 3P2D Dynamo/ruter recipe flow and output layout
- correct the `apply --bash` CLI contract and link the path from the docs

## Validation
- `git diff --check origin/main...HEAD`
- `uv run pytest tests/test_direct_plan.py tests/test_direct_host_runner.py tests/test_direct_runner.py tests/test_submit_cli.py`