### PR TITLE
feat: add agentx benchmark type for agentic-coding replay

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -652,6 +652,7 @@ benchmark:
 | `router`          | Router performance with prefix caching         |
 | `mooncake-router` | KV-aware routing with Mooncake trace           |
 | `agentperf`       | AgentPerf trajectory replay (agentperf-client) |
+| `agentx`          | Agentic-coding trace replay (InferenceX harness) |
 
 ### manual
 
@@ -712,6 +713,60 @@ Two caveats for `AIPERF_SERVER_METRICS_URLS`:
 
 Values in `benchmark.env` are applied last and can explicitly override any automatically injected
 variable.
+
+### agentx (Agentic Coding)
+
+Replays agentic-coding sessions from the `cc-traces` corpus through AIPerf's
+`inferencex-agentx-mvp` scenario. srt-slurm owns the deployment; the replay client is
+InferenceX's `agentic_srt.sh`.
+
+**Requires an InferenceX checkout.** The client stack is not bundled with srt-slurm. Clone it
+with submodules — `utils/aiperf` is one, and the harness installs from it — and export
+`INFMAX_WORKSPACE`, which srt-slurm mounts at `/infmax-workspace`:
+
+```bash
+git clone --recurse-submodules https://github.com/SemiAnalysisAI/InferenceX.git
+export INFMAX_WORKSPACE=/shared/path/to/InferenceX
+```
+
+The path is bind-mounted into the container, so it must resolve on the compute nodes rather than
+only on the login node. `srtctl dry-run` reports the mount, and flags it when the variable is
+unset; without it the job fails with exit 127 once the workers have loaded.
+
+```yaml
+benchmark:
+  type: agentx
+  model_prefix: "dsv4"        # Required: selects the trace corpus
+  concurrency: 8              # Required: one published point
+  duration_seconds: 3600      # Optional (default: 3600)
+  result_filename: "dsv4_tp8_conc8"  # Optional (default: the recipe name)
+  env:
+    KV_OFFLOADING: dram       # Harness metadata and AIPerf tuning knobs
+```
+
+| Field              | Type | Required | Default       | Description                                        |
+| ------------------ | ---- | -------- | ------------- | -------------------------------------------------- |
+| `model_prefix`     | str  | Yes      | -             | Trace-corpus selector, e.g. `dsv4`, `qwen3.5`, `kimik3` |
+| `concurrency`      | int  | Yes\*    | -             | Concurrency for a single point                      |
+| `concurrencies`    | list | Yes\*    | -             | Several points against one engine configuration     |
+| `duration_seconds` | int  | No       | `3600`        | Replay duration per point                           |
+| `result_filename`  | str  | No       | recipe `name` | Result basename                                     |
+
+\* Provide one of `concurrency` or `concurrencies`. Use `concurrencies` only when no engine
+parameter varies with concurrency; otherwise write one recipe per point (or a
+`zip_override_conc` variant) so each point gets its own engine configuration.
+
+srtctl derives the rest of the harness contract from the recipe — `MODEL`, `FRAMEWORK`,
+`PRECISION`, `PORT`, `IS_MULTINODE`, `RESULT_DIR`, and the backend's
+`AIPERF_REQUIRED_SERVER_METRIC_PREFIX` — and validates the required inputs before submission
+rather than letting the harness abort in the container. Like a custom command, this benchmark
+also receives `AIPERF_SERVER_METRICS_URLS` and the `SRT_*` worker endpoints, which the harness
+polls to confirm the deployment has drained between concurrencies.
+
+Values in `benchmark.env` are applied last and override anything derived above. Optional harness
+metadata such as `TP`, `EP`, `DP_ATTENTION`, `KV_OFFLOADING`, `KV_OFFLOAD_BACKEND`,
+`TOTAL_CPU_DRAM_GB`, and `WEKA_LOADER_OVERRIDE`, along with the `AIPERF_*` tuning knobs, are
+passed through there.
 
 ### sa-bench (Serving Accuracy)
 

--- a/src/srtctl/benchmarks/__init__.py
+++ b/src/srtctl/benchmarks/__init__.py
@@ -6,6 +6,7 @@
 # Import runners to trigger registration
 from srtctl.benchmarks import (
     agentperf,
+    agentx,
     custom,
     gpqa,
     gsm8k,
@@ -29,6 +30,7 @@ __all__ = [
     "BenchmarkRunner",
     # Runners
     "agentperf",
+    "agentx",
     "custom",
     "get_runner",
     "gpqa",

--- a/src/srtctl/benchmarks/agentx.py
+++ b/src/srtctl/benchmarks/agentx.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AgentX agentic-coding benchmark runner for the InferenceX harness."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import SrtConfig
+
+
+# Container path of the InferenceX checkout. RuntimeContext.from_config mounts it
+# there when INFMAX_WORKSPACE is set in the submitting environment.
+INFMAX_CONTAINER_WORKSPACE = "/infmax-workspace"
+
+# Entry point inside that checkout. Named for the directory it has always lived
+# in; it drives single-node deployments just as well.
+HARNESS_RELATIVE_PATH = "benchmarks/multi_node/agentic_srt.sh"
+
+# The harness refuses a point whose server-side counters it cannot read, and the
+# counter names are backend-specific.
+SERVER_METRIC_PREFIXES = {
+    "vllm": "vllm:",
+    "sglang": "sglang:",
+    "trtllm": "tensorrt_llm:",
+}
+
+# Every published AgentX point replays for an hour.
+DEFAULT_DURATION_SECONDS = 3600
+
+DEFAULT_RESULT_DIR = "/logs/agentic"
+
+
+@register_benchmark("agentx")
+class AgentXRunner(BenchmarkRunner):
+    """Agentic-coding trace replay driven by the InferenceX AgentX harness.
+
+    srt-slurm owns the deployment; the client is InferenceX's ``agentic_srt.sh``,
+    which replays the ``cc-traces`` corpus through AIPerf's
+    ``inferencex-agentx-mvp`` scenario. That client stack is not vendored here, so
+    this runner needs an InferenceX checkout mounted at ``/infmax-workspace``
+    through ``INFMAX_WORKSPACE`` -- the same contract the ``lm-eval`` runner uses.
+
+    Recipes previously expressed this as ``benchmark.type: custom`` with the
+    harness's environment contract inlined. That left the seven variables it
+    requires (``MODEL``, ``MODEL_PREFIX``, ``FRAMEWORK``, ``PRECISION``, ``CONC``,
+    ``RESULT_FILENAME``, ``DURATION``) either restated in every recipe or supplied
+    by whichever launcher happened to submit the job, so a recipe could be
+    complete on its own terms and still abort inside the container on
+    ``check_env_vars``. This runner derives them from the recipe and reports what
+    is missing before submission.
+
+    ``benchmark.env`` is applied last and overrides everything derived here.
+    """
+
+    @property
+    def name(self) -> str:
+        return "AgentX"
+
+    @property
+    def script_path(self) -> str:
+        return "/srtctl-benchmarks/agentx/bench.sh"
+
+    @property
+    def local_script_dir(self) -> str:
+        return str(SCRIPTS_DIR / "agentx")
+
+    def validate_config(self, config: SrtConfig) -> list[str]:
+        errors = []
+        env = config.benchmark.env
+
+        if not config.benchmark.model_prefix and "MODEL_PREFIX" not in env:
+            errors.append(
+                "benchmark.model_prefix is required for benchmark.type=agentx: the harness "
+                "selects its trace corpus from it (e.g. 'dsv4', 'qwen3.5', 'kimik3')"
+            )
+
+        if not self._concurrencies(config) and "CONC" not in env:
+            errors.append("benchmark.concurrency or benchmark.concurrencies is required for benchmark.type=agentx")
+
+        if config.backend.type not in SERVER_METRIC_PREFIXES and "AIPERF_REQUIRED_SERVER_METRIC_PREFIX" not in env:
+            errors.append(
+                f"no known server metric prefix for backend.type={config.backend.type!r}; "
+                "set AIPERF_REQUIRED_SERVER_METRIC_PREFIX in benchmark.env"
+            )
+
+        return errors
+
+    def build_command(self, config: SrtConfig, runtime: RuntimeContext) -> list[str]:
+        del config
+        return [
+            "bash",
+            self.script_path,
+            f"http://localhost:{runtime.frontend_port}",
+            INFMAX_CONTAINER_WORKSPACE,
+        ]
+
+    def get_environment(self, config: SrtConfig, runtime: RuntimeContext) -> dict[str, str]:
+        benchmark = config.benchmark
+        env = {
+            "INFMAX_CONTAINER_WORKSPACE": INFMAX_CONTAINER_WORKSPACE,
+            "RESULT_DIR": DEFAULT_RESULT_DIR,
+            "PORT": str(runtime.frontend_port),
+            "MODEL": config.served_model_name,
+            "FRAMEWORK": config.backend.type,
+            "PRECISION": config.model.precision,
+            "DURATION": str(benchmark.duration_seconds or DEFAULT_DURATION_SECONDS),
+            # The harness records this on every result row, and a single-node
+            # deployment reports differently from a slice of a rack.
+            "IS_MULTINODE": "true" if config.total_nodes > 1 else "false",
+            "RESULT_FILENAME": benchmark.result_filename or config.name,
+        }
+
+        if benchmark.model_prefix:
+            env["MODEL_PREFIX"] = benchmark.model_prefix
+
+        concurrencies = self._concurrencies(config)
+        if concurrencies:
+            # CONC drives a single point. CONC_LIST replays several against one
+            # engine configuration, which is only correct when no engine
+            # parameter varies with concurrency.
+            env["CONC"] = str(concurrencies[0])
+            if len(concurrencies) > 1:
+                env["CONC_LIST"] = " ".join(str(value) for value in concurrencies)
+
+        prefix = SERVER_METRIC_PREFIXES.get(config.backend.type)
+        if prefix:
+            env["AIPERF_REQUIRED_SERVER_METRIC_PREFIX"] = prefix
+
+        env.update(benchmark.env)
+        return env
+
+    @staticmethod
+    def _concurrencies(config: SrtConfig) -> list[int]:
+        if config.benchmark.concurrency is not None:
+            return [config.benchmark.concurrency]
+        return config.benchmark.get_concurrency_list()

--- a/src/srtctl/benchmarks/scripts/agentx/bench.sh
+++ b/src/srtctl/benchmarks/scripts/agentx/bench.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 SemiAnalysis LLC. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# AgentX agentic-coding trace replay using the InferenceX harness.
+# Expects: endpoint [infmax_workspace]
+#
+# srt-slurm owns the deployment. This script hands off to InferenceX's
+# agentic_srt.sh, which resolves the trace corpus, builds an isolated AIPerf
+# environment, and replays the agentic sessions. Its inputs arrive through the
+# environment; see srtctl/benchmarks/agentx.py for what srtctl derives.
+
+set -euo pipefail
+
+ENDPOINT=$1
+INFMAX_WORKSPACE=${2:-/infmax-workspace}
+
+HARNESS="${INFMAX_WORKSPACE}/benchmarks/multi_node/agentic_srt.sh"
+
+# Without the mount this is the first thing to fail, and it happens only after
+# the workers have loaded. Say what is missing rather than leaving a bare
+# "No such file or directory" from bash.
+if [ ! -f "${HARNESS}" ]; then
+    echo "ERROR: AgentX harness not found at ${HARNESS}" >&2
+    echo "The AgentX client stack lives in InferenceX and is not bundled with srt-slurm." >&2
+    echo "Clone it with submodules and point INFMAX_WORKSPACE at the checkout:" >&2
+    echo "  git clone --recurse-submodules https://github.com/SemiAnalysisAI/InferenceX.git" >&2
+    echo "  export INFMAX_WORKSPACE=<path to the checkout>   # before srtctl apply" >&2
+    exit 1
+fi
+
+# The harness reads the workspace from its own variable, and reaches the
+# frontend by port rather than by URL.
+export INFMAX_CONTAINER_WORKSPACE="${INFMAX_CONTAINER_WORKSPACE:-${INFMAX_WORKSPACE}}"
+export PORT="${PORT:-$(echo "${ENDPOINT}" | sed -E 's|.*:([0-9]+).*|\1|')}"
+
+echo "AgentX Config: endpoint=${ENDPOINT}; workspace=${INFMAX_WORKSPACE}; \
+model=${MODEL:-unset}; framework=${FRAMEWORK:-unset}; conc=${CONC_LIST:-${CONC:-unset}}"
+
+# Relative paths inside the harness resolve against the workspace.
+cd "${INFMAX_WORKSPACE}"
+
+exec bash "${HARNESS}"

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -700,10 +700,17 @@ class BenchmarkStageMixin:
         """Get environment variables for the benchmark script."""
         from srtctl.benchmarks.base import AIPerfBenchmarkRunner
 
-        is_custom = self.config.benchmark.type == "custom"
-        logical_endpoints = self._logical_worker_endpoints() if self.config.profiling.enabled or is_custom else None
+        # Benchmarks that drive an AIPerf client they own rather than inheriting
+        # from AIPerfBenchmarkRunner. They need the logical-worker view: a custom
+        # command because it may wrap AIPerf any way it likes, and agentx because
+        # the InferenceX harness polls AIPERF_SERVER_METRICS_URLS to decide when
+        # the deployment has drained between concurrencies.
+        wraps_own_aiperf = self.config.benchmark.type in ("custom", "agentx")
+        logical_endpoints = (
+            self._logical_worker_endpoints() if self.config.profiling.enabled or wraps_own_aiperf else None
+        )
         env = self._get_benchmark_profiling_env(runner, logical_endpoints)
-        if is_custom:
+        if wraps_own_aiperf:
             assert logical_endpoints is not None
             env.update(self._get_worker_endpoint_env(logical_endpoints))
         env["SRTCTL_FRONTEND_TYPE"] = self.config.frontend.type
@@ -730,15 +737,16 @@ class BenchmarkStageMixin:
             env.update(self._get_sa_bench_slow_down_env())
 
         # Built-in AIPerf runners retain physical-process metrics for vLLM DP.
-        # Custom commands commonly wrap AIPerf but do not inherit from its base
-        # class, so give them the logical-worker view needed by SGLang TP.
+        # Custom commands and agentx drive their own AIPerf without inheriting
+        # from its base class, so give them the logical-worker view needed by
+        # SGLang TP.
         # An explicit AIPERF_SERVER_METRICS_URLS in the recipe environment wins:
         # the operator may be pointing the client at a curated endpoint list,
         # and injection used to clobber it here silently.
         if "AIPERF_SERVER_METRICS_URLS" not in env:
             if isinstance(runner, AIPerfBenchmarkRunner):
                 env.update(self._get_aiperf_server_metrics_env())
-            elif is_custom:
+            elif wraps_own_aiperf:
                 assert logical_endpoints is not None
                 env.update(self._get_aiperf_server_metrics_env(logical_endpoints, logical_workers_only=True))
         if isinstance(runner, AIPerfBenchmarkRunner) and self.config.benchmark.aiperf_package:

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -275,10 +275,18 @@ def show_config_details(config: SrtConfig) -> None:
     # minutes in when it is missing, and the dry-run gave no hint either way -- the
     # table listed every other mount, which made its absence read as "no such mount
     # exists" rather than "not set".
+    #
+    # A custom command names the path itself, so it can be detected by reading the
+    # command. The agentx and lm-eval runners build that path in Python instead, so
+    # they have to be recognised by type or they get no warning at all.
     infmax_ws = os.environ.get("INFMAX_WORKSPACE")
+    needs_infmax_ws = "/infmax-workspace" in str(config.benchmark.command or "") or config.benchmark.type in (
+        "agentx",
+        "lm-eval",
+    )
     if infmax_ws:
         mounts_table.add_row("INFMAX_WORKSPACE", infmax_ws, "/infmax-workspace")
-    elif "/infmax-workspace" in str(config.benchmark.command or ""):
+    elif needs_infmax_ws:
         mounts_table.add_row(
             "[red]MISSING[/]",
             "[red]INFMAX_WORKSPACE is not set in this environment[/]",
@@ -287,7 +295,7 @@ def show_config_details(config: SrtConfig) -> None:
 
     console.print(Panel(mounts_table, border_style="green"))
 
-    if not infmax_ws and "/infmax-workspace" in str(config.benchmark.command or ""):
+    if not infmax_ws and needs_infmax_ws:
         console.print(
             "[red bold]ERROR:[/] this recipe runs its benchmark from /infmax-workspace, "
             "but INFMAX_WORKSPACE is not set, so that mount will be absent and the "

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -780,6 +780,12 @@ class BenchmarkConfig:
     agentperf_config: str | None = (
         None  # Container path to the client's workload YAML (endpoint/model/concurrency injected)
     )
+    # AgentX benchmark fields (InferenceX agentic-coding harness; see
+    # srtctl.benchmarks.agentx.AgentXRunner). Everything else the harness reads
+    # is either derived from this config or passed through benchmark.env.
+    model_prefix: str | None = None  # Trace-corpus selector, e.g. "dsv4", "qwen3.5", "kimik3"
+    duration_seconds: int | None = None  # Replay duration per point (default: 3600)
+    result_filename: str | None = None  # Result basename; defaults to the recipe name
     # Trace replay benchmark fields (uses aiperf with mooncake_trace dataset type)
     trace_file: str | None = None  # Path to trace JSONL file (container path, e.g., /traces/dataset.jsonl)
     custom_tokenizer: str | None = None  # Custom tokenizer class (e.g., "module.path.ClassName")

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1127,6 +1127,158 @@ class TestLMEvalRunner:
         ]
 
 
+class TestAgentXRunner:
+    """Test the AgentX runner.
+
+    The point of this runner is that the InferenceX harness aborts on
+    ``check_env_vars`` for seven variables which, under ``benchmark.type: custom``,
+    were either restated in every recipe or exported by whichever launcher
+    submitted the job. A recipe could therefore be complete on its own terms and
+    still fail after the workers had loaded. These tests pin the derivation and
+    the up-front validation that replace that arrangement.
+    """
+
+    def _config(self, backend=None, **benchmark_kwargs):
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        kwargs = {"type": "agentx", "model_prefix": "dsv4", "concurrency": 8}
+        kwargs.update(benchmark_kwargs)
+        config_kwargs = {
+            "name": "agg-b200-fp4-tp8-hicache-mtp-agentic",
+            "model": ModelConfig(path="/models/DeepSeek-V4-Pro", container="/image", precision="fp4"),
+            "resources": ResourceConfig(gpu_type="b200", gpus_per_node=8, agg_nodes=1, agg_workers=1),
+            "benchmark": BenchmarkConfig(**kwargs),
+        }
+        if backend is not None:
+            config_kwargs["backend"] = backend
+        return SrtConfig(**config_kwargs)
+
+    def _runtime(self, port=8000):
+        from unittest.mock import MagicMock
+
+        runtime = MagicMock()
+        runtime.frontend_port = port
+        return runtime
+
+    def test_registry_includes_agentx(self):
+        assert "agentx" in list_benchmarks()
+
+    def test_get_runner(self):
+        assert get_runner("agentx").name == "AgentX"
+
+    def test_script_path(self):
+        assert "agentx/bench.sh" in get_runner("agentx").script_path
+
+    def test_local_script_dir(self):
+        assert get_runner("agentx").local_script_dir.endswith("agentx")
+
+    def test_build_command_targets_the_frontend_and_the_mount(self):
+        runner = get_runner("agentx")
+        cmd = runner.build_command(self._config(), self._runtime())
+        assert cmd == [
+            "bash",
+            "/srtctl-benchmarks/agentx/bench.sh",
+            "http://localhost:8000",
+            "/infmax-workspace",
+        ]
+
+    def test_required_harness_variables_are_derived(self):
+        """The seven check_env_vars names must all be present without the recipe
+        restating any of them."""
+        runner = get_runner("agentx")
+        env = runner.get_environment(self._config(), self._runtime())
+        for key in ("MODEL", "MODEL_PREFIX", "FRAMEWORK", "PRECISION", "CONC", "RESULT_FILENAME", "DURATION"):
+            assert env[key], f"{key} is required by the harness but was not derived"
+        assert env["MODEL"] == "DeepSeek-V4-Pro"
+        assert env["FRAMEWORK"] == "sglang"
+        assert env["PRECISION"] == "fp4"
+        assert env["CONC"] == "8"
+        assert env["DURATION"] == "3600"
+        assert env["RESULT_FILENAME"] == "agg-b200-fp4-tp8-hicache-mtp-agentic"
+
+    def test_workspace_and_port_come_from_the_runtime(self):
+        runner = get_runner("agentx")
+        env = runner.get_environment(self._config(), self._runtime(port=8123))
+        assert env["INFMAX_CONTAINER_WORKSPACE"] == "/infmax-workspace"
+        assert env["PORT"] == "8123"
+        assert env["RESULT_DIR"] == "/logs/agentic"
+
+    def test_single_node_deployment_is_reported_as_such(self):
+        """The harness stamps IS_MULTINODE on every result row, so a wrong value
+        mislabels published data rather than failing anything."""
+        runner = get_runner("agentx")
+        env = runner.get_environment(self._config(), self._runtime())
+        assert env["IS_MULTINODE"] == "false"
+
+    def test_multi_node_deployment_is_reported_as_such(self):
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        config = SrtConfig(
+            name="agg-gb200-tp8-mtp-agentic",
+            model=ModelConfig(path="/models/DeepSeek-V4-Pro", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb200", gpus_per_node=4, agg_nodes=2, agg_workers=1),
+            benchmark=BenchmarkConfig(type="agentx", model_prefix="dsv4", concurrency=8),
+        )
+        env = get_runner("agentx").get_environment(config, self._runtime())
+        assert env["IS_MULTINODE"] == "true"
+
+    def test_single_concurrency_sets_conc_only(self):
+        env = get_runner("agentx").get_environment(self._config(), self._runtime())
+        assert env["CONC"] == "8"
+        assert "CONC_LIST" not in env
+
+    def test_several_concurrencies_become_a_list(self):
+        config = self._config(concurrency=None, concurrencies=[8, 10, 16])
+        env = get_runner("agentx").get_environment(config, self._runtime())
+        assert env["CONC"] == "8"
+        assert env["CONC_LIST"] == "8 10 16"
+
+    @pytest.mark.parametrize(
+        ("backend_type", "prefix"),
+        [("sglang", "sglang:"), ("vllm", "vllm:"), ("trtllm", "tensorrt_llm:")],
+    )
+    def test_server_metric_prefix_follows_the_backend(self, backend_type, prefix):
+        """The harness will not accept a point whose server counters it cannot
+        read, and the counter names differ per engine."""
+        backend = None
+        if backend_type == "vllm":
+            from srtctl.backends.vllm import VLLMProtocol
+
+            backend = VLLMProtocol()
+        elif backend_type == "trtllm":
+            from srtctl.backends.trtllm import TRTLLMProtocol
+
+            backend = TRTLLMProtocol()
+        config = self._config(backend=backend)
+        env = get_runner("agentx").get_environment(config, self._runtime())
+        assert env["AIPERF_REQUIRED_SERVER_METRIC_PREFIX"] == prefix
+
+    def test_benchmark_env_wins(self):
+        """Recipes pin AIPerf tuning knobs and occasionally a derived value; the
+        explicit setting has to survive."""
+        config = self._config(env={"DURATION": "1200", "AIPERF_TRACE_IDLE_GAP_CAP_SECONDS": "300"})
+        env = get_runner("agentx").get_environment(config, self._runtime())
+        assert env["DURATION"] == "1200"
+        assert env["AIPERF_TRACE_IDLE_GAP_CAP_SECONDS"] == "300"
+
+    def test_valid_config_has_no_errors(self):
+        assert get_runner("agentx").validate_config(self._config()) == []
+
+    def test_missing_model_prefix_is_an_error(self):
+        errors = get_runner("agentx").validate_config(self._config(model_prefix=None))
+        assert any("model_prefix" in error for error in errors)
+
+    def test_missing_concurrency_is_an_error(self):
+        errors = get_runner("agentx").validate_config(self._config(concurrency=None))
+        assert any("concurrency" in error for error in errors)
+
+    def test_env_can_satisfy_validation_directly(self):
+        """Recipes ported straight from the InferenceX launcher pass these in
+        benchmark.env; that must not be reported as missing."""
+        config = self._config(model_prefix=None, concurrency=None, env={"MODEL_PREFIX": "dsv4", "CONC": "8"})
+        assert get_runner("agentx").validate_config(config) == []
+
+
 class TestGSM8KRunner:
     """Test the unified GSM8K runner (backend auto-detect)."""
 
@@ -1247,6 +1399,28 @@ class TestScriptsExist:
         """SA-Bench script exists."""
         script = SCRIPTS_DIR / "sa-bench" / "bench.sh"
         assert script.exists()
+
+    def test_agentx_script_exists(self):
+        """AgentX script exists."""
+        script = SCRIPTS_DIR / "agentx" / "bench.sh"
+        assert script.exists()
+
+    def test_agentx_script_explains_a_missing_workspace(self):
+        """Without the mount this is the first thing to fail, and it fails only
+        after the workers have loaded, so the message has to name the cause."""
+        import subprocess
+
+        script = SCRIPTS_DIR / "agentx" / "bench.sh"
+        result = subprocess.run(
+            ["bash", str(script), "http://localhost:8000", "/nonexistent-workspace"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "not found" in result.stderr
+        assert "INFMAX_WORKSPACE" in result.stderr
+        assert "recurse-submodules" in result.stderr, "the clone needs submodules; say so here"
 
     @pytest.mark.parametrize(
         ("mode", "expected"),

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -8,6 +8,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 
 from srtctl.cli.submit import show_config_details
@@ -610,3 +611,16 @@ class TestInfmaxWorkspaceMount:
             show_config_details(config)
         output = capsys.readouterr().out
         assert "MISSING" not in output
+
+    @pytest.mark.parametrize("benchmark_type", ["agentx", "lm-eval"])
+    def test_absence_is_flagged_for_runners_that_build_the_path_themselves(self, capsys, benchmark_type):
+        """These two runners construct /infmax-workspace in Python rather than
+        naming it in benchmark.command, so scanning the command finds nothing and
+        the recipe reads as self-contained right up until it fails."""
+        config = _make_config({"benchmark": {"type": benchmark_type, "model_prefix": "dsv4", "concurrency": 8}})
+        env = {k: v for k, v in os.environ.items() if k != "INFMAX_WORKSPACE"}
+        with patch.dict(os.environ, env, clear=True):
+            show_config_details(config)
+        output = capsys.readouterr().out
+        assert "MISSING" in output
+        assert "127" in output


### PR DESCRIPTION


## Summary

AgentX recipes currently require an InferenceX clone, because the replay client (agentic_srt.sh, benchmark_lib.sh, and the utils/aiperf submodule) lives there and is not vendored in srt-slurm. A native agentx benchmark type is proposed upstream in [NVIDIA/srt-slurm#342](https://github.com/NVIDIA/srt-slurm/pull/342); once it lands we can validate these recipes in CI and update them to type: agentx.

### Example

```yaml
benchmark:
  type: agentx
  model_prefix: "dsv4"
  concurrency: 8
  env:
    KV_OFFLOADING: dram
```

## Test plan
