### PR TITLE
feat: add serve-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ make setup ARCH=aarch64  # or ARCH=x86_64
 # Submit job(s)
 srtctl apply -f config.yaml
 
+# Deploy an inference endpoint without running a benchmark
+srtctl apply -f config.yaml --serve-only
+
 # Submit with custom setup script
 srtctl apply -f config.yaml --setup-script custom-setup.sh
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,6 +34,9 @@ srtctl
 # Submit a job directly
 srtctl apply -f recipes/gb200-fp8/sglang-1p4d.yaml
 
+# Deploy the recipe and keep its inference endpoint available until cancellation
+srtctl apply -f recipes/gb200-fp8/sglang-1p4d.yaml --serve-only
+
 # Preview without submitting
 srtctl dry-run -f config.yaml
 
@@ -249,6 +252,7 @@ srtctl apply -f <config.yaml> [options]
 | `--sweep` | Force sweep mode (usually auto-detected) |
 | `--setup-script` | Custom setup script from `configs/` |
 | `--tags` | Comma-separated tags for the run |
+| `--serve-only` | Deploy the endpoint without running a benchmark; serve until cancellation |
 | `--bash` | Print a direct single-node lifecycle script to stdout without submitting |
 | `-y, --yes` | Skip confirmation prompts |
 
@@ -257,6 +261,9 @@ srtctl apply -f <config.yaml> [options]
 ```bash
 # Submit single job
 srtctl apply -f recipes/gb200-fp8/sglang-1p4d.yaml
+
+# Serve the same recipe without running its configured benchmark
+srtctl apply -f recipes/gb200-fp8/sglang-1p4d.yaml --serve-only
 
 # Submit sweep (auto-detected from sweep: section)
 srtctl apply -f configs/my-sweep.yaml
@@ -278,6 +285,11 @@ chmod +x job.sh
 # With tags
 srtctl apply -f config.yaml --tags "experiment-1,baseline"
 ```
+
+`--serve-only` submits the recipe normally, waits until the configured workers and frontend are healthy, prints
+the frontend URL in the sweep log, and keeps the service running until the job is cancelled or reaches its Slurm
+time limit. It ignores the recipe's configured benchmark for that submission. Use `scancel <job-id>` to stop the
+service; srtctl then cleans up the processes it started.
 
 `--bash` renders a small direct-host launcher; it is not an sbatch script. The launcher owns a Docker serving
 container and runs the serving lifecycle inside the selected SGLang image. It currently supports a one-node

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -640,6 +640,9 @@ benchmark:
 
 No benchmark is run. Use for manual testing and debugging.
 
+For a one-off serving run, `srtctl apply -f config.yaml --serve-only` provides the same behavior without changing
+the recipe's configured benchmark.
+
 ```yaml
 benchmark:
   type: "manual"

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -97,6 +97,7 @@ class SweepOrchestrator(
 
     config: SrtConfig
     runtime: RuntimeContext
+    serve_only: bool = False
 
     @property
     def backend(self):
@@ -727,7 +728,9 @@ class SweepOrchestrator(
 
             self._print_connection_info()
 
-            if os.environ.get("EVAL_ONLY", "false").lower() == "true":
+            if self.serve_only:
+                exit_code = self.run_benchmark(registry, stop_event, reporter)
+            elif os.environ.get("EVAL_ONLY", "false").lower() == "true":
                 reporter.report(JobStatus.BENCHMARK, JobStage.BENCHMARK, "Running eval-only evaluation")
                 logger.info("EVAL_ONLY=true: Skipping benchmark stage and running lm-eval evaluation...")
                 exit_code = self._run_post_eval(stop_event)
@@ -784,6 +787,11 @@ def main():
 
     parser = argparse.ArgumentParser(description="Run benchmark sweep")
     parser.add_argument("config", type=str, help="Path to YAML configuration file")
+    parser.add_argument(
+        "--serve-only",
+        action="store_true",
+        help="Keep the inference endpoint running without launching a benchmark.",
+    )
     args = parser.parse_args()
 
     setup_logging()
@@ -810,7 +818,7 @@ def main():
         # Type narrowing: job_id is str after the check above
         assert job_id is not None
         runtime = RuntimeContext.from_config(config, job_id)
-        orchestrator = SweepOrchestrator(config=config, runtime=runtime)
+        orchestrator = SweepOrchestrator(config=config, runtime=runtime, serve_only=args.serve_only)
         exit_code = orchestrator.run()
 
         sys.exit(exit_code)

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -237,6 +237,7 @@ class BenchmarkStageMixin:
         self, registry: "ProcessRegistry", stop_event: threading.Event, reporter: StatusReporter | None = None
     ) -> int:
         """Run the benchmark."""
+        serve_only = bool(getattr(self, "serve_only", False))
         logger.info("Waiting for workers to be ready...")
 
         n_prefill, n_decode, count_desc, num_workers = _get_health_expectations(self.config, self.backend_processes)
@@ -256,10 +257,11 @@ class BenchmarkStageMixin:
         ):
             logger.error("Server did not become healthy")
             if reporter:
-                reporter.report(JobStatus.FAILED, JobStage.BENCHMARK, "Workers failed health check")
+                stage = JobStage.FRONTEND if serve_only else JobStage.BENCHMARK
+                reporter.report(JobStatus.FAILED, stage, "Workers failed health check")
             return 1
 
-        logger.info("Server is healthy - starting benchmark")
+        logger.info("Server is healthy")
 
         # Identity verification: compare recipe identity against runtime fingerprints
         # Store results on self so postprocess can include them in the lockfile
@@ -282,28 +284,34 @@ class BenchmarkStageMixin:
         except Exception as e:  # noqa: BLE001
             logger.debug("Identity verification skipped: %s", e)
 
-        if reporter:
-            reporter.report(JobStatus.BENCHMARK, JobStage.BENCHMARK, "Running benchmark")
-
         benchmark_type = self.config.benchmark.type
-        if self.config.profiling.enabled:
+        if self.config.profiling.enabled and not serve_only:
             logger.info(
                 "Profiling enabled (type=%s) with benchmark type '%s'",
                 self.config.profiling.type,
                 benchmark_type,
             )
 
-        if benchmark_type == "manual":
-            logger.info("Benchmark type is 'manual' - server is ready for testing")
+        if serve_only or benchmark_type == "manual":
+            if reporter:
+                reporter.report(JobStatus.FRONTEND, JobStage.FRONTEND, "Inference endpoint ready")
+            if serve_only:
+                logger.info("Serve-only mode - no benchmark will be run")
+            else:
+                logger.info("Benchmark type is 'manual' - server is ready for testing")
             logger.info("Frontend URL: http://%s:%d", self._public_api_node(), FRONTEND_PUBLIC_PORT)
             logger.info("Press Ctrl+C to stop the job")
 
             while not stop_event.is_set():
                 if registry.check_failures():
-                    logger.error("Worker failure detected during manual mode")
+                    logger.error("Worker failure detected while serving")
                     return 1
                 time.sleep(5)
             return 0
+
+        logger.info("Starting benchmark")
+        if reporter:
+            reporter.report(JobStatus.BENCHMARK, JobStage.BENCHMARK, "Running benchmark")
 
         # Get the appropriate benchmark runner
         from srtctl.benchmarks import get_runner

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -462,6 +462,7 @@ def generate_minimal_sbatch_script(
     setup_script: str | None = None,
     output_dir: Path | None = None,
     runtime_config_filename: str = "config.yaml",
+    serve_only: bool = False,
 ) -> str:
     """Generate minimal sbatch script that calls the Python orchestrator.
 
@@ -474,6 +475,7 @@ def generate_minimal_sbatch_script(
         setup_script: Optional setup script override (passed via env var)
         output_dir: Custom output directory (CLI flag, highest priority)
         runtime_config_filename: Config file name under OUTPUT_DIR used by do_sweep
+        serve_only: Keep the inference endpoint running without launching a benchmark
 
     Returns:
         Rendered sbatch script as string
@@ -564,20 +566,24 @@ def generate_minimal_sbatch_script(
         srtctl_source=str(srtctl_source.resolve()),
         output_base=output_base,
         setup_script=setup_script,
+        serve_only=serve_only,
         config_environment={key: shlex.quote(str(value)) for key, value in config_environment.items()},
     )
 
     return rendered
 
 
-def _print_running_summary(config: SrtConfig, console: Console) -> None:
+def _print_running_summary(config: SrtConfig, console: Console, *, serve_only: bool = False) -> None:
     """Print what's being run and identity verification status."""
     console.print()
     console.print("[bold]Running:[/]")
     console.print(f"  Model:     {config.model.path}")
     console.print(f"  Container: {config.model.container}")
     console.print(f"  Backend:   {config.backend_type}")
-    console.print(f"  Benchmark: {config.benchmark.type}")
+    if serve_only:
+        console.print("  Mode:      Serve only (no benchmark)")
+    else:
+        console.print(f"  Benchmark: {config.benchmark.type}")
 
     has_identity = config.identity and (
         (config.identity.model and (config.identity.model.repo or config.identity.model.revision))
@@ -633,6 +639,7 @@ def submit_with_orchestrator(
     variant_suffix: str | None = None,
     source_config_path: Path | None = None,
     runtime_config_text: str | None = None,
+    serve_only: bool = False,
 ) -> str | None:
     """Submit job using the new Python orchestrator.
 
@@ -651,6 +658,7 @@ def submit_with_orchestrator(
                             while the job executes a resolved variant config.
         runtime_config_text: Resolved runtime YAML written under OUTPUT_DIR when
                              source_config_path is set.
+        serve_only: Keep the inference endpoint running without launching a benchmark.
 
     Returns:
         job_id string on success, None for dry_run.
@@ -673,6 +681,7 @@ def submit_with_orchestrator(
         setup_script=setup_script,
         output_dir=output_dir,
         runtime_config_filename=runtime_config_filename,
+        serve_only=serve_only,
     )
 
     # Identity validation (inline, <1s) — runs for both dry-run and submit
@@ -701,7 +710,7 @@ def submit_with_orchestrator(
         show_config_details(config)
 
         # Show running summary + identity in dry-run too
-        _print_running_summary(config, console)
+        _print_running_summary(config, console, serve_only=serve_only)
         return
 
     # Validate setup before submitting (not during dry-run)
@@ -792,6 +801,8 @@ def submit_with_orchestrator(
                 "osl": config.benchmark.osl,
             },
         }
+        if serve_only:
+            metadata["serve_only"] = True
         if tags:
             metadata["tags"] = tags
         if config.setup_script:
@@ -836,7 +847,7 @@ def submit_with_orchestrator(
         console.print(f"[dim]📋 Monitor:[/] tail -f {log}")
         console.print(f"[dim]📊 Queue:[/] squeue --job {job_id}")
 
-        _print_running_summary(config, console)
+        _print_running_summary(config, console, serve_only=serve_only)
 
         return job_id
 
@@ -862,6 +873,7 @@ def submit_single(
     source_config_path: Path | None = None,
     runtime_config_text: str | None = None,
     enforce_preflight: bool = True,
+    serve_only: bool = False,
 ) -> str | None:
     """Submit a single job from YAML config.
 
@@ -879,6 +891,7 @@ def submit_single(
                             resolved variant config.
         runtime_config_text: Resolved runtime YAML written under OUTPUT_DIR for
                              override submissions.
+        serve_only: Keep the inference endpoint running without launching a benchmark.
 
     Returns:
         job_id string on success, None for dry_run.
@@ -911,6 +924,7 @@ def submit_single(
         variant_suffix=variant_suffix,
         source_config_path=source_config_path,
         runtime_config_text=runtime_config_text,
+        serve_only=serve_only,
     )
 
 
@@ -1295,6 +1309,7 @@ def submit_override(
     tags: list[str] | None = None,
     output_dir: Path | None = None,
     enforce_preflight: bool = True,
+    serve_only: bool = False,
 ) -> None:
     """Expand an override config file and submit each variant.
 
@@ -1311,6 +1326,7 @@ def submit_override(
         enforce_preflight: When False, skip the pre-submit model/container/telemetry
             FS checks for every expanded variant (propagated to submit_single /
             submit_sweep).
+        serve_only: Keep the inference endpoint running without launching a benchmark.
     """
     with open(config_path) as f:
         raw_config = yaml.safe_load(f)
@@ -1333,6 +1349,8 @@ def submit_override(
     from srtctl.core.yaml_utils import dump_yaml_with_comments
 
     resolved_variants = resolve_override_yaml(config_path, selector=selector)
+    if serve_only and len(resolved_variants) != 1:
+        raise ValueError("--serve-only requires an override selector that resolves to exactly one job")
 
     for i, (suffix, config_cm) in enumerate(resolved_variants, 1):
         variant_label = "base" if suffix == "base" else f"override_{suffix}"
@@ -1350,6 +1368,8 @@ def submit_override(
         config = SrtConfig.Schema().load(resolved_config)
 
         if "sweep" in config_cm:
+            if serve_only:
+                raise ValueError("--serve-only does not support sweep configs")
             fd, temp_config_path = tempfile.mkstemp(suffix=".yaml", prefix="srtctl_override_", text=True)
             try:
                 with os.fdopen(fd, "w") as f:
@@ -1377,6 +1397,7 @@ def submit_override(
                 source_config_path=config_path,
                 runtime_config_text=runtime_config_text,
                 enforce_preflight=enforce_preflight,
+                serve_only=serve_only,
             )
 
 
@@ -1437,6 +1458,7 @@ def main():
         epilog="""Examples:
   srtctl                                         # Interactive mode
   srtctl apply -f config.yaml                    # Submit job
+  srtctl apply -f config.yaml --serve-only       # Serve until cancelled; do not benchmark
   srtctl apply -f config.yaml --bash             # Print a direct single-node Bash lifecycle script
   srtctl apply -f ./configs/                     # Submit all YAMLs in directory
   srtctl apply -f config.yaml --sweep            # Submit sweep
@@ -1470,6 +1492,11 @@ def main():
     add_common_args(apply_parser)
     apply_parser.add_argument("--setup-script", type=str, help="Custom setup script in configs/")
     apply_parser.add_argument("--tags", type=str, help="Comma-separated tags")
+    apply_parser.add_argument(
+        "--serve-only",
+        action="store_true",
+        help="Deploy the inference endpoint without running a benchmark; keep serving until the job is cancelled.",
+    )
     apply_parser.add_argument(
         "--bash",
         action="store_true",
@@ -1572,12 +1599,19 @@ def main():
     json_mode = bool(getattr(args, "json_output", False))
     mock_mode = bool(getattr(args, "mock_mode", False))
     bash_mode = bool(getattr(args, "bash_output", False))
+    serve_only = bool(getattr(args, "serve_only", False))
     if bash_mode and json_mode:
         parser.error("--bash cannot be combined with --json")
     if bash_mode and mock_mode:
         parser.error("--bash cannot be combined with --mock")
     if bash_mode and getattr(args, "sweep", False):
         parser.error("--bash currently supports single-job configs only; sweeps expand to multiple sbatch jobs")
+    if serve_only and bash_mode:
+        parser.error("--serve-only cannot be combined with --bash")
+    if serve_only and mock_mode:
+        parser.error("--serve-only cannot be combined with --mock")
+    if serve_only and getattr(args, "sweep", False):
+        parser.error("--serve-only does not support sweeps")
 
     # Always rebind the module console on each invocation so json-mode prose
     # goes to stderr and non-json prose returns to stdout. Save the original
@@ -1748,6 +1782,8 @@ def main():
 
             # Handle directory input
             if effective_config_path.is_dir():
+                if serve_only:
+                    raise ValueError("--serve-only expects a single config file, not a directory")
                 if selector:
                     logger.warning(f"Selector ':{selector}' ignored for directory input")
                 submit_directory(
@@ -1768,12 +1804,15 @@ def main():
                     tags=tags,
                     output_dir=output_dir,
                     enforce_preflight=enforce_preflight,
+                    serve_only=serve_only,
                 )
             else:
                 if selector:
                     logger.warning(f"Selector ':{selector}' ignored — config is not an override file")
                 is_sweep = args.sweep or is_sweep_config(effective_config_path)
                 if is_sweep:
+                    if serve_only:
+                        raise ValueError("--serve-only does not support sweep configs")
                     submit_sweep(
                         effective_config_path,
                         dry_run=is_dry_run,
@@ -1790,6 +1829,7 @@ def main():
                         tags=tags,
                         output_dir=output_dir,
                         enforce_preflight=enforce_preflight,
+                        serve_only=serve_only,
                     )
     except Exception as e:
         # Restore subprocess.run etc. before we exit so in-process test

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -93,7 +93,7 @@ export SRTCTL_OUTPUT_DIR="${OUTPUT_DIR}"
 exec 2>&1
 
 echo "=========================================="
-echo "🚀 srtctl Sweep Orchestrator"
+echo "🚀 srtctl {% if serve_only %}Serve-Only{% else %}Sweep{% endif %} Orchestrator"
 echo "=========================================="
 echo "Job ID: ${SLURM_JOB_ID}"
 echo "Config: {{ config_path }}"
@@ -166,16 +166,16 @@ cd "${SRTCTL_SOURCE}"
 # errors. The flock serializes only the venv init; the lock is released
 # before the actual sweep so jobs still run in parallel.
 flock -x "${SRTCTL_SOURCE}/.venv-compute.lock" uv sync --python 3.12 --no-dev
-uv run --python 3.12 --no-dev --no-sync -m srtctl.cli.do_sweep "${OUTPUT_DIR}/{{ runtime_config_filename }}"
+uv run --python 3.12 --no-dev --no-sync -m srtctl.cli.do_sweep "${OUTPUT_DIR}/{{ runtime_config_filename }}"{% if serve_only %} --serve-only{% endif %}
 EXIT_CODE=$?
 set -e  # Re-enable exit-on-error
 
 echo ""
 echo "=========================================="
 if [ $EXIT_CODE -eq 0 ]; then
-    echo "✓ Sweep completed successfully"
+    echo "✓ {% if serve_only %}Serve-only job ended successfully{% else %}Sweep completed successfully{% endif %}"
 else
-    echo "✗ Sweep failed (exit code: $EXIT_CODE)"
+    echo "✗ {% if serve_only %}Serve-only job failed{% else %}Sweep failed{% endif %} (exit code: $EXIT_CODE)"
 fi
 echo "End: $(date)"
 echo "=========================================="

--- a/tests/test_serve_only.py
+++ b/tests/test_serve_only.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from srtctl.cli import submit as submit_cli
+from srtctl.cli.do_sweep import SweepOrchestrator
+from srtctl.cli.mixins.benchmark_stage import BenchmarkStageMixin
+from srtctl.core.config import load_config
+from srtctl.core.runtime import Nodes, RuntimeContext
+from srtctl.core.schema import SrtConfig
+from srtctl.core.status import JobStage, JobStatus
+from srtctl.core.topology import Process
+
+CONFIG = {
+    "name": "serve-only-test",
+    "model": {
+        "path": "hf:fake/mock-model",
+        "container": "nvcr.io/fake:latest",
+        "precision": "fp8",
+    },
+    "resources": {
+        "gpu_type": "h100",
+        "gpus_per_node": 8,
+        "agg_nodes": 1,
+        "agg_workers": 1,
+    },
+    "backend": {"type": "sglang"},
+    "frontend": {"type": "sglang", "enable_multiple_frontends": False},
+    "benchmark": {"type": "sa-bench", "isl": 128, "osl": 128, "concurrencies": [1]},
+}
+
+
+def _write_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(CONFIG))
+    return config_path
+
+
+def test_apply_serve_only_reaches_single_job_submission(monkeypatch, tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    submitted: dict = {}
+
+    def capture_submit(**kwargs):
+        submitted.update(kwargs)
+
+    monkeypatch.setattr(submit_cli, "submit_single", capture_submit)
+    monkeypatch.setattr(sys, "argv", ["srtctl", "apply", "-f", str(config_path), "--serve-only"])
+
+    submit_cli.main()
+
+    assert submitted["config_path"] == config_path
+    assert submitted["serve_only"] is True
+
+
+def test_serve_only_is_forwarded_to_the_slurm_orchestrator(monkeypatch, tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    config = load_config(config_path)
+    monkeypatch.setattr(submit_cli, "get_srtslurm_setting", lambda *_args, **_kwargs: None)
+
+    normal_script = submit_cli.generate_minimal_sbatch_script(config, config_path)
+    serve_script = submit_cli.generate_minimal_sbatch_script(config, config_path, serve_only=True)
+
+    command = 'do_sweep "${OUTPUT_DIR}/config.yaml"'
+    assert f"{command} --serve-only" in serve_script
+    assert f"{command} --serve-only" not in normal_script
+    assert "Serve-Only Orchestrator" in serve_script
+    syntax_check = subprocess.run(["bash", "-n"], input=serve_script, text=True, capture_output=True, check=False)
+    assert syntax_check.returncode == 0, syntax_check.stderr
+
+
+class _ServeOnlyHarness(BenchmarkStageMixin):
+    def __init__(self, log_dir: Path) -> None:
+        self.serve_only = True
+        self.config = SrtConfig.Schema().load(CONFIG)
+        self.runtime = RuntimeContext(
+            job_id="12345",
+            run_name="serve-only-test",
+            nodes=Nodes(head="node0", bench="node0", infra="node0", worker=("node0",)),
+            head_node_ip="10.0.0.1",
+            infra_node_ip="10.0.0.1",
+            log_dir=log_dir,
+            model_path=Path("/model"),
+            container_image=Path("/container.sqsh"),
+            gpus_per_node=8,
+            network_interface=None,
+        )
+
+    @property
+    def backend_processes(self) -> list[Process]:
+        return []
+
+    def _public_api_node(self) -> str:
+        return "frontend-node"
+
+
+def test_serve_only_waits_for_health_but_never_loads_a_benchmark(tmp_path: Path) -> None:
+    harness = _ServeOnlyHarness(tmp_path)
+    registry = MagicMock()
+    reporter = MagicMock()
+    stop_event = threading.Event()
+    stop_event.set()
+
+    with (
+        patch(
+            "srtctl.cli.mixins.benchmark_stage._get_health_expectations",
+            return_value=(0, 1, "one aggregate worker", 1),
+        ),
+        patch("srtctl.cli.mixins.benchmark_stage.wait_for_model", return_value=True) as wait_for_model,
+        patch("srtctl.cli.mixins.benchmark_stage.collect_worker_fingerprints", return_value=[]),
+        patch("srtctl.benchmarks.get_runner") as get_runner,
+    ):
+        exit_code = harness.run_benchmark(registry, stop_event, reporter)
+
+    assert exit_code == 0
+    wait_for_model.assert_called_once()
+    get_runner.assert_not_called()
+    reporter.report.assert_called_once_with(JobStatus.FRONTEND, JobStage.FRONTEND, "Inference endpoint ready")
+
+
+def test_serve_only_takes_precedence_over_eval_only(monkeypatch, tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    config = load_config(config_path)
+    runtime = RuntimeContext(
+        job_id="12345",
+        run_name="serve-only-test",
+        nodes=Nodes(head="node0", bench="node0", infra="node0", worker=("node0",)),
+        head_node_ip="10.0.0.1",
+        infra_node_ip="10.0.0.1",
+        log_dir=tmp_path / "logs",
+        model_path=Path("/model"),
+        container_image=Path("/container.sqsh"),
+        gpus_per_node=8,
+        network_interface=None,
+    )
+    runtime.log_dir.mkdir()
+    orchestrator = SweepOrchestrator(config=config, runtime=runtime, serve_only=True)
+    reporter = MagicMock()
+    monkeypatch.setenv("EVAL_ONLY", "true")
+
+    with (
+        patch("srtctl.cli.do_sweep.record_resource_snapshot", return_value={}),
+        patch("srtctl.cli.do_sweep.write_lockfile"),
+        patch("srtctl.cli.do_sweep.StatusReporter.from_config", return_value=reporter),
+        patch("srtctl.cli.do_sweep.setup_signal_handlers"),
+        patch("srtctl.cli.do_sweep.start_process_monitor"),
+        patch.object(orchestrator, "start_head_infrastructure", return_value=MagicMock()),
+        patch.object(orchestrator, "start_mooncake_master", return_value=None),
+        patch.object(orchestrator, "start_all_workers", return_value={}),
+        patch.object(orchestrator, "start_frontend", return_value=[]),
+        patch.object(orchestrator, "start_tachometer", return_value=[]),
+        patch.object(orchestrator, "_print_connection_info"),
+        patch.object(orchestrator, "run_benchmark", return_value=0) as run_serve,
+        patch.object(orchestrator, "_run_post_eval") as run_eval,
+        patch.object(orchestrator, "finalize_power_telemetry", side_effect=lambda exit_code, **_kwargs: exit_code),
+        patch.object(orchestrator, "run_postprocess"),
+    ):
+        exit_code = orchestrator.run()
+
+    assert exit_code == 0
+    run_serve.assert_called_once()
+    run_eval.assert_not_called()


### PR DESCRIPTION
## Summary

Add `srtctl apply -f config.yaml --serve-only` to deploy a recipe's inference endpoint without running its configured benchmark.

The mode reuses the existing manual-serving lifecycle: it waits for the configured workers and frontend to become healthy, prints the frontend URL, and keeps the Slurm job serving until it is cancelled or reaches its time limit. Serve-only submissions also take precedence over inherited evaluation flags, so they never launch benchmark or evaluation runners.

## Usage

```bash
srtctl apply -f config.yaml --serve-only
```
