### PR TITLE
feat: render portable slurm serving lifecycle

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -72,6 +72,7 @@ profiling:                     # Optional: profiling config
 
 output:                        # Optional: output paths
   log_dir: "./outputs/{job_id}/logs"
+  record_launch_plan: false    # Save exact realized srun scripts and a manifest
 
 health_check:                  # Optional: health check settings
   max_attempts: 180
@@ -875,13 +876,26 @@ Output configuration with formattable paths.
 ```yaml
 output:
   log_dir: "./outputs/{job_id}/logs"
+  record_launch_plan: false
 ```
 
-| Field     | Type            | Default                      | Description              |
-| --------- | --------------- | ---------------------------- | ------------------------ |
-| `log_dir` | FormattablePath | "./outputs/{job_id}/logs"    | Directory for log files  |
+| Field                | Type            | Default                   | Description                                      |
+| -------------------- | --------------- | ------------------------- | ------------------------------------------------ |
+| `log_dir`            | FormattablePath | "./outputs/{job_id}/logs" | Directory for log files                          |
+| `record_launch_plan` | bool            | `false`                   | Save realized `srun` scripts and a JSON manifest |
 
 The `log_dir` supports FormattablePath templating. See [FormattablePath Template System](#formattablepath-template-system).
+
+When `record_launch_plan` is enabled, srtctl creates `logs/launch-plan/manifest.json` and one executable shell
+script for every realized `srun` invocation. Recording happens after Slurm assigns nodes, ports, heterogeneous
+groups, mounts, and container paths, so the scripts describe what was actually launched rather than a pre-submit
+estimate. Secret-like environment values are never persisted; the scripts name the environment variables that
+must be supplied for replay. The resolved recipe, outer `sbatch_script.sh`, lockfile, and resource snapshot remain
+alongside this directory and are referenced by the manifest.
+
+Set `record_launch_plan: true` at the top level of `srtslurm.yaml` to enable this artifact for every recipe on a
+cluster. Because the launch plan lives under the normal log directory, existing S3 postprocessing and external
+collectors that archive the complete log directory include it without a separate upload path.
 
 ---
 

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -33,8 +33,9 @@ from srtctl.cli.mixins import (
     TelemetryStageMixin,
     WorkerStageMixin,
 )
-from srtctl.core.config import load_config
+from srtctl.core.config import get_srtslurm_setting, load_config
 from srtctl.core.health import wait_for_port
+from srtctl.core.launch_plan import configure_launch_plan
 from srtctl.core.lockfile import write_lockfile
 from srtctl.core.processes import (
     ManagedProcess,
@@ -648,6 +649,12 @@ class SweepOrchestrator(
 
     def run(self) -> int:
         """Run the complete sweep."""
+        record_launch_plan = self.config.output.record_launch_plan or bool(
+            get_srtslurm_setting("record_launch_plan", False)
+        )
+        launch_plan_dir = self.runtime.log_dir / "launch-plan" if record_launch_plan else None
+        configure_launch_plan(launch_plan_dir, job_id=self.runtime.job_id)
+
         logger.info("Sweep Orchestrator")
         logger.info("Job ID: %s", self.runtime.job_id)
         logger.info("Run name: %s", self.runtime.run_name)
@@ -657,6 +664,10 @@ class SweepOrchestrator(
         logger.info("Worker nodes: %s", ", ".join(self.runtime.nodes.worker))
         if self.config.profiling.enabled:
             logger.info("Profiling: %s", self.config.profiling.type)
+        if launch_plan_dir is not None:
+            logger.info("Recording realized Slurm launch plan: %s", launch_plan_dir)
+            # Preserve submission provenance before any runtime stage can fail.
+            self._copy_config_to_logs()
 
         resource_snapshot = record_resource_snapshot(self.config, self.runtime)
 

--- a/src/srtctl/core/launch_plan.py
+++ b/src/srtctl/core/launch_plan.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persist the realized Slurm launch plan for post-run reproduction."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_SECRET_NAME = re.compile(r"(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|ACCESS_KEY|PRIVATE_KEY|CREDENTIAL)(?:_|$)")
+_SAFE_NAME = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _is_secret_name(name: str) -> bool:
+    return bool(_SECRET_NAME.search(name.upper()))
+
+
+def _slug(value: str) -> str:
+    normalized = _SAFE_NAME.sub("-", value).strip("-.").lower()
+    return normalized[:80] or "step"
+
+
+def _redacted_command(
+    command: list[str],
+    *,
+    env_to_set: dict[str, str] | None,
+    srun_export_env: dict[str, str] | None,
+) -> tuple[list[str], list[str]]:
+    """Return a replayable command with secret environment values removed."""
+    replay = list(command)
+    required_secrets: set[str] = set()
+
+    if srun_export_env:
+        for idx, arg in enumerate(replay):
+            if not arg.startswith("--export=ALL,"):
+                continue
+            exports = []
+            for item in arg.removeprefix("--export=ALL,").split(","):
+                name, separator, value = item.partition("=")
+                if separator and _is_secret_name(name):
+                    exports.append(name)
+                    required_secrets.add(name)
+                else:
+                    exports.append(item)
+            replay[idx] = "--export=ALL," + ",".join(exports)
+
+    if env_to_set:
+        bash_index = next((idx for idx in range(len(replay) - 1) if replay[idx : idx + 2] == ["bash", "-c"]), None)
+        if bash_index is not None:
+            bash_command = replay[bash_index + 2]
+            for name, value in env_to_set.items():
+                if not _is_secret_name(name):
+                    continue
+                actual = f"export {name}={shlex.quote(value)}"
+                replacement = f'export {name}="${{{name}:?Set {name} to replay this step}}"'
+                bash_command = bash_command.replace(actual, replacement)
+                required_secrets.add(name)
+            replay[bash_index + 2] = bash_command
+
+    return replay, sorted(required_secrets)
+
+
+class LaunchPlanRecorder:
+    """Thread-safe recorder for exact, realized ``srun`` invocations."""
+
+    def __init__(self, directory: Path, *, job_id: str | None = None) -> None:
+        self.directory = directory
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.job_id = job_id or os.environ.get("SLURM_JOB_ID") or os.environ.get("SLURM_JOBID")
+        self._lock = threading.Lock()
+        self._entries: list[dict[str, Any]] = []
+        self._write_manifest()
+
+    def record(
+        self,
+        command: list[str],
+        *,
+        label: str,
+        output: str | None,
+        nodelist: list[str] | None,
+        het_group: int | None,
+        container_image: str | None,
+        env_to_set: dict[str, str] | None,
+        srun_export_env: dict[str, str] | None,
+    ) -> Path:
+        replay, required_secrets = _redacted_command(
+            command,
+            env_to_set=env_to_set,
+            srun_export_env=srun_export_env,
+        )
+        with self._lock:
+            sequence = len(self._entries) + 1
+            filename = f"{sequence:03d}-{_slug(label)}.sh"
+            script_path = self.directory / filename
+            rendered = self._render_script(replay, required_secrets=required_secrets)
+            script_path.write_text(rendered)
+            script_path.chmod(0o750)
+
+            entry = {
+                "sequence": sequence,
+                "script": filename,
+                "recorded_at": _utc_now(),
+                "output": output,
+                "nodelist": list(nodelist or []),
+                "het_group": het_group,
+                "container_image": container_image,
+                "required_secret_environment": required_secrets,
+                "sha256": hashlib.sha256(rendered.encode()).hexdigest(),
+            }
+            self._entries.append(entry)
+            self._write_manifest()
+            return script_path
+
+    def _render_script(self, command: list[str], *, required_secrets: list[str]) -> str:
+        lines = [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "",
+            "# Generated from the exact srun argv used by srt-slurm.",
+            "# Run inside a compatible active Slurm allocation with the recorded recipe and container available.",
+        ]
+        if required_secrets:
+            lines.append("# Required secret environment (values intentionally omitted): " + ", ".join(required_secrets))
+            for name in required_secrets:
+                lines.append(f': "${{{name}:?Set {name} to replay this step}}"')
+        lines.extend(["", "exec " + shlex.join(command), ""])
+        return "\n".join(lines)
+
+    def _write_manifest(self) -> None:
+        manifest = {
+            "schema_version": 1,
+            "job_id": self.job_id,
+            "slurm_nodelist": os.environ.get("SLURM_NODELIST"),
+            "generated_at": _utc_now(),
+            "replay_scope": "Individual realized Slurm steps; orchestration order and lifecycle remain owned by srtctl.",
+            "secret_policy": "Secret-like environment values are omitted and named in required_secret_environment.",
+            "related_artifacts": [
+                "../config.yaml",
+                "../sbatch_script.sh",
+                "../recipe.lock.yaml",
+                "../resource_snapshot.json",
+            ],
+            "steps": self._entries,
+        }
+        temporary = self.directory / ".manifest.json.tmp"
+        temporary.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+        temporary.replace(self.directory / "manifest.json")
+
+
+_active_recorder: LaunchPlanRecorder | None = None
+
+
+def configure_launch_plan(directory: Path | None, *, job_id: str | None = None) -> LaunchPlanRecorder | None:
+    """Enable or disable process-wide launch recording for this orchestrator."""
+    global _active_recorder
+    _active_recorder = LaunchPlanRecorder(directory, job_id=job_id) if directory is not None else None
+    return _active_recorder
+
+
+def record_srun_command(
+    command: list[str],
+    *,
+    label: str,
+    output: str | None,
+    nodelist: list[str] | None,
+    het_group: int | None,
+    container_image: str | None,
+    env_to_set: dict[str, str] | None,
+    srun_export_env: dict[str, str] | None,
+) -> Path | None:
+    """Record a realized command when launch-plan capture is enabled."""
+    if _active_recorder is None:
+        return None
+    return _active_recorder.record(
+        command,
+        label=label,
+        output=output,
+        nodelist=nodelist,
+        het_group=het_group,
+        container_image=container_image,
+        env_to_set=env_to_set,
+        srun_export_env=srun_export_env,
+    )

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -197,6 +197,9 @@ class ClusterConfig:
     default_health_check: dict[str, int] | None = None
     srtctl_root: str | None = None
     output_dir: str | None = None  # Custom output directory for job logs
+    # Cluster-wide default for recording exact realized srun commands. Recipes
+    # can opt in independently with output.record_launch_plan.
+    record_launch_plan: bool = False
     model_paths: dict[str, str] | None = None
     containers: dict[str, str] | None = None
     cloud: dict[str, str] | None = None
@@ -1489,11 +1492,12 @@ class FrontendConfig:
 
 @dataclass(frozen=True)
 class OutputConfig:
-    """Output configuration with formattable paths."""
+    """Output paths and optional reproducibility artifacts."""
 
     log_dir: Annotated[FormattablePath, FormattablePathField()] = field(
         default_factory=lambda: FormattablePath(template="./outputs/{job_id}/logs")
     )
+    record_launch_plan: bool = False
 
     Schema: ClassVar[type[Schema]] = Schema
 

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from .ip_utils import get_node_ip
+from .launch_plan import record_srun_command
 
 logger = logging.getLogger(__name__)
 
@@ -353,6 +354,17 @@ def start_srun_process(
     # which dominates the orchestrator log. Re-enable with `--verbose` / by setting
     # the srtctl logger to DEBUG when troubleshooting srun arg construction.
     logger.debug("srun command: %s", shlex.join(srun_cmd))
+
+    record_srun_command(
+        srun_cmd,
+        label=Path(output).stem if output else Path(command[0]).name,
+        output=output,
+        nodelist=list(nodelist) if nodelist else None,
+        het_group=het_group,
+        container_image=str(container_image) if container_image else None,
+        env_to_set=env_to_set,
+        srun_export_env=srun_export_env,
+    )
 
     # Start the process
     proc = subprocess.Popen(

--- a/srtslurm.yaml.example
+++ b/srtslurm.yaml.example
@@ -26,6 +26,13 @@ use_gpus_per_node_directive: true  # Default: true
 use_segment_sbatch_directive: true  # Default: true
 # Set to true if your cluster requires --exclusive to be set.
 use_exclusive_sbatch_directive: false # Default: false
+
+# Reproducibility artifacts (optional)
+# Record every realized srun invocation as an executable, secret-redacted script
+# under outputs/<job_id>/logs/launch-plan/. Individual recipes can also enable
+# this with output.record_launch_plan: true.
+record_launch_plan: false
+
 # Container registry
 default_container: "/shared/containers/sglang-latest.sqsh"
 containers:

--- a/tests/test_launch_plan.py
+++ b/tests/test_launch_plan.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for opt-in recording of realized Slurm launch commands."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from srtctl.core.launch_plan import configure_launch_plan
+from srtctl.core.schema import ClusterConfig, OutputConfig
+from srtctl.core.slurm import start_srun_process
+
+
+@pytest.fixture(autouse=True)
+def _reset_launch_plan():
+    configure_launch_plan(None)
+    yield
+    configure_launch_plan(None)
+
+
+def _launch(tmp_path: Path, **kwargs) -> Path:
+    plan_dir = tmp_path / "logs" / "launch-plan"
+    configure_launch_plan(plan_dir, job_id="42042")
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="42042"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen", return_value=MagicMock()),
+    ):
+        start_srun_process(["python3", "-m", "worker"], **kwargs)
+    return plan_dir
+
+
+def test_launch_plan_is_opt_in_for_recipe_and_cluster() -> None:
+    assert OutputConfig().record_launch_plan is False
+    assert OutputConfig(record_launch_plan=True).record_launch_plan is True
+    assert ClusterConfig().record_launch_plan is False
+    assert ClusterConfig(record_launch_plan=True).record_launch_plan is True
+
+
+def test_disabled_recorder_writes_nothing(tmp_path: Path) -> None:
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="42042"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen", return_value=MagicMock()),
+    ):
+        start_srun_process(["python3", "-m", "worker"])
+
+    assert not (tmp_path / "launch-plan").exists()
+
+
+def test_records_exact_realized_srun_as_executable_script(tmp_path: Path) -> None:
+    output = tmp_path / "logs" / "node-a_prefill_w0.out"
+    plan_dir = _launch(
+        tmp_path,
+        nodelist=["node-a"],
+        output=str(output),
+        container_image="/containers/vllm.sqsh",
+        container_mounts={Path("/models/model"): Path("/model")},
+        env_to_set={"NCCL_DEBUG": "INFO"},
+        het_group=0,
+    )
+
+    scripts = list(plan_dir.glob("*.sh"))
+    assert [path.name for path in scripts] == ["001-node-a_prefill_w0.sh"]
+    script = scripts[0].read_text()
+    assert scripts[0].stat().st_mode & 0o100
+    assert "exec srun --jobid 42042 --overlap" in script
+    assert "--nodelist node-a" in script
+    assert "--het-group=0" in script
+    assert "--container-image /containers/vllm.sqsh" in script
+    assert "export NCCL_DEBUG=INFO" in script
+    assert "python3 -m worker" in script
+    syntax = subprocess.run(["bash", "-n", str(scripts[0])], capture_output=True, text=True, check=False)
+    assert syntax.returncode == 0, syntax.stderr
+
+    manifest = json.loads((plan_dir / "manifest.json").read_text())
+    assert manifest["job_id"] == "42042"
+    assert manifest["steps"][0]["script"] == scripts[0].name
+    assert manifest["steps"][0]["nodelist"] == ["node-a"]
+    assert manifest["steps"][0]["container_image"] == "/containers/vllm.sqsh"
+
+
+def test_secret_environment_values_are_not_persisted(tmp_path: Path) -> None:
+    plan_dir = _launch(
+        tmp_path,
+        output=str(tmp_path / "logs" / "benchmark.out"),
+        env_to_set={"HF_TOKEN": "hf-super-secret", "PUBLIC_VALUE": "visible"},
+        srun_export_env={"AWS_SECRET_ACCESS_KEY": "aws-super-secret", "ENROOT_REMAP_ROOT": "yes"},
+    )
+
+    script = next(plan_dir.glob("*.sh")).read_text()
+    manifest_text = (plan_dir / "manifest.json").read_text()
+    combined = script + manifest_text
+    assert "hf-super-secret" not in combined
+    assert "aws-super-secret" not in combined
+    assert 'export HF_TOKEN="${HF_TOKEN:?Set HF_TOKEN to replay this step}"' in script
+    assert "--export=ALL,AWS_SECRET_ACCESS_KEY,ENROOT_REMAP_ROOT=yes" in script
+    assert "export PUBLIC_VALUE=visible" in script
+
+    manifest = json.loads(manifest_text)
+    assert manifest["steps"][0]["required_secret_environment"] == ["AWS_SECRET_ACCESS_KEY", "HF_TOKEN"]
+
+
+def test_multiple_commands_have_stable_order_and_distinct_files(tmp_path: Path) -> None:
+    plan_dir = _launch(tmp_path, output=str(tmp_path / "logs" / "infra.out"))
+    with (
+        patch("srtctl.core.slurm.get_slurm_job_id", return_value="42042"),
+        patch("srtctl.core.slurm._get_cluster_bash_preamble", return_value=None),
+        patch("subprocess.Popen", return_value=MagicMock()),
+    ):
+        start_srun_process(["python3", "bench.py"], output=str(tmp_path / "logs" / "benchmark.out"))
+
+    manifest = json.loads((plan_dir / "manifest.json").read_text())
+    assert [entry["sequence"] for entry in manifest["steps"]] == [1, 2]
+    assert [entry["script"] for entry in manifest["steps"]] == ["001-infra.sh", "002-benchmark.sh"]


### PR DESCRIPTION
## Summary

Add `srtctl render-launch -f recipe.yaml` to compile a resolved Dynamo/SGLang recipe into a portable Slurm serving script.

The generated script discovers nodes and IPs from the active allocation, starts NATS/etcd, optional Mooncake infrastructure, workers, and the Dynamo frontend, waits for worker readiness, and cleans up the processes it owns. It uses the same command builders as normal execution without embedding a recorded job ID, hostname, IP address, endpoint, or secret value.

## Usage

```bash
srtctl render-launch -f recipe.yaml > launch.sh
chmod +x launch.sh
# Run launch.sh inside a compatible active Slurm allocation.
```

The initial scope is homogeneous Slurm allocations with the SGLang backend, a single Dynamo frontend, and no nginx. The artifact covers the serving lifecycle; benchmark, telemetry, and post-processing stages remain outside it.
