### PR TITLE
feat(benchmark): add agentperf benchmark type for trajectory replay

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -635,6 +635,7 @@ benchmark:
 | `longbenchv2`     | Long-context evaluation benchmark              |
 | `router`          | Router performance with prefix caching         |
 | `mooncake-router` | KV-aware routing with Mooncake trace           |
+| `agentperf`       | AgentPerf trajectory replay (agentperf-client) |
 
 ### manual
 
@@ -857,6 +858,60 @@ Dataset characteristics (conversation trace):
 - 12,031 requests over ~59 minutes (3.4 req/s)
 - Avg input: 12,035 tokens, Avg output: 343 tokens
 - 36.64% cache efficiency potential
+
+### agentperf
+
+Trajectory-replay benchmark using the standalone
+[agentperf-client](https://github.com/ArtificialAnalysis-External/agentperf-client) — a deterministic
+agentic load generator with a Rust streaming core. The client checkout is mounted into the container
+(pin the commit for comparable runs); the workload definition (trajectory dataset, user-assignments
+file, `settling_time_seconds`, `phase_timeout_seconds`, stop criteria) lives in the client's own
+config YAML. srtctl injects the endpoint, model and concurrency at run time via the client's
+`--base-url` / `--model` / `--concurrencies` flags. Note the client validates the workload YAML
+*before* merging CLI overrides, so the YAML must still carry syntactically valid placeholder
+`base_url`, `model` and `concurrencies` values — and `phase_timeout_seconds` must satisfy the
+client's ramp-up bound for the *injected* concurrency
+(`phase_timeout_seconds >= (concurrency - 1) / user_spawn_rate + settling_time_seconds +
+min_measurement_seconds`).
+
+```yaml
+benchmark:
+  type: "agentperf"
+  agentperf_client_dir: "/agentperf-client"       # Container path to the client checkout
+  agentperf_config: "/workloads/agentperf.yaml"   # Container path to the client's workload YAML
+  concurrencies: [1010]                           # One benchmark phase per level
+  env:
+    AGENTPERF_EXTRA_ARGS: "--seed 100"            # Optional: appended to agentperf/run.py verbatim
+
+extra_mount:
+  - "/path/on/host/agentperf-client:/agentperf-client"
+  - "/path/on/host/workloads:/workloads"
+```
+
+| Field                  | Type        | Required | Default | Description                                            |
+| ---------------------- | ----------- | -------- | ------- | ------------------------------------------------------ |
+| `agentperf_client_dir` | string      | Yes      | —       | Container path to an agentperf-client checkout         |
+| `agentperf_config`     | string      | Yes      | —       | Container path to the client's workload YAML           |
+| `concurrencies`        | list/string | Yes*     | —       | Levels, one client phase each; string form is x-separated (`"64x1010"`), matching other benchmark types |
+| `concurrency`          | int         | Yes*     | —       | Single level (alternative to `concurrencies`)          |
+
+*One of `concurrency` / `concurrencies` is required.
+
+Notes:
+- The first run of a job builds an isolated client runtime under `/tmp/agentperf-<jobid>`
+  (uv env, pinned Rust toolchain, `rustcore` extension, tokenizer cache) and stages the trajectory
+  and user-assignments datasets from shared storage to node-local `/tmp` — this preflight needs
+  network egress from the benchmark node and adds several minutes before the first phase.
+- The user-assignments file referenced by the workload YAML must cover the highest concurrency
+  level (`assign_trajectories` fails loudly otherwise).
+- Results land under `<log_dir>/agentperf/` (per-phase `*__traj*.{jsonl,txt,json}`,
+  `requests.jsonl`, `phase_manifest.jsonl`); `rollup.py` normalizes them into
+  `benchmark-rollup.json`.
+- Two runs must not share a results dir concurrently (the client resets `phase_manifest.jsonl`
+  at start).
+- `telemetry:` (DCGM power measurement windows) is not supported with agentperf — the schema
+  rejects non-sa-bench benchmark types at config load. Tachometer
+  (`observability.enabled`) works normally.
 
 ---
 

--- a/src/srtctl/benchmarks/__init__.py
+++ b/src/srtctl/benchmarks/__init__.py
@@ -5,6 +5,7 @@
 
 # Import runners to trigger registration
 from srtctl.benchmarks import (
+    agentperf,
     custom,
     gpqa,
     gsm8k,
@@ -27,6 +28,7 @@ from srtctl.benchmarks.base import (
 __all__ = [
     "BenchmarkRunner",
     # Runners
+    "agentperf",
     "custom",
     "get_runner",
     "gpqa",

--- a/src/srtctl/benchmarks/agentperf.py
+++ b/src/srtctl/benchmarks/agentperf.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AgentPerf benchmark runner.
+
+Drives the agentperf-client trajectory-replay load generator
+(https://github.com/ArtificialAnalysis-External/agentperf-client) against an
+srt-slurm-launched server. This is a different client from the InferenceX
+AgentX harness: agentperf-client is a standalone uv-managed Python project
+with its own Rust streaming core, invoked as ``agentperf/run.py``, and it
+produces per-phase trajectory outputs (``*__traj*.jsonl/.txt/.json``) plus a
+per-request ``requests.jsonl``.
+
+The client checkout is NOT vendored: mount it into the container via
+``extra_mount`` and point ``benchmark.agentperf_client_dir`` at the container
+path. Pin the checkout for comparable runs. The workload definition
+(trajectory dataset, user-assignments file, settling time, phase timeout,
+stop criteria) lives in the client's own config YAML, referenced by
+``benchmark.agentperf_config``; srtctl injects only the endpoint, model and
+concurrency so one workload file serves every topology.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
+
+if TYPE_CHECKING:
+    from srtctl.core.runtime import RuntimeContext
+    from srtctl.core.schema import SrtConfig
+
+
+def _format_concurrencies(config: SrtConfig) -> str:
+    b = config.benchmark
+    if b.concurrency is not None:
+        return str(b.concurrency)
+    return ",".join(str(c) for c in config.benchmark.get_concurrency_list())
+
+
+@register_benchmark("agentperf")
+class AgentPerfRunner(BenchmarkRunner):
+    """Run the agentperf-client trajectory replay against the frontend.
+
+    Required config fields:
+        - benchmark.agentperf_client_dir: Container path to an agentperf-client
+          checkout (mount via extra_mount; pin the commit for comparable runs)
+        - benchmark.agentperf_config: Container path to the client's config
+          YAML (trajectory_path, user_assignments_path, settling_time_seconds,
+          phase_timeout_seconds, stop criteria). The client validates this
+          YAML on its own BEFORE merging CLI overrides, so it must carry
+          syntactically valid placeholder base_url / model / concurrencies;
+          srtctl's injected --base-url / --model / --concurrencies then
+          override them.
+        - benchmark.concurrency or benchmark.concurrencies
+
+    Optional config fields:
+        - benchmark.env: extra environment for the client (e.g.
+          AGENTPERF_EXTRA_ARGS="--seed 100 --no-eval" appended verbatim to the
+          run.py invocation)
+    """
+
+    @property
+    def name(self) -> str:
+        return "AgentPerf"
+
+    @property
+    def script_path(self) -> str:
+        return "/srtctl-benchmarks/agentperf/bench.sh"
+
+    @property
+    def local_script_dir(self) -> str:
+        return str(SCRIPTS_DIR / "agentperf")
+
+    def validate_config(self, config: SrtConfig) -> list[str]:
+        errors = []
+        b = config.benchmark
+
+        if not b.agentperf_client_dir:
+            errors.append("benchmark.agentperf_client_dir is required for agentperf (mount the client via extra_mount)")
+        if not b.agentperf_config:
+            errors.append("benchmark.agentperf_config is required for agentperf (the client's workload YAML)")
+        if b.concurrency is None and b.concurrencies is None:
+            errors.append("benchmark.concurrency or benchmark.concurrencies is required for agentperf")
+        else:
+            try:
+                levels = [b.concurrency] if b.concurrency is not None else b.get_concurrency_list()
+                if not levels:
+                    # An empty list would make the client silently fall back to
+                    # whatever levels the workload YAML declares.
+                    errors.append("agentperf requires at least one concurrency level")
+                elif any(int(c) <= 0 for c in levels):
+                    errors.append(f"agentperf concurrencies must be positive, got: {levels}")
+            except (TypeError, ValueError):
+                errors.append(f"agentperf concurrencies must be integers, got: {b.concurrencies}")
+
+        return errors
+
+    def build_command(
+        self,
+        config: SrtConfig,
+        runtime: RuntimeContext,
+    ) -> list[str]:
+        b = config.benchmark
+        endpoint = f"http://localhost:{runtime.frontend_port}"
+        model_name = config.served_model_name or config.model.path
+
+        return [
+            "bash",
+            self.script_path,
+            endpoint,
+            model_name,
+            b.agentperf_client_dir or "",
+            b.agentperf_config or "",
+            _format_concurrencies(config),
+        ]
+
+    def get_environment(self, config: SrtConfig, runtime: RuntimeContext) -> dict[str, str]:
+        del runtime
+        return dict(config.benchmark.env)

--- a/src/srtctl/benchmarks/scripts/agentperf/bench.sh
+++ b/src/srtctl/benchmarks/scripts/agentperf/bench.sh
@@ -148,7 +148,7 @@ echo "[agentperf] endpoint=$ENDPOINT model=$MODEL_NAME concurrencies=$CONCURRENC
 read -r -a EXTRA_ARGS <<< "${AGENTPERF_EXTRA_ARGS:-}" || true
 uv run --no-sync python agentperf/run.py \
   --config "$RUNTIME/benchmark_config.yaml" \
-  --base-url "$ENDPOINT" \
+  --base-url "${ENDPOINT}${AGENTPERF_BASE_PATH:-/v1}" \
   --model "$MODEL_NAME" \
   --concurrencies "$CONCURRENCIES" \
   --request-log-path "$RESULTS_DIR/requests.jsonl" \

--- a/src/srtctl/benchmarks/scripts/agentperf/bench.sh
+++ b/src/srtctl/benchmarks/scripts/agentperf/bench.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# AgentPerf trajectory-replay benchmark.
+# srt-slurm owns server startup; this script prepares an isolated client
+# runtime under /tmp and runs the mounted agentperf-client checkout against
+# the ready frontend.
+#
+# The preflight is a faithful translation of the standalone disagg-harness
+# invocation this benchmark was ported from (prepare_agentperf_client.sh), so
+# results stay comparable:
+#   * HOME/CARGO_HOME/RUSTUP_HOME/UV_PROJECT_ENVIRONMENT all live under one
+#     job-scoped /tmp dir — the checkout can be mounted read-only and nothing
+#     leaks between jobs;
+#   * toolchain versions are pinned (override via AGENTPERF_RUST_VERSION /
+#     AGENTPERF_UV_VERSION);
+#   * the trajectory and user-assignments datasets are staged from shared
+#     storage to node-local /tmp before measurement — reading the multi-GiB
+#     trajectory file over Lustre mid-run is a perf artifact of its own.
+
+set -euo pipefail
+
+ENDPOINT=$1
+MODEL_NAME=$2
+CLIENT_DIR=$3
+CONFIG_PATH=$4
+CONCURRENCIES=$5
+
+# When the client runs on a different node than the frontend, localhost is
+# wrong; benchmark_stage injects the frontend's real host/port.
+if [[ -n "${SRT_FRONTEND_HOST:-}" ]]; then
+  PORT_FROM_ENDPOINT=$(echo "$ENDPOINT" | sed -E 's|.*:([0-9]+).*|\1|')
+  ENDPOINT="http://${SRT_FRONTEND_HOST}:${SRT_FRONTEND_PORT:-$PORT_FROM_ENDPOINT}"
+fi
+
+[[ -d "$CLIENT_DIR" ]] || { echo "ERROR: agentperf_client_dir $CLIENT_DIR not found in container (mount via extra_mount)" >&2; exit 1; }
+[[ -f "$CONFIG_PATH" ]] || { echo "ERROR: agentperf_config $CONFIG_PATH not found in container" >&2; exit 1; }
+
+RUNTIME="${AGENTPERF_RUNTIME:-/tmp/agentperf-${SLURM_JOB_ID:-$$}}"
+export HOME="$RUNTIME/home"
+export CARGO_HOME="$RUNTIME/cargo"
+export RUSTUP_HOME="$RUNTIME/rustup"
+export CARGO_TARGET_DIR="$RUNTIME/target"
+export UV_PROJECT_ENVIRONMENT="$RUNTIME/venv"
+export UV_CACHE_DIR="$RUNTIME/uv-cache"
+export TIKTOKEN_CACHE_DIR="$RUNTIME/tiktoken-cache"
+export PATH="$HOME/.local/bin:$CARGO_HOME/bin:/usr/local/bin:/usr/bin:/bin"
+mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME" "$UV_CACHE_DIR" "$RUNTIME/data" "$TIKTOKEN_CACHE_DIR"
+
+# The client holds one streaming connection per concurrent user; lift the
+# soft fd limit to the hard limit so high-concurrency phases don't starve.
+ulimit -n "$(ulimit -Hn)" 2>/dev/null || true
+
+# ---- preflight: build the client runtime once per job ----------------------
+# READY is self-validating: it records the arch + client commit it was built
+# for, so a relocated AGENTPERF_RUNTIME reused across jobs (or clusters of a
+# different arch) rebuilds instead of silently reusing a stale/wrong runtime.
+FINGERPRINT="$(uname -m):$(git -C "$CLIENT_DIR" rev-parse HEAD 2>/dev/null || echo unknown)"
+ready() { [[ "$(cat "$RUNTIME/READY" 2>/dev/null)" == "$FINGERPRINT" ]]; }
+HOLDING_LOCK=0
+if ! ready; then
+  # Atomic mkdir as a mutex: a concurrent job sharing this runtime waits for
+  # the builder instead of double-building into the same venv.
+  if mkdir "$RUNTIME/.build-lock" 2>/dev/null; then
+    HOLDING_LOCK=1
+  else
+    echo "[agentperf] preflight in progress elsewhere; waiting for READY"
+    for _ in $(seq 1 360); do
+      ready && break
+      sleep 5
+    done
+    ready || { echo "ERROR: timed out waiting for concurrent agentperf preflight in $RUNTIME" >&2; exit 1; }
+  fi
+fi
+if ! ready; then
+  echo "[agentperf] preflight: building client runtime in $RUNTIME (fingerprint $FINGERPRINT)"
+  cd "$CLIENT_DIR"
+
+  if [[ ! -x "$CARGO_HOME/bin/cargo" ]]; then
+    RUST_VERSION="${AGENTPERF_RUST_VERSION:-1.93.1}"
+    ARCH=$(uname -m)
+    RUSTUP_INIT="$RUNTIME/rustup-init-$ARCH"
+    wget --tries=3 --waitretry=5 -O "$RUSTUP_INIT" \
+      "https://static.rust-lang.org/rustup/archive/1.28.1/${ARCH}-unknown-linux-gnu/rustup-init"
+    chmod +x "$RUSTUP_INIT"
+    "$RUSTUP_INIT" -y --profile minimal --default-toolchain "$RUST_VERSION" --no-modify-path
+  fi
+  cargo --version
+  rustc --version
+
+  if ! command -v uv >/dev/null 2>&1; then
+    UV_VERSION="${AGENTPERF_UV_VERSION:-0.8.22}"
+    python3 -m pip install --disable-pip-version-check --no-cache-dir --user "uv==$UV_VERSION"
+  fi
+  uv --version
+
+  # --frozen fails fast on uv.lock drift instead of re-resolving (silently
+  # different deps) or trying to rewrite uv.lock in a read-only checkout;
+  # --no-sync afterwards because the env was just synced.
+  uv sync --frozen
+  # The default client_impl is the Rust streaming core; build it into the
+  # redirected venv (maturin develop installs there, CARGO_TARGET_DIR keeps
+  # build artifacts out of the possibly read-only checkout).
+  uv run --no-sync maturin develop --release -m rustcore/Cargo.toml
+  uv run --no-sync python -c 'import agentperf_rustcore; print("agentperf_rustcore", agentperf_rustcore.__version__)'
+  # Warm the tokenizer cache so a mid-run egress hiccup can't kill startup.
+  uv run --no-sync python -c "import tiktoken; tiktoken.get_encoding('o200k_base')" || true
+
+  # Stage the trajectory and assignment data from shared storage to
+  # node-local /tmp and write the config the benchmark actually uses with
+  # those two paths replaced.
+  uv run --no-sync python - "$CONFIG_PATH" "$RUNTIME/benchmark_config.yaml" "$RUNTIME/data" <<'PY'
+from pathlib import Path
+import shutil
+import sys
+import yaml
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+data_dir = Path(sys.argv[3])
+config = yaml.safe_load(source.read_text())
+for field in ("trajectory_path", "user_assignments_path"):
+    value = config.get(field)
+    if not value:
+        continue
+    source_data = Path(value)
+    target_data = data_dir / source_data.name
+    shutil.copy2(source_data, target_data)
+    if not target_data.stat().st_size:
+        raise RuntimeError(f"empty staged AgentPerf input: {target_data}")
+    config[field] = str(target_data)
+destination.write_text(yaml.safe_dump(config, sort_keys=False))
+PY
+
+  echo "$FINGERPRINT" > "$RUNTIME/READY"
+  echo "[agentperf] preflight complete"
+fi
+[[ "$HOLDING_LOCK" == 1 ]] && rmdir "$RUNTIME/.build-lock" 2>/dev/null || true
+
+# ---- run --------------------------------------------------------------------
+RESULTS_DIR=/logs/agentperf
+mkdir -p "$RESULTS_DIR"
+
+cd "$CLIENT_DIR"
+echo "[agentperf] endpoint=$ENDPOINT model=$MODEL_NAME concurrencies=$CONCURRENCIES config=$RUNTIME/benchmark_config.yaml"
+# Simple space-separated tokens only — values are word-split, never shell-parsed.
+read -r -a EXTRA_ARGS <<< "${AGENTPERF_EXTRA_ARGS:-}" || true
+uv run --no-sync python agentperf/run.py \
+  --config "$RUNTIME/benchmark_config.yaml" \
+  --base-url "$ENDPOINT" \
+  --model "$MODEL_NAME" \
+  --concurrencies "$CONCURRENCIES" \
+  --request-log-path "$RESULTS_DIR/requests.jsonl" \
+  --results-dir "$RESULTS_DIR" \
+  ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}

--- a/src/srtctl/benchmarks/scripts/agentperf/port_harness_run.py
+++ b/src/srtctl/benchmarks/scripts/agentperf/port_harness_run.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Port a script-harness AgentPerf run directory to an srt-slurm recipe.
+
+Host-side developer tool (not executed inside jobs). Given the ``c<N>/`` run
+directory of a standalone disagg-harness AgentPerf run, it reads the readable
+artifacts the harness leaves behind and emits:
+
+  * an srt-slurm recipe (server topology, engine configs, worker/frontend env)
+  * the agentperf-client workload YAML (settle/timeout/datasets/knobs)
+  * a provenance report on stdout: every generated field -> the artifact it
+    came from, plus a TODO list of what could not be inferred.
+
+Sources parsed (all verified against real harness runs):
+  job_params.env         container image, model path, concurrencies, backend
+  ctx_config.yaml        -> backend.trtllm_config.prefill (verbatim, paths rewritten)
+  gen_config.yaml        -> backend.trtllm_config.decode  (verbatim, paths rewritten)
+  client_cmds_base.sh    pinned agentperf-client checkout path
+  client.log             the client's resolved-config banner (workload knobs)
+  job.log                srun lines: worker env, frontend env, topology
+  agentperf/*traj*.json  settling time (encoded in the output filename stem)
+  3_output_CTX_0.log     cpu-pinning detection (taskset -c lines)
+
+Known translations applied automatically:
+  DYN_KV_BLOCK_SIZE -> DYN_TRTLLM_KV_BLOCK_SIZE  (harness env is inert under
+      srt-slurm; dynamo's own env fallback must carry the block size)
+  DYN_UCX_TLS       -> UCX_TLS                    (the harness script exported it)
+  path rewrites (default /lustre/ -> /scratch/)   (on clusters where /lustre is
+      a symlink, containers only mount /scratch)
+  drops: CUDA_VISIBLE_DEVICES, ETCD_ENDPOINTS, PATH, LD_PRELOAD, VIRTUAL_ENV,
+      NIXL_PLUGIN_DIR, HOME (srt-slurm or the image manage these)
+  frontend --dyn-*-parser flags are NOT ported to frontend.args (the frontend
+      rejects them; parsers stay worker-side via env)
+
+Usage:
+  python3 port_harness_run.py <old_run_dir> \\
+      --out recipe.yaml --workload-out workload.yaml \\
+      [--dataset-root DIR ...] [--path-rewrite OLD=NEW ...] [--no-default-rewrites]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+DEFAULT_REWRITES = [("/lustre/", "/scratch/")]
+ENV_DROP = {
+    "CUDA_VISIBLE_DEVICES",
+    "ETCD_ENDPOINTS",
+    "PATH",
+    "LD_PRELOAD",
+    "VIRTUAL_ENV",
+    "NIXL_PLUGIN_DIR",
+    "HOME",
+}
+ENV_RENAME = {
+    "DYN_KV_BLOCK_SIZE": "DYN_TRTLLM_KV_BLOCK_SIZE",
+    "DYN_UCX_TLS": "UCX_TLS",
+}
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+SETTLE_RE = re.compile(r"__settle(\d+(?:\.\d+)?)s__")
+
+
+class Provenance:
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str]] = []
+        self.todos: list[str] = []
+
+    def add(self, field: str, source: str) -> None:
+        self.rows.append((field, source))
+
+    def todo(self, msg: str) -> None:
+        self.todos.append(msg)
+
+    def report(self) -> str:
+        out = ["", "=== provenance ==="]
+        out += [f"  {f:<42} <- {s}" for f, s in self.rows]
+        if self.todos:
+            out += ["", "=== TODO (could not be inferred — edit before submitting) ==="]
+            out += [f"  ! {t}" for t in self.todos]
+        return "\n".join(out)
+
+
+def _read(path: Path) -> str | None:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return None
+
+
+def rewrite(value: str, rewrites: list[tuple[str, str]]) -> str:
+    for old, new in rewrites:
+        if value.startswith(old):
+            return new + value[len(old):]
+    return value
+
+
+def rewrite_tree(obj, rewrites):
+    """Apply path-prefix rewrites to every string in a nested YAML structure."""
+    if isinstance(obj, str):
+        return rewrite(obj, rewrites)
+    if isinstance(obj, list):
+        return [rewrite_tree(v, rewrites) for v in obj]
+    if isinstance(obj, dict):
+        return {k: rewrite_tree(v, rewrites) for k, v in obj.items()}
+    return obj
+
+
+def absolute_paths(obj) -> list[str]:
+    found = []
+    if isinstance(obj, str) and obj.startswith("/"):
+        found.append(obj)
+    elif isinstance(obj, list):
+        for v in obj:
+            found += absolute_paths(v)
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            found += absolute_paths(v)
+    return found
+
+
+def parse_job_params(run_dir: Path, prov: Provenance) -> dict:
+    out: dict = {}
+    txt = _read(run_dir / "job_params.env")
+    if txt is None:
+        prov.todo("job_params.env unreadable: set model.path / model.container by hand")
+        return out
+    for line in txt.splitlines():
+        m = re.match(r'([A-Z_]+)=["\']?([^"\']*)["\']?\s*$', line.strip())
+        if m:
+            out[m.group(1)] = m.group(2)
+    for key in ("MODEL_PATH", "CONTAINER_IMAGE", "CONCURRENCIES", "SERVER_BACKEND"):
+        if key in out:
+            prov.add(key, "job_params.env")
+    return out
+
+
+def parse_client_dir(run_dir: Path, prov: Provenance) -> str | None:
+    txt = _read(run_dir / "client_cmds_base.sh")
+    if not txt:
+        prov.todo("client_cmds_base.sh unreadable: set benchmark.agentperf_client_dir by hand")
+        return None
+    m = re.search(r"cd ([^;]+);\s*uv run python agentperf/run\.py", txt)
+    if m:
+        prov.add("benchmark.agentperf_client_dir", "client_cmds_base.sh (cd before run.py)")
+        return m.group(1).strip()
+    prov.todo("could not find the client checkout in client_cmds_base.sh")
+    return None
+
+
+def parse_client_banner(run_dir: Path, prov: Provenance) -> dict:
+    """Workload knobs from the client's resolved-config startup banner."""
+    txt = _read(run_dir / "client.log")
+    if not txt:
+        prov.todo("client.log unreadable: fill the workload YAML knobs by hand")
+        return {}
+    knobs: dict = {}
+    patterns = {
+        "server_type": r"Server type:\s*(\S+)",
+        "max_workers": r"Max workers:\s*(\d+)",
+        "phase_timeout_seconds": r"Phase Timeout:\s*([\d.]+)s",
+        "max_starting_line_offset": r"Max ISL offset:\s*(\d+)",
+        "max_tokens": r"Max tokens:\s*(\d+)",
+        "reasoning_effort": r"Reasoning effort:\s*(\S+)",
+        "seed": r"Seed:\s*(\d+)",
+    }
+    for line in txt.splitlines():
+        line = ANSI.sub("", re.sub(r"^\d+:\s?", "", line))
+        for key, pat in patterns.items():
+            m = re.search(pat, line)
+            if m and key not in knobs:
+                v = m.group(1)
+                knobs[key] = float(v) if "." in v else (v if not v.isdigit() else int(v))
+        if "Conversation routing headers:" in line:
+            knobs["send_conversation_routing_headers"] = "enabled" in line
+        if "Dynamo conv-aware routing" in line:
+            knobs["use_dynamo_conv_aware_routing"] = "enabled" in line
+        m = re.search(r"User assignments:\s*(\S+)", line)
+        if m:
+            knobs["_assignments_basename"] = Path(m.group(1)).name
+        m = re.search(r"Loading trajectories from\s*(\S+?)\.{0,3}$", line)
+        if m:
+            knobs["_trajectory_basename"] = Path(m.group(1)).name
+    for k in sorted(k for k in knobs if not k.startswith("_")):
+        prov.add(f"workload.{k}", "client.log resolved-config banner")
+    return knobs
+
+
+def parse_settle(run_dir: Path, prov: Provenance) -> float | None:
+    for p in sorted((run_dir / "agentperf").glob("*traj*")) if (run_dir / "agentperf").is_dir() else []:
+        m = SETTLE_RE.search(p.name)
+        if m:
+            prov.add("workload.settling_time_seconds", f"output filename stem ({p.name})")
+            return float(m.group(1))
+    prov.todo("settling_time_seconds not recoverable (no agentperf/*traj* outputs); it is YAML-only — set it by hand")
+    return None
+
+
+def _quoted_env_tokens(line: str) -> list[str]:
+    """Pick the single-quoted argument that looks like a KEY=val env token list."""
+    best: list[str] = []
+    for quoted in re.findall(r"'([^']*)'", line):
+        toks = quoted.split()
+        if toks and sum(bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", t)) for t in toks) >= max(2, len(toks) - 1):
+            if len(toks) > len(best):
+                best = toks
+    return best
+
+
+def translate_env(tokens: list[str]) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for tok in tokens:
+        key, _, val = tok.partition("=")
+        if key in ENV_DROP:
+            continue
+        env[ENV_RENAME.get(key, key)] = val
+    # The harness set no DYN_LOG; srt-slurm setdefaults a noisier filter on
+    # workers. Pin plain 'info' so the ported run matches the reference logs.
+    env.setdefault("DYN_LOG", "info")
+    return env
+
+
+def parse_job_log(run_dir: Path, prov: Provenance) -> dict:
+    """Worker/frontend env + topology from the harness's srun launch lines."""
+    txt = _read(run_dir / "job.log")
+    out: dict = {"prefill_env": {}, "decode_env": {}, "frontend_env": {}, "topology": {}}
+    if not txt:
+        prov.todo("job.log unreadable: set worker/frontend env and resources by hand")
+        return out
+    ctx_nodes, gen_nodelists, gpus_per_node = set(), [], None
+    for line in txt.splitlines():
+        if "Executing: srun" not in line:
+            continue
+        nodelist = re.search(r"--nodelist[ =]([\w.,-]+)", line)
+        if re.search(r"3_output_CTX_\d+\.log", line):
+            toks = _quoted_env_tokens(line)
+            if toks and not out["prefill_env"]:
+                out["prefill_env"] = translate_env(toks)
+                prov.add("backend.prefill_environment", "job.log CTX srun line (translated)")
+                cvd = next((t for t in toks if t.startswith("CUDA_VISIBLE_DEVICES=")), None)
+                if cvd:
+                    gpus_per_node = len(cvd.split("=", 1)[1].split(","))
+            if nodelist:
+                ctx_nodes.add(nodelist.group(1))
+        elif re.search(r"3_output_GEN_\d+\.log", line):
+            toks = _quoted_env_tokens(line)
+            if toks and not out["decode_env"]:
+                out["decode_env"] = translate_env(toks)
+                prov.add("backend.decode_environment", "job.log GEN srun line (translated)")
+            if nodelist:
+                gen_nodelists.append(nodelist.group(1).split(","))
+        elif "4_output_frontend" in line:
+            m = re.search(r"--export=ALL,(\S+)", line)
+            if m and not out["frontend_env"]:
+                env = {}
+                for tok in m.group(1).split(","):
+                    key, _, val = tok.partition("=")
+                    if key and key not in ENV_DROP:
+                        env[key] = val
+                # The harness's infra script exported HOME=/tmp unconditionally
+                # (the image HOME is read-only); carry that for the frontend.
+                env.setdefault("HOME", "/tmp")
+                out["frontend_env"] = env
+                prov.add("frontend.env", "job.log frontend srun line --export list")
+    out["topology"] = {
+        "prefill_workers": len(ctx_nodes),
+        "prefill_nodes": len(ctx_nodes),
+        "decode_workers": len(gen_nodelists),
+        "decode_nodes": len(gen_nodelists[0]) if gen_nodelists else None,
+        "gpus_per_node": gpus_per_node,
+    }
+    prov.add("resources (topology)", "job.log srun nodelists")
+    return out
+
+
+def detect_cpu_pinning(run_dir: Path, prov: Provenance) -> bool:
+    txt = _read(run_dir / "3_output_CTX_0.log")
+    if txt and re.search(r"taskset -c \d", txt):
+        prov.add("backend.numa_cpu_bind=true", "3_output_CTX_0.log (taskset -c lines present)")
+        return True
+    return False
+
+
+def find_dataset(basename: str | None, roots: list[Path], prov: Provenance, label: str) -> str:
+    placeholder = f"/TODO/path/to/{basename or label}"
+    if not basename:
+        prov.todo(f"{label}: not found in client.log; set it by hand")
+        return placeholder
+    for root in roots:
+        hits = list(root.rglob(basename)) if root.is_dir() else []
+        if hits:
+            prov.add(f"workload.{label}", f"found under --dataset-root {root}")
+            return str(hits[0])
+    prov.todo(
+        f"{label}: the banner only shows the node-local staged copy ({basename}); "
+        f"locate the original (try --dataset-root) and replace the placeholder"
+    )
+    return placeholder
+
+
+def build_frontend_args(frontend_env: dict[str, str]) -> dict:
+    """Reconstruct the dynamo.frontend flags the harness's infra script derived from env."""
+    return {
+        "router-mode": frontend_env.get("ROUTER_MODE", "kv"),
+        "no-router-kv-events": frontend_env.get("DYN_FRONTEND_ENABLE_KV_EVENTS", "0") != "1",
+        "kv-cache-block-size": int(frontend_env.get("DYN_KV_BLOCK_SIZE", "128")),
+        "enforce-disagg": True,
+        "request-plane": frontend_env.get("DYN_REQUEST_PLANE", "tcp"),
+        "event-plane": "zmq",
+        # NO dyn-*-parser flags: the frontend rejects them; parsers are worker-side env.
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("run_dir", type=Path, help="the harness c<N>/ run directory")
+    ap.add_argument("--out", type=Path, required=True, help="output recipe YAML path")
+    ap.add_argument("--workload-out", type=Path, required=True, help="output agentperf workload YAML path")
+    ap.add_argument("--dataset-root", type=Path, action="append", default=[],
+                    help="root(s) to search for the original trajectory/assignments files")
+    ap.add_argument("--path-rewrite", action="append", default=[], metavar="OLD=NEW",
+                    help="path prefix rewrite applied to all ported paths (repeatable)")
+    ap.add_argument("--no-default-rewrites", action="store_true",
+                    help=f"disable the default rewrites {DEFAULT_REWRITES}")
+    args = ap.parse_args(argv)
+
+    rewrites = [] if args.no_default_rewrites else list(DEFAULT_REWRITES)
+    for spec in args.path_rewrite:
+        old, _, new = spec.partition("=")
+        if not old or not new:
+            ap.error(f"--path-rewrite must be OLD=NEW, got: {spec}")
+        rewrites.append((old, new))
+
+    run_dir, prov = args.run_dir, Provenance()
+    if not run_dir.is_dir():
+        print(f"ERROR: {run_dir} is not a directory", file=sys.stderr)
+        return 1
+
+    params = parse_job_params(run_dir, prov)
+    if params.get("SERVER_BACKEND", "dynamo") != "dynamo":
+        prov.todo(f"SERVER_BACKEND={params.get('SERVER_BACKEND')}: this porter only handles the dynamo "
+                  "frontend path; the trtllm-serve path needs a hand-written recipe")
+
+    ctx = yaml.safe_load(_read(run_dir / "ctx_config.yaml") or "") or {}
+    gen = yaml.safe_load(_read(run_dir / "gen_config.yaml") or "") or {}
+    if ctx:
+        prov.add("backend.trtllm_config.prefill", "ctx_config.yaml (verbatim, paths rewritten)")
+    else:
+        prov.todo("ctx_config.yaml unreadable")
+    if gen:
+        prov.add("backend.trtllm_config.decode", "gen_config.yaml (verbatim, paths rewritten)")
+    else:
+        prov.todo("gen_config.yaml unreadable")
+    ctx, gen = rewrite_tree(ctx, rewrites), rewrite_tree(gen, rewrites)
+    for p in absolute_paths({"prefill": ctx, "decode": gen}):
+        prov.todo(f"engine config references {p} — confirm it is readable from the compute containers "
+                  "(copy to your own scratch if it lives under another user)")
+
+    client_dir = parse_client_dir(run_dir, prov)
+    knobs = parse_client_banner(run_dir, prov)
+    settle = parse_settle(run_dir, prov)
+    joblog = parse_job_log(run_dir, prov)
+    cpu_pinned = detect_cpu_pinning(run_dir, prov)
+
+    concurrencies = [int(c) for c in str(params.get("CONCURRENCIES", "")).split()] or None
+    if concurrencies is None:
+        prov.todo("CONCURRENCIES not found in job_params.env; set benchmark.concurrency by hand")
+
+    workload = {
+        "base_url": "http://placeholder:8000/v1",
+        "api_key": "dummy",
+        "model": "placeholder",
+        "server_type": knobs.get("server_type", "trtllm"),
+        "concurrencies": concurrencies or [1],
+        "phase_timeout_seconds": knobs.get("phase_timeout_seconds", 3600.0),
+        "settling_time_seconds": settle if settle is not None else 240.0,
+        "trajectory_path": find_dataset(knobs.get("_trajectory_basename"), args.dataset_root, prov, "trajectory_path"),
+        "user_assignments_path": find_dataset(knobs.get("_assignments_basename"), args.dataset_root, prov,
+                                              "user_assignments_path"),
+        "max_starting_line_offset": knobs.get("max_starting_line_offset", 10),
+        "seed": knobs.get("seed", 42),
+        "timeout_seconds": 300.0,
+        "max_workers": knobs.get("max_workers", 8),
+        "max_tokens": knobs.get("max_tokens", 16384),
+        "reasoning_effort": knobs.get("reasoning_effort"),
+        "client_impl": "rust",
+        "send_conversation_routing_headers": knobs.get("send_conversation_routing_headers", False),
+        "use_dynamo_conv_aware_routing": knobs.get("use_dynamo_conv_aware_routing", False),
+        "power_dcgm_url": None,
+    }
+
+    topo = joblog["topology"]
+    model_path = rewrite(params.get("MODEL_PATH", "/TODO/model/path"), rewrites)
+    recipe = {
+        "name": re.sub(r"[^a-zA-Z0-9-]+", "-", run_dir.resolve().parent.name)[:64] or "agentperf-ported-run",
+        "model": {
+            "path": model_path,
+            "container": rewrite(params.get("CONTAINER_IMAGE", "/TODO/container.sqsh"), rewrites),
+            "precision": "fp4" if "fp4" in model_path.lower() or "nvfp4" in model_path.lower() else "fp8",
+        },
+        "resources": {
+            "gpu_type": "gb300",  # TODO'd below — not recoverable from the run dir
+            "gpus_per_node": topo.get("gpus_per_node") or 4,
+            "prefill_nodes": topo.get("prefill_nodes") or 1,
+            "prefill_workers": topo.get("prefill_workers") or 1,
+            "decode_nodes": topo.get("decode_nodes") or 1,
+            "decode_workers": topo.get("decode_workers") or 1,
+        },
+        "dynamo": {"install": False, "request_plane": joblog["frontend_env"].get("DYN_REQUEST_PLANE", "tcp"),
+                   "event_plane": "zmq"},
+        "backend": {
+            "type": "trtllm",
+            "numa_memory_bind": True,
+            "numa_cpu_bind": cpu_pinned,
+            "prefill_environment": joblog["prefill_env"],
+            "decode_environment": joblog["decode_env"],
+            "trtllm_config": {"prefill": ctx, "decode": gen},
+        },
+        "frontend": {
+            "type": "dynamo",
+            "enable_multiple_frontends": False,
+            "args": build_frontend_args(joblog["frontend_env"]),
+            "env": joblog["frontend_env"],
+        },
+        "infra": {"etcd_nats_dedicated_node": False},
+        "observability": {"enabled": False},
+        "benchmark": {
+            "type": "agentperf",
+            "client_placement": "last_decode",
+            "concurrency": concurrencies[0] if concurrencies and len(concurrencies) == 1 else None,
+            "concurrencies": concurrencies if concurrencies and len(concurrencies) > 1 else None,
+            "agentperf_client_dir": rewrite(client_dir, rewrites) if client_dir else "/TODO/agentperf-client",
+            "agentperf_config": str(args.workload_out.resolve()),
+        },
+        "extra_mount": ["/scratch:/scratch"],
+    }
+    recipe["benchmark"] = {k: v for k, v in recipe["benchmark"].items() if v is not None}
+    prov.todo("resources.gpu_type is guessed as gb300 — set it for your cluster")
+    prov.todo(f"benchmark.agentperf_config is set to {args.workload_out.resolve()} — "
+              "move the workload YAML somewhere container-visible and update the path")
+    prov.todo("review benchmark.client_placement (last_decode = client on the decode leader node, "
+              "matching the harness's client-on-GEN placement)")
+
+    args.out.write_text(yaml.safe_dump(recipe, sort_keys=False))
+    args.workload_out.write_text(yaml.safe_dump(workload, sort_keys=False))
+    print(f"wrote recipe:   {args.out}")
+    print(f"wrote workload: {args.workload_out}")
+    print(prov.report())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/srtctl/benchmarks/scripts/agentperf/rollup.py
+++ b/src/srtctl/benchmarks/scripts/agentperf/rollup.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate benchmark-rollup.json from agentperf per-phase stats.
+
+The client writes one ``<stem>__traj<N>.json`` per phase under
+``<log_dir>/agentperf/`` containing the same statistics as the human-readable
+phase summary. This rollup flattens each phase into one record so downstream
+consumers don't need to know the client's filename scheme.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# model__<N>u__phase<i>__dur<D>s__settle<S>s__traj<T>.json
+# dur/settle are floats in the client and render with a decimal point when
+# non-whole (e.g. dur300.5s), so those two groups must accept decimals.
+STEM_RE = re.compile(r"__(\d+)u__phase(\d+)__dur(\d+(?:\.\d+)?)s__settle(\d+(?:\.\d+)?)s__traj(\d+)\.json$")
+
+
+def main(log_dir: str) -> int:
+    results_dir = Path(log_dir) / "agentperf"
+    if not results_dir.is_dir():
+        print(f"no agentperf results dir at {results_dir}", file=sys.stderr)
+        return 0
+
+    phases = []
+    for path in sorted(results_dir.glob("*__traj*.json")):
+        m = STEM_RE.search(path.name)
+        if not m:
+            print(f"skipping {path.name}: does not match the phase-stem pattern", file=sys.stderr)
+            continue
+        try:
+            stats = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"skipping unreadable {path.name}: {exc}", file=sys.stderr)
+            continue
+        phases.append(
+            {
+                "file": path.name,
+                "concurrency": int(m.group(1)),
+                "phase_idx": int(m.group(2)),
+                "phase_timeout_seconds": float(m.group(3)),
+                "settling_time_seconds": float(m.group(4)),
+                "trajectories_per_user": int(m.group(5)),
+                "stats": stats,
+            }
+        )
+
+    if not phases:
+        print(f"no agentperf phase stats found under {results_dir}", file=sys.stderr)
+        return 0
+
+    out = Path(log_dir) / "benchmark-rollup.json"
+    out.write_text(json.dumps({"benchmark": "agentperf", "phases": phases}, indent=1))
+    print(f"wrote {out} ({len(phases)} phase(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "."))

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -729,6 +729,11 @@ class BenchmarkConfig:
     # Custom dataset fields (sa-bench)
     dataset_name: str | None = None  # "random" (default) or "custom"
     dataset_path: str | None = None  # Container path to dataset file (mount via extra_mount)
+    # AgentPerf benchmark fields (agentperf-client trajectory replay)
+    agentperf_client_dir: str | None = None  # Container path to an agentperf-client checkout (mount via extra_mount)
+    agentperf_config: str | None = (
+        None  # Container path to the client's workload YAML (endpoint/model/concurrency injected)
+    )
     # Trace replay benchmark fields (uses aiperf with mooncake_trace dataset type)
     trace_file: str | None = None  # Path to trace JSONL file (container path, e.g., /traces/dataset.jsonl)
     custom_tokenizer: str | None = None  # Custom tokenizer class (e.g., "module.path.ClassName")

--- a/tests/test_agentperf_porter.py
+++ b/tests/test_agentperf_porter.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the AgentPerf harness-run porter (scripts/agentperf/port_harness_run.py)."""
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+from srtctl.benchmarks.base import SCRIPTS_DIR
+
+_spec = importlib.util.spec_from_file_location(
+    "port_harness_run", SCRIPTS_DIR / "agentperf" / "port_harness_run.py"
+)
+porter = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(porter)
+
+
+CLIENT_BANNER = """0: ============================================================
+0: AA-AGENTPERF: Deterministic Load Test
+0: ============================================================
+0:   Base URL: http://node-01:8333/v1
+0:   Model: /lustre/proj/models/dsv4/hf-abc_orig
+0:   Server type: trtllm
+0:   Concurrencies: [1010]
+0:   Max workers: 8
+0:   Phase Timeout: 2400.0s
+0:   Max ISL offset: 10
+0:   User assignments: /tmp/agentperf-1/data/assignments-20k.json
+0:   Max tokens: 2000
+0:   Reasoning effort: high
+0:   Tool-call delays: enabled
+0:   Conversation routing headers: enabled
+0:   Dynamo conv-aware routing (X-Dynamo-Session-ID): enabled
+0:   Seed: 42
+0: ============================================================
+0: Loading trajectories from /tmp/agentperf-1/data/traj_500.jsonl...
+"""
+
+WORKER_ENV = (
+    "TLLM_LOG_LEVEL=INFO TRTLLM_ENABLE_PDL=1 DYN_KV_BLOCK_SIZE=128 DYN_UCX_TLS=cuda_ipc,sm,self,tcp "
+    "CUDA_VISIBLE_DEVICES=0,1,2,3 ETCD_ENDPOINTS=http://node-09:2379 PATH=/opt/bin "
+    "DYN_TOOL_CALL_PARSER=deepseek_v4 PYTHONUNBUFFERED=1"
+)
+
+JOB_LOG = f"""[server] Executing: srun -l --export=ALL --nodelist node-09 x.sqsh bash start.sh CTX 0 /model 8102 e2e '1010' true /logs '0-0' /r/ctx_config.yaml '{WORKER_ENV}' none none &> /r/3_output_CTX_0.log &
+[server] Executing: srun -l --export=ALL --nodelist node-10 x.sqsh bash start.sh CTX 1 /model 8103 e2e '1010' true /logs '0-0' /r/ctx_config.yaml '{WORKER_ENV}' none none &> /r/3_output_CTX_1.log &
+[server] Executing: srun -l --export=ALL --nodelist node-01,node-02,node-03 x.sqsh bash start.sh GEN 0 /model 8101 e2e '1010' true /logs '0-0' /r/gen_config.yaml '{WORKER_ENV}' none none &> /r/3_output_GEN_0.log &
+[server] Executing: srun -l --export=ALL,ETCD_ENDPOINTS=http://node-09:2379,ROUTER_MODE=kv,DYN_KV_BLOCK_SIZE=128,DYN_REQUEST_PLANE=tcp,DYN_FRONTEND_ENABLE_KV_EVENTS=0,DYN_ROUTER_TEMPERATURE=0 --nodelist node-09 bash infra.sh frontend node-09 8333 &> /r/4_output_frontend.log &
+"""
+
+
+def make_run_dir(tmp_path: Path, with_taskset: bool = False) -> Path:
+    d = tmp_path / "c1010"
+    (d / "agentperf").mkdir(parents=True)
+    (d / "job_params.env").write_text(
+        'MODEL_PATH="/lustre/proj/models/dsv4/hf-abc_orig"\n'
+        'CONCURRENCIES="1010"\n'
+        'CONTAINER_IMAGE="/lustre/proj/images/dyn.sqsh"\n'
+        'SERVER_BACKEND="dynamo"\n'
+    )
+    (d / "ctx_config.yaml").write_text(
+        yaml.safe_dump({"tensor_parallel_size": 4, "kv_cache_config": {"dtype": "fp8"}})
+    )
+    (d / "gen_config.yaml").write_text(
+        yaml.safe_dump({
+            "tensor_parallel_size": 12,
+            "moe_config": {"load_balancer": "/lustre/proj/eplb/gen.yaml"},
+        })
+    )
+    (d / "client_cmds_base.sh").write_text(
+        "srun ... bash -c ' set -e; cd /lustre/proj/agentperf-client-worktrees/abc123; "
+        "uv run python agentperf/run.py --config x.yaml'"
+    )
+    (d / "client.log").write_text(CLIENT_BANNER)
+    (d / "job.log").write_text(JOB_LOG)
+    (d / "agentperf" / "m__1010u__phase0__dur2400s__settle240s__traj3.json").write_text("{}")
+    (d / "3_output_CTX_0.log").write_text("taskset -c 0-35 numactl -m 0,1\n" if with_taskset else "clean\n")
+    return d
+
+
+def run_porter(run_dir: Path, tmp_path: Path, extra: list[str] | None = None):
+    out, wl = tmp_path / "recipe.yaml", tmp_path / "workload.yaml"
+    rc = porter.main([str(run_dir), "--out", str(out), "--workload-out", str(wl), *(extra or [])])
+    assert rc == 0
+    return yaml.safe_load(out.read_text()), yaml.safe_load(wl.read_text())
+
+
+class TestAgentPerfPorter:
+    def test_full_port(self, tmp_path):
+        recipe, workload = run_porter(make_run_dir(tmp_path), tmp_path)
+
+        # model + default /lustre -> /scratch rewrite
+        assert recipe["model"]["path"] == "/scratch/proj/models/dsv4/hf-abc_orig"
+        assert recipe["model"]["container"] == "/scratch/proj/images/dyn.sqsh"
+
+        # topology from job.log: 2 CTX single-node workers, 1 GEN over 3 nodes, 4 GPUs/node
+        r = recipe["resources"]
+        assert (r["prefill_workers"], r["prefill_nodes"]) == (2, 2)
+        assert (r["decode_workers"], r["decode_nodes"]) == (1, 3)
+        assert r["gpus_per_node"] == 4
+
+        # env translation: rename, drop, passthrough
+        penv = recipe["backend"]["prefill_environment"]
+        assert penv["DYN_TRTLLM_KV_BLOCK_SIZE"] == "128"
+        assert penv["UCX_TLS"] == "cuda_ipc,sm,self,tcp"
+        assert "DYN_KV_BLOCK_SIZE" not in penv
+        assert "CUDA_VISIBLE_DEVICES" not in penv and "ETCD_ENDPOINTS" not in penv and "PATH" not in penv
+        assert penv["DYN_TOOL_CALL_PARSER"] == "deepseek_v4"
+        assert penv["DYN_LOG"] == "info"  # pinned to override srt-slurm's noisier default
+        assert recipe["frontend"]["env"]["HOME"] == "/tmp"  # image HOME is read-only
+
+        # engine configs verbatim + rewritten paths
+        assert recipe["backend"]["trtllm_config"]["prefill"]["tensor_parallel_size"] == 4
+        assert recipe["backend"]["trtllm_config"]["decode"]["moe_config"]["load_balancer"] == "/scratch/proj/eplb/gen.yaml"
+
+        # frontend args derived from env; parser flags must NOT be ported
+        fargs = recipe["frontend"]["args"]
+        assert fargs["router-mode"] == "kv"
+        assert fargs["no-router-kv-events"] is True
+        assert fargs["kv-cache-block-size"] == 128
+        assert "dyn-tool-call-parser" not in fargs
+
+        # baseline: no cpu pinning detected
+        assert recipe["backend"]["numa_cpu_bind"] is False
+
+        # benchmark section
+        b = recipe["benchmark"]
+        assert b["type"] == "agentperf"
+        assert b["concurrency"] == 1010
+        assert b["agentperf_client_dir"] == "/scratch/proj/agentperf-client-worktrees/abc123"
+
+        # workload knobs from the banner + settle from the filename stem
+        assert workload["settling_time_seconds"] == 240.0
+        assert workload["phase_timeout_seconds"] == 2400.0
+        assert workload["max_workers"] == 8
+        assert workload["max_tokens"] == 2000
+        assert workload["reasoning_effort"] == "high"
+        assert workload["seed"] == 42
+        assert workload["send_conversation_routing_headers"] is True
+        assert workload["use_dynamo_conv_aware_routing"] is True
+        assert workload["base_url"].startswith("http://placeholder")
+
+    def test_taskset_detection(self, tmp_path):
+        recipe, _ = run_porter(make_run_dir(tmp_path, with_taskset=True), tmp_path)
+        assert recipe["backend"]["numa_cpu_bind"] is True
+
+    def test_dataset_root_resolution(self, tmp_path):
+        root = tmp_path / "datasets"
+        root.mkdir()
+        (root / "traj_500.jsonl").write_text("{}")
+        (root / "assignments-20k.json").write_text("{}")
+        _, workload = run_porter(make_run_dir(tmp_path), tmp_path, ["--dataset-root", str(root)])
+        assert workload["trajectory_path"] == str(root / "traj_500.jsonl")
+        assert workload["user_assignments_path"] == str(root / "assignments-20k.json")
+
+    def test_unresolved_datasets_become_placeholders(self, tmp_path):
+        _, workload = run_porter(make_run_dir(tmp_path), tmp_path)
+        assert workload["trajectory_path"].startswith("/TODO/")
+        assert workload["user_assignments_path"].startswith("/TODO/")
+
+    def test_recipe_is_schema_loadable(self, tmp_path):
+        """The generated recipe must at least round-trip through SrtConfig's schema."""
+        recipe, _ = run_porter(make_run_dir(tmp_path), tmp_path)
+        from srtctl.core.schema import SrtConfig
+
+        cfg = SrtConfig.Schema().load(recipe)
+        assert cfg.benchmark.type == "agentperf"
+        assert cfg.backend.numa_cpu_bind is False

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -930,6 +930,147 @@ class TestTraceReplayRunner:
         assert config.benchmark.itl_threshold_ms == 7
 
 
+class TestAgentPerfRunner:
+    """Test AgentPerf benchmark runner."""
+
+    def _config(self, **benchmark_kwargs):
+        from srtctl.core.schema import BenchmarkConfig, ModelConfig, ResourceConfig, SrtConfig
+
+        return SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model/dsv4", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="gb300"),
+            benchmark=BenchmarkConfig(type="agentperf", **benchmark_kwargs),
+        )
+
+    def test_in_registry(self):
+        """agentperf is registered in benchmark list."""
+        assert "agentperf" in list_benchmarks()
+
+    def test_get_runner(self):
+        """Can get runner for agentperf."""
+        runner = get_runner("agentperf")
+        assert runner.name == "AgentPerf"
+        assert "agentperf" in runner.script_path
+
+    def test_validate_missing_client_dir(self):
+        """Validates that agentperf_client_dir is required."""
+        runner = get_runner("agentperf")
+        errors = runner.validate_config(
+            self._config(agentperf_config="/workload/agentperf.yaml", concurrency=1010)
+        )
+        assert any("agentperf_client_dir" in e for e in errors)
+
+    def test_validate_missing_config(self):
+        """Validates that agentperf_config is required."""
+        runner = get_runner("agentperf")
+        errors = runner.validate_config(
+            self._config(agentperf_client_dir="/agentperf-client", concurrency=1010)
+        )
+        assert any("agentperf_config" in e for e in errors)
+
+    def test_validate_missing_concurrency(self):
+        """Validates that a concurrency is required."""
+        runner = get_runner("agentperf")
+        errors = runner.validate_config(
+            self._config(agentperf_client_dir="/agentperf-client", agentperf_config="/workload/agentperf.yaml")
+        )
+        assert any("concurrency" in e for e in errors)
+
+    def test_validate_rejects_empty_concurrencies(self):
+        """An empty concurrencies list must not silently defer to the workload YAML."""
+        runner = get_runner("agentperf")
+        errors = runner.validate_config(
+            self._config(
+                agentperf_client_dir="/agentperf-client",
+                agentperf_config="/workload/agentperf.yaml",
+                concurrencies=[],
+            )
+        )
+        assert any("at least one concurrency" in e for e in errors)
+
+    def test_validate_rejects_nonpositive_concurrency(self):
+        """Zero or negative concurrencies are rejected."""
+        runner = get_runner("agentperf")
+        errors = runner.validate_config(
+            self._config(
+                agentperf_client_dir="/agentperf-client",
+                agentperf_config="/workload/agentperf.yaml",
+                concurrencies=[0, 8],
+            )
+        )
+        assert any("positive" in e for e in errors)
+
+    def test_validate_valid(self):
+        """Valid config passes validation."""
+        runner = get_runner("agentperf")
+        errors = runner.validate_config(
+            self._config(
+                agentperf_client_dir="/agentperf-client",
+                agentperf_config="/workload/agentperf.yaml",
+                concurrencies=[64, 1010],
+            )
+        )
+        assert errors == []
+
+    def test_build_command(self):
+        """Build command carries endpoint, model, client dir, config and concurrencies."""
+        from unittest.mock import MagicMock
+
+        runner = get_runner("agentperf")
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        config = self._config(
+            agentperf_client_dir="/agentperf-client",
+            agentperf_config="/workload/agentperf.yaml",
+            concurrencies=[64, 1010],
+        )
+        cmd = runner.build_command(config, runtime)
+        assert cmd[0] == "bash"
+        assert cmd[1] == "/srtctl-benchmarks/agentperf/bench.sh"
+        assert cmd[2] == "http://localhost:8000"
+        # served_model_name derives the basename; the client must use the name
+        # the frontend actually serves.
+        assert cmd[3] == "dsv4"
+        assert cmd[4] == "/agentperf-client"
+        assert cmd[5] == "/workload/agentperf.yaml"
+        assert cmd[6] == "64,1010"
+
+    def test_build_command_single_concurrency(self):
+        """benchmark.concurrency (singular) wins over concurrencies."""
+        from unittest.mock import MagicMock
+
+        runner = get_runner("agentperf")
+        runtime = MagicMock()
+        runtime.frontend_port = 8000
+        config = self._config(
+            agentperf_client_dir="/agentperf-client",
+            agentperf_config="/workload/agentperf.yaml",
+            concurrency=1010,
+        )
+        cmd = runner.build_command(config, runtime)
+        assert cmd[6] == "1010"
+
+    def test_script_exists(self):
+        """agentperf bench.sh and rollup.py ship with the package."""
+        assert (SCRIPTS_DIR / "agentperf" / "bench.sh").exists()
+        assert (SCRIPTS_DIR / "agentperf" / "rollup.py").exists()
+
+    def test_environment_passthrough(self):
+        """benchmark.env reaches the client environment."""
+        from unittest.mock import MagicMock
+
+        runner = get_runner("agentperf")
+        config = self._config(
+            agentperf_client_dir="/agentperf-client",
+            agentperf_config="/workload/agentperf.yaml",
+            concurrency=8,
+            env={"AGENTPERF_EXTRA_ARGS": "--seed 100 --no-eval"},
+        )
+        env = runner.get_environment(config, MagicMock())
+        assert env["AGENTPERF_EXTRA_ARGS"] == "--seed 100 --no-eval"
+
+
 class TestLMEvalRunner:
     """Test LM-Eval runner."""
 


### PR DESCRIPTION
## What

Adds an `agentperf` benchmark type that lets srt-slurm orchestrate the [agentperf-client](https://github.com/ArtificialAnalysis-External/agentperf-client) trajectory-replay load generator (deterministic agentic workload, Rust streaming core, per-phase `*__traj*.{jsonl,txt,json}` outputs + per-request `requests.jsonl`).

This is a **different client** from the InferenceX AgentX harness in #342 — the two are complementary benchmark types.

## Launching an AgentPerf load: client-side steps

### Step 0 (optional) — port an existing script-harness run automatically

If you already have a run directory from the standalone disagg-harness (a `bm_agentperf_*/.../c<N>/` dir), you don't need to reverse-engineer it by hand — this PR ships a porter:

```bash
python3 src/srtctl/benchmarks/scripts/agentperf/port_harness_run.py \
    /path/to/old/.../c1010 \
    --out my-recipe.yaml --workload-out my-workload.yaml \
    --dataset-root /scratch/.../datasets      # where the original trajectory/assignments live
```

You don't need to know how the old harness worked. The script reads the artifacts every harness run leaves behind — the job parameter file (container image, model, concurrency), the engine configs (copied verbatim into the recipe), the client launch script (which pinned agentperf-client checkout was used), the client's own startup banner in `client.log` (all workload knobs: phase timeout, settling time, worker/token limits, routing flags, seed), and the `srun` launch lines in `job.log` (worker/frontend environment and the node topology) — and emits a ready-to-edit srt-slurm recipe plus the client workload YAML.

It also applies the translations that are easy to get wrong when porting by hand: environment variables that only the old harness understood are renamed to the ones dynamo actually reads (e.g. the KV block size, which would otherwise silently fall back to a wrong default), variables that srt-slurm or the container manage are dropped, `/lustre` paths are rewritten for clusters where containers only mount `/scratch`, CPU pinning is auto-detected from the old worker logs, and frontend flags that would crash the frontend are excluded.

Everything it generates is traceable: it prints a provenance report (each field → the artifact it came from) and a **TODO list** of the few things it cannot infer — chiefly where the original datasets live (the logs only show staged copies; `--dataset-root` lets it search), your cluster's `gpu_type`, and whether paths owned by other users are readable from your compute containers. Review the TODOs, then continue at Step 4.

Verified: ported the DSV4 c1010 GB300 baseline run and compared against a hand-validated parity recipe — 176/184 recipe fields and 19/19 workload fields identical, every remaining diff benign and TODO-flagged.

### Step 1 — mount a pinned agentperf-client checkout

The client is not vendored. Put a checkout at a pinned commit somewhere container-visible and mount it:

```yaml
extra_mount:
  - "/scratch/.../agentperf-client:/agentperf-client"
```

### Step 2 — write the workload YAML

This is the client's own config (`benchmark.agentperf_config`). It carries what the client CLI can't set: `settling_time_seconds`, `user_spawn_rate`, stop criteria, dataset paths. Three rules:

- It must contain syntactically valid **placeholder** `base_url` / `model` / `concurrencies` — the client validates the YAML *before* merging CLI overrides; srtctl then overrides all three at run time.
- `phase_timeout_seconds ≥ (max concurrency − 1)/user_spawn_rate + settling_time_seconds + min_measurement_seconds`, computed for the concurrency the *recipe* injects.
- The user-assignments file must cover the highest concurrency level (the client fails loudly otherwise).

### Step 3 — recipe benchmark section

```yaml
benchmark:
  type: agentperf
  agentperf_client_dir: /agentperf-client
  agentperf_config: /workloads/my-workload.yaml
  concurrency: 1010              # or concurrencies: [64, 1010] — one client phase per level
  client_placement: last_decode  # optional: put the client on the decode leader node
```

### Step 4 — validate and submit

```bash
srtctl dry-run -f recipe.yaml   # shows mounts/env so you can verify before burning nodes
srtctl apply -f recipe.yaml
```

### Step 5 — what happens and where results land

On first run the bench step preflights an isolated client runtime under `/tmp/agentperf-<jobid>` (pinned Rust + uv, `uv sync --frozen`, maturin `rustcore` build, tokenizer cache) and stages the trajectory/assignments datasets to node-local `/tmp` — needs network egress from the benchmark node, adds ~5–10 min before the first phase. Results land in the run's log dir: `agentperf/*__traj*.{txt,jsonl,json}` (per-phase summary + per-request metrics), `agentperf/requests.jsonl`, `agentperf/phase_manifest.jsonl`, and a normalized `benchmark-rollup.json`.

## Implementation notes

- `src/srtctl/benchmarks/agentperf.py` — runner: validates `agentperf_client_dir` / `agentperf_config` / concurrencies, injects endpoint + served model + concurrency via the client's CLI overrides.
- `scripts/agentperf/bench.sh` — a faithful translation of the standalone disagg-harness client invocation (same isolated /tmp runtime layout, pinned rust/uv toolchain preflight, `uv sync --frozen` + maturin rustcore build, node-local dataset staging). READY marker is self-validating (arch + client commit) with an atomic build lock for relocated runtimes.
- `scripts/agentperf/port_harness_run.py` — the Step-0 porter (host-side tool; provenance report + TODOs).
- `scripts/agentperf/rollup.py` — normalizes per-phase stats into `benchmark-rollup.json`.
- Schema: two new `BenchmarkConfig` fields (`agentperf_client_dir`, `agentperf_config`).
- Docs: `config-reference.md` types table + full section. Tests: runner + porter suites; `make check`: 1480 passed.

## Draft until parity is proven

This PR is the first half of a two-step deliverable: the same DSV4 c1010 configuration (5p1d, dep4/dep32, GB300) is being run under srt-slurm orchestration and compared against the script-harness reference numbers (server-reported output throughput, TTFT percentiles). Marking ready once the parity evidence is attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
