### PR TITLE
[1/3] fix(benchmark): stop advertising dead TRT-LLM worker metrics URLs

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -684,6 +684,15 @@ so list positions remain aligned. With a Dynamo frontend, endpoint and metrics U
 leader's `DYN_SYSTEM_PORT`; other frontends use the worker HTTP port. If KVBM metrics are configured,
 their URLs are appended to `AIPERF_SERVER_METRICS_URLS` after the logical worker URLs.
 
+Two caveats for `AIPERF_SERVER_METRICS_URLS`:
+
+- **TRT-LLM worker URLs are omitted when the workers publish no metrics.** A TRT-LLM worker
+  launched without `--publish-events-and-metrics` (the default; `observability.enabled` turns it
+  on) serves nothing on its sys-port `/metrics`, so those URLs are not advertised. KVBM URLs are
+  unaffected — KVBM serves its own endpoint regardless of the flag.
+- **An explicit `AIPERF_SERVER_METRICS_URLS` in the recipe `environment:` wins.** Injection is
+  skipped when the variable is already set, so a curated endpoint list is never clobbered.
+
 Values in `benchmark.env` are applied last and can explicitly override any automatically injected
 variable.
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -607,10 +607,19 @@ class BenchmarkStageMixin:
                 if urls:
                     return {"AIPERF_SERVER_METRICS_URLS": ",".join(sorted(set(urls)))}
 
-            for process in self.backend_processes:
-                if process.sys_port > 0:
-                    host = get_hostname_ip(process.node, self.runtime.network_interface)
-                    urls.append(f"http://{host}:{process.sys_port}/metrics")
+            # TRT-LLM workers only publish engine metrics when launched with
+            # --publish-events-and-metrics (pre-v1.3.0 Dynamo gates the whole
+            # worker /metrics surface on it; observability.enabled sets it at
+            # config load). Without the flag the sys-port endpoints serve
+            # nothing, so advertising them would only create the impression
+            # that worker metrics are being captured.
+            if self.config.backend_type != "trtllm" or getattr(
+                self.config.backend, "publish_events_and_metrics", False
+            ):
+                for process in self.backend_processes:
+                    if process.sys_port > 0:
+                        host = get_hostname_ip(process.node, self.runtime.network_interface)
+                        urls.append(f"http://{host}:{process.sys_port}/metrics")
 
         # Add KVBM metrics endpoints for prefill processes with DYN_KVBM_METRICS_PORT
         prefill_env = getattr(self.config.backend, "prefill_environment", {})
@@ -769,11 +778,15 @@ class BenchmarkStageMixin:
         # Built-in AIPerf runners retain physical-process metrics for vLLM DP.
         # Custom commands commonly wrap AIPerf but do not inherit from its base
         # class, so give them the logical-worker view needed by SGLang TP.
-        if isinstance(runner, AIPerfBenchmarkRunner):
-            env.update(self._get_aiperf_server_metrics_env())
-        elif is_custom:
-            assert logical_endpoints is not None
-            env.update(self._get_aiperf_server_metrics_env(logical_endpoints, logical_workers_only=True))
+        # An explicit AIPERF_SERVER_METRICS_URLS in the recipe environment wins:
+        # the operator may be pointing the client at a curated endpoint list,
+        # and injection used to clobber it here silently.
+        if "AIPERF_SERVER_METRICS_URLS" not in env:
+            if isinstance(runner, AIPerfBenchmarkRunner):
+                env.update(self._get_aiperf_server_metrics_env())
+            elif is_custom:
+                assert logical_endpoints is not None
+                env.update(self._get_aiperf_server_metrics_env(logical_endpoints, logical_workers_only=True))
         if isinstance(runner, AIPerfBenchmarkRunner) and self.config.benchmark.aiperf_package:
             env["AIPERF_PACKAGE"] = self.config.benchmark.aiperf_package
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1080,8 +1080,11 @@ class ObservabilityConfig:
 
     Scope is deliberately server-side. The knob configures what the workers and
     frontend *emit*, and captures that surface by scraping the endpoints
-    directly. It never reaches into the benchmark client to ask it to re-export
-    what the servers already publish.
+    directly. It never asks the benchmark client to re-export what the servers
+    already publish. (One indirect exception: on TRT-LLM the client's
+    ``AIPERF_SERVER_METRICS_URLS`` worker list exists only when
+    ``publish_events_and_metrics`` gives those endpoints content, and this knob
+    is one way that flag gets set — see ``BenchmarkStageMixin``.)
 
     It does **not** decide whether the component perf dashboard is built. That
     happens on every run (see :mod:`srtctl.analysis.perf_dashboard`); ``enabled``

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -233,8 +233,11 @@ class TestCustomBenchmarkRunner:
         processes,
         *,
         benchmark_type="custom",
+        backend_type="sglang",
+        publish_events_and_metrics=False,
         prefill_environment=None,
         aggregated_environment=None,
+        environment=None,
     ):
         from types import SimpleNamespace
 
@@ -249,16 +252,19 @@ class TestCustomBenchmarkRunner:
         stage.config = SimpleNamespace(
             benchmark=SimpleNamespace(type=benchmark_type, aiperf_package=None),
             backend=SimpleNamespace(
+                type=backend_type,
+                publish_events_and_metrics=publish_events_and_metrics,
                 prefill_environment=prefill_environment or {},
                 aggregated_environment=aggregated_environment or {},
             ),
+            backend_type=backend_type,
             frontend=SimpleNamespace(type=frontend_type),
             profiling=SimpleNamespace(enabled=False),
             resources=SimpleNamespace(num_agg=sum(p.endpoint_mode == "agg" and p.is_leader for p in processes)),
             telemetry=SimpleNamespace(enabled=False),
         )
         stage.runtime = SimpleNamespace(
-            environment={},
+            environment=environment or {},
             frontend_port=8000,
             network_interface="ibp1s0",
             nodes=SimpleNamespace(head="head-node"),
@@ -516,6 +522,122 @@ class TestCustomBenchmarkRunner:
         assert env["AIPERF_SERVER_METRICS_URLS"] == (
             "http://ip-node-a:7500/metrics,http://ip-node-b:7501/metrics,http://ip-node-c:7502/metrics"
         )
+
+    def test_builtin_aiperf_omits_dead_trtllm_worker_urls(self):
+        """A TRT-LLM worker without --publish-events-and-metrics serves nothing.
+
+        Advertising its sys-port endpoints to AIPerf only creates the
+        impression that worker metrics are captured, so the URLs are omitted.
+        """
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "decode", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "dynamo",
+            processes,
+            benchmark_type="trace-replay",
+            backend_type="trtllm",
+            publish_events_and_metrics=False,
+        )
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(TraceReplayRunner())
+
+        assert "AIPERF_SERVER_METRICS_URLS" not in env
+
+    def test_builtin_aiperf_keeps_trtllm_worker_urls_when_publishing(self):
+        """With the publish flag on (e.g. via observability.enabled) the worker
+        endpoints have content, so the physical-process contract is retained."""
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "decode", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "dynamo",
+            processes,
+            benchmark_type="trace-replay",
+            backend_type="trtllm",
+            publish_events_and_metrics=True,
+        )
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(TraceReplayRunner())
+
+        assert env["AIPERF_SERVER_METRICS_URLS"] == (
+            "http://ip-node-a:7500/metrics,http://ip-node-b:7501/metrics"
+        )
+
+    def test_dead_trtllm_worker_urls_still_advertise_kvbm(self):
+        """KVBM serves its own /metrics independently of the publish flag,
+        so its endpoints survive the dead-worker-URL omission."""
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "decode", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "dynamo",
+            processes,
+            benchmark_type="trace-replay",
+            backend_type="trtllm",
+            publish_events_and_metrics=False,
+            prefill_environment={"DYN_KVBM_METRICS_PORT": "9345"},
+        )
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(TraceReplayRunner())
+
+        assert env["AIPERF_SERVER_METRICS_URLS"] == "http://ip-node-a:9345/metrics"
+
+    def test_explicit_server_metrics_urls_env_wins(self):
+        """An operator-supplied AIPERF_SERVER_METRICS_URLS in the recipe
+        environment is respected verbatim, never clobbered by injection."""
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "dynamo",
+            processes,
+            benchmark_type="trace-replay",
+            environment={"AIPERF_SERVER_METRICS_URLS": "http://curated:9999/metrics"},
+        )
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(TraceReplayRunner())
+
+        assert env["AIPERF_SERVER_METRICS_URLS"] == "http://curated:9999/metrics"
 
 
 class TestSGLangBenchRunner:


### PR DESCRIPTION
## What

First of a 3-PR observability-consolidation series (1: fix AIPerf URL semantics, 2: tachometer scrapes the complement of client-polled endpoints under `observability.enabled`, 3: remove the RAW scraper capture path).

A TRT-LLM worker launched without `--publish-events-and-metrics` (the default; `observability.enabled` sets it at config load) serves nothing on its sys-port `/metrics`. `AIPERF_SERVER_METRICS_URLS` still advertised every worker endpoint, so AIPerf polled dead endpoints and the resulting `server_metrics_export` carries frontend families only — creating the impression that worker metrics were captured. (Verified on a real GB300 run: 1.3 GB export, 88 metric names, zero `trtllm_*`.)

## Changes

- **Omit TRT-LLM worker sys-port URLs when `publish_events_and_metrics` is off.** With the flag on (recipe or observability expansion), the physical-process contract is unchanged.
- **KVBM endpoints are unaffected** — KVBM serves its own `/metrics` independently of the flag.
- **An explicit `AIPERF_SERVER_METRICS_URLS` in the recipe `environment:` now wins** instead of being silently clobbered by injection.
- **Custom-benchmark logical-leader injection is unchanged**, so consumers that use the URL list for drain detection (e.g. the agentx runner in #342) keep receiving it.

## Notes

- On Dynamo >= v1.3.0 the worker metrics surface is unconditional (`--publish-events-and-metrics` is a deprecated alias of `--publish-kv-events` and only controls KV events); the gate here keys off the srt-slurm config flag, which remains the correct signal for the pinned pre-1.3.0 recipe fleet.
- Tests: 4 new cases (dead-case omission, alive-case retention, KVBM survival, explicit-override respect); `make check` green (1455 passed).