### PR TITLE
feat: render portable slurm serving lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ srtctl apply -f config.yaml --tags experiment,baseline
 # Dry-run (validate without submitting)
 srtctl dry-run -f config.yaml
 
+# Render a portable serving lifecycle for a future Slurm allocation
+srtctl render-launch -f config.yaml > launch.sh
+
 # Render and run one single-node recipe through Docker
 srtctl apply -f config.yaml -o /absolute/path/to/runs --bash > job.sh
 chmod +x job.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,11 @@ When you run `srtctl apply -f config.yaml`, the tool:
 
 For a single GPU host, render the same recipe with `srtctl apply -f config.yaml --bash`. The resulting launcher owns a Docker serving container on the current host instead of submitting to SLURM. It uses the same topology and lifecycle plan, including worker/router readiness, Tachometer, benchmark execution, and ruter post-processing where configured. See [Direct Host Lifecycle](direct-host.md) for requirements and a complete example.
 
+To inspect or replay the Slurm serving lifecycle without recording a particular job, use
+`srtctl render-launch -f config.yaml > launch.sh`. Run the generated script inside a compatible allocation; it
+discovers the current nodes and IPs, launches NATS/etcd, Dynamo workers, and the frontend, waits for readiness,
+and cleans up the services it owns. Allocation IDs, hostnames, and endpoints are resolved only when the script runs.
+
 The `srtctl-mcp` server is different from `srtctl apply`: it is a schema and
 recipe-authoring helper. It does not use host-side `srtslurm.yaml` for cluster
 defaults, aliases, containers, model paths, filesystem checks, or dry-run
@@ -48,6 +53,7 @@ Once allocated, workers launch inside containers, discover each other through ET
 | `srtctl apply -f <config> --setup-script <script>` | Submit with custom setup script         |
 | `srtctl apply -f <config> --tags tag1,tag2`        | Submit with tags for filtering          |
 | `srtctl dry-run -f <config>`                       | Validate and preview without submitting |
+| `srtctl render-launch -f <config>`                  | Render a portable Slurm serving script  |
 | `srtctl apply -f <config> --bash`                  | Render a one-host Docker lifecycle       |
 | `srtctl validate -f <config>`                      | Alias for dry-run                       |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -288,6 +288,25 @@ separate worker, router, Tachometer, and benchmark logs, gates load on worker/ro
 chat-completions smoke request, then cleans up only containers and process groups it owns. See
 [Direct Host Lifecycle](direct-host.md) for the complete setup and the included 3P2D Dynamo recipe.
 
+### `srtctl render-launch`
+
+Render the recipe's serving lifecycle as a Bash script without submitting or tracing a job.
+
+```bash
+srtctl render-launch -f config.yaml > launch.sh
+chmod +x launch.sh
+salloc <matching resource options>
+./launch.sh
+```
+
+The script must run inside a compatible active Slurm allocation. It discovers the allocation's nodes and IPs at
+runtime, then starts NATS/etcd, optional Mooncake infrastructure, SGLang workers, and the Dynamo frontend using the
+same command builders as normal execution. It contains readiness gates, process monitoring, and cleanup, but does
+not embed the original job ID, hostnames, IP addresses, secrets, benchmark, telemetry, or post-processing stages.
+
+Current support is homogeneous Slurm allocations using the SGLang backend, the Dynamo frontend, and a single
+frontend without nginx. Secret-like environment values are named as required runtime inputs and never rendered.
+
 ### `srtctl dry-run`
 
 Preview what would be submitted without actually submitting.

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -45,7 +45,7 @@ from srtctl.core.processes import (
 from srtctl.core.resource_snapshot import record_resource_snapshot
 from srtctl.core.runtime import RuntimeContext
 from srtctl.core.schema import SrtConfig
-from srtctl.core.slurm import get_slurm_job_id, start_srun_process
+from srtctl.core.slurm import SrunSpec, get_slurm_job_id, start_srun_process, start_srun_spec
 from srtctl.core.status import JobStage, JobStatus, StatusReporter
 from srtctl.core.topology import Endpoint, NodePortAllocator, Process, allocate_endpoints_het
 from srtctl.logging_utils import setup_logging
@@ -149,16 +149,9 @@ class SweepOrchestrator(
             frontend_type=self.config.frontend.type,
         )
 
-    def start_head_infrastructure(self, registry: ProcessRegistry) -> ManagedProcess:
-        """Start NATS and etcd on the infra node.
-
-        When etcd_nats_dedicated_node is enabled, services run on a dedicated node.
-        Otherwise, they run on the head node (default behavior).
-        """
+    def build_head_infrastructure_srun(self) -> SrunSpec:
+        """Build the NATS/etcd launch without starting it."""
         infra_node = self.runtime.nodes.infra
-        logger.info("Starting infrastructure services (NATS, etcd)")
-        logger.info("Infra node: %s", infra_node)
-
         setup_script = Path(__file__).parent / "setup_head.py"
         if not setup_script.exists():
             raise RuntimeError(f"setup_head.py not found at {setup_script}")
@@ -183,14 +176,23 @@ class SweepOrchestrator(
         # This ensures etcd WAL writes go to fast local disk, not network storage
         mounts[Path("/tmp")] = Path("/host-tmp")
 
-        proc = start_srun_process(
-            command=cmd,
-            nodelist=[infra_node],
+        return SrunSpec(
+            command=tuple(cmd),
+            nodelist=(infra_node,),
             output=str(infra_log),
             container_image=str(self.runtime.container_image),
             container_mounts=mounts,
             het_group=self.runtime.nodes.het_group_for(infra_node),
         )
+
+    def start_head_infrastructure(self, registry: ProcessRegistry) -> ManagedProcess:
+        """Start NATS and etcd on the infra node."""
+        infra_node = self.runtime.nodes.infra
+        logger.info("Starting infrastructure services (NATS, etcd)")
+        logger.info("Infra node: %s", infra_node)
+        spec = self.build_head_infrastructure_srun()
+        proc = start_srun_spec(spec, launcher=start_srun_process)
+        infra_log = Path(spec.output or self.runtime.log_dir / "infra.out")
 
         managed = ManagedProcess(
             name="infra_services",
@@ -212,6 +214,24 @@ class SweepOrchestrator(
         logger.info("etcd is ready")
 
         return managed
+
+    def build_mooncake_master_srun(self) -> SrunSpec | None:
+        """Build the optional Mooncake master launch without starting it."""
+        backend = self.config.backend
+        if not isinstance(backend, (SGLangProtocol, VLLMProtocol)):
+            return None
+        mooncake_cfg = backend.mooncake_kv_store
+        if mooncake_cfg is None:
+            return None
+        infra_node = self.runtime.nodes.infra
+        return SrunSpec(
+            command=tuple(_build_mooncake_master_command(mooncake_cfg)),
+            nodelist=(infra_node,),
+            output=str(self.runtime.log_dir / "mooncake_master.out"),
+            container_image=mooncake_cfg.container or str(self.runtime.container_image),
+            container_mounts=self.runtime.container_mounts,
+            het_group=self.runtime.nodes.het_group_for(infra_node),
+        )
 
     def start_mooncake_master(self, registry: ProcessRegistry) -> ManagedProcess | None:
         """Launch mooncake_master on the infra node if mooncake_kv_store is configured.
@@ -239,7 +259,6 @@ class SweepOrchestrator(
             return None
 
         infra_node = self.runtime.nodes.infra
-        container = mooncake_cfg.container or str(self.runtime.container_image)
         mooncake_log = self.runtime.log_dir / "mooncake_master.out"
 
         # vLLM's MooncakeStoreConnector reads its config from a JSON file
@@ -259,14 +278,9 @@ class SweepOrchestrator(
             MOONCAKE_METRICS_PORT,
         )
 
-        proc = start_srun_process(
-            command=_build_mooncake_master_command(mooncake_cfg),
-            nodelist=[infra_node],
-            output=str(mooncake_log),
-            container_image=container,
-            container_mounts=self.runtime.container_mounts,
-            het_group=self.runtime.nodes.het_group_for(infra_node),
-        )
+        spec = self.build_mooncake_master_srun()
+        assert spec is not None
+        proc = start_srun_spec(spec, launcher=start_srun_process)
 
         managed = ManagedProcess(
             name="mooncake_master",
@@ -657,7 +671,6 @@ class SweepOrchestrator(
         logger.info("Worker nodes: %s", ", ".join(self.runtime.nodes.worker))
         if self.config.profiling.enabled:
             logger.info("Profiling: %s", self.config.profiling.type)
-
         resource_snapshot = record_resource_snapshot(self.config, self.runtime)
 
         # Create status reporter (fire-and-forget, no-op if not configured)

--- a/src/srtctl/cli/mixins/worker_stage.py
+++ b/src/srtctl/cli/mixins/worker_stage.py
@@ -10,6 +10,7 @@ Handles starting backend worker processes (prefill/decode/agg).
 import logging
 import shlex
 from collections import defaultdict
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any
 
@@ -17,7 +18,13 @@ from srtctl.core.fingerprint import generate_capture_script
 from srtctl.core.health import wait_for_health
 from srtctl.core.processes import ManagedProcess, NamedProcesses
 from srtctl.core.schema import build_otel_env, installs_dynamo
-from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, get_hostname_ip, start_srun_process
+from srtctl.core.slurm import (
+    CONTAINER_REMAP_ROOT_EXPORT,
+    SrunSpec,
+    get_hostname_ip,
+    start_srun_process,
+    start_srun_spec,
+)
 from srtctl.ports import ETCD_CLIENT_PORT, KV_EVENTS_PORT_BASE, KVBM_ZMQ_PORT_BASE, NATS_PORT
 
 if TYPE_CHECKING:
@@ -94,7 +101,12 @@ class WorkerStageMixin:
 
         return " && ".join(parts)
 
-    def _apply_kvbm_endpoint_env(self, env_to_set: dict[str, str], endpoint_processes: list["Process"]) -> None:
+    def _apply_kvbm_endpoint_env(
+        self,
+        env_to_set: dict[str, str],
+        endpoint_processes: list["Process"],
+        resolve_node_ip: Callable[[str, str | None], str] = get_hostname_ip,
+    ) -> None:
         """Fill KVBM leader ZMQ settings for an endpoint.
 
         KVBM defaults its leader control sockets to 127.0.0.1. That works for
@@ -110,7 +122,7 @@ class WorkerStageMixin:
         endpoint_nodes = list(dict.fromkeys(p.node for p in endpoint_processes))
 
         if len(endpoint_nodes) > 1:
-            leader_host = get_hostname_ip(leader.node, self.runtime.network_interface)
+            leader_host = resolve_node_ip(leader.node, self.runtime.network_interface)
             env_to_set.setdefault("DYN_KVBM_LEADER_ZMQ_HOST", leader_host)
 
         if leader.kv_events_port is None:
@@ -123,12 +135,17 @@ class WorkerStageMixin:
             env_to_set.setdefault("DYN_KVBM_LEADER_ZMQ_PUB_PORT", str(pub_port))
             env_to_set.setdefault("DYN_KVBM_LEADER_ZMQ_ACK_PORT", str(ack_port))
 
-    def start_worker(self, process: "Process", endpoint_processes: list["Process"]) -> ManagedProcess:
-        """Start a single worker process (one srun per node, used by SGLang)."""
+    def build_worker_srun(
+        self,
+        process: "Process",
+        endpoint_processes: list["Process"],
+        *,
+        resolve_node_ip: Callable[[str, str | None], str] = get_hostname_ip,
+        include_fingerprint: bool = True,
+    ) -> SrunSpec:
+        """Build one per-process worker launch without starting it."""
         mode = process.endpoint_mode
         index = process.endpoint_index
-
-        logger.info("Starting %s worker %d on %s", mode, index, process.node)
 
         # Log and config files
         worker_log = self.runtime.log_dir / f"{process.node}_{mode}_w{index}.out"
@@ -137,8 +154,6 @@ class WorkerStageMixin:
         # Profiling setup
         profiling = self.config.profiling
         nsys_prefix = None
-        if profiling.enabled:
-            (self.runtime.log_dir / "profiles" / mode).mkdir(parents=True, exist_ok=True)
         if profiling.is_nsys:
             gpu_label = process.cuda_visible_devices.replace(",", "-")
             nsys_output = f"/logs/profiles/{mode}/{process.node}_{mode}_w{index}_profile_gpu{gpu_label}"
@@ -209,26 +224,19 @@ class WorkerStageMixin:
         # worker's own IP so MOONCAKE_LOCAL_HOSTNAME is correct for multi-node
         # peer-to-peer transfers (defaulting to "localhost" silently breaks them).
         if hasattr(self.backend, "get_mooncake_worker_env"):
-            local_hostname = get_hostname_ip(process.node, self.runtime.network_interface)
+            local_hostname = resolve_node_ip(process.node, self.runtime.network_interface)
             env_to_set.update(self.backend.get_mooncake_worker_env(self.runtime.infra_node_ip, local_hostname))
 
-        self._apply_kvbm_endpoint_env(env_to_set, endpoint_processes)
-
-        # Log env vars in the format: VAR=value VAR2=value2
-        env_str = " ".join(f"{k}={v}" for k, v in sorted(env_to_set.items()))
-        logger.info("Env: %s", env_str)
-        logger.info("Command: %s", shlex.join(cmd))
-        logger.info("Log: %s", worker_log)
-        if profiling.enabled:
-            logger.info("Profiling: %s mode", profiling.type)
+        self._apply_kvbm_endpoint_env(env_to_set, endpoint_processes, resolve_node_ip)
 
         # Build bash preamble (setup script + dynamo install + fingerprint)
         bash_preamble = self._build_worker_preamble()
-        fp_cmd = generate_capture_script(f"/logs/fingerprint_{mode}_w{index}.json")
-        # Keep fingerprint failures non-fatal, but do not let its `|| true`
-        # mask failures from setup/dynamo install commands before it.
-        fp_cmd = f"( {fp_cmd} )"
-        bash_preamble = f"{bash_preamble} && {fp_cmd}" if bash_preamble else fp_cmd
+        if include_fingerprint:
+            fp_cmd = generate_capture_script(f"/logs/fingerprint_{mode}_w{index}.json")
+            # Keep fingerprint failures non-fatal, but do not let its `|| true`
+            # mask failures from setup/dynamo install commands before it.
+            fp_cmd = f"( {fp_cmd} )"
+            bash_preamble = f"{bash_preamble} && {fp_cmd}" if bash_preamble else fp_cmd
 
         # vLLM uses VLLM_PORT as the initial port for its internal message
         # queues. In a multi-node endpoint, concurrent TP ranks inherit the
@@ -237,19 +245,39 @@ class WorkerStageMixin:
         endpoint_nodes = {endpoint_process.node for endpoint_process in endpoint_processes}
         env_to_unset = ["VLLM_PORT"] if self.backend.type == "vllm" and len(endpoint_nodes) > 1 else None
 
-        proc = start_srun_process(
-            command=cmd,
-            nodelist=[process.node],
+        return SrunSpec(
+            command=tuple(cmd),
+            nodelist=(process.node,),
             output=str(worker_log),
             container_image=str(self.runtime.container_image),
             container_mounts=self.runtime.container_mounts,
             env_to_set=env_to_set,
-            env_to_unset=env_to_unset,
+            env_to_unset=tuple(env_to_unset) if env_to_unset else None,
             bash_preamble=bash_preamble,
             srun_options=self.runtime.srun_options,
             srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if installs_dynamo(self.config) else None,
             het_group=process.het_group,
         )
+
+    def start_worker(self, process: "Process", endpoint_processes: list["Process"]) -> ManagedProcess:
+        """Start a single worker process (one srun per node, used by SGLang)."""
+        mode = process.endpoint_mode
+        index = process.endpoint_index
+        logger.info("Starting %s worker %d on %s", mode, index, process.node)
+
+        if self.config.profiling.enabled:
+            (self.runtime.log_dir / "profiles" / mode).mkdir(parents=True, exist_ok=True)
+
+        spec = self.build_worker_srun(process, endpoint_processes)
+        env_str = " ".join(f"{k}={v}" for k, v in sorted((spec.env_to_set or {}).items()))
+        logger.info("Env: %s", env_str)
+        logger.info("Command: %s", shlex.join(spec.command))
+        logger.info("Log: %s", spec.output)
+        if self.config.profiling.enabled:
+            logger.info("Profiling: %s mode", self.config.profiling.type)
+
+        proc = start_srun_spec(spec, launcher=start_srun_process)
+        worker_log = self.runtime.log_dir / f"{process.node}_{mode}_w{index}.out"
 
         return ManagedProcess(
             name=f"{mode}_{index}_{process.node}",

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -63,6 +63,7 @@ from srtctl.render.direct_plan import (
     build_direct_plan_context,
     render_direct_container_shim,
 )
+from srtctl.render.slurm_plan import render_slurm_launch_script
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -1287,6 +1288,51 @@ def render_bash_script(
     return render(config)
 
 
+def render_launch_script(
+    config_path: Path,
+    selector: str | None = None,
+    output_dir: Path | None = None,
+) -> str:
+    """Render a portable serving lifecycle for a future Slurm allocation."""
+    if config_path.is_dir():
+        raise ValueError("render-launch expects a single config file, not a directory")
+
+    srtctl_root = get_srtslurm_setting("srtctl_root")
+    source_dir = Path(srtctl_root) if srtctl_root else Path(__file__).parent.parent.parent.parent
+    if output_dir:
+        output_base = output_dir.resolve()
+    else:
+        configured_output_dir = get_srtslurm_setting("output_dir")
+        output_base = (
+            Path(os.path.expandvars(configured_output_dir)).resolve()
+            if configured_output_dir
+            else (source_dir / "outputs").resolve()
+        )
+
+    def render(config: SrtConfig) -> str:
+        return render_slurm_launch_script(config, source_dir=source_dir, output_base=output_base)
+
+    if is_override_config(config_path):
+        from srtctl.core.config import resolve_override_yaml
+
+        resolved_variants = resolve_override_yaml(config_path, selector=selector)
+        if len(resolved_variants) != 1:
+            raise ValueError(
+                "render-launch for override configs requires a selector that resolves to exactly one variant"
+            )
+        _suffix, config_cm = resolved_variants[0]
+        if "sweep" in config_cm:
+            raise ValueError("render-launch does not support override variants that contain a sweep")
+        resolved_config = resolve_config_with_defaults(config_cm, load_cluster_config())
+        return render(SrtConfig.Schema().load(resolved_config))
+
+    if selector:
+        logger.warning(f"Selector ':{selector}' ignored — config is not an override file")
+    if is_sweep_config(config_path):
+        raise ValueError("render-launch currently supports single-job configs only")
+    return render(load_config(config_path))
+
+
 def submit_override(
     config_path: Path,
     selector: str | None = None,
@@ -1438,6 +1484,7 @@ def main():
   srtctl                                         # Interactive mode
   srtctl apply -f config.yaml                    # Submit job
   srtctl apply -f config.yaml --bash             # Print a direct single-node Bash lifecycle script
+  srtctl render-launch -f config.yaml             # Print a portable Slurm serving lifecycle
   srtctl apply -f ./configs/                     # Submit all YAMLs in directory
   srtctl apply -f config.yaml --sweep            # Submit sweep
   srtctl preflight -f config.yaml                # Check model/container availability
@@ -1514,6 +1561,12 @@ def main():
 
     dry_run_parser = subparsers.add_parser("dry-run", help="Validate without submitting")
     add_common_args(dry_run_parser)
+
+    render_launch_parser = subparsers.add_parser(
+        "render-launch",
+        help="Render a portable serving script for an active Slurm allocation",
+    )
+    add_common_args(render_launch_parser)
 
     preflight_parser = subparsers.add_parser(
         "preflight",
@@ -1724,6 +1777,19 @@ def main():
 
             setup_script = getattr(args, "setup_script", None)
             output_dir = getattr(args, "output_dir", None)
+
+            if args.command == "render-launch":
+                script_content = render_launch_script(
+                    effective_config_path,
+                    selector=selector,
+                    output_dir=output_dir,
+                )
+                sys.stdout.write(script_content)
+                if not script_content.endswith("\n"):
+                    sys.stdout.write("\n")
+                sys.stdout.flush()
+                restore_console()
+                return
 
             if bash_mode:
                 script_content = render_bash_script(

--- a/src/srtctl/core/runtime.py
+++ b/src/srtctl/core/runtime.py
@@ -9,6 +9,7 @@ replacing scattered bash variables and Jinja templating with typed Python.
 """
 
 import os
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -102,16 +103,6 @@ class Nodes:
                                       colocating with whichever node ends up
                                       being head; infra falls back to head).
         """
-        dedicated_roles = [
-            role
-            for role, wanted in (
-                ("infra", etcd_nats_dedicated_node),
-                ("frontend", frontend_dedicated_node),
-                ("client", client_dedicated_node),
-            )
-            if wanted
-        ]
-
         het_lists = get_slurm_het_nodelists()
         if het_lists is not None:
             if frontend_dedicated_node or client_dedicated_node:
@@ -123,6 +114,37 @@ class Nodes:
         nodelist = get_slurm_nodelist()
         if not nodelist:
             raise RuntimeError("SLURM_NODELIST not set - are we running in SLURM?")
+
+        return cls.from_nodelist(
+            nodelist,
+            frontend_dedicated_node=frontend_dedicated_node,
+            client_dedicated_node=client_dedicated_node,
+            etcd_nats_dedicated_node=etcd_nats_dedicated_node,
+            colocate_dedicated_nodes=colocate_dedicated_nodes,
+        )
+
+    @classmethod
+    def from_nodelist(
+        cls,
+        nodelist: list[str],
+        *,
+        frontend_dedicated_node: bool = False,
+        client_dedicated_node: bool = False,
+        etcd_nats_dedicated_node: bool = False,
+        colocate_dedicated_nodes: bool = True,
+    ) -> "Nodes":
+        """Assign logical roles from an already expanded homogeneous nodelist."""
+        if not nodelist:
+            raise ValueError("nodelist must contain at least one node")
+        dedicated_roles = [
+            role
+            for role, wanted in (
+                ("infra", etcd_nats_dedicated_node),
+                ("frontend", frontend_dedicated_node),
+                ("client", client_dedicated_node),
+            )
+            if wanted
+        ]
 
         if not dedicated_roles:
             head = bench = infra = nodelist[0]
@@ -263,6 +285,12 @@ class RuntimeContext:
         config: "SrtConfig",
         job_id: str,
         log_dir_base: Path | None = None,
+        *,
+        nodes: Nodes | None = None,
+        node_ip_resolver: Callable[[str], str] = get_hostname_ip,
+        validate_paths: bool = True,
+        create_log_dir: bool = True,
+        prefer_output_env: bool = True,
     ) -> "RuntimeContext":
         """Create RuntimeContext from config and job_id.
 
@@ -273,24 +301,26 @@ class RuntimeContext:
             job_id: SLURM job ID
             log_dir_base: Base directory for logs (default: ./outputs)
         """
-        # Get nodes from SLURM
-        nodes = Nodes.from_slurm(
-            frontend_dedicated_node=config.frontend.dedicated_node,
-            client_dedicated_node=config.benchmark.client_dedicated_node,
-            etcd_nats_dedicated_node=config.infra.etcd_nats_dedicated_node,
-            colocate_dedicated_nodes=config.benchmark.colocate_with_frontend,
-        )
+        # Runtime execution discovers nodes from Slurm. Renderers can provide a
+        # symbolic topology while reusing every other path/env calculation.
+        if nodes is None:
+            nodes = Nodes.from_slurm(
+                frontend_dedicated_node=config.frontend.dedicated_node,
+                client_dedicated_node=config.benchmark.client_dedicated_node,
+                etcd_nats_dedicated_node=config.infra.etcd_nats_dedicated_node,
+                colocate_dedicated_nodes=config.benchmark.colocate_with_frontend,
+            )
 
         # Compute run_name
         run_name = f"{config.name}_{job_id}"
 
         # Resolve node IPs
-        head_node_ip = get_hostname_ip(nodes.head)
-        infra_node_ip = get_hostname_ip(nodes.infra)
+        head_node_ip = node_ip_resolver(nodes.head)
+        infra_node_ip = node_ip_resolver(nodes.infra)
 
         # Compute log directory using FormattablePath or default logic
         # Check for SRTCTL_OUTPUT_DIR from sbatch script first (ensures consistency)
-        output_dir_env = os.environ.get("SRTCTL_OUTPUT_DIR")
+        output_dir_env = os.environ.get("SRTCTL_OUTPUT_DIR") if prefer_output_env else None
         if output_dir_env:
             log_dir = Path(output_dir_env) / "logs"
         elif log_dir_base is None:
@@ -298,7 +328,8 @@ class RuntimeContext:
             log_dir = log_dir_base / job_id / "logs"
         else:
             log_dir = log_dir_base / job_id / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
+        if create_log_dir:
+            log_dir.mkdir(parents=True, exist_ok=True)
 
         # Resolve model path (expand env vars)
         # Support HuggingFace model IDs with "hf:" prefix (e.g., "hf:facebook/opt-125m")
@@ -312,9 +343,9 @@ class RuntimeContext:
         else:
             # Local path - validate exists
             model_path = Path(model_path_str).resolve()
-            if not model_path.exists():
+            if validate_paths and not model_path.exists():
                 raise FileNotFoundError(f"Model path does not exist: {model_path}")
-            if not model_path.is_dir():
+            if validate_paths and not model_path.is_dir():
                 raise ValueError(f"Model path is not a directory: {model_path}")
 
         # Resolve container image (expand env vars)
@@ -327,9 +358,9 @@ class RuntimeContext:
         # Image names are typically registry paths without leading / or ./
         if container_image_str.startswith(("/", "./")):
             container_image = Path(container_image_str).resolve()
-            if not container_image.exists():
+            if validate_paths and not container_image.exists():
                 raise FileNotFoundError(f"Container image path does not exist: {container_image}")
-            if not container_image.is_file():
+            if validate_paths and not container_image.is_file():
                 raise ValueError(f"Container image path is not a file: {container_image}")
         else:
             # Image name (e.g., nvcr.io/nvidia/pytorch:23.12) - keep as string, convert to Path for type compatibility

--- a/src/srtctl/core/slurm.py
+++ b/src/srtctl/core/slurm.py
@@ -16,7 +16,8 @@ import os
 import shlex
 import socket
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from .ip_utils import get_node_ip
@@ -181,9 +182,97 @@ def get_node_ips(
 CONTAINER_REMAP_ROOT_EXPORT = {"ENROOT_REMAP_ROOT": "yes"}
 
 
-def start_srun_process(
+@dataclass(frozen=True)
+class SrunSpec:
+    """Declarative inputs for one ``srun`` launch.
+
+    Stage builders return this object so normal execution and launch-script
+    rendering consume the same command definition.
+    """
+
+    command: tuple[str, ...]
+    nodes: int = 1
+    ntasks: int = 1
+    cpus_per_task: int | None = None
+    nodelist: tuple[str, ...] | None = None
+    output: str | None = None
+    container_image: str | None = None
+    container_mounts: dict[Path, Path] | None = None
+    env_to_pass_through: tuple[str, ...] | None = None
+    env_to_set: dict[str, str] | None = None
+    env_to_unset: tuple[str, ...] | None = None
+    bash_preamble: str | None = None
+    srun_options: dict[str, str] | None = None
+    srun_export_env: dict[str, str] | None = None
+    overlap: bool = True
+    use_bash_wrapper: bool = True
+    mpi: str | None = None
+    oversubscribe: bool = False
+    cpu_bind: str | None = None
+    het_group: int | None = None
+
+    def argv(self, *, job_id: str | None = None) -> list[str]:
+        """Render this launch for a specific allocation or portable replay."""
+        return build_srun_command(
+            list(self.command),
+            job_id=job_id,
+            nodes=self.nodes,
+            ntasks=self.ntasks,
+            cpus_per_task=self.cpus_per_task,
+            nodelist=self.nodelist,
+            output=self.output,
+            container_image=self.container_image,
+            container_mounts=self.container_mounts,
+            env_to_pass_through=list(self.env_to_pass_through) if self.env_to_pass_through else None,
+            env_to_set=self.env_to_set,
+            env_to_unset=list(self.env_to_unset) if self.env_to_unset else None,
+            bash_preamble=self.bash_preamble,
+            srun_options=self.srun_options,
+            srun_export_env=self.srun_export_env,
+            overlap=self.overlap,
+            use_bash_wrapper=self.use_bash_wrapper,
+            mpi=self.mpi,
+            oversubscribe=self.oversubscribe,
+            cpu_bind=self.cpu_bind,
+            het_group=self.het_group,
+        )
+
+
+def start_srun_spec(
+    spec: SrunSpec,
+    *,
+    launcher: Callable[..., subprocess.Popen] | None = None,
+) -> subprocess.Popen:
+    """Launch a stage-built spec in the current allocation."""
+    launch = launcher or start_srun_process
+    return launch(
+        list(spec.command),
+        nodes=spec.nodes,
+        ntasks=spec.ntasks,
+        cpus_per_task=spec.cpus_per_task,
+        nodelist=spec.nodelist,
+        output=spec.output,
+        container_image=spec.container_image,
+        container_mounts=spec.container_mounts,
+        env_to_pass_through=list(spec.env_to_pass_through) if spec.env_to_pass_through else None,
+        env_to_set=spec.env_to_set,
+        env_to_unset=list(spec.env_to_unset) if spec.env_to_unset else None,
+        bash_preamble=spec.bash_preamble,
+        srun_options=spec.srun_options,
+        srun_export_env=spec.srun_export_env,
+        overlap=spec.overlap,
+        use_bash_wrapper=spec.use_bash_wrapper,
+        mpi=spec.mpi,
+        oversubscribe=spec.oversubscribe,
+        cpu_bind=spec.cpu_bind,
+        het_group=spec.het_group,
+    )
+
+
+def build_srun_command(
     command: list[str],
     *,
+    job_id: str | None = None,
     nodes: int = 1,
     ntasks: int = 1,
     cpus_per_task: int | None = None,
@@ -203,14 +292,17 @@ def start_srun_process(
     oversubscribe: bool = False,
     cpu_bind: str | None = None,
     het_group: int | None = None,
-) -> subprocess.Popen:
-    """Start a process via srun with container support.
+) -> list[str]:
+    """Build an ``srun`` argv without launching it.
 
-    This is the central function for launching all srun processes.
-    It handles container mounts, environment variables, and output redirection.
+    Keeping construction pure lets runtime execution and portable launch-script
+    rendering share the exact same command path. ``job_id`` is explicit: pass
+    the current allocation ID for normal execution, or ``None`` for a command
+    that inherits whichever allocation is active when it is run.
 
     Args:
         command: Command to run as list of strings
+        job_id: Optional allocation ID to pass via ``--jobid``.
         nodes: Number of nodes (default: 1)
         ntasks: Number of tasks (default: 1)
         cpus_per_task: CPUs per task (optional)
@@ -234,11 +326,12 @@ def start_srun_process(
         cpu_bind: CPU binding mode (e.g., "verbose,none" for TRTLLM)
 
     Returns:
-        subprocess.Popen object for the srun process
+        Fully constructed ``srun`` argv.
 
     Example:
-        proc = start_srun_process(
+        command = build_srun_command(
             command=["python3", "-m", "dynamo.sglang", "--model-path", "/model"],
+            job_id=None,
             nodelist=["node1"],
             container_image="/containers/sglang.sqsh",
             container_mounts={Path("/models/llama"): Path("/model")},
@@ -248,9 +341,8 @@ def start_srun_process(
     srun_cmd = ["srun"]
 
     # ensures srun runs in the same job context
-    slurm_job_id = get_slurm_job_id()
-    if slurm_job_id:
-        srun_cmd.extend(["--jobid", slurm_job_id])
+    if job_id:
+        srun_cmd.extend(["--jobid", job_id])
 
     # Basic options
     if overlap:
@@ -348,13 +440,59 @@ def start_srun_process(
             )
         srun_cmd.extend(command)
 
-    # Demoted to debug — every worker srun line is multi-KB once the
-    # fingerprint heredoc is inlined (see core/fingerprint.generate_capture_script),
-    # which dominates the orchestrator log. Re-enable with `--verbose` / by setting
-    # the srtctl logger to DEBUG when troubleshooting srun arg construction.
-    logger.debug("srun command: %s", shlex.join(srun_cmd))
+    return srun_cmd
 
-    # Start the process
+
+def start_srun_process(
+    command: list[str],
+    *,
+    nodes: int = 1,
+    ntasks: int = 1,
+    cpus_per_task: int | None = None,
+    nodelist: Sequence[str] | None = None,
+    output: str | None = None,
+    container_image: str | None = None,
+    container_mounts: dict[Path, Path] | None = None,
+    env_to_pass_through: list[str] | None = None,
+    env_to_set: dict[str, str] | None = None,
+    env_to_unset: list[str] | None = None,
+    bash_preamble: str | None = None,
+    srun_options: dict[str, str] | None = None,
+    srun_export_env: dict[str, str] | None = None,
+    overlap: bool = True,
+    use_bash_wrapper: bool = True,
+    mpi: str | None = None,
+    oversubscribe: bool = False,
+    cpu_bind: str | None = None,
+    het_group: int | None = None,
+) -> subprocess.Popen:
+    """Build and start an ``srun`` child in the current allocation."""
+    srun_cmd = build_srun_command(
+        command,
+        job_id=get_slurm_job_id(),
+        nodes=nodes,
+        ntasks=ntasks,
+        cpus_per_task=cpus_per_task,
+        nodelist=nodelist,
+        output=output,
+        container_image=container_image,
+        container_mounts=container_mounts,
+        env_to_pass_through=env_to_pass_through,
+        env_to_set=env_to_set,
+        env_to_unset=env_to_unset,
+        bash_preamble=bash_preamble,
+        srun_options=srun_options,
+        srun_export_env=srun_export_env,
+        overlap=overlap,
+        use_bash_wrapper=use_bash_wrapper,
+        mpi=mpi,
+        oversubscribe=oversubscribe,
+        cpu_bind=cpu_bind,
+        het_group=het_group,
+    )
+
+    # Every worker srun line is multi-KB once fingerprint capture is inlined.
+    logger.debug("srun command: %s", shlex.join(srun_cmd))
     proc = subprocess.Popen(
         srun_cmd,
         stdout=subprocess.PIPE if not output else None,

--- a/src/srtctl/frontends/dynamo.py
+++ b/src/srtctl/frontends/dynamo.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from srtctl.core.health import WorkerHealthResult, check_dynamo_health
 from srtctl.core.schema import build_otel_env
-from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, start_srun_process
+from srtctl.core.slurm import CONTAINER_REMAP_ROOT_EXPORT, SrunSpec, start_srun_process, start_srun_spec
 from srtctl.ports import ETCD_CLIENT_PORT, NATS_PORT
 
 if TYPE_CHECKING:
@@ -74,10 +74,27 @@ class DynamoFrontend:
         from srtctl.core.processes import ManagedProcess
 
         processes: list[ManagedProcess] = []
-
-        for idx, node in enumerate(topology.frontend_nodes):
+        for idx, spec in enumerate(self.build_frontend_sruns(topology=topology, runtime=runtime, config=config)):
+            node = (spec.nodelist or (runtime.nodes.head,))[0]
             logger.info("Starting dynamo frontend %d on %s", idx, node)
+            frontend_log = runtime.log_dir / f"{node}_frontend_{idx}.out"
+            proc = start_srun_spec(spec, launcher=start_srun_process)
+            processes.append(
+                ManagedProcess(
+                    name=f"frontend_{idx}",
+                    popen=proc,
+                    log_file=frontend_log,
+                    node=node,
+                    critical=True,
+                )
+            )
 
+        return processes
+
+    def build_frontend_sruns(self, *, topology: Any, runtime: "RuntimeContext", config: Any) -> list[SrunSpec]:
+        """Build all Dynamo frontend launches without starting them."""
+        specs: list[SrunSpec] = []
+        for idx, node in enumerate(topology.frontend_nodes):
             frontend_log = runtime.log_dir / f"{node}_frontend_{idx}.out"
             cmd = ["python3", "-m", "dynamo.frontend", f"--http-port={topology.frontend_port}"]
             cmd.extend(self.get_frontend_args_list(config.frontend.args))
@@ -105,34 +122,25 @@ class DynamoFrontend:
             # Build bash preamble (setup script + dynamo install)
             bash_preamble = self._build_preamble(config)
 
-            proc = start_srun_process(
-                command=cmd,
-                nodelist=[node],
-                output=str(frontend_log),
-                container_image=str(runtime.container_image),
-                container_mounts=runtime.container_mounts,
-                env_to_set=env_to_set,
-                bash_preamble=bash_preamble,
-                # Frontend container runs the dynamo install (see _build_preamble), whose
-                # cold build needs root inside the container. Remap via enroot env var.
-                srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if config.dynamo.install else None,
-                # TODO(jthomson): I don't have the faintest clue of
-                # why this is needed in later versions of Dynamo, but it is.
-                mpi="pmix",
-                het_group=runtime.nodes.het_group_for(node),
-            )
-
-            processes.append(
-                ManagedProcess(
-                    name=f"frontend_{idx}",
-                    popen=proc,
-                    log_file=frontend_log,
-                    node=node,
-                    critical=True,
+            specs.append(
+                SrunSpec(
+                    command=tuple(cmd),
+                    nodelist=(node,),
+                    output=str(frontend_log),
+                    container_image=str(runtime.container_image),
+                    container_mounts=runtime.container_mounts,
+                    env_to_set=env_to_set,
+                    bash_preamble=bash_preamble,
+                    # Frontend container runs the dynamo install (see _build_preamble), whose
+                    # cold build needs root inside the container. Remap via enroot env var.
+                    srun_export_env=CONTAINER_REMAP_ROOT_EXPORT if config.dynamo.install else None,
+                    # TODO(jthomson): I don't have the faintest clue of
+                    # why this is needed in later versions of Dynamo, but it is.
+                    mpi="pmix",
+                    het_group=runtime.nodes.het_group_for(node),
                 )
             )
-
-        return processes
+        return specs
 
     def _build_preamble(self, config: Any) -> str | None:
         """Build bash preamble for dynamo frontend processes."""

--- a/src/srtctl/render/slurm_plan.py
+++ b/src/srtctl/render/slurm_plan.py
@@ -1,0 +1,437 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compile a portable Slurm serving lifecycle from a resolved recipe."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from srtctl.backends.sglang import SGLangProtocol
+from srtctl.cli.do_sweep import SweepOrchestrator
+from srtctl.core.config import get_srtslurm_setting
+from srtctl.core.runtime import Nodes, RuntimeContext
+from srtctl.core.schema import SrtConfig
+from srtctl.core.slurm import SrunSpec
+from srtctl.frontends.dynamo import DynamoFrontend
+from srtctl.ports import (
+    ETCD_CLIENT_PORT,
+    FRONTEND_PUBLIC_PORT,
+    MOONCAKE_HTTP_METADATA_PORT,
+    MOONCAKE_MASTER_PORT,
+    MOONCAKE_METRICS_PORT,
+    NATS_PORT,
+)
+
+_SECRET_NAME = re.compile(r"(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|ACCESS_KEY|PRIVATE_KEY|CREDENTIAL)(?:_|$)")
+_PLACEHOLDER = re.compile(r"__SRTCTL_(?:NODE|IP)_\d+__|__SRTCTL_(?:JOB_ID|OUTPUT_ROOT|SOURCE_DIR)__")
+
+
+@dataclass(frozen=True)
+class LaunchStep:
+    """One background service plus readiness gates that follow its launch."""
+
+    label: str
+    stage: str
+    spec: SrunSpec
+    waits: tuple[tuple[str, int, int, str], ...] = ()
+
+
+def _is_secret_name(name: str) -> bool:
+    return bool(_SECRET_NAME.search(name.upper()))
+
+
+def _allocation_node_count(config: SrtConfig) -> int:
+    count = config.total_nodes
+    dedicated_roles = sum(
+        (
+            config.infra.etcd_nats_dedicated_node,
+            config.frontend.dedicated_node,
+            config.benchmark.client_dedicated_node,
+        )
+    )
+    if dedicated_roles:
+        count += 1 if config.benchmark.colocate_with_frontend else dedicated_roles
+    return count
+
+
+def _symbolic_topology(config: SrtConfig) -> tuple[Nodes, dict[str, str], int]:
+    required_nodes = _allocation_node_count(config)
+    nodelist = [f"__SRTCTL_NODE_{index}__" for index in range(required_nodes)]
+    nodes = Nodes.from_nodelist(
+        nodelist,
+        frontend_dedicated_node=config.frontend.dedicated_node,
+        client_dedicated_node=config.benchmark.client_dedicated_node,
+        etcd_nats_dedicated_node=config.infra.etcd_nats_dedicated_node,
+        colocate_dedicated_nodes=config.benchmark.colocate_with_frontend,
+    )
+    ips = {node: f"__SRTCTL_IP_{index}__" for index, node in enumerate(nodelist)}
+    return nodes, ips, required_nodes
+
+
+def _redact_command(argv: list[str], spec: SrunSpec) -> tuple[list[str], set[str]]:
+    """Remove secret values while preserving the environment contract."""
+    redacted = list(argv)
+    required: set[str] = set()
+
+    if spec.srun_export_env:
+        for index, arg in enumerate(redacted):
+            if not arg.startswith("--export=ALL,"):
+                continue
+            exports: list[str] = []
+            for item in arg.removeprefix("--export=ALL,").split(","):
+                name, separator, _value = item.partition("=")
+                if separator and _is_secret_name(name):
+                    exports.append(name)
+                    required.add(name)
+                else:
+                    exports.append(item)
+            redacted[index] = "--export=ALL," + ",".join(exports)
+
+    if spec.env_to_set:
+        bash_index = next(
+            (index for index in range(len(redacted) - 1) if redacted[index : index + 2] == ["bash", "-c"]),
+            None,
+        )
+        if bash_index is not None:
+            bash_command = redacted[bash_index + 2]
+            for name, value in spec.env_to_set.items():
+                if not _is_secret_name(name):
+                    continue
+                bash_command = bash_command.replace(
+                    f"export {name}={shlex.quote(value)}",
+                    f'export {name}="${{{name}:?Set {name} before running this script}}"',
+                )
+                required.add(name)
+            redacted[bash_index + 2] = bash_command
+
+    return redacted, required
+
+
+def _replace_static_paths(value: str, *, source_dir: Path) -> str:
+    source = str(source_dir.resolve())
+    return value.replace(source, "__SRTCTL_SOURCE_DIR__").replace("/__SRTCTL_OUTPUT_ROOT__", "__SRTCTL_OUTPUT_ROOT__")
+
+
+def _shell_word(value: str, *, source_dir: Path) -> str:
+    """Quote one argv item while allowing only generated placeholders to expand."""
+    value = _replace_static_paths(value, source_dir=source_dir)
+    pieces: list[str] = []
+    cursor = 0
+    for match in _PLACEHOLDER.finditer(value):
+        if match.start() > cursor:
+            pieces.append(shlex.quote(value[cursor : match.start()]))
+        token = match.group(0)
+        if token == "__SRTCTL_JOB_ID__":
+            expression = "${SLURM_JOB_ID}"
+        elif token == "__SRTCTL_OUTPUT_ROOT__":
+            expression = "${SRTCTL_OUTPUT_ROOT}"
+        elif token == "__SRTCTL_SOURCE_DIR__":
+            expression = "${SRTCTL_SOURCE_DIR}"
+        elif token.startswith("__SRTCTL_NODE_"):
+            index = token.removeprefix("__SRTCTL_NODE_").removesuffix("__")
+            expression = f"${{SRTCTL_NODES[{index}]}}"
+        else:
+            index = token.removeprefix("__SRTCTL_IP_").removesuffix("__")
+            expression = f"${{SRTCTL_NODE_IPS[{index}]}}"
+        pieces.append(f'"{expression}"')
+        cursor = match.end()
+    if cursor < len(value):
+        pieces.append(shlex.quote(value[cursor:]))
+    return "".join(pieces) or "''"
+
+
+def _render_command(argv: list[str], *, source_dir: Path) -> str:
+    return " \\\n  ".join(_shell_word(arg, source_dir=source_dir) for arg in argv)
+
+
+def _validate_config(config: SrtConfig) -> None:
+    if config.resources.het_jobs:
+        raise ValueError("render-launch currently supports homogeneous Slurm allocations only")
+    if not isinstance(config.backend, SGLangProtocol):
+        raise NotImplementedError("render-launch currently supports backend.type: sglang only")
+    if config.frontend.type != "dynamo":
+        raise NotImplementedError("render-launch currently supports frontend.type: dynamo only")
+    if config.frontend.enable_multiple_frontends:
+        raise ValueError("render-launch currently requires frontend.enable_multiple_frontends: false")
+    if config.backend.get_srun_config().launch_per_endpoint:
+        raise ValueError("render-launch does not yet support MPI-style endpoint launches")
+    if config.model.stage_dir:
+        raise ValueError("render-launch does not yet support model.stage_dir")
+
+
+def _build_steps(
+    config: SrtConfig,
+    *,
+    source_dir: Path,
+    output_base: Path,
+) -> tuple[list[LaunchStep], int, str, str]:
+    nodes, node_ips, required_nodes = _symbolic_topology(config)
+
+    def resolve_node_ip(node: str, _network_interface: str | None = None) -> str:
+        return node_ips[node]
+
+    runtime = RuntimeContext.from_config(
+        config,
+        "__SRTCTL_JOB_ID__",
+        log_dir_base=Path("/__SRTCTL_OUTPUT_ROOT__"),
+        nodes=nodes,
+        node_ip_resolver=lambda node: resolve_node_ip(node),
+        validate_paths=False,
+        create_log_dir=False,
+        prefer_output_env=False,
+    )
+    orchestrator = SweepOrchestrator(config, runtime)
+    steps: list[LaunchStep] = []
+
+    infra = orchestrator.build_head_infrastructure_srun()
+    steps.append(
+        LaunchStep(
+            label="infra",
+            stage="infrastructure",
+            spec=infra,
+            waits=(
+                (runtime.nodes.infra, NATS_PORT, 300, "NATS"),
+                (runtime.nodes.infra, ETCD_CLIENT_PORT, 300, "etcd"),
+            ),
+        )
+    )
+
+    mooncake = orchestrator.build_mooncake_master_srun()
+    if mooncake is not None:
+        steps.append(
+            LaunchStep(
+                label="mooncake-master",
+                stage="infrastructure",
+                spec=mooncake,
+                waits=(
+                    (runtime.nodes.infra, MOONCAKE_MASTER_PORT, 120, "Mooncake RPC"),
+                    (runtime.nodes.infra, MOONCAKE_HTTP_METADATA_PORT, 120, "Mooncake metadata"),
+                    (runtime.nodes.infra, MOONCAKE_METRICS_PORT, 120, "Mooncake metrics"),
+                ),
+            )
+        )
+
+    grouped: dict[tuple[str, int], list] = defaultdict(list)
+    for process in orchestrator.backend_processes:
+        grouped[(process.endpoint_mode, process.endpoint_index)].append(process)
+    for process in orchestrator.backend_processes:
+        endpoint_processes = grouped[(process.endpoint_mode, process.endpoint_index)]
+        spec = orchestrator.build_worker_srun(
+            process,
+            endpoint_processes,
+            resolve_node_ip=resolve_node_ip,
+            include_fingerprint=False,
+        )
+        steps.append(
+            LaunchStep(
+                label=f"{process.endpoint_mode}-{process.endpoint_index}-rank-{process.node_rank}",
+                stage="workers",
+                spec=spec,
+            )
+        )
+
+    topology = orchestrator._compute_frontend_topology()
+    if topology.uses_nginx:
+        raise ValueError("render-launch does not yet support nginx/multiple frontends")
+    frontend = DynamoFrontend()
+    frontend_specs = frontend.build_frontend_sruns(topology=topology, runtime=runtime, config=config)
+    for index, spec in enumerate(frontend_specs):
+        frontend_node = (spec.nodelist or (runtime.nodes.head,))[0]
+        steps.append(
+            LaunchStep(
+                label=f"frontend-{index}",
+                stage="frontend",
+                spec=spec,
+                waits=((frontend_node, FRONTEND_PUBLIC_PORT, 300, "Dynamo frontend"),),
+            )
+        )
+
+    frontend_node = topology.frontend_nodes[0]
+    return steps, required_nodes, node_ips[frontend_node], str(output_base.resolve())
+
+
+def render_slurm_launch_script(config: SrtConfig, *, source_dir: Path, output_base: Path) -> str:
+    """Render a standalone serving launcher for a future Slurm allocation."""
+    _validate_config(config)
+    steps, required_nodes, frontend_ip, output_default = _build_steps(
+        config,
+        source_dir=source_dir,
+        output_base=output_base,
+    )
+
+    rendered_steps: list[tuple[LaunchStep, str]] = []
+    required_secrets: set[str] = set()
+    for step in steps:
+        argv, secrets = _redact_command(step.spec.argv(job_id=None), step.spec)
+        required_secrets.update(secrets)
+        rendered_steps.append((step, _render_command(argv, source_dir=source_dir)))
+
+    network_interface = str(get_srtslurm_setting("network_interface", "eth0"))
+    lines = [
+        "#!/usr/bin/env bash",
+        "# Generated by `srtctl render-launch`; allocation identities are resolved when this script runs.",
+        "set -Eeuo pipefail",
+        "",
+        ': "${SLURM_JOB_ID:?Run this script inside an active Slurm allocation}"',
+        'SRTCTL_RAW_NODELIST="${SLURM_JOB_NODELIST:-${SLURM_NODELIST:-}}"',
+        ': "${SRTCTL_RAW_NODELIST:?SLURM_JOB_NODELIST or SLURM_NODELIST must be set}"',
+        f"SRTCTL_REQUIRED_NODES={required_nodes}",
+        'SRTCTL_SOURCE_DIR="${SRTCTL_SOURCE_DIR:-}"',
+        f'if [[ -z "${{SRTCTL_SOURCE_DIR}}" ]]; then SRTCTL_SOURCE_DIR={shlex.quote(str(source_dir.resolve()))}; fi',
+        'SRTCTL_OUTPUT_ROOT="${SRTCTL_OUTPUT_ROOT:-}"',
+        f'if [[ -z "${{SRTCTL_OUTPUT_ROOT}}" ]]; then SRTCTL_OUTPUT_ROOT={shlex.quote(output_default)}; fi',
+        'SRTCTL_NETWORK_INTERFACE="${SRTCTL_NETWORK_INTERFACE:-}"',
+        f'if [[ -z "${{SRTCTL_NETWORK_INTERFACE}}" ]]; then SRTCTL_NETWORK_INTERFACE={shlex.quote(network_interface)}; fi',
+        'SRTCTL_LOG_DIR="${SRTCTL_OUTPUT_ROOT}/${SLURM_JOB_ID}/logs"',
+        'mkdir -p "${SRTCTL_LOG_DIR}"',
+        "",
+    ]
+    for name in sorted(required_secrets):
+        lines.append(f': "${{{name}:?Set {name} before running this script}}"')
+    if required_secrets:
+        lines.append("")
+
+    lines.extend(
+        [
+            "declare -a SRTCTL_NODES=()",
+            "while IFS= read -r node; do",
+            '  [[ -n "${node}" ]] || continue',
+            '  if (( ${#SRTCTL_NODES[@]} < SRTCTL_REQUIRED_NODES )); then SRTCTL_NODES+=("${node}"); fi',
+            'done < <(scontrol show hostnames "${SRTCTL_RAW_NODELIST}")',
+            "if (( ${#SRTCTL_NODES[@]} < SRTCTL_REQUIRED_NODES )); then",
+            '  echo "Need ${SRTCTL_REQUIRED_NODES} nodes; allocation has ${#SRTCTL_NODES[@]}" >&2',
+            "  exit 2",
+            "fi",
+            "declare -a SRTCTL_NODE_IPS=()",
+            'for node in "${SRTCTL_NODES[@]}"; do',
+            '  ip=$(srun --overlap --nodes 1 --ntasks 1 --nodelist "${node}" bash -c \'',
+            '    interface="$1"',
+            '    if command -v ip >/dev/null 2>&1 && ip -o -4 addr show dev "${interface}" >/dev/null 2>&1; then',
+            '      ip -o -4 addr show dev "${interface}" | while read -r _ _ _ cidr _; do printf "%s\\n" "${cidr%/*}"; break; done',
+            "    else",
+            '      read -r first _ <<< "$(hostname -I)"; printf "%s\\n" "${first}"',
+            "    fi",
+            '  \' _ "${SRTCTL_NETWORK_INTERFACE}")',
+            '  [[ -n "${ip}" ]] || { echo "Could not resolve IP for ${node}" >&2; exit 2; }',
+            '  SRTCTL_NODE_IPS+=("${ip}")',
+            "done",
+            "",
+            "declare -a SRTCTL_PIDS=()",
+            "declare -a SRTCTL_LABELS=()",
+            "cleanup() {",
+            "  local rc=$?",
+            "  trap - EXIT INT TERM",
+            "  set +e",
+            '  for pid in "${SRTCTL_PIDS[@]}"; do kill "${pid}" 2>/dev/null || true; done',
+            '  for pid in "${SRTCTL_PIDS[@]}"; do wait "${pid}" 2>/dev/null || true; done',
+            '  exit "${rc}"',
+            "}",
+            "trap cleanup EXIT INT TERM",
+            "",
+            "launch() {",
+            "  local label=$1",
+            "  shift",
+            '  echo "Starting ${label}"',
+            '  "$@" &',
+            '  SRTCTL_PIDS+=("$!")',
+            '  SRTCTL_LABELS+=("${label}")',
+            "}",
+            "",
+            "wait_for_port() {",
+            '  python3 - "$1" "$2" "$3" "$4" <<\'PY\'',
+            "import socket",
+            "import sys",
+            "import time",
+            "host, port, timeout, label = sys.argv[1], int(sys.argv[2]), float(sys.argv[3]), sys.argv[4]",
+            "deadline = time.monotonic() + timeout",
+            "while time.monotonic() < deadline:",
+            "    try:",
+            "        with socket.create_connection((host, port), timeout=2):",
+            '            print(f"{label} is ready at {host}:{port}")',
+            "            raise SystemExit(0)",
+            "    except OSError:",
+            "        time.sleep(1)",
+            'raise SystemExit(f"Timed out waiting for {label} at {host}:{port}")',
+            "PY",
+            "}",
+            "",
+            "wait_for_dynamo() {",
+            '  python3 - "$1" "$2" "$3" "$4" "$5" "$6" <<\'PY\'',
+            "import json",
+            "import sys",
+            "import time",
+            "import urllib.request",
+            "host, port = sys.argv[1], int(sys.argv[2])",
+            "expected_prefill, expected_decode = int(sys.argv[3]), int(sys.argv[4])",
+            "timeout, interval = float(sys.argv[5]), float(sys.argv[6])",
+            "deadline = time.monotonic() + timeout",
+            "while time.monotonic() < deadline:",
+            "    try:",
+            '        with urllib.request.urlopen(f"http://{host}:{port}/health", timeout=5) as response:',
+            '            instances = json.load(response).get("instances", [])',
+            '        prefills = sum(i.get("endpoint") == "generate" and i.get("component") == "prefill" for i in instances)',
+            '        decodes = sum(i.get("endpoint") == "generate" and i.get("component") in {"decode", "tensorrt_llm", "backend"} for i in instances)',
+            "        if prefills >= expected_prefill and decodes >= expected_decode:",
+            '            print(f"Dynamo workers are ready ({prefills} prefill, {decodes} decode)")',
+            "            raise SystemExit(0)",
+            "    except Exception:",
+            "        pass",
+            "    time.sleep(interval)",
+            'raise SystemExit(f"Timed out waiting for Dynamo workers at {host}:{port}")',
+            "PY",
+            "}",
+            "",
+        ]
+    )
+
+    current_stage = ""
+    for step, command in rendered_steps:
+        if step.stage != current_stage:
+            current_stage = step.stage
+            lines.extend((f"# {current_stage}",))
+        lines.extend((f"launch {shlex.quote(step.label)} \\", f"  {command}"))
+        for host, port, timeout, label in step.waits:
+            lines.append(
+                "wait_for_port "
+                f"{_shell_word(host.replace('__SRTCTL_NODE_', '__SRTCTL_IP_'), source_dir=source_dir)} "
+                f"{port} {timeout} {shlex.quote(label)}"
+            )
+        lines.append("")
+
+    expected_prefill = 0 if config.resources.num_agg else config.resources.num_prefill
+    expected_decode = config.resources.num_agg or config.resources.num_decode
+    health_interval = max(1, int(config.health_check.interval_seconds))
+    health_timeout = max(1, int(config.health_check.max_attempts) * health_interval)
+    frontend_expression = _shell_word(frontend_ip, source_dir=source_dir)
+    frontend_inline = frontend_expression[1:-1] if frontend_expression.startswith('"') else frontend_expression
+    lines.extend(
+        [
+            f"wait_for_dynamo {frontend_expression} {FRONTEND_PUBLIC_PORT} {expected_prefill} {expected_decode} {health_timeout} {health_interval}",
+            "",
+            f'echo "Dynamo serving stack is ready at http://{frontend_inline}:{FRONTEND_PUBLIC_PORT}"',
+            'echo "Logs: ${SRTCTL_LOG_DIR}"',
+            'echo "Press Ctrl-C to stop all launched services."',
+            "",
+            "while true; do",
+            '  for index in "${!SRTCTL_PIDS[@]}"; do',
+            '    pid="${SRTCTL_PIDS[$index]}"',
+            '    if ! kill -0 "${pid}" 2>/dev/null; then',
+            "      set +e",
+            '      wait "${pid}"',
+            "      rc=$?",
+            "      set -e",
+            '      echo "${SRTCTL_LABELS[$index]} exited with status ${rc}" >&2',
+            '      exit "${rc}"',
+            "    fi",
+            "  done",
+            "  sleep 2",
+            "done",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/tests/test_slurm_plan.py
+++ b/tests/test_slurm_plan.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for portable Slurm serving-script rendering."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from srtctl.cli import submit as submit_cli
+from srtctl.core.config import load_config
+from srtctl.core.slurm import build_srun_command
+from srtctl.render.slurm_plan import render_slurm_launch_script
+
+
+def _config() -> dict:
+    return {
+        "name": "portable-dynamo-pd",
+        "model": {
+            "path": "hf:fake/model",
+            "container": "nvcr.io/fake/sglang:latest",
+            "precision": "fp8",
+        },
+        "resources": {
+            "gpu_type": "h200",
+            "gpus_per_node": 8,
+            "prefill_nodes": 1,
+            "decode_nodes": 1,
+            "prefill_workers": 1,
+            "decode_workers": 1,
+        },
+        "dynamo": {"install": False},
+        "environment": {
+            "HF_TOKEN": "must-not-be-rendered",
+            "PUBLIC_SETTING": "visible",
+        },
+        "frontend": {
+            "type": "dynamo",
+            "enable_multiple_frontends": False,
+            "args": {"router-mode": "kv"},
+        },
+        "backend": {
+            "type": "sglang",
+            "sglang_config": {
+                "prefill": {"tensor-parallel-size": 8},
+                "decode": {"tensor-parallel-size": 8},
+            },
+        },
+        "benchmark": {"type": "custom", "command": "echo benchmark-is-not-part-of-serving-launch"},
+    }
+
+
+def _write_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "recipe.yaml"
+    config_path.write_text(yaml.safe_dump(_config()))
+    return config_path
+
+
+def test_build_srun_command_can_inherit_a_future_allocation() -> None:
+    portable = build_srun_command(["python3", "-m", "server"], job_id=None, nodelist=["node-a"])
+    realized = build_srun_command(["python3", "-m", "server"], job_id="42042", nodelist=["node-a"])
+
+    assert "--jobid" not in portable
+    assert realized[:4] == ["srun", "--jobid", "42042", "--overlap"]
+
+
+def test_rendered_script_contains_portable_serving_lifecycle(tmp_path: Path) -> None:
+    config = load_config(_write_config(tmp_path))
+    script = render_slurm_launch_script(config, source_dir=tmp_path, output_base=tmp_path / "outputs")
+    script_path = tmp_path / "launch.sh"
+    script_path.write_text(script)
+
+    syntax = subprocess.run(["bash", "-n", str(script_path)], capture_output=True, text=True, check=False)
+    assert syntax.returncode == 0, syntax.stderr
+    assert "scontrol show hostnames" in script
+    assert "SRTCTL_NODE_IPS" in script
+    assert "python3 -m dynamo.sglang" in script
+    assert "--disaggregation-mode prefill" in script
+    assert "--disaggregation-mode decode" in script
+    assert "python3 -m dynamo.frontend" in script
+    assert "wait_for_port" in script
+    assert "trap cleanup EXIT INT TERM" in script
+    assert "--jobid" not in script
+    assert "must-not-be-rendered" not in script
+    assert ': "${HF_TOKEN:?Set HF_TOKEN before running this script}"' in script
+    assert "export PUBLIC_SETTING=visible" in script
+    assert "benchmark-is-not-part-of-serving-launch" not in script
+
+
+def test_rendered_script_hydrates_nodes_and_runs_with_stubbed_slurm(tmp_path: Path) -> None:
+    config = load_config(_write_config(tmp_path))
+    script_path = tmp_path / "launch.sh"
+    script_path.write_text(render_slurm_launch_script(config, source_dir=tmp_path, output_base=tmp_path / "outputs"))
+    script_path.chmod(0o750)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "scontrol").write_text("#!/bin/sh\nprintf 'node-a\\nnode-b\\n'\n")
+    (fake_bin / "srun").write_text("#!/bin/sh\nprintf '10.0.0.1\\n'\n")
+    (fake_bin / "python3").write_text("#!/bin/sh\ncat >/dev/null\nexit 0\n")
+    for executable in fake_bin.iterdir():
+        executable.chmod(0o750)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+        "SLURM_JOB_ID": "9001",
+        "SLURM_JOB_NODELIST": "node-[a-b]",
+        "HF_TOKEN": "provided-at-runtime",
+    }
+    result = subprocess.run(
+        ["bash", str(script_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Starting infra" in result.stdout
+    assert "Starting prefill-0-rank-0" in result.stdout
+    assert "Starting decode-0-rank-0" in result.stdout
+    assert "Starting frontend-0" in result.stdout
+    assert "Dynamo serving stack is ready" in result.stdout
+
+
+def test_render_launch_cli_prints_only_the_script(monkeypatch, tmp_path: Path, capsys) -> None:
+    config_path = _write_config(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["srtctl", "render-launch", "-f", str(config_path)])
+
+    submit_cli.main()
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("#!/usr/bin/env bash\n")
+    assert "--jobid" not in captured.out
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

Add `srtctl render-launch -f recipe.yaml` to compile a resolved Dynamo/SGLang recipe into a portable Slurm serving script.

The generated script discovers nodes and IPs from the active allocation, starts NATS/etcd, optional Mooncake infrastructure, workers, and the Dynamo frontend, waits for worker readiness, and cleans up the processes it owns. It uses the same command builders as normal execution without embedding a recorded job ID, hostname, IP address, endpoint, or secret value.

## Usage

```bash
srtctl render-launch -f recipe.yaml > launch.sh
chmod +x launch.sh
# Run launch.sh inside a compatible active Slurm allocation.
```

The initial scope is homogeneous Slurm allocations with the SGLang backend, a single Dynamo frontend, and no nginx. The artifact covers the serving lifecycle; benchmark, telemetry, and post-processing stages remain outside it.
