### PR TITLE
[2/3] feat(observability): tachometer scrapes the complement of client-polled endpoints

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1042,37 +1042,30 @@ infra:
 
 ## observability
 
-`observability.enabled` turns on the server metrics and trace surfaces and captures raw Prometheus responses during the benchmark window:
+`observability.enabled` turns on the server metrics and trace surfaces and collects them with the native Tachometer scraper for the whole run:
 
 ```yaml
 observability:
   enabled: true
 ```
 
-The default Python scraper writes `<log_dir>/raw_prometheus.jsonl`. To additionally collect parsed Parquet with the native Tachometer scraper:
+Tachometer scrapes the **complement** of what the benchmark client polls: worker endpoints that appear in `AIPERF_SERVER_METRICS_URLS` are left to the client (a worker endpoint is never double-polled — the extra scrape load has previously made a submission irreproducible), while the frontend, DCGM, and node-exporter endpoints are always Tachometer's. On runs whose benchmark has no aiperf client (sa-bench, lm-eval, serve-only, manual), the complement expands to every endpoint.
 
-```yaml
-observability:
-  enabled: true
-  tachometer:
-    enabled: true
-```
-
-Set `scrape_metrics: false` beside `enabled` to use Tachometer without also writing the raw JSONL capture. Otherwise the Python RAW scraper and Tachometer run together.
+The legacy Python RAW scraper (`<log_dir>/raw_prometheus.jsonl`) no longer follows `enabled`; opt in with `scrape_metrics: true` if you need the verbatim exposition capture — it then runs **in addition to** Tachometer and the client, and srtctl warns about the double-polling.
 
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
-| `enabled` | bool | `false` | Enable server-side metrics/traces and the raw Python scraper |
-| `scrape_metrics` | bool/null | `null` | Override raw capture; `null` follows `enabled` |
-| `scrape_interval_seconds` | float | `1.0` | Interval between raw Prometheus scrape sweeps |
-| `scrape_output` | string | `raw_prometheus.jsonl` | Raw capture filename below the run log directory |
+| `enabled` | bool | `false` | Enable server-side metrics/traces, Tachometer collection, and host sampling |
+| `scrape_metrics` | bool/null | `null` | Legacy RAW scraper opt-in; `null`/`false` means off |
+| `scrape_interval_seconds` | float | `1.0` | Interval between RAW scrape sweeps (opt-in only) |
+| `scrape_output` | string | `raw_prometheus.jsonl` | RAW capture filename below the run log directory |
 | `enable_otel` | bool | `false` | Inject OTEL tracing environment variables |
 | `otel_endpoint` | string/null | `null` | OTEL collector endpoint |
-| `tachometer` | object | `enabled: false` | Native Tachometer collection settings |
+| `tachometer` | object | `enabled: null` | Native Tachometer collection settings; `enabled: null` follows `observability.enabled`, explicit `false` opts out |
 
 The component perf dashboard is **not** configured here. It is built in post-processing on every run; `enabled` decides which capture legs exist and therefore which tabs the page carries. See [Component Performance Dashboard](component-dashboard.md).
 
-Tachometer always collects worker and frontend metrics. DCGM and node exporters are optional additions:
+Tachometer collects worker-leader and frontend metrics by default (minus the client-polled complement described above). DCGM and node exporters are optional additions:
 
 ```yaml
 observability:
@@ -1095,7 +1088,7 @@ observability:
 
 | Tachometer field | Type | Default | Description |
 | ---------------- | ---- | ------- | ----------- |
-| `enabled` | bool | `false` | Enable native Tachometer collection |
+| `enabled` | bool/null | `null` | `null` follows `observability.enabled`; explicit `false` opts out; explicit `true` without `observability.enabled` is a validation error |
 | `binary_path` | string | `tachometer-scraper` | Scraper command or path on the compute nodes |
 | `default_frequency` | float | `5.0` | Scrape frequency in Hz |
 | `sync_interval_secs` | int | `120` | Interval for intermediate Parquet compaction; `0` disables it |
@@ -1107,7 +1100,9 @@ observability:
 
 `make setup ARCH=<compute_arch>` downloads and checksum-verifies the matching Tachometer binary from the latest srt-slurm release. The scraper runs as a native `srun` process on the head node; configured exporters remain containerized on worker nodes. Run `make tachometer-scraper` to build from source instead.
 
-Tachometer writes `<log_dir>/<storage_subdir>/final.parquet`. Intermediate files remain in `<log_dir>/<storage_subdir>/local` until shutdown compaction completes.
+Tachometer writes its Parquet stream under `<log_dir>/<storage_subdir>/raw/scrape/` (the leaf is created by the scraper itself — srtctl pre-creates only the parent, because the scraper refuses a pre-existing storage directory), compacting to `final.parquet` there on shutdown. Intermediate files remain in `<log_dir>/<storage_subdir>/local` until shutdown compaction completes. Rows carry an epoch `timestamp_ns` column, so they join directly with AIPerf records and Dynamo spans; the post-processing ingest converts the Parquet into the dashboard's `server_metrics_export.jsonl`.
+
+The scraper runs as a best-effort process: if it dies (or the binary is missing at runtime), the benchmark continues and the loss is visible in `tachometer.out` and the sweep log. `srtctl validate-setup` still fails fast at submit time when `bin/tachometer-scraper` is absent.
 
 ---
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -684,6 +684,15 @@ so list positions remain aligned. With a Dynamo frontend, endpoint and metrics U
 leader's `DYN_SYSTEM_PORT`; other frontends use the worker HTTP port. If KVBM metrics are configured,
 their URLs are appended to `AIPERF_SERVER_METRICS_URLS` after the logical worker URLs.
 
+Two caveats for `AIPERF_SERVER_METRICS_URLS`:
+
+- **TRT-LLM worker URLs are omitted when the workers publish no metrics.** A TRT-LLM worker
+  launched without `--publish-events-and-metrics` (the default; `observability.enabled` turns it
+  on) serves nothing on its sys-port `/metrics`, so those URLs are not advertised. KVBM URLs are
+  unaffected — KVBM serves its own endpoint regardless of the flag.
+- **An explicit `AIPERF_SERVER_METRICS_URLS` in the recipe `environment:` wins.** Injection is
+  skipped when the variable is already set, so a curated endpoint list is never clobbered.
+
 Values in `benchmark.env` are applied last and can explicitly override any automatically injected
 variable.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1065,7 +1065,7 @@ The legacy Python RAW scraper (`<log_dir>/raw_prometheus.jsonl`) no longer follo
 
 The component perf dashboard is **not** configured here. It is built in post-processing on every run; `enabled` decides which capture legs exist and therefore which tabs the page carries. See [Component Performance Dashboard](component-dashboard.md).
 
-Tachometer collects worker-leader and frontend metrics by default (minus the client-polled complement described above). DCGM and node exporters are optional additions:
+Tachometer collects every worker rank and frontend metrics by default (minus the client-polled complement described above). DCGM and node exporters are optional additions:
 
 ```yaml
 observability:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "questionary>=2.0.0",
     "ruamel.yaml>=0.18.0",
     "matplotlib>=3.7.0",
+    "pyarrow>=25.0.0",
 ]
 
 [project.optional-dependencies]

--- a/recipes/qwen3-32b/ruter-3p2d-dynamo.yaml
+++ b/recipes/qwen3-32b/ruter-3p2d-dynamo.yaml
@@ -81,11 +81,11 @@ backend:
       fp8-gemm-backend: triton
       disaggregation-transfer-backend: nixl
 
+# enabled: true now implies Tachometer collection (no RAW scraper) — the
+# explicit scrape_metrics/tachometer knobs this recipe used to carry are
+# the defaults.
 observability:
   enabled: true
-  scrape_metrics: false
-  tachometer:
-    enabled: true
 
 benchmark:
   type: custom

--- a/src/ingest/__init__.py
+++ b/src/ingest/__init__.py
@@ -74,6 +74,10 @@ Processor registry
                    The only server-metrics source on runs predating
                    `observability.enabled`, which is where the before/after
                    pairs for already-landed fixes live.
+      "aiperf-jsonl" AIPerf per-scrape server_metrics_export.jsonl -> schema 2.
+                                                         (metrics_aiperf_jsonl.process)
+      "tachometer" Tachometer parquet -> schema 2.        (metrics_tachometer.process)
+                   Needs pyarrow (the one non-stdlib processor in this package).
     request_trace -> request_trace.jsonl
       "dynamo"  dynamo-request-trace -> schema 4.            (request_trace.process)
     iter_log -> iter_bins.json
@@ -165,6 +169,8 @@ PROCESSORS: dict[str, dict[str, Callable]] = {
     "metrics": {
         "prometheus": _lazy("metrics_prometheus"),
         "aiperf-json": _lazy("metrics_aiperf_json"),
+        "aiperf-jsonl": _lazy("metrics_aiperf_jsonl"),
+        "tachometer": _lazy("metrics_tachometer"),
     },
     "request_trace": {
         "dynamo": _lazy("request_trace"),

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -94,6 +94,26 @@ AIPERF_METRIC_PATTERNS = [
     "artifacts/*/server_metrics_export.json",
 ]
 
+# AIPerf's per-scrape jsonl sibling (written with --server-metrics-formats json jsonl),
+# mirroring AIPERF_METRIC_PATTERNS. One line per (scrape, endpoint), values verbatim.
+AIPERF_JSONL_PATTERNS = [
+    "agentic/*/aiperf_artifacts/server_metrics_export.jsonl",
+    "agentic/*/server_metrics_export.jsonl",
+    "artifacts/*/server_metrics_export.jsonl",
+]
+
+# Where the Tachometer leg leaves its parquet, in preference order: the post-run
+# compaction writes final.parquet under the storage leaf (tachometer/raw/scrape);
+# tachometer/final holds the direct-host explicit-compact output; tachometer/local
+# holds out-N/incomplete-N leftovers that only matter when compaction never ran.
+TACHOMETER_PATTERNS = [
+    "tachometer/raw/scrape/final.parquet",
+    "tachometer/raw/scrape/*.parquet",
+    "tachometer/final/final.parquet",
+    "tachometer/local/final.parquet",
+    "tachometer/local/*.parquet",
+]
+
 CLIENT_PATTERNS = [
     "agentic/*/aiperf_artifacts/profile_export.jsonl",
     "agentic/*/profile_export.jsonl",
@@ -302,6 +322,7 @@ def generate_dashboard_yaml(
     have_request_trace: bool = False,
     warmup_end_ns: int | None = None,
     warmup_source: str | None = None,
+    metrics_source: str | None = None,
 ) -> str:
     """Render a dashboard.yaml (skeleton fields: name/description/mode/framework/
     topology/sources) whose ``sources:`` point at the bundle's own files (so the
@@ -346,7 +367,13 @@ def generate_dashboard_yaml(
     if have_traces:
         lines.append("  tempo_traces:   tempo_traces")
     if have_metrics:
-        lines.append("  server_metrics: server_metrics_export.jsonl")
+        # metrics_source is only set for the sources whose provenance is not obvious
+        # from the run dir (tachometer / aiperf per-scrape jsonl); the annotation is a
+        # comment, so the sources: entry itself stays byte-identical for L3.
+        sm_line = "  server_metrics: server_metrics_export.jsonl"
+        if metrics_source:
+            sm_line += f"   # source: {metrics_source}"
+        lines.append(sm_line)
     if have_request_trace:
         lines.append("  request_trace:  request_trace.jsonl")
     return "\n".join(lines) + "\n"
@@ -441,20 +468,77 @@ def run_metrics(args, run_dir: Path, bundle: Path) -> bool:
 
     mode = args.metrics
     if mode == "auto":
-        # Pick the source the run actually captured. An `observability.enabled` run has
+        # Pick the source the run actually captured, best first: the tachometer
+        # parquet (whole-window, per-replica, every endpoint) wins over the in-job
+        # raw_prometheus.jsonl, which wins over AIPerf's own exports (per-scrape
+        # jsonl over the aggregate json). An `observability.enabled` run has
         # raw_prometheus.jsonl; a run without it usually still has AIPerf's own export,
         # because the frontend's /metrics surface exists regardless of that knob and
         # the benchmark scrapes it. Choosing here rather than at every call site is
-        # what lets one ingest command work on both.
+        # what lets one ingest command work on all of them.
+        tach: list[str] = []
+        for pat in ([args.tachometer_parquet] if args.tachometer_parquet else TACHOMETER_PATTERNS):
+            tach.extend(resolve_inputs(pat, run_dir))
         raw = resolve_inputs(args.raw_prometheus or "raw_prometheus.jsonl", run_dir)
-        if raw:
+        if tach:
+            mode = "tachometer"
+        elif raw:
             mode = "prometheus"
         else:
-            found: list[str] = []
-            for pat in AIPERF_METRIC_PATTERNS:
-                found.extend(resolve_inputs(pat, run_dir))
-            mode = "aiperf-json" if found else "prometheus"
+            found_jsonl: list[str] = []
+            for pat in AIPERF_JSONL_PATTERNS:
+                found_jsonl.extend(resolve_inputs(pat, run_dir))
+            if found_jsonl:
+                mode = "aiperf-jsonl"
+            else:
+                found: list[str] = []
+                for pat in AIPERF_METRIC_PATTERNS:
+                    found.extend(resolve_inputs(pat, run_dir))
+                mode = "aiperf-json" if found else "prometheus"
         _log("L2 metrics", f"auto-selected source: {mode}")
+
+    if mode == "tachometer":
+        # The in-job Tachometer scraper's parquet: the whole-window per-replica
+        # capture of every /metrics endpoint. First pattern with a hit wins, so
+        # final.parquet is preferred over shards/leftovers.
+        patterns = ([args.tachometer_parquet] if args.tachometer_parquet
+                    else list(TACHOMETER_PATTERNS))
+        srcs: list[str] = []
+        for pat in patterns:
+            srcs = resolve_inputs(pat, run_dir)
+            if srcs:
+                break
+        if not srcs:
+            _log("L2 metrics", f"WARN no tachometer parquet matched {patterns} under {run_dir}; skipping")
+            return False
+        shards = f" (+{len(srcs) - 1} shard(s))" if len(srcs) > 1 else ""
+        _log("L1", f"metrics raw: {srcs[0]}{shards} (tachometer parquet)")
+        proc = get_processor("metrics", "tachometer")
+        n = proc(srcs if len(srcs) > 1 else srcs[0], str(out))
+        nin, nout = dedup_server_metrics(out)
+        _log("L2 metrics", f"tachometer -> {out.name}: {n} timestamps, dedup {nin} -> {nout} lines")
+        args._metrics_source = "tachometer parquet"
+        return out.exists()
+
+    if mode == "aiperf-jsonl":
+        # AIPerf's per-scrape export (--server-metrics-formats json jsonl): raw
+        # readings per (scrape, endpoint), so no timeslice reconstruction needed.
+        patterns = ([args.aiperf_server_metrics_jsonl] if args.aiperf_server_metrics_jsonl
+                    else list(AIPERF_JSONL_PATTERNS))
+        srcs = []
+        for pat in patterns:
+            srcs.extend(resolve_inputs(pat, run_dir))
+        srcs = sorted(dict.fromkeys(srcs))
+        if not srcs:
+            _log("L2 metrics", f"WARN no aiperf per-scrape jsonl matched {patterns} under {run_dir}; skipping")
+            return False
+        _log("L1", f"metrics raw: {srcs[0]} (AIPerf per-scrape server_metrics_export.jsonl)")
+        proc = get_processor("metrics", "aiperf-jsonl")
+        n = proc(srcs[0], str(out))
+        nin, nout = dedup_server_metrics(out)
+        _log("L2 metrics", f"aiperf-jsonl -> {out.name}: {n} timestamps, dedup {nin} -> {nout} lines")
+        args._metrics_source = "aiperf per-scrape jsonl"
+        return out.exists()
 
     if mode == "aiperf-json":
         # AIPerf's own export. The only server-metrics source on a run that predates
@@ -1132,12 +1216,19 @@ def build_parser() -> argparse.ArgumentParser:
                         "(default: *_prefill_w*.out, *_decode_w*.out, *_agg_w*.out)")
 
     # metrics axis
-    p.add_argument("--metrics", choices=["auto", "prometheus", "aiperf-json", "none"],
+    p.add_argument("--metrics", choices=["auto", "tachometer", "prometheus", "aiperf-jsonl", "aiperf-json", "none"],
                    default="auto",
-                   help="metrics source; 'auto' uses raw_prometheus.jsonl when the run has it "
-                        "and falls back to AIPerf's own export when it does not")
+                   help="metrics source; 'auto' prefers the tachometer parquet, then "
+                        "raw_prometheus.jsonl, then AIPerf's per-scrape jsonl, then "
+                        "AIPerf's aggregate json")
     p.add_argument("--raw-prometheus", default=None,
                    help="raw_prometheus.jsonl path/glob (default: raw_prometheus.jsonl)")
+    p.add_argument("--tachometer-parquet", default=None,
+                   help="tachometer parquet path/glob for --metrics tachometer "
+                        "(default: tachometer/raw/scrape/final.parquet, then shards/local leftovers)")
+    p.add_argument("--aiperf-server-metrics-jsonl", default=None,
+                   help="AIPerf per-scrape server_metrics_export.jsonl path/glob for --metrics aiperf-jsonl "
+                        "(default: agentic/*/ then artifacts/*/)")
     p.add_argument("--aiperf-server-metrics", default=None,
                    help="AIPerf server_metrics_export.json path/glob for --metrics aiperf-json "
                         "(default: agentic/*/ then artifacts/*/)")
@@ -1211,6 +1302,7 @@ def main(argv=None) -> int:
         have_request_trace=have_req_trace,
         warmup_end_ns=warmup_ns,
         warmup_source=warmup_src,
+        metrics_source=getattr(args, "_metrics_source", None),
     )
     yaml_path = bundle / "dashboard.yaml"
     yaml_path.write_text(yaml_text)

--- a/src/ingest/metrics_aiperf_jsonl.py
+++ b/src/ingest/metrics_aiperf_jsonl.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 processor: AIPerf per-scrape ``server_metrics_export.jsonl`` -> schema 2.
+
+When the benchmark passes ``--server-metrics-formats json jsonl``, AIPerf writes -- in
+addition to the aggregate/timesliced JSON that :mod:`.metrics_aiperf_json` reads -- one
+JSON line per (scrape, endpoint), each carrying the endpoint's metric families at that
+instant (observed schema, from a real 1.9 GB export)::
+
+    {"timestamp_ns": <int>, "endpoint_url": <str>, "endpoint_latency_ns": <int>,
+     "request_sent_ns": <int>, "first_byte_ns": <int>,
+     "metrics": {"<family>": [{"labels": {...}, "value": <num>}, ...
+                              {"labels": {...}, "buckets": {"<le>": <num>, ...},
+                               "sum": <num>, "count": <num>}]}}
+
+Values are the raw scraped readings -- counters stay cumulative, histogram buckets stay
+cumulative (the "+Inf" bucket equals ``count``) -- so unlike the aggregate export there
+is NO cumulative/interval detection to do: everything is written through verbatim, the
+same way :mod:`.metrics_prometheus` treats a raw exposition body.
+
+NAME SUFFIXES (same interchange contract as :mod:`.metrics_aiperf_json`): AIPerf keys a
+COUNTER family by its base name (``dynamo_component_router_requests_total`` arrives as
+``dynamo_component_router_requests``; verified against the same run's
+``raw_prometheus.jsonl``) while gauges keep their exposition names verbatim. The jsonl
+carries no type information, so every plain-valued family that does not already end in
+``_total`` is emitted under BOTH its own name and the ``_total`` alias -- a panel naming
+either form resolves, and the alias on a gauge is inert (no panel reads a name that was
+never exposed). Histogram entries expand to exposition components:
+``<family>_bucket`` (with the ``le`` label, cumulative), ``<family>_sum``,
+``<family>_count``.
+
+No ``worker_id``/``dynamo_component`` labels are invented: the endpoint's role is not
+knowable from the export alone, mirroring :mod:`.metrics_aiperf_json`.
+
+Timestamps are snapped to whole seconds (``metrics_aiperf_json``'s slice snapping) and
+the per-endpoint lines sharing a second merge into one schema-2 line, deduped with the
+same idempotent (labels, value) fold. The export can exceed a GB, so lines are streamed
+with a small reorder window (endpoints are scraped concurrently, so their lines can
+interleave by milliseconds): a buffered second is flushed once every line seen is
+``_FLUSH_LAG_S`` seconds past it. A pathologically late line is emitted as its own
+(duplicate-timestamp) line rather than dropped, and counted in the log.
+
+Stdlib only (runs under a bare cluster python3).
+
+Usage:
+    python3 -m src.ingest.metrics_aiperf_jsonl RAW.jsonl OUT.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):  # pragma: no cover - only on the bare-script path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.ingest.metrics_prometheus import _dedup  # noqa: E402  (shared idempotent fold)
+
+logger = logging.getLogger("metrics_aiperf_jsonl")
+
+# Reorder window, in seconds. Endpoint scrape skew is milliseconds; a line arriving
+# this far behind the newest one seen means the writer itself was out of order.
+_FLUSH_LAG_S = 5
+
+
+def _snap(ts_ns: int) -> int:
+    """Epoch ns -> whole-second epoch ns (same grid as metrics_aiperf_json)."""
+    return int(round(ts_ns / 1e9)) * 1_000_000_000
+
+
+def _finite(v) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)
+
+
+def _emit_line(rec: dict, merged: dict) -> int:
+    """Expand one raw line's families into ``merged`` (schema-2 metrics dict)."""
+    n = 0
+    for family, entries in (rec.get("metrics") or {}).items():
+        for entry in entries or []:
+            if not isinstance(entry, dict):
+                continue
+            labels = dict(entry.get("labels") or {})
+            if "buckets" in entry:
+                for le, cnt in (entry.get("buckets") or {}).items():
+                    if not _finite(cnt):
+                        continue
+                    blabels = dict(labels)
+                    blabels["le"] = str(le)
+                    merged.setdefault(f"{family}_bucket", []).append(
+                        {"labels": blabels, "value": float(cnt)}
+                    )
+                    n += 1
+                for f, suffix in (("sum", "_sum"), ("count", "_count")):
+                    v = entry.get(f)
+                    if _finite(v):
+                        merged.setdefault(f"{family}{suffix}", []).append(
+                            {"labels": dict(labels), "value": float(v)}
+                        )
+                        n += 1
+            else:
+                v = entry.get("value")
+                if not _finite(v):
+                    continue
+                # Counter families arrive with _total stripped; the alias makes a
+                # panel naming either form resolve (see the module docstring).
+                out_names = [family] if family.endswith("_total") else [family, f"{family}_total"]
+                for out_name in out_names:
+                    merged.setdefault(out_name, []).append(
+                        {"labels": dict(labels), "value": float(v)}
+                    )
+                    n += 1
+    return n
+
+
+def process(raw_path: str, out_path: str) -> int:
+    """Convert AIPerf's per-scrape jsonl to schema 2. Returns lines written."""
+    pending: dict[int, dict] = {}
+    lines_written = samples = late = 0
+    max_ts = None
+
+    with open(raw_path) as f, open(out_path, "w") as out:
+
+        def flush_older_than(limit_ns):
+            nonlocal lines_written
+            for ts in sorted(pending):
+                if limit_ns is not None and ts >= limit_ns:
+                    break
+                metrics = pending.pop(ts)
+                for name in metrics:
+                    metrics[name] = _dedup(metrics[name])
+                out.write(json.dumps({"timestamp_ns": ts, "metrics": metrics}) + "\n")
+                lines_written += 1
+
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            ts = _snap(rec["timestamp_ns"])
+            if max_ts is not None and ts < max_ts - _FLUSH_LAG_S * 1_000_000_000:
+                # Its second may already be flushed; it becomes its own line below.
+                late += 1
+            merged = pending.setdefault(ts, {})
+            samples += _emit_line(rec, merged)
+            if max_ts is None or ts > max_ts:
+                max_ts = ts
+            flush_older_than(max_ts - _FLUSH_LAG_S * 1_000_000_000)
+        flush_older_than(None)
+
+    logger.info(
+        "read %d samples -> %d timestamps%s",
+        samples, lines_written, f" ({late} late line(s) past the reorder window)" if late else "",
+    )
+    return lines_written
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S"
+    )
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("raw_path", help="input AIPerf per-scrape server_metrics_export.jsonl")
+    ap.add_argument("out_path", help="output server_metrics_export.jsonl (schema 2)")
+    args = ap.parse_args(argv)
+    n = process(args.raw_path, args.out_path)
+    logger.info("wrote %s: %d timestamps", args.out_path, n)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ingest/metrics_tachometer.py
+++ b/src/ingest/metrics_tachometer.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 processor: Tachometer parquet -> ``server_metrics_export.jsonl`` (schema 2).
+
+Tachometer (``src/tachometer``, the Rust scraper srt-slurm starts in-job) polls every
+``/metrics`` endpoint and writes rows into parquet; on shutdown it compacts them into
+``final.parquet`` under its storage leaf. This module is the inverse of that capture:
+it turns the parquet rows back into the fixed schema-2 stream that L3 reads, so a
+tachometer-instrumented run renders with the exact same panels as a
+``raw_prometheus.jsonl`` run.
+
+Input discovery (``raw_path`` may be a parquet file, a glob, or a run log dir):
+
+    tachometer/raw/scrape/final.parquet     post-run compaction output (preferred)
+    tachometer/raw/scrape/*.parquet         incomplete-N shards (compaction never ran)
+    tachometer/final/final.parquet          the direct-host explicit-compact output
+    tachometer/local/final.parquet          local copy kept after a successful upload
+    tachometer/local/*.parquet              out-N/incomplete-N leftovers (last resort)
+
+Parquet row schema (tachometer-writer ``writer.rs::Row``): ``scraper_endpoint`` Utf8,
+``metric_name`` Utf8, ``metric_value`` Float64, ``histogram_bucket_lower`` /
+``histogram_bucket_upper`` / ``histogram_sum`` / ``histogram_count`` nullable Float64,
+``time_since_start`` Float64, ``timestamp_ns`` Int64 (epoch ns), plus one Utf8 column
+per metadata key (union across endpoints, "" when an endpoint lacks the key; on worker
+endpoints: hostname/worker_index/worker_process/worker_role, on frontend endpoints:
+frontend_index/hostname). Post-compaction files also carry ``metric_name_clean``.
+
+Parquet row -> schema 2 mapping (derived from tachometer-scraper ``parse.rs`` +
+``filters.rs``; the ``backend``/``frontend`` filters srt-slurm configures format a row's
+name as ``<base>{k="v",...}`` where ``<base>`` is the exposition sample name with any
+``_bucket``/``_count``/``_sum`` suffix stripped):
+
+* PLAIN row (all histogram columns null, no ``le`` label): ``name{labels}`` is parsed
+  back into (name, labels) and emitted verbatim -- ``metric_value`` is the raw scraped
+  sample value, so counters stay cumulative exactly as in ``raw_prometheus.jsonl``.
+* HISTOGRAM BUCKET row (``le`` in the inline labels, or ``histogram_bucket_upper``
+  non-null): ``parse.rs`` folds one exposition ``<fam>_bucket{le=...}`` sample into one
+  row whose ``metric_value`` is the sample's CUMULATIVE bucket count, copied verbatim
+  (``samples_to_rows_with_filter`` pushes ``sample.value`` unchanged). Re-emitted as
+  ``<fam>_bucket`` with the ``le`` label kept -- cumulative semantics round-trip 1:1
+  with what ``metrics_prometheus`` produces. (Unfiltered endpoints keep the ``_bucket``
+  suffix in the stored name; it is then not re-appended.)
+* ``<fam>_sum`` / ``<fam>_count``: ``parse.rs`` DROPS the exposition ``_sum``/``_count``
+  samples and instead attaches their values to every bucket row of the family via the
+  ``histogram_sum``/``histogram_count`` columns. Its fix-up misses the ``+Inf`` bucket
+  on filtered endpoints (the row's upper is null and its name no longer contains
+  "_bucket", so ``fix_histogram_bucket_bounds_and_stats`` never groups it), so the
+  reconstruction takes the first non-null column value across the family's bucket rows
+  per (second, labels-ex-le) group. ``_count`` prefers the ``+Inf`` bucket's own value
+  (by exposition semantics ``le="+Inf"`` == count) and falls back to the column.
+* Known capture-side loss (documented, not repaired): on filtered endpoints the writer
+  strips ``_bucket``/``_count``/``_sum`` from EVERY name (``parse.rs::strip_suffix`` is
+  unconditional), so a plain gauge named ``foo_count`` is stored -- and re-emitted here
+  -- as ``foo``, and summary ``_sum``/``_count`` samples collapse onto the quantile
+  series name. The suffix cannot be recovered from the parquet.
+
+Label enrichment mirrors :mod:`.metrics_prometheus`: every non-empty per-row metadata
+column is folded into the entry's labels via ``setdefault`` (never clobbering a real
+scraped label) so per-node/per-GPU series stay distinguishable, and rows whose
+``worker_role`` metadata maps prefill -> "prefill" / decode -> "backend" additionally
+get ``dynamo_component`` and ``worker_id`` (= the ``hostname`` metadata). Frontend
+endpoints carry no ``worker_role``, so they get no invented worker labels.
+
+Timestamps are snapped to whole seconds (``metrics_aiperf_json``'s slice snapping) and
+all rows sharing a second merge into one schema-2 line, deduped with the same
+idempotent (labels, value) fold, emitted in timestamp order. The regroup spills into
+time-contiguous per-minute shards (the compacted parquet is sorted by metric name, not
+time, and a whole run does not fit in memory on a shared login node).
+
+Needs ``pyarrow`` (the only non-stdlib dependency in this package; imported lazily so
+the registry and the stdlib-only siblings stay importable without it).
+
+Usage:
+    python3 -m src.ingest.metrics_tachometer LOG_DIR_OR_PARQUET OUT_PATH
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import logging
+import math
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+if __package__ in (None, ""):  # pragma: no cover - only on the bare-script path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.ingest.metrics_prometheus import _dedup  # noqa: E402  (shared idempotent fold)
+
+logger = logging.getLogger("metrics_tachometer")
+
+# Columns owned by the writer schema (writer.rs) + compaction (metric_name_clean).
+# Everything else is a per-endpoint metadata column.
+_FIXED_COLUMNS = frozenset({
+    "scraper_endpoint",
+    "metric_name",
+    "metric_name_clean",
+    "metric_value",
+    "histogram_bucket_lower",
+    "histogram_bucket_upper",
+    "histogram_sum",
+    "histogram_count",
+    "time_since_start",
+    "timestamp_ns",
+})
+
+# worker_role metadata -> dynamo_component label. Mirrors metrics_prometheus's
+# _ROLE_COMPONENT; roles outside the map (agg, "") get no injection.
+_ROLE_COMPONENT = {"prefill": "prefill", "decode": "backend"}
+
+# Search order under a run log dir. final.parquet is authoritative when present;
+# local/ leftovers only matter when compaction never ran.
+_SEARCH_ORDER = (
+    "tachometer/raw/scrape/final.parquet",
+    "tachometer/raw/scrape/*.parquet",
+    "tachometer/final/final.parquet",
+    "tachometer/local/final.parquet",
+    "tachometer/local/*.parquet",
+)
+
+# Spill shard width, same rationale as metrics_aiperf_json: per-minute shards keep the
+# per-timestamp regroup bounded to one minute of samples.
+_SHARD_NS = 60_000_000_000
+
+_INF_LE = ("+Inf", "Inf", "inf")
+
+
+def find_parquets(path) -> list[str]:
+    """Resolve ``path`` (parquet file | glob | run log dir) to an ordered file list."""
+    p = os.fspath(path)
+    if glob.has_magic(p):
+        return sorted(glob.glob(p))
+    if os.path.isfile(p):
+        return [p]
+    if os.path.isdir(p):
+        for pat in _SEARCH_ORDER:
+            hits = sorted(glob.glob(os.path.join(p, pat)))
+            if hits:
+                return hits
+        return sorted(glob.glob(os.path.join(p, "*.parquet")))
+    return []
+
+
+def _parse_name(name: str) -> tuple[str, dict]:
+    """``base{k="v",k2=v2}`` -> (base, labels). Handles both quoting styles the
+    scraper's filters emit (backend/frontend quote values, node_exporter does not).
+    Same limitation as the writer itself: a comma inside a quoted value mis-splits."""
+    brace = name.find("{")
+    if brace < 0:
+        return name, {}
+    base = name[:brace]
+    end = name.rfind("}")
+    body = name[brace + 1 : end if end > brace else len(name)]
+    labels: dict = {}
+    for pair in body.split(","):
+        k, eq, v = pair.partition("=")
+        if not eq:
+            continue
+        v = v.strip()
+        if len(v) >= 2 and v[0] == '"' and v[-1] == '"':
+            v = v[1:-1]
+        labels[k.strip()] = v
+    return base, labels
+
+
+def _finite(v) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)
+
+
+def _import_parquet():
+    try:
+        import pyarrow.parquet as pq  # noqa: PLC0415 - lazy: keep the package stdlib-importable
+    except ImportError as e:  # pragma: no cover - environment-dependent
+        raise ImportError(
+            "metrics_tachometer needs pyarrow to read the tachometer parquet "
+            "(pip install pyarrow)"
+        ) from e
+    return pq
+
+
+def process(raw_path, out_path: str) -> int:
+    """Convert tachometer parquet row(s) to schema 2. Returns lines written.
+
+    ``raw_path`` may be a parquet file, a glob, a run log dir (searched in
+    ``_SEARCH_ORDER``), or a list of parquet paths (shards, read in order).
+    """
+    if isinstance(raw_path, (str, os.PathLike)):
+        paths = find_parquets(raw_path)
+    else:
+        paths = [os.fspath(p) for p in raw_path]
+    if not paths:
+        raise FileNotFoundError(f"no tachometer parquet found under {raw_path!r}")
+    pq = _import_parquet()
+
+    tmp_dir = os.path.dirname(os.path.abspath(out_path)) or "."
+    spill_dir = tempfile.mkdtemp(prefix=".tach_sm_", dir=tmp_dir)
+    shards: dict[int, object] = {}
+    # (snapped_ts, family, labels-ex-le json) -> {"sum", "count", "inf"} for the
+    # _sum/_count reconstruction (see the module docstring's mapping).
+    hist_stats: dict = {}
+    rows_read = samples = 0
+    try:
+
+        def write(ts, name, labels, value):
+            key = ts // _SHARD_NS
+            fh = shards.get(key)
+            if fh is None:
+                fh = shards[key] = open(os.path.join(spill_dir, f"{key}.tsv"), "w")
+            fh.write(f"{ts}\t{name}\t{json.dumps(labels, sort_keys=True)}\t{value!r}\n")
+
+        for path in paths:
+            pf = pq.ParquetFile(path)
+            col_names = list(pf.schema_arrow.names)
+            meta_cols = [c for c in col_names if c not in _FIXED_COLUMNS]
+            for batch in pf.iter_batches():
+                names = batch.column("metric_name").to_pylist()
+                values = batch.column("metric_value").to_pylist()
+                uppers = batch.column("histogram_bucket_upper").to_pylist()
+                sums = batch.column("histogram_sum").to_pylist()
+                counts = batch.column("histogram_count").to_pylist()
+                tss = batch.column("timestamp_ns").to_pylist()
+                metas = {c: batch.column(c).to_pylist() for c in meta_cols}
+                for i in range(batch.num_rows):
+                    rows_read += 1
+                    value = values[i]
+                    if not _finite(value):
+                        continue
+                    value = float(value)
+                    # Snap to the second grid, like metrics_aiperf_json's _slice_ts.
+                    ts = int(round(tss[i] / 1e9)) * 1_000_000_000
+                    base, labels = _parse_name(names[i])
+                    meta = {}
+                    for c in meta_cols:
+                        v = metas[c][i]
+                        if v not in (None, ""):
+                            meta[c] = v
+                    component = _ROLE_COMPONENT.get(meta.get("worker_role", ""))
+                    if component is not None:
+                        labels.setdefault("dynamo_component", component)
+                        if meta.get("hostname"):
+                            labels.setdefault("worker_id", meta["hostname"])
+                    for k, v in meta.items():
+                        labels.setdefault(k, v)  # never clobber a real scraped label
+
+                    upper = uppers[i]
+                    if "le" in labels or upper is not None:
+                        # Histogram bucket row: metric_value is the verbatim
+                        # cumulative bucket count (see mapping in the docstring).
+                        le = labels.get("le") or ("+Inf" if upper is None else format(upper, "g"))
+                        out_name = base if base.endswith("_bucket") else f"{base}_bucket"
+                        fam = out_name[: -len("_bucket")]
+                        blabels = dict(labels)
+                        blabels["le"] = le
+                        write(ts, out_name, blabels, value)
+                        samples += 1
+                        group_labels = {k: v for k, v in labels.items() if k != "le"}
+                        key = (ts, fam, json.dumps(group_labels, sort_keys=True))
+                        st = hist_stats.setdefault(key, {"sum": None, "count": None, "inf": None})
+                        if st["sum"] is None and _finite(sums[i]):
+                            st["sum"] = float(sums[i])
+                        if st["count"] is None and _finite(counts[i]):
+                            st["count"] = float(counts[i])
+                        if le in _INF_LE:
+                            st["inf"] = value
+                    else:
+                        write(ts, base, labels, value)
+                        samples += 1
+
+        # Reconstruct <fam>_sum / <fam>_count once per (second, family, labels) group.
+        for (ts, fam, labels_key), st in hist_stats.items():
+            labels = json.loads(labels_key)
+            count = st["inf"] if st["inf"] is not None else st["count"]
+            if count is not None:
+                write(ts, f"{fam}_count", labels, count)
+                samples += 1
+            if st["sum"] is not None:
+                write(ts, f"{fam}_sum", labels, st["sum"])
+                samples += 1
+        for fh in shards.values():
+            fh.close()
+        logger.info(
+            "read %d parquet row(s) from %d file(s) -> %d samples across %d shard(s)",
+            rows_read, len(paths), samples, len(shards),
+        )
+
+        lines = 0
+        with open(out_path, "w") as out:
+            for key in sorted(shards):
+                by_ts: dict[int, dict] = {}
+                with open(os.path.join(spill_dir, f"{key}.tsv")) as sp:
+                    for line in sp:
+                        ts_s, name, labels_s, value_s = line.rstrip("\n").split("\t", 3)
+                        merged = by_ts.setdefault(int(ts_s), {})
+                        merged.setdefault(name, []).append(
+                            {"labels": json.loads(labels_s), "value": float(value_s)}
+                        )
+                for ts in sorted(by_ts):
+                    metrics = by_ts[ts]
+                    for name in metrics:
+                        metrics[name] = _dedup(metrics[name])
+                    out.write(json.dumps({"timestamp_ns": ts, "metrics": metrics}) + "\n")
+                    lines += 1
+        return lines
+    finally:
+        for fh in shards.values():
+            if not fh.closed:
+                fh.close()
+        for fn in os.listdir(spill_dir):
+            os.remove(os.path.join(spill_dir, fn))
+        os.rmdir(spill_dir)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S"
+    )
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("raw_path", help="run log dir, tachometer parquet file, or glob")
+    ap.add_argument("out_path", help="output server_metrics_export.jsonl (schema 2)")
+    args = ap.parse_args(argv)
+    n = process(args.raw_path, args.out_path)
+    logger.info("wrote %s: %d timestamps", args.out_path, n)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/srtctl/analysis/host_sampler.py
+++ b/src/srtctl/analysis/host_sampler.py
@@ -244,11 +244,13 @@ def try_start_host_sampler(log_dir: Path, observability, stop_event: threading.E
     :func:`srtctl.analysis.metrics_scraper.try_start_raw_scraper`. All failures are
     logged and swallowed -- host telemetry never blocks a benchmark.
 
-    Gated on the same ``scraper_enabled`` knob rather than a new one: it answers the
+    Gated on ``observability.enabled`` rather than a new knob: it answers the
     same question (is this run capturing observability?) and a second switch would let a
-    run be half-instrumented in a way nobody intends.
+    run be half-instrumented in a way nobody intends. (It used to share the RAW
+    scraper's ``scraper_enabled``; that scraper is now opt-in only, while host
+    telemetry belongs to every observability run.)
     """
-    if getattr(observability, "scraper_enabled", False) is not True:
+    if getattr(observability, "enabled", False) is not True:
         return None
     try:
         s = HostSampler(log_dir)

--- a/src/srtctl/benchmarks/scripts/mooncake-router/bench.sh
+++ b/src/srtctl/benchmarks/scripts/mooncake-router/bench.sh
@@ -23,6 +23,7 @@ if [ -n "${AIPERF_SERVER_METRICS_URLS:-}" ]; then
     IFS=',' read -r -a server_metrics_urls <<< "${AIPERF_SERVER_METRICS_URLS}"
     if [ ${#server_metrics_urls[@]} -gt 0 ]; then
         SERVER_METRICS_ARGS+=(--server-metrics "${server_metrics_urls[@]}")
+        SERVER_METRICS_ARGS+=(--server-metrics-formats json jsonl)
     fi
 fi
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -607,10 +607,19 @@ class BenchmarkStageMixin:
                 if urls:
                     return {"AIPERF_SERVER_METRICS_URLS": ",".join(sorted(set(urls)))}
 
-            for process in self.backend_processes:
-                if process.sys_port > 0:
-                    host = get_hostname_ip(process.node, self.runtime.network_interface)
-                    urls.append(f"http://{host}:{process.sys_port}/metrics")
+            # TRT-LLM workers only publish engine metrics when launched with
+            # --publish-events-and-metrics (pre-v1.3.0 Dynamo gates the whole
+            # worker /metrics surface on it; observability.enabled sets it at
+            # config load). Without the flag the sys-port endpoints serve
+            # nothing, so advertising them would only create the impression
+            # that worker metrics are being captured.
+            if self.config.backend_type != "trtllm" or getattr(
+                self.config.backend, "publish_events_and_metrics", False
+            ):
+                for process in self.backend_processes:
+                    if process.sys_port > 0:
+                        host = get_hostname_ip(process.node, self.runtime.network_interface)
+                        urls.append(f"http://{host}:{process.sys_port}/metrics")
 
         # Add KVBM metrics endpoints for prefill processes with DYN_KVBM_METRICS_PORT
         prefill_env = getattr(self.config.backend, "prefill_environment", {})
@@ -769,11 +778,15 @@ class BenchmarkStageMixin:
         # Built-in AIPerf runners retain physical-process metrics for vLLM DP.
         # Custom commands commonly wrap AIPerf but do not inherit from its base
         # class, so give them the logical-worker view needed by SGLang TP.
-        if isinstance(runner, AIPerfBenchmarkRunner):
-            env.update(self._get_aiperf_server_metrics_env())
-        elif is_custom:
-            assert logical_endpoints is not None
-            env.update(self._get_aiperf_server_metrics_env(logical_endpoints, logical_workers_only=True))
+        # An explicit AIPERF_SERVER_METRICS_URLS in the recipe environment wins:
+        # the operator may be pointing the client at a curated endpoint list,
+        # and injection used to clobber it here silently.
+        if "AIPERF_SERVER_METRICS_URLS" not in env:
+            if isinstance(runner, AIPerfBenchmarkRunner):
+                env.update(self._get_aiperf_server_metrics_env())
+            elif is_custom:
+                assert logical_endpoints is not None
+                env.update(self._get_aiperf_server_metrics_env(logical_endpoints, logical_workers_only=True))
         if isinstance(runner, AIPerfBenchmarkRunner) and self.config.benchmark.aiperf_package:
             env["AIPERF_PACKAGE"] = self.config.benchmark.aiperf_package
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -366,9 +366,10 @@ class BenchmarkStageMixin:
         # opted in via reporting.live_metrics in the cluster config.
         snapshotter = try_start_snapshotter(self.runtime.log_dir, stop_event)
 
-        # RAW /metrics capture for the benchmark window — no-op unless opted in.
-        # These endpoints die with the job, so this is the only chance to record
-        # them; it runs alongside the client rather than after it.
+        # Legacy RAW /metrics capture — strictly opt-in via scrape_metrics: true
+        # (Tachometer is the default server-side capture and runs from the
+        # telemetry stage). Opting in double-polls the endpoints; the warning
+        # below spells out the cost.
         #
         # The opt-in is re-checked here rather than left to try_start_raw_scraper
         # alone: Python evaluates arguments before the call, so building the
@@ -383,7 +384,6 @@ class BenchmarkStageMixin:
         # switch the scraper on for those callers.
         observability = getattr(self.config, "observability", None)
         raw_scraper = None
-        host_sampler = None
         if getattr(observability, "scraper_enabled", False) is True:
             self._warn_on_double_metric_polling()
             raw_scraper = try_start_raw_scraper(
@@ -392,10 +392,14 @@ class BenchmarkStageMixin:
                 observability,
                 stop_event,
             )
-            # Host/process telemetry alongside the endpoint scrape. The Prometheus
-            # families describe what Dynamo publishes; they say nothing about the
-            # machine underneath, where host CPU saturation, lock convoys and fd
-            # exhaustion live. Same opt-in, same best-effort contract.
+
+        # Host/process telemetry for the benchmark window. The Prometheus
+        # families describe what Dynamo publishes; they say nothing about the
+        # machine underneath, where host CPU saturation, lock convoys and fd
+        # exhaustion live. Follows observability.enabled (it used to share the
+        # RAW scraper's knob); same best-effort contract.
+        host_sampler = None
+        if getattr(observability, "enabled", False) is True:
             from srtctl.analysis.host_sampler import try_start_host_sampler
 
             host_sampler = try_start_host_sampler(self.runtime.log_dir, observability, stop_event)
@@ -638,6 +642,38 @@ class BenchmarkStageMixin:
         urls = list(dict.fromkeys(urls)) if logical_workers_only else sorted(set(urls))
         return {"AIPERF_SERVER_METRICS_URLS": ",".join(urls)}
 
+    def _client_polled_metric_urls(self) -> frozenset[str]:
+        """The ``/metrics`` URLs the benchmark client will poll on its own.
+
+        Tachometer scrapes the complement of this set (see
+        ``TelemetryStageMixin.start_tachometer``), so it is derived from the
+        same logic that injects ``AIPERF_SERVER_METRICS_URLS`` — including the
+        dead-TRT-LLM-worker omission and the explicit recipe override. It is
+        deliberately NOT a second endpoint list to maintain: when the injected
+        set changes, the complement moves with it. A serve-only or manual run
+        has no client, so nothing is polled and Tachometer covers everything.
+        """
+        if bool(getattr(self, "serve_only", False)):
+            return frozenset()
+        explicit = self.runtime.environment.get("AIPERF_SERVER_METRICS_URLS")
+        if explicit is not None:
+            return frozenset(url for url in explicit.split(",") if url)
+        from srtctl.benchmarks.base import AIPerfBenchmarkRunner, get_runner
+
+        benchmark_type = self.config.benchmark.type
+        if benchmark_type == "custom":
+            env = self._get_aiperf_server_metrics_env(logical_workers_only=True)
+        else:
+            try:
+                runner = get_runner(benchmark_type)
+            except ValueError:
+                return frozenset()
+            if not isinstance(runner, AIPerfBenchmarkRunner):
+                return frozenset()
+            env = self._get_aiperf_server_metrics_env()
+        urls = env.get("AIPERF_SERVER_METRICS_URLS", "")
+        return frozenset(url for url in urls.split(",") if url)
+
     def _warn_on_double_metric_polling(self) -> None:
         """Warn when the RAW scraper and an AIPerf client will poll /metrics together.
 
@@ -666,13 +702,12 @@ class BenchmarkStageMixin:
         if not is_aiperf:
             return
         logger.warning(
-            "Double /metrics polling: the observability RAW scraper AND the %s client "
-            "will both poll the worker endpoints for the duration of this run. Both "
-            "captures are valid, but the extra scrape load perturbs the measurement and "
-            "has previously made a submission irreproducible. Set "
-            "observability.scrape_metrics: false to keep only the client's polling, or "
-            "drop AIPERF_SERVER_METRICS_URLS from the benchmark to keep only the RAW "
-            "capture (which is what the perf dashboard reads).",
+            "Double /metrics polling: the legacy RAW scraper (scrape_metrics: true) AND "
+            "the %s client will both poll the worker endpoints for the duration of this "
+            "run — and Tachometer's complement only accounts for the client, not the RAW "
+            "scraper. The extra scrape load perturbs the measurement and has previously "
+            "made a submission irreproducible. Remove scrape_metrics: true to keep the "
+            "default capture (client + Tachometer complement).",
             self.config.benchmark.type,
         )
 

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shlex
 from collections.abc import Callable
 from pathlib import Path
@@ -19,7 +20,7 @@ from srtctl.core.power.topology import build_expected_devices
 from srtctl.core.processes import ManagedProcess, ProcessRegistry
 from srtctl.core.schema import TelemetryExporterConfig
 from srtctl.core.slurm import start_srun_process
-from srtctl.core.telemetry import generate_tachometer_config
+from srtctl.core.telemetry import TACHOMETER_STORAGE_PARENT, generate_tachometer_config
 
 if TYPE_CHECKING:
     from srtctl.core.runtime import RuntimeContext
@@ -264,14 +265,46 @@ class TelemetryStageMixin:
             return 1
         return exit_code
 
+    def _resolve_tachometer_binary(self, binary_path: str) -> str:
+        """Resolve the default bare binary name against the checkout's bin/.
+
+        An explicit ``binary_path`` is always respected verbatim. The default
+        bare name used to rely on ``$PATH`` inside the srun step, while
+        ``make setup`` installs the binary to ``<srtctl_root>/bin/`` — the
+        same place ``validate_setup`` checks and the --bash lifecycle uses.
+        """
+        if binary_path != "tachometer-scraper":
+            return binary_path
+        candidates = []
+        source_dir = os.environ.get("SRTCTL_SOURCE_DIR")
+        if source_dir:
+            candidates.append(Path(source_dir) / "bin" / binary_path)
+        candidates.append(Path(__file__).resolve().parents[4] / "bin" / binary_path)
+        for candidate in candidates:
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+        return binary_path
+
     def start_tachometer(self) -> list[ManagedProcess]:
-        """Start optional Tachometer collection from observability."""
-        tachometer = self.config.observability.tachometer
-        if tachometer.enabled is not True:
+        """Start Tachometer collection (follows ``observability.enabled``)."""
+        observability = self.config.observability
+        tachometer = observability.tachometer
+        if not observability.tachometer_enabled:
             logger.info("Tachometer disabled")
             return []
 
         logger.info("Starting Tachometer")
+
+        # Scrape the complement of what the benchmark client already polls;
+        # the helper lives on BenchmarkStageMixin (same orchestrator object).
+        client_urls_fn = getattr(self, "_client_polled_metric_urls", None)
+        exclude_urls = client_urls_fn() if client_urls_fn is not None else frozenset()
+        if exclude_urls:
+            logger.info(
+                "Tachometer excludes %d endpoint(s) the benchmark client polls: %s",
+                len(exclude_urls),
+                ",".join(sorted(exclude_urls)),
+            )
 
         power_telemetry = self.config.telemetry
         dcgm_exporter = power_telemetry.dcgm_exporter if power_telemetry.enabled else tachometer.dcgm_exporter
@@ -285,11 +318,14 @@ class TelemetryStageMixin:
                 tachometer=tachometer,
                 dcgm_exporter=dcgm_exporter,
                 frontend_type=self.config.frontend.type,
+                exclude_urls=exclude_urls,
             )
         )
 
         tachometer_dir = self.runtime.log_dir / tachometer.storage_subdir
-        tachometer_dir.mkdir(parents=True, exist_ok=True)
+        # Create only the PARENT of the storage path: tachometer-scraper aborts if the
+        # storage leaf already exists. Same rule the --bash lifecycle already follows.
+        (tachometer_dir / TACHOMETER_STORAGE_PARENT).mkdir(parents=True, exist_ok=True)
         local_dir = tachometer_dir / "local"
         local_dir.mkdir(parents=True, exist_ok=True)
 
@@ -320,7 +356,7 @@ class TelemetryStageMixin:
             )
 
         cmd = [
-            tachometer.binary_path,
+            self._resolve_tachometer_binary(tachometer.binary_path),
             "--config",
             str(config_path),
             "--local-dir",
@@ -346,6 +382,10 @@ class TelemetryStageMixin:
                 ),
                 log_file=self.runtime.log_dir / "tachometer.out",
                 node=self.runtime.nodes.head,
+                # Best-effort by contract: telemetry must never kill a
+                # benchmark. A dead scraper costs the capture, not the run;
+                # the loss is visible in tachometer.out and the sweep log.
+                critical=False,
             )
         )
         logger.info("Tachometer started with artifacts under %s", tachometer_dir)

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -331,6 +331,11 @@ class TelemetryStageMixin:
 
         worker_nodes = sorted({process.node for process in self.backend_processes})
         processes: list[ManagedProcess] = []
+        # Exporters run shell-less (distroless images have no bash — the same
+        # rule the power path follows) and non-critical: telemetry sidecars
+        # must never tear down the benchmark. Verified the hard way: a
+        # bash-wrapped node-exporter (FROM scratch) died with execve() ENOENT
+        # and, as a critical process, killed a 7-node run at startup.
         if not power_telemetry.enabled and tachometer.dcgm_exporter is not None:
             processes.extend(
                 self._start_exporter_container(
@@ -339,6 +344,8 @@ class TelemetryStageMixin:
                     nodelist=worker_nodes,
                     log_file=self.runtime.log_dir / "tachometer_dcgm_exporter.out",
                     default_command_template=DCGM_EXPORTER_COMMAND_TEMPLATE,
+                    use_bash_wrapper=False,
+                    critical=False,
                 )
             )
         if tachometer.node_exporter is not None:
@@ -352,6 +359,8 @@ class TelemetryStageMixin:
                         "/bin/node_exporter --web.listen-address=:{port} "
                         "--collector.disable-defaults --collector.cpu --collector.infiniband --collector.meminfo"
                     ),
+                    use_bash_wrapper=False,
+                    critical=False,
                 )
             )
 

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -387,7 +387,7 @@ def show_config_details(config: SrtConfig) -> None:
         if config.observability.enabled:
             details.add_row("observability", "raw_metrics", str(config.observability.scraper_enabled))
         tachometer = config.observability.tachometer
-        if tachometer.enabled:
+        if config.observability.tachometer_enabled:
             details.add_row("observability", "tachometer", "enabled")
             details.add_row("observability", "storage_subdir", tachometer.storage_subdir)
             details.add_row("observability", "frequency", str(tachometer.default_frequency))

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1030,9 +1030,17 @@ class TelemetryExporterConfig:
 
 @dataclass(frozen=True)
 class TachometerConfig:
-    """Native Tachometer collection for an observability-enabled run."""
+    """Native Tachometer collection for an observability-enabled run.
 
-    enabled: bool = False
+    ``enabled`` is tri-state: ``None`` (the default) follows
+    ``observability.enabled``, so an observability run collects Tachometer
+    data with no ``tachometer:`` block at all; an explicit ``false`` opts
+    out; an explicit ``true`` under ``observability.enabled: false`` is a
+    validation error (Tachometer's targets only have content when the
+    observability expansion ran).
+    """
+
+    enabled: bool | None = None
     binary_path: str = "tachometer-scraper"
     default_frequency: float = 5.0
     sync_interval_secs: int = 120
@@ -1070,10 +1078,12 @@ class ObservabilityConfig:
     * ``DYN_LOGGING_SPAN_EVENTS`` / ``DYN_LOGGING_JSONL`` / ``DYN_LOG=debug`` on
       prefill, decode and frontend -- per-request ``SPAN_CLOSED`` trace lines.
 
-    and, at benchmark time (see ``BenchmarkStageMixin``):
+    and, for the run's server-side capture:
 
-    * an in-job Prometheus scraper writing ``raw_prometheus.jsonl`` for the whole
-      benchmark window (see ``scrape_*`` below).
+    * native Tachometer collection of every ``/metrics`` endpoint the benchmark
+      client does not already poll (see ``TelemetryStageMixin.start_tachometer``
+      and ``tachometer`` below). The legacy in-job RAW Prometheus scraper is now
+      opt-in only via ``scrape_metrics: true`` (see ``scrape_*`` below).
 
     Every expansion uses setdefault semantics: an explicit value in the recipe
     always wins, so ``observability.enabled`` is safe to switch on globally.
@@ -1099,15 +1109,17 @@ class ObservabilityConfig:
             and frontends. Requires otel_endpoint to be set. Default: False.
         otel_endpoint: OTEL collector endpoint (e.g. "http://10.0.0.1:4317").
             Required when enable_otel is True.
-        scrape_metrics: Run the in-job RAW Prometheus scraper. Defaults to the
-            value of ``enabled``; set False to opt out while keeping the rest.
+        scrape_metrics: Run the legacy in-job RAW Prometheus scraper. Off by
+            default (Tachometer is the default capture); set True to opt in —
+            it then runs alongside Tachometer, double-polling the endpoints.
         scrape_interval_seconds: Seconds between scrape sweeps. Default: 1.0.
             The floor is 0.5; a sweep slower than the interval simply runs
             back-to-back rather than queueing (see the drift-free pacing in
             ``RawMetricsScraper``).
         scrape_output: Filename (under the run's log dir) for the RAW capture.
-        tachometer: Optional native Tachometer capture configuration. It runs
-            alongside RAW capture when both are enabled.
+        tachometer: Native Tachometer capture configuration. Follows ``enabled``
+            unless ``tachometer.enabled`` is set explicitly (see
+            :class:`TachometerConfig`).
     """
 
     enabled: bool = False
@@ -1123,8 +1135,17 @@ class ObservabilityConfig:
 
     @property
     def scraper_enabled(self) -> bool:
-        """Whether the in-job RAW Prometheus scraper should run."""
-        return self.enabled if self.scrape_metrics is None else self.scrape_metrics
+        """Whether the legacy in-job RAW Prometheus scraper should run.
+
+        No longer follows ``enabled``: Tachometer is the default server-side
+        capture, so the RAW scraper is strictly opt-in.
+        """
+        return bool(self.scrape_metrics)
+
+    @property
+    def tachometer_enabled(self) -> bool:
+        """Resolved Tachometer enablement (tri-state ``tachometer.enabled``)."""
+        return self.enabled if self.tachometer.enabled is None else self.tachometer.enabled
 
 
 @dataclass(frozen=True)
@@ -2062,13 +2083,13 @@ class SrtConfig:
             raise ValidationError("telemetry requires a non-empty list of unique positive benchmark.concurrencies")
 
     def _validate_observability(self):
-        """Validate optional Tachometer collection under observability."""
+        """Validate Tachometer collection under observability."""
         observability = self.observability
         tachometer = observability.tachometer
-        if not tachometer.enabled:
-            return
-        if not observability.enabled:
+        if tachometer.enabled is True and not observability.enabled:
             raise ValidationError("observability.tachometer requires observability.enabled: true")
+        if not observability.tachometer_enabled:
+            return
         if self.telemetry.enabled and tachometer.dcgm_exporter is not None:
             raise ValidationError(
                 "configure the shared DCGM exporter under telemetry, not observability.tachometer, "

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1080,8 +1080,11 @@ class ObservabilityConfig:
 
     Scope is deliberately server-side. The knob configures what the workers and
     frontend *emit*, and captures that surface by scraping the endpoints
-    directly. It never reaches into the benchmark client to ask it to re-export
-    what the servers already publish.
+    directly. It never asks the benchmark client to re-export what the servers
+    already publish. (One indirect exception: on TRT-LLM the client's
+    ``AIPERF_SERVER_METRICS_URLS`` worker list exists only when
+    ``publish_events_and_metrics`` gives those endpoints content, and this knob
+    is one way that flag gets set — see ``BenchmarkStageMixin``.)
 
     It does **not** decide whether the component perf dashboard is built. That
     happens on every run (see :mod:`srtctl.analysis.perf_dashboard`); ``enabled``

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -19,6 +19,14 @@ if TYPE_CHECKING:
     from srtctl.core.topology import Process
 
 
+# Tachometer owns its final storage directory and rejects a pre-existing leaf
+# (see tachometer-scraper `parse_storage`). srtctl must therefore create only the
+# parent and hand the scraper a not-yet-existing leaf. This mirrors what the
+# direct-host path already does in templates/local_lifecycle.sh.j2.
+TACHOMETER_STORAGE_PARENT = "raw"
+TACHOMETER_STORAGE_LEAF = "scrape"
+
+
 @dataclass(frozen=True)
 class TelemetryEndpoint:
     """One telemetry endpoint entry in the scraper config."""
@@ -39,8 +47,17 @@ def generate_tachometer_config(
     tachometer: TachometerConfig,
     dcgm_exporter: TelemetryExporterConfig | None = None,
     frontend_type: str = "dynamo",
+    exclude_urls: frozenset[str] | set[str] = frozenset(),
 ) -> str:
-    """Generate Tachometer TOML from backend and frontend topology."""
+    """Generate Tachometer TOML from backend and frontend topology.
+
+    ``exclude_urls`` is the set of ``/metrics`` URLs the benchmark client
+    already polls (``AIPERF_SERVER_METRICS_URLS``). Tachometer scrapes the
+    complement so a worker endpoint is never double-polled — the extra scrape
+    load has previously made a submission irreproducible. Frontend, DCGM and
+    node-exporter endpoints are never excluded: the frontend scrape is cheap
+    and Tachometer is the only whole-window, per-replica capture of it.
+    """
     dcgm_exporter = dcgm_exporter or tachometer.dcgm_exporter
     node_exporter = tachometer.node_exporter
     endpoints: list[TelemetryEndpoint] = []
@@ -85,10 +102,17 @@ def generate_tachometer_config(
             )
 
     for process in sorted(processes, key=lambda p: (p.endpoint_mode, p.endpoint_index, p.node_rank, p.node)):
-        if frontend_type == "vllm" and process.endpoint_mode == "agg" and not process.is_leader:
+        # Leaders only: rank zero serves the logical worker's /metrics, so
+        # follower sys-ports would only add duplicate or empty rows.
+        if not process.is_leader:
             continue
         node_ip = get_hostname_ip(process.node, runtime.network_interface)
         port = FRONTEND_PUBLIC_PORT if frontend_type == "vllm" and process.endpoint_mode == "agg" else process.sys_port
+        url = f"http://{node_ip}:{port}/metrics"
+        if url in exclude_urls:
+            # The benchmark client already polls this endpoint on its own
+            # cadence; scrape the complement instead of double-polling.
+            continue
         node_metadata = {
             "hostname": process.node,
             "worker_index": str(process.endpoint_index),
@@ -99,7 +123,7 @@ def generate_tachometer_config(
         endpoints.append(
             TelemetryEndpoint(
                 name=f"backend_{process.endpoint_mode}{process.endpoint_index}_rank{process.node_rank}",
-                url=f"http://{node_ip}:{port}/metrics",
+                url=url,
                 frequency=tachometer.default_frequency,
                 filter="backend",
                 node_metadata=node_metadata,
@@ -138,7 +162,7 @@ def generate_tachometer_config(
 
     return _dump_toml(
         endpoints=endpoints,
-        storage=str(runtime.log_dir / tachometer.storage_subdir),
+        storage=str(runtime.log_dir / tachometer.storage_subdir / TACHOMETER_STORAGE_PARENT / TACHOMETER_STORAGE_LEAF),
     )
 
 

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -102,9 +102,10 @@ def generate_tachometer_config(
             )
 
     for process in sorted(processes, key=lambda p: (p.endpoint_mode, p.endpoint_index, p.node_rank, p.node)):
-        # Leaders only: rank zero serves the logical worker's /metrics, so
-        # follower sys-ports would only add duplicate or empty rows.
-        if not process.is_leader:
+        # Every rank is a target (vLLM agg followers excepted below): follower
+        # metadata columns keep rows distinguishable, and rank coverage is
+        # exactly what the physical-process client list provides for vLLM DP.
+        if frontend_type == "vllm" and process.endpoint_mode == "agg" and not process.is_leader:
             continue
         node_ip = get_hostname_ip(process.node, runtime.network_interface)
         port = FRONTEND_PUBLIC_PORT if frontend_type == "vllm" and process.endpoint_mode == "agg" else process.sys_port

--- a/src/tachometer/tachometer-scraper/src/parse.rs
+++ b/src/tachometer/tachometer-scraper/src/parse.rs
@@ -157,16 +157,16 @@ pub fn samples_to_rows_with_filter(
     processed_samples.extend(cpu_aggregated);
 
     // First pass: collect histogram sum and count values
-    let mut histogram_stats: HashMap<String, (Option<f32>, Option<f32>)> = HashMap::new();
+    let mut histogram_stats: HashMap<String, (Option<f64>, Option<f64>)> = HashMap::new();
 
     for sample in &processed_samples {
         let key = make_histogram_key(&sample.metric_name, &sample.labels);
         match sample.metric_type {
             MetricType::HistogramSum => {
-                histogram_stats.entry(key).or_insert((None, None)).0 = Some(sample.value as f32);
+                histogram_stats.entry(key).or_insert((None, None)).0 = Some(sample.value);
             }
             MetricType::HistogramCount => {
-                histogram_stats.entry(key).or_insert((None, None)).1 = Some(sample.value as f32);
+                histogram_stats.entry(key).or_insert((None, None)).1 = Some(sample.value);
             }
             _ => {}
         }
@@ -185,13 +185,13 @@ pub fn samples_to_rows_with_filter(
                 let upper_bound = if le_str == "+Inf" {
                     None // +Inf is represented as None
                 } else {
-                    le_str.parse::<f32>().ok()
+                    le_str.parse::<f64>().ok()
                 };
 
                 rows.push(Row {
                     scraper_endpoint: scraper_endpoint.to_string(),
                     metric_name: filtered_name,
-                    metric_value: sample.value as f32,
+                    metric_value: sample.value,
                     histogram_bucket_lower: None, // Will be calculated later
                     histogram_bucket_upper: upper_bound,
                     histogram_sum: None,   // Will be set later for all buckets
@@ -207,7 +207,7 @@ pub fn samples_to_rows_with_filter(
                 rows.push(Row {
                     scraper_endpoint: scraper_endpoint.to_string(),
                     metric_name: filtered_name,
-                    metric_value: sample.value as f32,
+                    metric_value: sample.value,
                     histogram_bucket_lower: None,
                     histogram_bucket_upper: None,
                     histogram_sum: None,
@@ -231,16 +231,16 @@ pub fn samples_to_rows(samples: Vec<ParsedSample>, scraper_endpoint: &str) -> Ve
     let mut rows = Vec::new();
 
     // First pass: collect histogram sum and count values
-    let mut histogram_stats: HashMap<String, (Option<f32>, Option<f32>)> = HashMap::new();
+    let mut histogram_stats: HashMap<String, (Option<f64>, Option<f64>)> = HashMap::new();
 
     for sample in &samples {
         let key = make_histogram_key(&sample.metric_name, &sample.labels);
         match sample.metric_type {
             MetricType::HistogramSum => {
-                histogram_stats.entry(key).or_insert((None, None)).0 = Some(sample.value as f32);
+                histogram_stats.entry(key).or_insert((None, None)).0 = Some(sample.value);
             }
             MetricType::HistogramCount => {
-                histogram_stats.entry(key).or_insert((None, None)).1 = Some(sample.value as f32);
+                histogram_stats.entry(key).or_insert((None, None)).1 = Some(sample.value);
             }
             _ => {}
         }
@@ -257,13 +257,13 @@ pub fn samples_to_rows(samples: Vec<ParsedSample>, scraper_endpoint: &str) -> Ve
                 let upper_bound = if le_str == "+Inf" {
                     None
                 } else {
-                    le_str.parse::<f32>().ok()
+                    le_str.parse::<f64>().ok()
                 };
 
                 rows.push(Row {
                     scraper_endpoint: scraper_endpoint.to_string(),
                     metric_name,
-                    metric_value: sample.value as f32,
+                    metric_value: sample.value,
                     histogram_bucket_lower: None,
                     histogram_bucket_upper: upper_bound,
                     histogram_sum: None,   // Will be set later for all buckets
@@ -278,7 +278,7 @@ pub fn samples_to_rows(samples: Vec<ParsedSample>, scraper_endpoint: &str) -> Ve
                 rows.push(Row {
                     scraper_endpoint: scraper_endpoint.to_string(),
                     metric_name,
-                    metric_value: sample.value as f32,
+                    metric_value: sample.value,
                     histogram_bucket_lower: None,
                     histogram_bucket_upper: None,
                     histogram_sum: None,
@@ -522,7 +522,7 @@ fn make_histogram_key(metric_name: &str, labels: &HashMap<String, String>) -> St
 
 fn fix_histogram_bucket_bounds_and_stats(
     rows: &mut [Row],
-    histogram_stats: HashMap<String, (Option<f32>, Option<f32>)>,
+    histogram_stats: HashMap<String, (Option<f64>, Option<f64>)>,
 ) {
     // Group histogram buckets by metric name and set lower bounds
     use std::collections::BTreeMap;
@@ -549,10 +549,10 @@ fn fix_histogram_bucket_bounds_and_stats(
     // Set lower bounds for each group and attach sum/count to all buckets
     for (base_name, indices) in bucket_groups.iter_mut() {
         indices.sort_by(|&i, &j| {
-            let upper_i = rows[i].histogram_bucket_upper.unwrap_or(f32::INFINITY);
-            let upper_j = rows[j].histogram_bucket_upper.unwrap_or(f32::INFINITY);
+            let upper_i = rows[i].histogram_bucket_upper.unwrap_or(f64::INFINITY);
+            let upper_j = rows[j].histogram_bucket_upper.unwrap_or(f64::INFINITY);
             // Sort: +Inf comes last, then by value
-            match (upper_i == f32::INFINITY, upper_j == f32::INFINITY) {
+            match (upper_i == f64::INFINITY, upper_j == f64::INFINITY) {
                 (true, true) => std::cmp::Ordering::Equal,
                 (true, false) => std::cmp::Ordering::Greater,
                 (false, true) => std::cmp::Ordering::Less,

--- a/src/tachometer/tachometer-writer/src/writer.rs
+++ b/src/tachometer/tachometer-writer/src/writer.rs
@@ -15,11 +15,11 @@ use tokio::time::{Duration, Instant};
 pub struct Row {
     pub scraper_endpoint: String,
     pub metric_name: String,
-    pub metric_value: f32,
-    pub histogram_bucket_lower: Option<f32>,
-    pub histogram_bucket_upper: Option<f32>,
-    pub histogram_sum: Option<f32>,
-    pub histogram_count: Option<f32>,
+    pub metric_value: f64,
+    pub histogram_bucket_lower: Option<f64>,
+    pub histogram_bucket_upper: Option<f64>,
+    pub histogram_sum: Option<f64>,
+    pub histogram_count: Option<f64>,
     pub extras: Vec<(String, String)>, // Sorted metadata key-value pairs
 }
 
@@ -31,17 +31,23 @@ pub struct DatasetWriter {
     rows_per_parquet: usize,
     save_handle: tokio::task::JoinHandle<()>,
     start_time: Instant,
+    /// Wall-clock time at writer start, as nanoseconds since UNIX_EPOCH.
+    /// Captured at the same moment as `start_time` so that
+    /// `start_epoch_ns + start_time.elapsed()` yields a monotonic epoch
+    /// timestamp even if the wall clock steps afterwards.
+    start_epoch_ns: i64,
 }
 
 struct RecordBatchBuffer {
     scraper_endpoints: Vec<String>,
     metric_names: Vec<String>,
-    metric_values: Vec<f32>,
-    histogram_bucket_lowers: Vec<Option<f32>>,
-    histogram_bucket_uppers: Vec<Option<f32>>,
-    histogram_sums: Vec<Option<f32>>,
-    histogram_counts: Vec<Option<f32>>,
+    metric_values: Vec<f64>,
+    histogram_bucket_lowers: Vec<Option<f64>>,
+    histogram_bucket_uppers: Vec<Option<f64>>,
+    histogram_sums: Vec<Option<f64>>,
+    histogram_counts: Vec<Option<f64>>,
     time_since_starts: Vec<f64>,
+    timestamp_ns: Vec<i64>,
     extras_columns: Vec<Vec<String>>, // One Vec<String> per extra column
     extra_column_names: Vec<String>,  // Names of extra columns (sorted)
 }
@@ -58,6 +64,7 @@ impl RecordBatchBuffer {
             histogram_sums: Vec::new(),
             histogram_counts: Vec::new(),
             time_since_starts: Vec::new(),
+            timestamp_ns: Vec::new(),
             extras_columns,
             extra_column_names,
         }
@@ -67,7 +74,7 @@ impl RecordBatchBuffer {
         self.scraper_endpoints.len()
     }
 
-    fn append_row(&mut self, row: &Row, time_since_start: f64) {
+    fn append_row(&mut self, row: &Row, time_since_start: f64, timestamp_ns: i64) {
         self.scraper_endpoints.push(row.scraper_endpoint.clone());
         self.metric_names.push(row.metric_name.clone());
         self.metric_values.push(row.metric_value);
@@ -78,6 +85,7 @@ impl RecordBatchBuffer {
         self.histogram_sums.push(row.histogram_sum);
         self.histogram_counts.push(row.histogram_count);
         self.time_since_starts.push(time_since_start);
+        self.timestamp_ns.push(timestamp_ns);
 
         // Populate extras columns - ensure all columns have values (empty string if missing)
         for (col_idx, col_name) in self.extra_column_names.iter().enumerate() {
@@ -100,6 +108,7 @@ impl RecordBatchBuffer {
         self.histogram_sums.clear();
         self.histogram_counts.clear();
         self.time_since_starts.clear();
+        self.timestamp_ns.clear();
         for col in &mut self.extras_columns {
             col.clear();
         }
@@ -115,12 +124,13 @@ impl RecordBatchBuffer {
         let mut fields = vec![
             Field::new("scraper_endpoint", DataType::Utf8, false),
             Field::new("metric_name", DataType::Utf8, false),
-            Field::new("metric_value", DataType::Float32, false),
-            Field::new("histogram_bucket_lower", DataType::Float32, true),
-            Field::new("histogram_bucket_upper", DataType::Float32, true),
-            Field::new("histogram_sum", DataType::Float32, true),
-            Field::new("histogram_count", DataType::Float32, true),
+            Field::new("metric_value", DataType::Float64, false),
+            Field::new("histogram_bucket_lower", DataType::Float64, true),
+            Field::new("histogram_bucket_upper", DataType::Float64, true),
+            Field::new("histogram_sum", DataType::Float64, true),
+            Field::new("histogram_count", DataType::Float64, true),
             Field::new("time_since_start", DataType::Float64, false),
+            Field::new("timestamp_ns", DataType::Int64, false),
         ];
 
         // Add extra columns to schema
@@ -133,12 +143,13 @@ impl RecordBatchBuffer {
         let mut arrays: Vec<Arc<dyn Array>> = vec![
             Arc::new(StringArray::from(self.scraper_endpoints.clone())),
             Arc::new(StringArray::from(self.metric_names.clone())),
-            Arc::new(Float32Array::from(self.metric_values.clone())),
-            Arc::new(Float32Array::from(self.histogram_bucket_lowers.clone())),
-            Arc::new(Float32Array::from(self.histogram_bucket_uppers.clone())),
-            Arc::new(Float32Array::from(self.histogram_sums.clone())),
-            Arc::new(Float32Array::from(self.histogram_counts.clone())),
+            Arc::new(Float64Array::from(self.metric_values.clone())),
+            Arc::new(Float64Array::from(self.histogram_bucket_lowers.clone())),
+            Arc::new(Float64Array::from(self.histogram_bucket_uppers.clone())),
+            Arc::new(Float64Array::from(self.histogram_sums.clone())),
+            Arc::new(Float64Array::from(self.histogram_counts.clone())),
             Arc::new(Float64Array::from(self.time_since_starts.clone())),
+            Arc::new(Int64Array::from(self.timestamp_ns.clone())),
         ];
 
         // Add extra column arrays
@@ -176,7 +187,19 @@ impl DatasetWriter {
         let buffer = Arc::new(Mutex::new(RecordBatchBuffer::new(extra_column_names)));
         let row_count = Arc::new(Mutex::new(0));
         let parquet_index = Arc::new(Mutex::new(1));
+        // Capture the monotonic and wall-clock start times at the same moment.
+        // All per-row epoch timestamps are derived as start_epoch_ns + elapsed
+        // (monotonic), so rows stay monotonic even if the wall clock steps.
         let start_time = Instant::now();
+        let start_epoch_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| {
+                crate::NoMoreError::Io(std::io::Error::other(format!(
+                    "System clock is before UNIX_EPOCH: {}",
+                    e
+                )))
+            })?
+            .as_nanos() as i64;
 
         let buffer_clone = buffer.clone();
         let local_dir_clone = local_dir.clone();
@@ -193,6 +216,7 @@ impl DatasetWriter {
             rows_per_parquet,
             save_handle,
             start_time,
+            start_epoch_ns,
         })
     }
 
@@ -202,11 +226,13 @@ impl DatasetWriter {
     }
 
     pub async fn append_row(&self, row: Row) -> Result<()> {
-        let time_since_start = self.start_time.elapsed().as_secs_f64();
+        let elapsed = self.start_time.elapsed();
+        let time_since_start = elapsed.as_secs_f64();
+        let timestamp_ns = self.start_epoch_ns + elapsed.as_nanos() as i64;
         let mut buffer = self.buffer.lock().await;
         let mut row_count = self.row_count.lock().await;
 
-        buffer.append_row(&row, time_since_start);
+        buffer.append_row(&row, time_since_start, timestamp_ns);
         *row_count += 1;
 
         // Check if we need to create a numbered parquet file
@@ -228,12 +254,14 @@ impl DatasetWriter {
     }
 
     pub async fn append_rows(&self, rows: Vec<Row>) -> Result<()> {
-        let time_since_start = self.start_time.elapsed().as_secs_f64();
+        let elapsed = self.start_time.elapsed();
+        let time_since_start = elapsed.as_secs_f64();
+        let timestamp_ns = self.start_epoch_ns + elapsed.as_nanos() as i64;
         let mut buffer = self.buffer.lock().await;
         let mut row_count = self.row_count.lock().await;
 
         for row in rows {
-            buffer.append_row(&row, time_since_start);
+            buffer.append_row(&row, time_since_start, timestamp_ns);
             *row_count += 1;
         }
 

--- a/src/tachometer/tachometer-writer/tests/integration_test.rs
+++ b/src/tachometer/tachometer-writer/tests/integration_test.rs
@@ -30,7 +30,7 @@ fn create_test_rows(count: usize, metric_prefix: &str) -> Vec<Row> {
         .map(|i| Row {
             scraper_endpoint: "test_endpoint".to_string(),
             metric_name: format!("{}_{}", metric_prefix, i),
-            metric_value: i as f32,
+            metric_value: i as f64,
             histogram_bucket_lower: None,
             histogram_bucket_upper: None,
             histogram_sum: None,
@@ -434,12 +434,12 @@ async fn test_writer_handles_histogram_rows() {
     let lowers = batch
         .column(3)
         .as_any()
-        .downcast_ref::<arrow::array::Float32Array>()
+        .downcast_ref::<arrow::array::Float64Array>()
         .unwrap();
     let uppers = batch
         .column(4)
         .as_any()
-        .downcast_ref::<arrow::array::Float32Array>()
+        .downcast_ref::<arrow::array::Float64Array>()
         .unwrap();
 
     // Check that values are not null and have correct values
@@ -484,8 +484,8 @@ async fn test_compact_and_upload_preserves_all_columns() {
     let batch = &batches[0];
     let schema = batch.schema();
 
-    // Should have 9 columns with required names (order may vary with polars)
-    assert_eq!(schema.fields().len(), 9);
+    // Should have 10 columns with required names (order may vary with polars)
+    assert_eq!(schema.fields().len(), 10);
 
     // Verify all required columns exist by name
     let required_columns = [
@@ -498,6 +498,7 @@ async fn test_compact_and_upload_preserves_all_columns() {
         "histogram_sum",
         "histogram_count",
         "time_since_start",
+        "timestamp_ns",
     ];
 
     for col_name in &required_columns {
@@ -612,7 +613,7 @@ async fn test_compact_and_upload_skips_corrupt_files() {
     std::fs::create_dir_all(&local_dir).unwrap();
 
     // Create a valid parquet file manually
-    use arrow::array::{Float32Array, Float64Array, StringArray};
+    use arrow::array::{Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use parquet::arrow::ArrowWriter;
@@ -620,12 +621,13 @@ async fn test_compact_and_upload_skips_corrupt_files() {
     let schema = Arc::new(Schema::new(vec![
         Field::new("scraper_endpoint", DataType::Utf8, false),
         Field::new("metric_name", DataType::Utf8, false),
-        Field::new("metric_value", DataType::Float32, false),
-        Field::new("histogram_bucket_lower", DataType::Float32, true),
-        Field::new("histogram_bucket_upper", DataType::Float32, true),
-        Field::new("histogram_sum", DataType::Float32, true),
-        Field::new("histogram_count", DataType::Float32, true),
+        Field::new("metric_value", DataType::Float64, false),
+        Field::new("histogram_bucket_lower", DataType::Float64, true),
+        Field::new("histogram_bucket_upper", DataType::Float64, true),
+        Field::new("histogram_sum", DataType::Float64, true),
+        Field::new("histogram_count", DataType::Float64, true),
         Field::new("time_since_start", DataType::Float64, false),
+        Field::new("timestamp_ns", DataType::Int64, false),
     ]));
 
     // Write a valid out-1.parquet
@@ -634,12 +636,16 @@ async fn test_compact_and_upload_skips_corrupt_files() {
         vec![
             Arc::new(StringArray::from(vec!["ep1", "ep1"])),
             Arc::new(StringArray::from(vec!["valid_metric_1", "valid_metric_2"])),
-            Arc::new(Float32Array::from(vec![1.0, 2.0])),
-            Arc::new(Float32Array::from(vec![None, None])),
-            Arc::new(Float32Array::from(vec![None, None])),
-            Arc::new(Float32Array::from(vec![None, None])),
-            Arc::new(Float32Array::from(vec![None, None])),
+            Arc::new(Float64Array::from(vec![1.0, 2.0])),
+            Arc::new(Float64Array::from(vec![None, None])),
+            Arc::new(Float64Array::from(vec![None, None])),
+            Arc::new(Float64Array::from(vec![None, None])),
+            Arc::new(Float64Array::from(vec![None, None])),
             Arc::new(Float64Array::from(vec![0.1, 0.2])),
+            Arc::new(Int64Array::from(vec![
+                1_700_000_000_000_000_000i64,
+                1_700_000_000_100_000_000i64,
+            ])),
         ],
     )
     .unwrap();
@@ -778,7 +784,7 @@ async fn test_compact_handles_multiple_incomplete_files() {
     std::fs::create_dir_all(&local_dir).unwrap();
 
     // Create multiple incomplete-*.parquet files manually
-    use arrow::array::{Float32Array, Float64Array, StringArray};
+    use arrow::array::{Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use parquet::arrow::ArrowWriter;
@@ -786,12 +792,13 @@ async fn test_compact_handles_multiple_incomplete_files() {
     let schema = Arc::new(Schema::new(vec![
         Field::new("scraper_endpoint", DataType::Utf8, false),
         Field::new("metric_name", DataType::Utf8, false),
-        Field::new("metric_value", DataType::Float32, false),
-        Field::new("histogram_bucket_lower", DataType::Float32, true),
-        Field::new("histogram_bucket_upper", DataType::Float32, true),
-        Field::new("histogram_sum", DataType::Float32, true),
-        Field::new("histogram_count", DataType::Float32, true),
+        Field::new("metric_value", DataType::Float64, false),
+        Field::new("histogram_bucket_lower", DataType::Float64, true),
+        Field::new("histogram_bucket_upper", DataType::Float64, true),
+        Field::new("histogram_sum", DataType::Float64, true),
+        Field::new("histogram_count", DataType::Float64, true),
         Field::new("time_since_start", DataType::Float64, false),
+        Field::new("timestamp_ns", DataType::Int64, false),
     ]));
 
     // Create incomplete-1.parquet and incomplete-2.parquet
@@ -805,15 +812,20 @@ async fn test_compact_handles_multiple_incomplete_files() {
                     format!("metric_{}_b", idx),
                     format!("metric_{}_c", idx),
                 ])),
-                Arc::new(Float32Array::from(vec![1.0, 2.0, 3.0])),
-                Arc::new(Float32Array::from(vec![None, None, None])),
-                Arc::new(Float32Array::from(vec![None, None, None])),
-                Arc::new(Float32Array::from(vec![None, None, None])),
-                Arc::new(Float32Array::from(vec![None, None, None])),
+                Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0])),
+                Arc::new(Float64Array::from(vec![None, None, None])),
+                Arc::new(Float64Array::from(vec![None, None, None])),
+                Arc::new(Float64Array::from(vec![None, None, None])),
+                Arc::new(Float64Array::from(vec![None, None, None])),
                 Arc::new(Float64Array::from(vec![
                     idx as f64 * 0.1,
                     idx as f64 * 0.2,
                     idx as f64 * 0.3,
+                ])),
+                Arc::new(Int64Array::from(vec![
+                    1_700_000_000_000_000_000i64 + idx as i64,
+                    1_700_000_000_000_000_001i64 + idx as i64,
+                    1_700_000_000_000_000_002i64 + idx as i64,
                 ])),
             ],
         )
@@ -851,4 +863,139 @@ async fn test_compact_handles_multiple_incomplete_files() {
         0,
         "All incomplete files should be deleted"
     );
+}
+
+/// Regression guard for the two schema defects:
+/// (a) rows must carry an epoch-nanosecond `timestamp_ns` join key that is
+///     plausibly recent and non-decreasing across appended rows;
+/// (b) metric values must be stored as Float64 so that integers above f32's
+///     24-bit mantissa (2^24 = 16,777,216) round-trip exactly. Under the old
+///     Float32 schema, 16_777_217.0 would come back as 16_777_216.0.
+#[tokio::test]
+async fn test_timestamp_ns_and_f64_precision() {
+    let (_local_temp, _remote_temp, local_dir, _remote_store, _remote_path) =
+        create_test_setup().await;
+
+    let writer = Arc::new(
+        DatasetWriter::new(
+            local_dir.clone(),
+            3,    // rows_per_parquet: cut a parquet file after 3 rows
+            1000, // save_interval_secs (long to avoid periodic saves during test)
+            vec![],
+        )
+        .unwrap(),
+    );
+
+    // 2^24 + 1: the first integer NOT representable in f32
+    const F32_UNREPRESENTABLE: f64 = 16_777_217.0;
+
+    let make_row = |name: &str, value: f64| Row {
+        scraper_endpoint: "test_endpoint".to_string(),
+        metric_name: name.to_string(),
+        metric_value: value,
+        histogram_bucket_lower: None,
+        histogram_bucket_upper: None,
+        histogram_sum: Some(F32_UNREPRESENTABLE),
+        histogram_count: Some(F32_UNREPRESENTABLE),
+        extras: vec![],
+    };
+
+    // Append one row at a time with small sleeps so timestamps advance
+    writer
+        .append_row(make_row("big_counter_bytes", F32_UNREPRESENTABLE))
+        .await
+        .unwrap();
+    tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+    writer.append_row(make_row("metric_b", 1.5)).await.unwrap();
+    tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+    writer.append_row(make_row("metric_c", 2.5)).await.unwrap();
+
+    // 3 rows == rows_per_parquet, so out-1.parquet must exist
+    let path = local_dir.join("out-1.parquet");
+    assert!(path.exists(), "Parquet file should exist at {:?}", path);
+
+    let batches = read_local_parquet_file(&path);
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    assert_eq!(batch.num_rows(), 3);
+
+    // (a) timestamp_ns: present, Int64, non-nullable, recent, non-decreasing
+    let schema = batch.schema();
+    let ts_field = schema
+        .field_with_name("timestamp_ns")
+        .expect("Schema should contain timestamp_ns column");
+    assert_eq!(ts_field.data_type(), &arrow::datatypes::DataType::Int64);
+    assert!(
+        !ts_field.is_nullable(),
+        "timestamp_ns should be non-nullable"
+    );
+
+    let timestamps = batch
+        .column_by_name("timestamp_ns")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow::array::Int64Array>()
+        .expect("timestamp_ns should be an Int64Array");
+
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as i64;
+    const ONE_HOUR_NS: i64 = 3_600 * 1_000_000_000;
+
+    for i in 0..timestamps.len() {
+        assert!(!timestamps.is_null(i), "timestamp_ns must not be null");
+        let ts = timestamps.value(i);
+        assert!(
+            (now_ns - ts).abs() < ONE_HOUR_NS,
+            "timestamp_ns {} should be within an hour of now {}",
+            ts,
+            now_ns
+        );
+    }
+    for i in 1..timestamps.len() {
+        assert!(
+            timestamps.value(i) >= timestamps.value(i - 1),
+            "timestamp_ns must be non-decreasing across appended rows: row {} ({}) < row {} ({})",
+            i,
+            timestamps.value(i),
+            i - 1,
+            timestamps.value(i - 1)
+        );
+    }
+    // Rows appended with sleeps in between must have strictly increasing timestamps
+    assert!(
+        timestamps.value(2) > timestamps.value(0),
+        "timestamps of rows appended later should advance"
+    );
+
+    // (b) f64 round-trip: 2^24 + 1 must survive exactly (fails under Float32)
+    let values = batch
+        .column_by_name("metric_value")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow::array::Float64Array>()
+        .expect("metric_value should be a Float64Array");
+    assert_eq!(
+        values.value(0),
+        F32_UNREPRESENTABLE,
+        "metric_value must round-trip 2^24+1 exactly (f32 would truncate to 16_777_216)"
+    );
+
+    let sums = batch
+        .column_by_name("histogram_sum")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow::array::Float64Array>()
+        .expect("histogram_sum should be a Float64Array");
+    let counts = batch
+        .column_by_name("histogram_count")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow::array::Float64Array>()
+        .expect("histogram_count should be a Float64Array");
+    assert_eq!(sums.value(0), F32_UNREPRESENTABLE);
+    assert_eq!(counts.value(0), F32_UNREPRESENTABLE);
+
+    writer.shutdown().await.unwrap();
 }

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -233,8 +233,11 @@ class TestCustomBenchmarkRunner:
         processes,
         *,
         benchmark_type="custom",
+        backend_type="sglang",
+        publish_events_and_metrics=False,
         prefill_environment=None,
         aggregated_environment=None,
+        environment=None,
     ):
         from types import SimpleNamespace
 
@@ -249,16 +252,19 @@ class TestCustomBenchmarkRunner:
         stage.config = SimpleNamespace(
             benchmark=SimpleNamespace(type=benchmark_type, aiperf_package=None),
             backend=SimpleNamespace(
+                type=backend_type,
+                publish_events_and_metrics=publish_events_and_metrics,
                 prefill_environment=prefill_environment or {},
                 aggregated_environment=aggregated_environment or {},
             ),
+            backend_type=backend_type,
             frontend=SimpleNamespace(type=frontend_type),
             profiling=SimpleNamespace(enabled=False),
             resources=SimpleNamespace(num_agg=sum(p.endpoint_mode == "agg" and p.is_leader for p in processes)),
             telemetry=SimpleNamespace(enabled=False),
         )
         stage.runtime = SimpleNamespace(
-            environment={},
+            environment=environment or {},
             frontend_port=8000,
             network_interface="ibp1s0",
             nodes=SimpleNamespace(head="head-node"),
@@ -516,6 +522,122 @@ class TestCustomBenchmarkRunner:
         assert env["AIPERF_SERVER_METRICS_URLS"] == (
             "http://ip-node-a:7500/metrics,http://ip-node-b:7501/metrics,http://ip-node-c:7502/metrics"
         )
+
+    def test_builtin_aiperf_omits_dead_trtllm_worker_urls(self):
+        """A TRT-LLM worker without --publish-events-and-metrics serves nothing.
+
+        Advertising its sys-port endpoints to AIPerf only creates the
+        impression that worker metrics are captured, so the URLs are omitted.
+        """
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "decode", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "dynamo",
+            processes,
+            benchmark_type="trace-replay",
+            backend_type="trtllm",
+            publish_events_and_metrics=False,
+        )
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(TraceReplayRunner())
+
+        assert "AIPERF_SERVER_METRICS_URLS" not in env
+
+    def test_builtin_aiperf_keeps_trtllm_worker_urls_when_publishing(self):
+        """With the publish flag on (e.g. via observability.enabled) the worker
+        endpoints have content, so the physical-process contract is retained."""
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "decode", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "dynamo",
+            processes,
+            benchmark_type="trace-replay",
+            backend_type="trtllm",
+            publish_events_and_metrics=True,
+        )
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(TraceReplayRunner())
+
+        assert env["AIPERF_SERVER_METRICS_URLS"] == (
+            "http://ip-node-a:7500/metrics,http://ip-node-b:7501/metrics"
+        )
+
+    def test_dead_trtllm_worker_urls_still_advertise_kvbm(self):
+        """KVBM serves its own /metrics independently of the publish flag,
+        so its endpoints survive the dead-worker-URL omission."""
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "decode", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "dynamo",
+            processes,
+            benchmark_type="trace-replay",
+            backend_type="trtllm",
+            publish_events_and_metrics=False,
+            prefill_environment={"DYN_KVBM_METRICS_PORT": "9345"},
+        )
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(TraceReplayRunner())
+
+        assert env["AIPERF_SERVER_METRICS_URLS"] == "http://ip-node-a:9345/metrics"
+
+    def test_explicit_server_metrics_urls_env_wins(self):
+        """An operator-supplied AIPERF_SERVER_METRICS_URLS in the recipe
+        environment is respected verbatim, never clobbered by injection."""
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.trace_replay import TraceReplayRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "dynamo",
+            processes,
+            benchmark_type="trace-replay",
+            environment={"AIPERF_SERVER_METRICS_URLS": "http://curated:9999/metrics"},
+        )
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(TraceReplayRunner())
+
+        assert env["AIPERF_SERVER_METRICS_URLS"] == "http://curated:9999/metrics"
 
 
 class TestSGLangBenchRunner:

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -265,6 +265,15 @@ class TestDryRunExecutionExtensions:
         assert "tachometer-scraper" in output
         assert "storage_subdir" in output
 
+    def test_tachometer_details_shown_without_explicit_block(self, capsys):
+        """observability.enabled alone implies Tachometer; dry-run must say so."""
+        config = _make_config({"observability": {"enabled": True}})
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "tachometer" in output
+        assert "enabled" in output
+        assert "storage_subdir" in output
+
     def test_dcgm_power_telemetry_details_shown(self, capsys):
         config = _make_config(
             {

--- a/tests/test_metrics_aiperf_jsonl.py
+++ b/tests/test_metrics_aiperf_jsonl.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the AIPerf per-scrape jsonl L2 processor (``src/ingest/metrics_aiperf_jsonl.py``).
+
+The fixture lines reproduce the observed schema of aiperf's own
+``server_metrics_export.jsonl`` (requested via ``--server-metrics-formats json jsonl``):
+one line per (scrape, endpoint), families keyed by aiperf's base names (``_total``
+stripped from counters), each family a LIST of entries -- plain ``{labels?, value}`` or
+histogram ``{labels?, buckets, sum, count}`` with cumulative bucket counts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+T0 = 1_786_194_627_000_000_000
+SECOND = 1_000_000_000
+
+
+def _fixture_lines() -> list[dict]:
+    return [
+        {
+            "timestamp_ns": T0 + 10_000_000,
+            "endpoint_url": "http://head:8000/metrics",
+            "endpoint_latency_ns": 1_000_000,
+            "metrics": {
+                # A counter family: aiperf strips _total, so the alias must be re-attached.
+                "foo_requests": [{"labels": {"model": "m"}, "value": 5.0}],
+                # A gauge that legitimately ends in _total: no double alias.
+                "lora_total": [{"value": 7.0}],
+                # A histogram family: expands to _bucket/_sum/_count.
+                "req_seconds": [
+                    {"labels": {"model": "m"}, "buckets": {"0.5": 3.0, "+Inf": 5.0}, "sum": 1.25, "count": 5.0}
+                ],
+            },
+        },
+        {
+            # Second endpoint scraped milliseconds later: merges into the same second.
+            "timestamp_ns": T0 + 30_000_000,
+            "endpoint_url": "http://node1:8081/metrics",
+            "metrics": {"foo_requests": [{"labels": {"model": "m"}, "value": 2.0}]},
+        },
+        {
+            "timestamp_ns": T0 + SECOND + 20_000_000,
+            "endpoint_url": "http://head:8000/metrics",
+            "metrics": {"foo_requests": [{"labels": {"model": "m"}, "value": 6.0}]},
+        },
+    ]
+
+
+def _write_jsonl(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(line) + "\n" for line in _fixture_lines()))
+    return path
+
+
+def _process(tmp_path: Path) -> list[dict]:
+    from src.ingest.metrics_aiperf_jsonl import process
+
+    raw = _write_jsonl(tmp_path / "server_metrics_export.jsonl")
+    out = tmp_path / "out.jsonl"
+    n = process(str(raw), str(out))
+    lines = [json.loads(x) for x in out.read_text().splitlines() if x.strip()]
+    assert n == len(lines)
+    return lines
+
+
+class TestAiperfJsonlProcessor:
+    def test_per_second_grouping_sorted(self, tmp_path: Path):
+        lines = _process(tmp_path)
+        assert [ln["timestamp_ns"] for ln in lines] == [T0, T0 + SECOND]
+
+    def test_endpoints_sharing_a_second_merge(self, tmp_path: Path):
+        lines = _process(tmp_path)
+        values = sorted(e["value"] for e in lines[0]["metrics"]["foo_requests"])
+        assert values == [2.0, 5.0], "both endpoints' readings land on the one line"
+        assert lines[1]["metrics"]["foo_requests"][0]["value"] == 6.0
+
+    def test_total_alias_is_reattached(self, tmp_path: Path):
+        """Counters arrive with _total stripped; the alias makes a panel naming
+        either form resolve (metrics_aiperf_json's interchange contract)."""
+        lines = _process(tmp_path)
+        m = lines[0]["metrics"]
+        assert m["foo_requests_total"] == m["foo_requests"]
+        # A family already ending in _total is not double-aliased.
+        assert m["lora_total"][0]["value"] == 7.0
+        assert "lora_total_total" not in m
+
+    def test_histogram_expands_to_exposition_components(self, tmp_path: Path):
+        lines = _process(tmp_path)
+        m = lines[0]["metrics"]
+        buckets = {e["labels"]["le"]: e["value"] for e in m["req_seconds_bucket"]}
+        assert buckets == {"0.5": 3.0, "+Inf": 5.0}, "cumulative counts pass through verbatim"
+        assert m["req_seconds_sum"] == [{"labels": {"model": "m"}, "value": 1.25}]
+        assert m["req_seconds_count"] == [{"labels": {"model": "m"}, "value": 5.0}]
+        # The base family must not also appear as a plain (or _total-aliased) series.
+        assert "req_seconds" not in m
+        assert "req_seconds_total" not in m
+
+    def test_no_worker_labels_are_invented(self, tmp_path: Path):
+        """Roles are unknowable from the export alone (mirrors metrics_aiperf_json)."""
+        lines = _process(tmp_path)
+        for line in lines:
+            for entries in line["metrics"].values():
+                for entry in entries:
+                    assert "worker_id" not in entry["labels"]
+                    assert "dynamo_component" not in entry["labels"]
+
+
+class TestMetricsAutoSelection:
+    def test_auto_prefers_jsonl_over_aggregate_json(self, tmp_path: Path, caplog):
+        """With only AIPerf's own exports present (no tachometer parquet, no
+        raw_prometheus.jsonl), auto picks the per-scrape jsonl over the aggregate."""
+        from src.ingest.ingest import build_parser, run_metrics
+
+        run_dir = tmp_path / "logs"
+        art = run_dir / "artifacts" / "model_workload_20260826_000000"
+        _write_jsonl(art / "server_metrics_export.jsonl")
+        (art / "server_metrics_export.json").write_text("{}")
+
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+        args = build_parser().parse_args(["--run-dir", str(run_dir)])
+        with caplog.at_level(logging.INFO, logger="ingest"):
+            assert run_metrics(args, run_dir, bundle) is True
+        assert "auto-selected source: aiperf-jsonl" in caplog.text
+        out = bundle / "server_metrics_export.jsonl"
+        lines = [json.loads(x) for x in out.read_text().splitlines() if x.strip()]
+        assert "foo_requests_total" in lines[0]["metrics"], "the jsonl leg was processed"

--- a/tests/test_metrics_scraper.py
+++ b/tests/test_metrics_scraper.py
@@ -55,8 +55,15 @@ def metrics_server():
 
 
 class TestScraperConfig:
-    def test_scraper_follows_enabled(self):
+    def test_scraper_no_longer_follows_enabled(self):
+        """Tachometer is the default capture; RAW is strictly opt-in now."""
         cfg = SrtConfig.Schema().load({**BASE_CONFIG, "observability": {"enabled": True}})
+        assert cfg.observability.scraper_enabled is False
+        assert cfg.observability.tachometer_enabled is True
+
+    def test_scraper_can_be_opted_in_explicitly(self):
+        cfg = SrtConfig.Schema().load({**BASE_CONFIG, "observability": {"enabled": True, "scrape_metrics": True}})
+        assert cfg.observability.enabled is True
         assert cfg.observability.scraper_enabled is True
 
     def test_scraper_can_be_opted_out_independently(self):

--- a/tests/test_metrics_tachometer.py
+++ b/tests/test_metrics_tachometer.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the tachometer-parquet L2 processor (``src/ingest/metrics_tachometer.py``).
+
+The fixture parquet reproduces what the Rust writer actually emits (tachometer-writer
+``writer.rs`` schema; ``parse.rs`` + the backend/frontend filters' naming): base family
+names with inline ``{labels}`` (``le`` kept inline on bucket rows), cumulative bucket
+counts in ``metric_value``, ``histogram_sum``/``histogram_count`` attached to finite
+buckets but MISSING on the ``+Inf`` bucket (the writer's fix-up never groups it on
+filtered endpoints), and per-endpoint metadata columns padded with "".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+# A fixed wall-epoch anchor on a whole second, so the 1 s snapping is easy to reason about.
+T0 = 1_786_194_627_000_000_000
+SECOND = 1_000_000_000
+
+_META_COLUMNS = ("frontend_index", "hostname", "job_id", "run_name", "worker_index", "worker_process", "worker_role")
+
+
+def _write_parquet(path: Path, rows: list[dict]) -> Path:
+    """Build a parquet file with the exact column layout of tachometer-writer's Row."""
+    cols = {
+        "scraper_endpoint": pa.array([r["endpoint"] for r in rows], pa.string()),
+        "metric_name": pa.array([r["name"] for r in rows], pa.string()),
+        "metric_value": pa.array([r["value"] for r in rows], pa.float64()),
+        "histogram_bucket_lower": pa.array([r.get("lower") for r in rows], pa.float64()),
+        "histogram_bucket_upper": pa.array([r.get("upper") for r in rows], pa.float64()),
+        "histogram_sum": pa.array([r.get("sum") for r in rows], pa.float64()),
+        "histogram_count": pa.array([r.get("count") for r in rows], pa.float64()),
+        "time_since_start": pa.array([(r["ts"] - T0) / 1e9 for r in rows], pa.float64()),
+        "timestamp_ns": pa.array([r["ts"] for r in rows], pa.int64()),
+    }
+    for meta in _META_COLUMNS:
+        cols[meta] = pa.array([r.get(meta, "") for r in rows], pa.string())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.table(cols), path)
+    return path
+
+
+def _backend(role: str, host: str, **kw) -> dict:
+    return {
+        "endpoint": f"backend_{role}0_rank0",
+        "hostname": host,
+        "worker_index": "0",
+        "worker_process": "0",
+        "worker_role": role,
+        "job_id": "12345",
+        "run_name": "testrun",
+        **kw,
+    }
+
+
+def _fixture_rows() -> list[dict]:
+    return [
+        # backend prefill worker: a plain gauge (f64-fidelity probe) + one histogram.
+        _backend(
+            "prefill",
+            "node1",
+            name='trtllm_kv_cache_used_blocks{model_name="m"}',
+            value=16777217.0,
+            ts=T0 + 100_000_000,
+        ),
+        _backend(
+            "prefill",
+            "node1",
+            name='req_latency_seconds{le="0.5",model="m"}',
+            value=3.0,
+            lower=0.0,
+            upper=0.5,
+            sum=1.25,
+            count=5.0,
+            ts=T0 + 120_000_000,
+        ),
+        _backend(
+            "prefill",
+            "node1",
+            name='req_latency_seconds{le="1",model="m"}',
+            value=4.0,
+            lower=0.5,
+            upper=1.0,
+            sum=1.25,
+            count=5.0,
+            ts=T0 + 120_000_000,
+        ),
+        # The +Inf bucket: upper/lower/sum/count all null, exactly as the writer's
+        # fix-up leaves it on backend/frontend-filtered endpoints.
+        _backend("prefill", "node1", name='req_latency_seconds{le="+Inf",model="m"}', value=5.0, ts=T0 + 120_000_000),
+        # backend decode worker on another node: decode maps to dynamo_component=backend.
+        _backend(
+            "decode", "node2", name='trtllm_kv_cache_used_blocks{model_name="m"}', value=200.0, ts=T0 + 130_000_000
+        ),
+        # frontend endpoint, two scrapes one second apart (per-second grouping probe).
+        {
+            "endpoint": "frontend0",
+            "frontend_index": "0",
+            "hostname": "node0",
+            "job_id": "12345",
+            "run_name": "testrun",
+            "name": 'dynamo_frontend_requests_total{model="m"}',
+            "value": 42.0,
+            "ts": T0 + 200_000_000,
+        },
+        {
+            "endpoint": "frontend0",
+            "frontend_index": "0",
+            "hostname": "node0",
+            "job_id": "12345",
+            "run_name": "testrun",
+            "name": 'dynamo_frontend_requests_total{model="m"}',
+            "value": 43.0,
+            "ts": T0 + SECOND + 150_000_000,
+        },
+    ]
+
+
+@pytest.fixture
+def log_dir(tmp_path: Path) -> Path:
+    """A miniature run log dir whose tachometer leg holds a compacted final.parquet."""
+    d = tmp_path / "logs"
+    _write_parquet(d / "tachometer" / "raw" / "scrape" / "final.parquet", _fixture_rows())
+    return d
+
+
+def _process(log_dir: Path, tmp_path: Path) -> list[dict]:
+    from src.ingest.metrics_tachometer import process
+
+    out = tmp_path / "server_metrics_export.jsonl"
+    n = process(str(log_dir), str(out))
+    lines = [json.loads(x) for x in out.read_text().splitlines() if x.strip()]
+    assert n == len(lines)
+    return lines
+
+
+class TestTachometerProcessor:
+    def test_per_second_grouping_sorted(self, log_dir: Path, tmp_path: Path):
+        lines = _process(log_dir, tmp_path)
+        assert [ln["timestamp_ns"] for ln in lines] == [T0, T0 + SECOND]
+        # Both scrapes of the frontend family land, one per second.
+        assert lines[0]["metrics"]["dynamo_frontend_requests_total"][0]["value"] == 42.0
+        assert lines[1]["metrics"]["dynamo_frontend_requests_total"][0]["value"] == 43.0
+
+    def test_inline_labels_are_parsed(self, log_dir: Path, tmp_path: Path):
+        lines = _process(log_dir, tmp_path)
+        entries = lines[0]["metrics"]["trtllm_kv_cache_used_blocks"]
+        assert all(e["labels"]["model_name"] == "m" for e in entries)
+        # The label block must not leak into the metric name.
+        assert all("{" not in name for name in lines[0]["metrics"])
+
+    def test_worker_labels_are_injected(self, log_dir: Path, tmp_path: Path):
+        """Mirrors metrics_prometheus: prefill -> "prefill", decode -> "backend",
+        worker_id from the hostname metadata, injected via setdefault."""
+        lines = _process(log_dir, tmp_path)
+        entries = lines[0]["metrics"]["trtllm_kv_cache_used_blocks"]
+        by_worker = {e["labels"]["worker_id"]: e["labels"]["dynamo_component"] for e in entries}
+        assert by_worker == {"node1": "prefill", "node2": "backend"}
+
+    def test_frontend_series_get_no_worker_labels(self, log_dir: Path, tmp_path: Path):
+        lines = _process(log_dir, tmp_path)
+        for line in lines:
+            for entry in line["metrics"]["dynamo_frontend_requests_total"]:
+                assert "worker_id" not in entry["labels"]
+                assert "dynamo_component" not in entry["labels"]
+                # Real capture metadata IS carried (it distinguishes replicas).
+                assert entry["labels"]["frontend_index"] == "0"
+                assert entry["labels"]["hostname"] == "node0"
+
+    def test_histogram_reconstruction(self, log_dir: Path, tmp_path: Path):
+        """Bucket rows -> <fam>_bucket with le (cumulative, verbatim); _sum/_count are
+        rebuilt from the histogram_sum/histogram_count columns, with _count taken from
+        the +Inf bucket's own value (the writer leaves +Inf rows' columns null)."""
+        lines = _process(log_dir, tmp_path)
+        m = lines[0]["metrics"]
+        buckets = {e["labels"]["le"]: e["value"] for e in m["req_latency_seconds_bucket"]}
+        assert buckets == {"0.5": 3.0, "1": 4.0, "+Inf": 5.0}
+        (sum_entry,) = m["req_latency_seconds_sum"]
+        assert sum_entry["value"] == 1.25
+        (count_entry,) = m["req_latency_seconds_count"]
+        assert count_entry["value"] == 5.0
+        for entry in (sum_entry, count_entry):
+            assert "le" not in entry["labels"]
+            assert entry["labels"]["model"] == "m"
+            assert entry["labels"]["dynamo_component"] == "prefill"
+        # The base family must not also appear as a plain series.
+        assert "req_latency_seconds" not in m
+
+    def test_f64_values_survive(self, log_dir: Path, tmp_path: Path):
+        """16777217 is not representable in f32; it must round-trip exactly."""
+        lines = _process(log_dir, tmp_path)
+        entries = lines[0]["metrics"]["trtllm_kv_cache_used_blocks"]
+        assert any(e["value"] == 16777217.0 for e in entries)
+
+    def test_final_parquet_is_preferred_over_leftovers(self, log_dir: Path, tmp_path: Path):
+        """local/ leftovers only matter when compaction never produced final.parquet."""
+        from src.ingest.metrics_tachometer import find_parquets
+
+        leftover = log_dir / "tachometer" / "local" / "out-1.parquet"
+        _write_parquet(leftover, _fixture_rows()[:1])
+        assert find_parquets(str(log_dir)) == [str(log_dir / "tachometer" / "raw" / "scrape" / "final.parquet")]
+        (log_dir / "tachometer" / "raw" / "scrape" / "final.parquet").unlink()
+        assert find_parquets(str(log_dir)) == [str(leftover)]
+
+
+class TestMetricsAutoSelection:
+    def test_auto_prefers_tachometer_over_everything(self, log_dir: Path, tmp_path: Path, caplog):
+        """A run dir with the tachometer parquet AND raw_prometheus.jsonl AND both
+        AIPerf exports must pick the tachometer leg (whole-window, per-replica)."""
+        from src.ingest.ingest import build_parser, run_metrics
+
+        (log_dir / "raw_prometheus.jsonl").write_text(
+            json.dumps(
+                {
+                    "timestamp_ns": T0,
+                    "endpoint_url": "http://head:8000/metrics",
+                    "role": "frontend",
+                    "worker_id": None,
+                    "text": "a 1\n",
+                }
+            )
+            + "\n"
+        )
+        art = log_dir / "artifacts" / "model_workload_20260826_000000"
+        art.mkdir(parents=True)
+        (art / "server_metrics_export.json").write_text("{}")
+        (art / "server_metrics_export.jsonl").write_text(
+            json.dumps(
+                {"timestamp_ns": T0, "endpoint_url": "http://head:8000/metrics", "metrics": {"foo": [{"value": 1.0}]}}
+            )
+            + "\n"
+        )
+
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+        args = build_parser().parse_args(["--run-dir", str(log_dir)])
+        with caplog.at_level(logging.INFO, logger="ingest"):
+            assert run_metrics(args, log_dir, bundle) is True
+        assert "auto-selected source: tachometer" in caplog.text
+        out = bundle / "server_metrics_export.jsonl"
+        lines = [json.loads(x) for x in out.read_text().splitlines() if x.strip()]
+        # Tachometer content, not the decoy sources.
+        assert "trtllm_kv_cache_used_blocks" in lines[0]["metrics"]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -264,6 +264,8 @@ class TestObservabilitySchema:
 
         cfg = SrtConfig.from_yaml(config_path)
 
-        assert cfg.observability.scraper_enabled is True
+        # RAW is opt-in only now; Tachometer is the default capture.
+        assert cfg.observability.scraper_enabled is False
         assert cfg.observability.tachometer.enabled is True
+        assert cfg.observability.tachometer_enabled is True
         assert cfg.observability.tachometer.default_frequency == 2.0

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -415,9 +415,9 @@ class TestTachometerConfigGeneration:
         assert 'url = "http://10.0.0.1:8000/metrics"' in config_text
 
     @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
-    def test_backend_targets_are_leaders_only(self, _mock_get_hostname_ip):
-        """Only rank zero serves the logical worker's /metrics; follower
-        sys-ports would produce duplicate or empty rows."""
+    def test_backend_targets_cover_every_rank(self, _mock_get_hostname_ip):
+        """Every worker rank is a scrape target (vLLM agg followers excepted);
+        follower metadata keeps rows distinguishable."""
         tachometer = TachometerConfig(enabled=True)
         runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
         runtime.log_dir = Path("/runs/12345/logs")
@@ -448,7 +448,7 @@ class TestTachometerConfigGeneration:
         )
 
         assert 'name = "backend_prefill0_rank0"' in config_text
-        assert "rank1" not in config_text
+        assert 'name = "backend_prefill0_rank1"' in config_text
 
     @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
     def test_generate_config_without_exporters_targets_servers_only(self, _mock_get_hostname_ip):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -35,13 +35,13 @@ def _make_config(
     telemetry: TelemetryConfig | None = None,
     benchmark: BenchmarkConfig | None = None,
 ) -> SrtConfig:
-    tachometer = tachometer or TachometerConfig()
+    tachometer = tachometer or TachometerConfig(enabled=False)
     return SrtConfig(
         name="test",
         model=ModelConfig(path="/model", container="/image", precision="fp4"),
         resources=ResourceConfig(gpu_type="h100"),
         benchmark=benchmark or BenchmarkConfig(type="manual"),
-        observability=ObservabilityConfig(enabled=tachometer.enabled, tachometer=tachometer),
+        observability=ObservabilityConfig(enabled=bool(tachometer.enabled), tachometer=tachometer),
         telemetry=telemetry or TelemetryConfig(),
     )
 
@@ -322,11 +322,133 @@ class TestTachometerConfigGeneration:
             tachometer=tachometer,
         )
 
-        assert 'storage = "/runs/12345/logs/tachometer"' in config_text
+        # The storage leaf must NOT be a directory srtctl has already created --
+        # tachometer-scraper aborts on a pre-existing storage dir.
+        assert 'storage = "/runs/12345/logs/tachometer/raw/scrape"' in config_text
         assert 'name = "dcgm_node-a"' in config_text
         assert 'url = "http://10.0.0.1:8081/metrics"' in config_text
         assert '"cluster" = "pdx"' in config_text
         assert 'name = "frontend0"' in config_text
+
+    @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
+    def test_storage_leaf_is_never_pre_created(self, _mock_get_hostname_ip, tmp_path):
+        """Regression guard for the pre-existing-storage-dir abort.
+
+        tachometer-scraper refuses to start when its storage path already exists
+        as a directory (main.rs ``parse_storage``). srtctl must create only the
+        PARENT of the storage path. Before the fix, telemetry_stage.py mkdir'd
+        the leaf itself and the scraper exited 1 on every sweep-mode run.
+        """
+        from srtctl.core.telemetry import TACHOMETER_STORAGE_PARENT
+
+        tachometer = TachometerConfig(enabled=True)
+        runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
+        runtime.log_dir = tmp_path
+        processes = [
+            Process(
+                node="node-a",
+                gpu_indices=frozenset({0}),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="agg",
+                endpoint_index=0,
+                node_rank=0,
+            )
+        ]
+        topology = FrontendTopology(nginx_node=None, frontend_nodes=["node-a"], frontend_port=8000, public_port=8000)
+
+        config_text = generate_tachometer_config(
+            processes=processes, frontend_topology=topology, runtime=runtime, tachometer=tachometer
+        )
+
+        # Recreate exactly the directories the stage pre-creates.
+        tachometer_dir = tmp_path / tachometer.storage_subdir
+        (tachometer_dir / TACHOMETER_STORAGE_PARENT).mkdir(parents=True, exist_ok=True)
+        (tachometer_dir / "local").mkdir(parents=True, exist_ok=True)
+
+        storage_line = next(line for line in config_text.splitlines() if line.startswith("storage = "))
+        storage_path = Path(json.loads(storage_line.removeprefix("storage = ")))
+        assert not storage_path.exists(), "the storage leaf must be left for tachometer-scraper to create"
+        # local/ must stay a SIBLING of the storage tree, never nested inside it.
+        local_dir = (tachometer_dir / "local").resolve()
+        assert not local_dir.is_relative_to(storage_path)
+
+    @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
+    def test_client_polled_urls_are_excluded_from_backend_targets(self, _mock_get_hostname_ip):
+        """Tachometer scrapes the complement of the client's URL list."""
+        tachometer = TachometerConfig(enabled=True)
+        runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
+        runtime.log_dir = Path("/runs/12345/logs")
+        processes = [
+            Process(
+                node="node-a",
+                gpu_indices=frozenset({0}),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=0,
+            ),
+            Process(
+                node="node-a",
+                gpu_indices=frozenset({1}),
+                sys_port=8082,
+                http_port=30000,
+                endpoint_mode="decode",
+                endpoint_index=0,
+                node_rank=0,
+            ),
+        ]
+        topology = FrontendTopology(nginx_node=None, frontend_nodes=["node-a"], frontend_port=8000, public_port=8000)
+
+        config_text = generate_tachometer_config(
+            processes=processes,
+            frontend_topology=topology,
+            runtime=runtime,
+            tachometer=tachometer,
+            exclude_urls={"http://10.0.0.1:8081/metrics"},
+        )
+
+        assert 'url = "http://10.0.0.1:8081/metrics"' not in config_text
+        assert 'url = "http://10.0.0.1:8082/metrics"' in config_text
+        # The frontend endpoint is never excluded (whole-window coverage).
+        assert 'url = "http://10.0.0.1:8000/metrics"' in config_text
+
+    @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
+    def test_backend_targets_are_leaders_only(self, _mock_get_hostname_ip):
+        """Only rank zero serves the logical worker's /metrics; follower
+        sys-ports would produce duplicate or empty rows."""
+        tachometer = TachometerConfig(enabled=True)
+        runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
+        runtime.log_dir = Path("/runs/12345/logs")
+        processes = [
+            Process(
+                node="node-a",
+                gpu_indices=frozenset({0}),
+                sys_port=8081,
+                http_port=30000,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=0,
+            ),
+            Process(
+                node="node-b",
+                gpu_indices=frozenset({0}),
+                sys_port=8082,
+                http_port=0,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=1,
+            ),
+        ]
+        topology = FrontendTopology(nginx_node=None, frontend_nodes=["node-a"], frontend_port=8000, public_port=8000)
+
+        config_text = generate_tachometer_config(
+            processes=processes, frontend_topology=topology, runtime=runtime, tachometer=tachometer
+        )
+
+        assert 'name = "backend_prefill0_rank0"' in config_text
+        assert "rank1" not in config_text
 
     @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
     def test_generate_config_without_exporters_targets_servers_only(self, _mock_get_hostname_ip):
@@ -474,6 +596,9 @@ class TestTachometerStageMixin:
 
         mock_srun.return_value = _running_exporter()
         harness = Harness()
+        # Pin the default-name PATH fallback so the assertion below does not
+        # depend on whether the developer's checkout has bin/tachometer-scraper.
+        harness._resolve_tachometer_binary = lambda binary_path: binary_path
 
         procs = harness.start_tachometer()
 
@@ -493,6 +618,92 @@ class TestTachometerStageMixin:
         ]
         assert "container_image" not in scraper_call.kwargs
         assert "container_mounts" not in scraper_call.kwargs
+        # Telemetry is best-effort by contract: a dead scraper must never
+        # tear down the benchmark via the critical-process check.
+        assert procs[-1].name == "tachometer"
+        assert procs[-1].critical is False
+
+    def test_resolve_tachometer_binary(self, tmp_path, monkeypatch):
+        """Explicit paths are respected verbatim; the default bare name
+        prefers the checkout's bin/ (where make setup installs it)."""
+        stage = TelemetryStageMixin()
+
+        assert stage._resolve_tachometer_binary("/opt/custom/tachometer-scraper") == "/opt/custom/tachometer-scraper"
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        binary = bin_dir / "tachometer-scraper"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        monkeypatch.setenv("SRTCTL_SOURCE_DIR", str(tmp_path))
+        assert stage._resolve_tachometer_binary("tachometer-scraper") == str(binary)
+
+    @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
+    def test_tachometer_auto_starts_under_observability_enabled(self, mock_srun, tmp_path):
+        """observability.enabled alone starts Tachometer — no tachometer: block needed."""
+        import dataclasses
+
+        class Harness(TelemetryStageMixin):
+            def __init__(self):
+                base = _make_config()
+                self.config = dataclasses.replace(base, observability=ObservabilityConfig(enabled=True))
+                self.runtime = MagicMock()
+                self.runtime.log_dir = tmp_path
+                self.runtime.job_id = "12345"
+                self.runtime.run_name = "test_12345"
+                self.runtime.network_interface = "eth0"
+                self.runtime.nodes.head = "node-a"
+                self._backend_processes = [
+                    Process(
+                        node="node-a",
+                        gpu_indices=frozenset({0}),
+                        sys_port=8081,
+                        http_port=30000,
+                        endpoint_mode="agg",
+                        endpoint_index=0,
+                        node_rank=0,
+                    )
+                ]
+
+            @property
+            def backend_processes(self):
+                return self._backend_processes
+
+            def _compute_frontend_topology(self):
+                return FrontendTopology(
+                    nginx_node=None,
+                    frontend_nodes=["node-a"],
+                    frontend_port=8000,
+                    public_port=8000,
+                )
+
+        mock_srun.return_value = _running_exporter()
+        harness = Harness()
+        harness._resolve_tachometer_binary = lambda binary_path: binary_path
+
+        procs = harness.start_tachometer()
+
+        assert [proc.name for proc in procs] == ["tachometer"]
+        assert (tmp_path / "tachometer_config.toml").exists()
+
+    @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
+    def test_tachometer_explicit_false_opts_out(self, mock_srun, tmp_path):
+        """An explicit tachometer.enabled: false wins over observability.enabled."""
+        import dataclasses
+
+        class Harness(TelemetryStageMixin):
+            def __init__(self):
+                base = _make_config()
+                self.config = dataclasses.replace(
+                    base,
+                    observability=ObservabilityConfig(enabled=True, tachometer=TachometerConfig(enabled=False)),
+                )
+                self.runtime = MagicMock()
+
+        procs = Harness().start_tachometer()
+
+        assert procs == []
+        assert mock_srun.call_count == 0
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
     def test_start_tachometer_reuses_the_power_dcgm_exporter(self, mock_srun, tmp_path):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -622,6 +622,13 @@ class TestTachometerStageMixin:
         # tear down the benchmark via the critical-process check.
         assert procs[-1].name == "tachometer"
         assert procs[-1].critical is False
+        # Exporter sidecars share the contract: shell-less launch (distroless
+        # images have no bash) and non-critical (a dead sidecar never kills
+        # the run — regression guard for the 7-node startup teardown).
+        for call in mock_srun.call_args_list[:-1]:
+            assert call.kwargs["use_bash_wrapper"] is False
+        for proc in procs[:-1]:
+            assert proc.critical is False
 
     def test_resolve_tachometer_binary(self, tmp_path, monkeypatch):
         """Explicit paths are respected verbatim; the default bare name


### PR DESCRIPTION
## What

Second of the 3-PR observability-consolidation series. **Stacked on #349** — review the last 4 commits; the first commit here is #349's.

`observability.enabled: true` now collects server metrics with the native Tachometer scraper for the whole run, with no `tachometer:` block required, scraping the **complement** of what the benchmark client polls. The legacy Python RAW scraper no longer follows `enabled` (strictly opt-in via `scrape_metrics: true`), removed entirely in PR 3/3.

## Why

- The RAW scraper + aiperf double-polled every worker endpoint by default; the in-tree warning documents a submission that became irreproducible from exactly that. The complement makes single-polling structural instead of advisory: the excluded set is **derived from the same code that injects `AIPERF_SERVER_METRICS_URLS`**, so if the client's endpoint set ever changes, tachometer's complement moves with it.
- Sweep-mode tachometer has never produced output: srtctl pre-created the storage dir the scraper refuses to start into (every attempted run died at startup, e.g. hecate job 452644). Fixed via the `raw/scrape` nested layout the --bash lifecycle already uses.
- Tachometer Parquet was unjoinable (monotonic-relative timestamps only) and lossy (f32 values corrupt counters above 2^24). Rows now carry epoch `timestamp_ns` (Int64) and Float64 values.
- Nothing ingested the Parquet. Two new L2 processors converge on the frozen schema-2 `server_metrics_export.jsonl`: `metrics_tachometer` (parquet; reconstructs `_bucket`/`_sum`/`_count`, injects `worker_id`/`dynamo_component` like the prometheus path) and `metrics_aiperf_jsonl` (aiperf's per-scrape export, preferred over the opinionated aggregate json). Auto-selection: tachometer → raw_prometheus.jsonl → aiperf-jsonl → aiperf-json.

## Behavior notes

- Tachometer is **best-effort** (`critical=False`): a dead scraper costs the capture, never the benchmark. `validate-setup` still fails fast at submit when `bin/tachometer-scraper` is missing; the default bare binary name now resolves against the checkout's `bin/` before $PATH.
- Backend scrape targets are leaders-only (rank zero serves the logical worker's /metrics); frontend/DCGM/node-exporter endpoints always belong to tachometer.
- Explicit `tachometer.enabled: false` opts out; explicit `true` without `observability.enabled` still raises.
- Host sampler re-gated from the RAW knob onto `observability.enabled`.

## Verification

`make check` green (1477 passed), `cargo test --workspace --locked` green (41 tests incl. new timestamp/precision regression guards), recipe validation green (the qwen3-32b ruter recipe simplifies to just `enabled: true`). New tests: complement exclusion, leaders-only, storage-leaf invariant, tri-state resolution, critical=False, binary resolution, dry-run display, both L2 processors (incl. f64 fidelity and source auto-selection).