### PR TITLE
feat(observability): default tachometer frequency 1 Hz

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1069,7 +1069,7 @@ observability:
   enabled: true
   tachometer:
     enabled: true
-    default_frequency: 5
+    default_frequency: 1
     sync_interval_secs: 120
     compaction_threads: 4
     storage_subdir: tachometer
@@ -1087,7 +1087,7 @@ observability:
 | ---------------- | ---- | ------- | ----------- |
 | `enabled` | bool/null | `null` | `null` follows `observability.enabled`; explicit `false` opts out; explicit `true` without `observability.enabled` is a validation error |
 | `binary_path` | string | `tachometer-scraper` | Scraper command or path on the compute nodes |
-| `default_frequency` | float | `5.0` | Scrape frequency in Hz |
+| `default_frequency` | float | `1.0` | Scrape frequency in Hz |
 | `sync_interval_secs` | int | `120` | Interval for intermediate Parquet compaction; `0` disables it |
 | `compaction_threads` | int | `4` | Value passed as `POLARS_MAX_THREADS` |
 | `storage_subdir` | string | `tachometer` | Output directory below the run log directory |

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1042,7 +1042,7 @@ class TachometerConfig:
 
     enabled: bool | None = None
     binary_path: str = "tachometer-scraper"
-    default_frequency: float = 5.0
+    default_frequency: float = 1.0
     sync_interval_secs: int = 120
     compaction_threads: int = 4
     storage_subdir: str = "tachometer"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -84,6 +84,14 @@ class TestTachometerConfig:
         assert config.observability.tachometer.dcgm_exporter is None
         assert config.observability.tachometer.node_exporter is None
 
+    def test_default_frequency_is_one_hz(self):
+        """1 Hz matches the retired RAW scraper's cadence; 5 Hz produced ~9M
+        rows in a 25-minute run with no analysis consuming the extra
+        resolution, and scrape load on worker endpoints is not free."""
+        config = _make_config(tachometer=TachometerConfig(enabled=True))
+
+        assert config.observability.tachometer.default_frequency == 1.0
+
     def test_scraper_requires_nonempty_binary_path(self):
         with pytest.raises(ValidationError, match="observability.tachometer.binary_path"):
             _make_config(


### PR DESCRIPTION
Lowers `observability.tachometer.default_frequency` from 5 Hz to 1 Hz.

**Why:** 5 Hz produced ~9M rows over a 25-minute production run (job 2806252) with no analysis consuming the extra resolution — the dashboard's panel layer works at 1 Hz — and every scrape adds load on the worker `/metrics` endpoints (the same perturbation concern that motivated the complement design in #350). 1 Hz matches the retired RAW scraper's cadence, so default capture density is unchanged from what runs relied on before the consolidation. Recipes that need higher resolution (e.g. DCGM power transients) set `default_frequency` explicitly.

Default pinned by a new test; docs table + example aligned. `make check` green (1463 passed).