### PR TITLE
feat(observability): host sampler on every node + scheduler-contention metrics

### DIFF
--- a/docs/host-attribution-metrics.md
+++ b/docs/host-attribution-metrics.md
@@ -1,0 +1,58 @@
+# Host attribution metrics: pinning vs frontend placement
+
+srt-slurm's host sampler collects the telemetry needed to answer, **from a
+baseline run alone**, two questions that end-to-end serving metrics cannot:
+
+1. Are worker ranks losing CPU time to scheduler contention/migration?
+   (remedy: `backend.numa_cpu_bind: true`)
+2. Is the frontend/etcd interfering with the workers sharing its node?
+   (remedy: `frontend.dedicated_node` / `infra.etcd_nats_dedicated_node`)
+
+Both effects are real and independently worth ~1% output throughput each at
+high concurrency on GB300 disaggregated serving — but they are invisible in
+throughput/TTFT alone, which is why the collectors below exist.
+
+## Collection
+
+With `observability.enabled: true`, the `/proc` host sampler runs on the
+orchestrator node (in-process) **and on every other allocated node**
+(`observability.host_sampler_all_nodes`, default true: one persistent
+`srun --overlap` per node group running `host_sampler.py` standalone). Each
+node writes `host_samples_<node>.jsonl` into the run's log dir; the ingest
+merges them into `host_series.json` with a per-node `hosts` map. This closes
+the previous gaps: worker nodes had no per-process host telemetry, and a
+dedicated frontend node had none at all.
+
+## Metric set
+
+Per sampled process (workers, frontend, benchmark client — matched by cmdline):
+
+| Field (raw JSONL) | Ingest series | Diagnoses | Points at |
+|---|---|---|---|
+| `run_delay_ns` (`/proc/pid/schedstat`) | `run_delay_ms_per_s` | Task runnable but not running: scheduler contention on its cores | pinning |
+| `nr_migrations` (`/proc/pid/sched`) | `migrations_rate` | Cross-core churn; near-zero when pinned | pinning |
+| `affinity_ncpus` (`sched_getaffinity`) | `affinity_ncpus` | Direct pinning-state observable (144 = floating, 36 = pinned rank on GB200/GB300) | pinning (config state) |
+| `ctx_invol` (`/proc/pid/status`) | `ctx_invol_rate` | Involuntary descheduling (lock convoys, neighbor pressure) | pinning / placement |
+| `cpu_jiffies` | `cpu_pct` | Per-process CPU use — splits a shared node's load into frontend vs etcd vs ranks | placement |
+| host `procs_running/blocked` (`/proc/stat`) | `procs_runnable` | Whole-node run-queue pressure vs core count | either (localizes with the per-process rows) |
+| `t` + `t_mono` | — | Per-node clock-offset estimation; cross-node wall clocks have been observed seconds apart | metric hygiene |
+
+## Attribution logic (draft rubric, thresholds pending validation runs)
+
+Comparing the node hosting frontend+etcd against its clean peers **within one
+baseline run** (same model, same traffic mix, cache-aware normalization):
+
+- **Placement signal**: the co-located node's worker ranks show elevated
+  `run_delay_ms_per_s` / `ctx_invol_rate` correlated with `cpu_pct` bursts of
+  the frontend/etcd processes, and its GPUs run ~2–3 pp lower utilization than
+  peer nodes → move the frontend (`frontend.dedicated_node: true`).
+- **Pinning signal**: elevated `migrations_rate` and `run_delay_ms_per_s`
+  across **all** worker nodes (not just the shared one) with `affinity_ncpus`
+  at the full core count → pin the ranks (`backend.numa_cpu_bind: true`).
+- **Double dissociation** (how a metric earns its place): a pinning metric
+  must go green when `numa_cpu_bind` flips on and stay unchanged when only the
+  frontend moves; a placement metric the reverse.
+
+Cross-node timing comparisons must estimate per-node clock offsets first
+(pair `t` with `t_mono`, or use a constant frontend→worker dispatch offset);
+raw cross-node wall-clock deltas are unreliable at millisecond scale.

--- a/docs/host-attribution-metrics.md
+++ b/docs/host-attribution-metrics.md
@@ -37,22 +37,44 @@ Per sampled process (workers, frontend, benchmark client — matched by cmdline)
 | host `procs_running/blocked` (`/proc/stat`) | `procs_runnable` | Whole-node run-queue pressure vs core count | either (localizes with the per-process rows) |
 | `t` + `t_mono` | — | Per-node clock-offset estimation; cross-node wall clocks have been observed seconds apart | metric hygiene |
 
-## Attribution logic (draft rubric, thresholds pending validation runs)
+## Decision rubric (thresholds from the c1010 validation matrix, GB300/oci-aga)
 
-Comparing the node hosting frontend+etcd against its clean peers **within one
-baseline run** (same model, same traffic mix, cache-aware normalization):
+You are looking at `host_series.json` from ONE run. You do not need to know what
+"taskset" or "frontend placement" are — the rubric names the config change.
 
-- **Placement signal**: the co-located node's worker ranks show elevated
-  `run_delay_ms_per_s` / `ctx_invol_rate` correlated with `cpu_pct` bursts of
-  the frontend/etcd processes, and its GPUs run ~2–3 pp lower utilization than
-  peer nodes → move the frontend (`frontend.dedicated_node: true`).
-- **Pinning signal**: elevated `migrations_rate` and `run_delay_ms_per_s`
-  across **all** worker nodes (not just the shared one) with `affinity_ncpus`
-  at the full core count → pin the ranks (`backend.numa_cpu_bind: true`).
-- **Double dissociation** (how a metric earns its place): a pinning metric
-  must go green when `numa_cpu_bind` flips on and stay unchanged when only the
-  frontend moves; a placement metric the reverse.
+**Step 1 — is the bottleneck host-CPU-side at all?**
+Look at the per-node `procs` map for the busiest process per worker node
+(highest `cpu_pct`). If every worker node shows `run_delay_ms_per_s` p50
+< 0.1 and `migrations_rate` ≈ 0, host-CPU scheduling is NOT the problem —
+stop here. (Validated: clean nodes sit at 0.00–0.01 ms/s.)
+
+**Step 2 — check the pinning state directly.**
+`affinity_ncpus` of the worker ranks equals the node's full logical-CPU count
+(e.g. 144 or 288) → the ranks are NOT pinned. Remedy:
+`backend.numa_cpu_bind: true`. Validated effect at c1010: +4.0% output
+throughput on 288-CPU GB300 nodes (+1.1% on 144-CPU nodes in the reference
+campaign — the gain grows with core count). If `affinity_ncpus` equals
+(CPUs ÷ GPUs per node), the ranks are already pinned.
+
+**Step 3 — look for the single-node asymmetry.**
+Compare each worker rank's `run_delay_ms_per_s` p50 against the median of its
+peers on other nodes. Threshold: **>10× the peer median AND >0.5 ms/s absolute,
+on exactly the node(s) that also host a non-worker process with
+`affinity_ncpus` = full width and `cpu_pct` > 1000** (the frontend: measured
+~4,100–5,000% of one core at c1010). That is co-location interference.
+Remedy: `frontend.dedicated_node: true`. Validated effect: +0.5% throughput
+(+0.85% in the reference campaign) — and the asymmetry itself is huge even
+when the throughput cost is small: measured 140–350× on the shared node,
+collapsing to 1× in all three dedicated-frontend runs.
+Note the dissociation, confirmed both ways across 7 runs: this asymmetry is
+UNCHANGED by pinning (190× with ranks pinned), and `affinity_ncpus` is
+UNCHANGED by moving the frontend. Each signal names exactly one remedy.
+
+**Expected-gain estimate**: single-node asymmetry affecting 1 of N prefill
+groups → small-percent gain (≈ its share of prefill capacity); full-width
+affinity on all ranks → the pinning gain for your node's core count.
 
 Cross-node timing comparisons must estimate per-node clock offsets first
 (pair `t` with `t_mono`, or use a constant frontend→worker dispatch offset);
-raw cross-node wall-clock deltas are unreliable at millisecond scale.
+raw cross-node wall-clock deltas are unreliable at millisecond scale —
+observed inter-node skew up to 2.1 s.

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -1007,13 +1007,43 @@ def run_host_samples(run_dir: Path, bundle: Path) -> dict:
     single core, so >100 means the process is genuinely using more than one.
     """
     src = Path(run_dir) / "host_samples.jsonl"
-    if not src.exists():
-        _log("L2 host", "no host_samples.jsonl; host CPU / fd / client-bottleneck "
+    per_node = sorted(Path(run_dir).glob("host_samples_*.jsonl"))
+    if not src.exists() and not per_node:
+        _log("L2 host", "no host_samples*.jsonl; host CPU / fd / client-bottleneck "
                         "signals unavailable for this run")
         return {}
 
+    out: dict = {}
+    if src.exists():
+        out = _host_series_from_rows(_read_host_rows(src)) or {}
+
+    # Per-node samplers (observability.host_sampler_all_nodes) write one file per
+    # node; keyed by hostname so worker nodes and a dedicated frontend node are
+    # separable downstream. The orchestrator-node series stays at the top level
+    # for backward compatibility with existing consumers.
+    hosts: dict[str, dict] = {}
+    for path in per_node:
+        series = _host_series_from_rows(_read_host_rows(path))
+        if series:
+            hosts[series["host"] or path.stem.removeprefix("host_samples_")] = series
+    if hosts:
+        out.setdefault("hosts", {}).update(hosts)
+    if not out:
+        _log("L2 host", "host sample files present but none had >= 2 rows")
+        return {}
+
+    with open(bundle / "host_series.json", "w") as f:
+        json.dump(out, f)
+    peak_cpu = max((v for _, v in out.get("host_cpu_pct", [])), default=None)
+    _log("L2 host", f"{out.get('samples', 0)} samples on {out.get('host')} (+{len(hosts)} remote node(s)): "
+                    f"peak host CPU {peak_cpu}%, "
+                    f"{len(out.get('procs', {}))} process(es) tracked")
+    return out
+
+
+def _read_host_rows(path: Path) -> list[dict]:
     rows = []
-    with open(src, errors="replace") as fh:
+    with open(path, errors="replace") as fh:
         for line in fh:
             line = line.strip()
             if not line:
@@ -1022,14 +1052,24 @@ def run_host_samples(run_dir: Path, bundle: Path) -> dict:
                 rows.append(json.loads(line))
             except Exception:
                 continue
-    if len(rows) < 2:
-        _log("L2 host", f"only {len(rows)} host sample(s); a rate needs two")
-        return {}
+    return rows
 
-    host_cpu, fds, conns, mem = [], [], [], []
+
+def _host_series_from_rows(rows: list[dict]) -> dict | None:
+    """Difference cumulative counters into rate series for one node's samples."""
+    if len(rows) < 2:
+        return None
+
+    host_cpu, fds, conns, mem, runq, blocked_series = [], [], [], [], [], []
     procs: dict = {}
     for prev, cur in zip(rows, rows[1:]):
-        dt = (cur.get("t") or 0) - (prev.get("t") or 0)
+        # Rate denominators prefer the monotonic clock: NTP steps can make
+        # wall-clock dt negative (pair dropped) or inflated (rates deflated).
+        # Wall-clock t stays as the series x-axis for cross-source alignment.
+        if cur.get("t_mono") is not None and prev.get("t_mono") is not None:
+            dt = cur["t_mono"] - prev["t_mono"]
+        else:
+            dt = (cur.get("t") or 0) - (prev.get("t") or 0)
         if dt <= 0:
             continue
         t = cur["t"]
@@ -1042,19 +1082,35 @@ def run_host_samples(run_dir: Path, bundle: Path) -> dict:
             mem.append([t, round(100.0 * (1 - m["MemAvailable"] / m["MemTotal"]), 2)])
         if cur.get("established_conns") is not None:
             conns.append([t, cur["established_conns"]])
+        if cur.get("procs_running") is not None:
+            runq.append([t, cur["procs_running"]])
+        if cur.get("procs_blocked") is not None:
+            blocked_series.append([t, cur["procs_blocked"]])
 
         prev_by_pid = {p["pid"]: p for p in (prev.get("procs") or [])}
         for p in cur.get("procs") or []:
             q = prev_by_pid.get(p["pid"])
             key = f"{p.get('name', 'proc')}:{p['pid']}"
             e = procs.setdefault(key, {"cpu_pct": [], "rss_kb": [], "ctx_invol_rate": [],
-                                       "open_fds": [], "threads": []})
+                                       "open_fds": [], "threads": [],
+                                       "run_delay_ms_per_s": [], "migrations_rate": [],
+                                       "affinity_ncpus": []})
             if q and p.get("cpu_jiffies") is not None and q.get("cpu_jiffies") is not None:
                 # Jiffies are 1/100 s on Linux; /dt gives percent of ONE core.
                 e["cpu_pct"].append([t, round((p["cpu_jiffies"] - q["cpu_jiffies"]) / dt, 1)])
             if q and p.get("ctx_invol") is not None and q.get("ctx_invol") is not None:
                 e["ctx_invol_rate"].append(
                     [t, round((p["ctx_invol"] - q["ctx_invol"]) / dt, 1)])
+            if q and p.get("run_delay_ns") is not None and q.get("run_delay_ns") is not None:
+                # ms of run-queue wait accumulated per wall second: the direct
+                # scheduler-contention rate that CPU pinning is the remedy for.
+                e["run_delay_ms_per_s"].append(
+                    [t, round((p["run_delay_ns"] - q["run_delay_ns"]) / 1e6 / dt, 2)])
+            if q and p.get("nr_migrations") is not None and q.get("nr_migrations") is not None:
+                e["migrations_rate"].append(
+                    [t, round((p["nr_migrations"] - q["nr_migrations"]) / dt, 1)])
+            if p.get("affinity_ncpus") is not None:
+                e["affinity_ncpus"].append([t, p["affinity_ncpus"]])
             if p.get("rss_kb") is not None:
                 e["rss_kb"].append([t, p["rss_kb"]])
             if p.get("open_fds") is not None:
@@ -1067,10 +1123,12 @@ def run_host_samples(run_dir: Path, bundle: Path) -> dict:
 
     fd_limit = rows[-1].get("fd_limit")
     peak_fds = max((v for _, v in fds), default=0)
-    out = {
+    return {
         "host_cpu_pct": host_cpu,
         "host_mem_used_pct": mem,
         "established_conns": conns,
+        "procs_runnable": runq,
+        "procs_blocked": blocked_series,
         "open_fds_total": fds,
         "fd_limit": fd_limit,
         # The number that matters for PERF-40: how close the run came to the ceiling.
@@ -1082,14 +1140,6 @@ def run_host_samples(run_dir: Path, bundle: Path) -> dict:
         "samples": len(rows),
         "host": rows[-1].get("host"),
     }
-    with open(bundle / "host_series.json", "w") as f:
-        json.dump(out, f)
-    peak_cpu = max((v for _, v in host_cpu), default=None)
-    _log("L2 host", f"{len(rows)} samples on {out['host']}: peak host CPU {peak_cpu}%, "
-                    f"peak open fds {peak_fds}/{fd_limit} "
-                    f"({out['fd_headroom_pct']}% of limit), "
-                    f"{len(procs)} process(es) tracked")
-    return out
 
 
 def run_provenance(run_dir: Path, bundle: Path) -> list[str]:

--- a/src/srtctl/analysis/host_sampler.py
+++ b/src/srtctl/analysis/host_sampler.py
@@ -34,11 +34,14 @@ import contextlib
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+_NR_MIGRATIONS_RE = re.compile(r"se\.nr_migrations\s*:\s*(\d+)")
 
 # Process names worth sampling individually. Matched as substrings against the
 # process's own cmdline, so a wrapper script does not hide the real one.
@@ -71,6 +74,25 @@ def _cpu_totals() -> tuple[int, int] | None:
             idle = f[3] + (f[4] if len(f) > 4 else 0)  # idle + iowait
             return sum(f) - idle, sum(f)
     return None
+
+
+def _procs_running_blocked() -> tuple[int | None, int | None]:
+    """(procs_running, procs_blocked) from ``/proc/stat``.
+
+    Instantaneous run-queue pressure for the whole host: sustained
+    procs_running above the core count is contention no per-process
+    counter can localize.
+    """
+    txt = _read("/proc/stat") or ""
+    running = blocked = None
+    for line in txt.splitlines():
+        if line.startswith("procs_running"):
+            with contextlib.suppress(IndexError, ValueError):
+                running = int(line.split()[1])
+        elif line.startswith("procs_blocked"):
+            with contextlib.suppress(IndexError, ValueError):
+                blocked = int(line.split()[1])
+    return running, blocked
 
 
 def _meminfo() -> dict:
@@ -107,8 +129,11 @@ def _interesting_pids(limit: int = 32) -> list[int]:
         entries = os.listdir("/proc")
     except OSError:
         return []
+    own_pid = os.getpid()
     for e in entries:
-        if not e.isdigit():
+        if not e.isdigit() or int(e) == own_pid:
+            # Never sample self: the standalone sampler's own cmdline carries the
+            # log-dir path, which routinely contains a pattern word ("dynamo").
             continue
         cmd = _read(f"/proc/{e}/cmdline")
         if not cmd or not any(p in cmd for p in _PROC_PATTERNS):
@@ -143,6 +168,28 @@ def _proc_sample(pid: int) -> dict | None:
         # utime+stime, fields 14/15 after the (possibly space-containing) comm field.
         tail = stat[stat.rfind(")") + 2 :].split()
         d["cpu_jiffies"] = int(tail[11]) + int(tail[12])
+    schedstat = _read(f"/proc/{pid}/schedstat")
+    if schedstat:
+        with contextlib.suppress(IndexError, ValueError):
+            parts = schedstat.split()
+            # Field 2 is cumulative RUN-QUEUE WAIT: time the task was runnable but
+            # not running. THE scheduler-contention signal — a rising rate here with
+            # idle CPUs elsewhere means this task is losing its core to neighbors,
+            # which is exactly what CPU pinning remedies.
+            d["cpu_ns"] = int(parts[0])
+            d["run_delay_ns"] = int(parts[1])
+    sched = _read(f"/proc/{pid}/sched")
+    if sched:
+        m = _NR_MIGRATIONS_RE.search(sched)
+        if m:
+            # Cross-core migrations: near-zero when pinned, so this doubles as a
+            # direct observable of whether pinning is in effect AND of scheduler
+            # churn when it is not.
+            d["nr_migrations"] = int(m.group(1))
+    with contextlib.suppress(OSError):
+        # Allowed-CPU count: 144 = free-floating on GB200/GB300, 36 = taskset-pinned
+        # rank. Reads the pinning CONFIG state directly, no inference needed.
+        d["affinity_ncpus"] = len(os.sched_getaffinity(pid))
     try:
         d["open_fds"] = len(os.listdir(f"/proc/{pid}/fd"))
     except OSError:
@@ -216,11 +263,18 @@ class HostSampler:
                 while not stop_event.is_set() and not self._own_stop.is_set():
                     try:
                         cpu = _cpu_totals()
+                        running, blocked = _procs_running_blocked()
                         row = {
                             "t": time.time(),
+                            # Monotonic companion: cross-node wall clocks can disagree by
+                            # seconds (observed 2.1s NVL72 skew); pairs of (t, t_mono) let
+                            # the consumer estimate per-node offsets post-hoc.
+                            "t_mono": time.monotonic(),
                             "host": os.uname().nodename,
                             "cpu_busy_jiffies": cpu[0] if cpu else None,
                             "cpu_total_jiffies": cpu[1] if cpu else None,
+                            "procs_running": running,
+                            "procs_blocked": blocked,
                             "loadavg": (_read("/proc/loadavg") or "").split()[:3],
                             "mem": _meminfo(),
                             "fd_limit": fd_limit,
@@ -256,3 +310,69 @@ def try_start_host_sampler(log_dir: Path, observability, stop_event: threading.E
     except Exception as exc:  # noqa: BLE001 - best effort
         logger.warning("Host sampler failed to start (continuing without it): %s", exc)
         return None
+
+
+def plan_remote_sampler_nodes(all_nodes: list[str], local_host: str) -> list[str]:
+    """Nodes that need a standalone sampler: every allocated node except the one
+    already covered by the in-process sampler. Pure so it is unit-testable.
+
+    ``local_host`` may be a short hostname while the nodelist carries FQDNs (or
+    vice versa); match on the first dot-separated label to be safe.
+    """
+    local_label = local_host.split(".")[0]
+    seen: set[str] = set()
+    out: list[str] = []
+    for node in all_nodes:
+        if not node or node in seen:
+            continue
+        seen.add(node)
+        if node.split(".")[0] != local_label:
+            out.append(node)
+    return out
+
+
+def _main() -> int:
+    """Standalone per-node entry point (``python3 host_sampler.py --log-dir D``).
+
+    Runs on bare compute nodes with nothing but a system python3: this module
+    deliberately imports only the standard library. Writes
+    ``host_samples_<hostname>.jsonl`` so per-node files never collide on the
+    shared log dir, and exits cleanly on SIGTERM/SIGINT (srun teardown).
+    """
+    import argparse
+    import signal
+
+    ap = argparse.ArgumentParser(description="Standalone /proc sampler for one node")
+    ap.add_argument("--log-dir", required=True)
+    ap.add_argument("--interval", type=float, default=2.0, help="seconds between samples (floored to 1.0)")
+    ap.add_argument("--max-samples", type=int, default=0, help="stop after N samples (0 = until signaled)")
+    args = ap.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="[host_sampler %(levelname)s] %(message)s")
+    stop = threading.Event()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(sig, lambda *_: stop.set())
+
+    sampler = HostSampler(
+        Path(args.log_dir),
+        interval_seconds=args.interval,
+        output_name=f"host_samples_{os.uname().nodename}.jsonl",
+    )
+    sampler.start(stop)
+    while not stop.is_set():
+        if args.max_samples and sampler.samples >= args.max_samples:
+            stop.set()
+            break
+        if sampler._thread is not None and not sampler._thread.is_alive():
+            # Sampler thread died (e.g. unwritable log dir): exit nonzero so the
+            # failure is visible in the srun step output instead of idling forever.
+            logger.error("sampler thread exited after %d samples; aborting", sampler.samples)
+            sampler.stop()
+            return 1
+        stop.wait(0.5)
+    sampler.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -8,7 +8,9 @@ Handles benchmark execution and profiling.
 """
 
 import logging
+import os
 import shlex
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -375,28 +377,34 @@ class BenchmarkStageMixin:
         # truthy, and plain truthiness would silently switch it on there.
         observability = getattr(self.config, "observability", None)
         host_sampler = None
+        remote_samplers: list[subprocess.Popen] = []
         if getattr(observability, "enabled", False) is True:
             from srtctl.analysis.host_sampler import try_start_host_sampler
 
             host_sampler = try_start_host_sampler(self.runtime.log_dir, observability, stop_event)
-
-        bench_node = self._benchmark_node()
-        proc = start_srun_process(
-            command=cmd,
-            nodelist=[bench_node],
-            output=str(log_file),
-            container_image=str(container_image),
-            container_mounts=container_mounts,
-            env_to_set=env_to_set,
-            srun_options=self.runtime.srun_options,
-            het_group=self.runtime.nodes.het_group_for(bench_node),
-        )
+            if getattr(observability, "host_sampler_all_nodes", False) is True:
+                remote_samplers = self._start_remote_host_samplers()
 
         # The signal handler raises SystemExit, so only finally can establish
         # how the local srun client stopped before telemetry finalizes.
+        # proc is created INSIDE the try: _benchmark_node()/start_srun_process can
+        # raise (bad client_placement, fork failure), and the finally must still
+        # tear down the remote samplers launched above.
         self.benchmark_child_reaped = False
         self.benchmark_child_allows_window_mutation = False
+        proc: subprocess.Popen | None = None
         try:
+            bench_node = self._benchmark_node()
+            proc = start_srun_process(
+                command=cmd,
+                nodelist=[bench_node],
+                output=str(log_file),
+                container_image=str(container_image),
+                container_mounts=container_mounts,
+                env_to_set=env_to_set,
+                srun_options=self.runtime.srun_options,
+                het_group=self.runtime.nodes.het_group_for(bench_node),
+            )
             while proc.poll() is None:
                 if stop_event.is_set():
                     logger.info("Stop requested, terminating benchmark")
@@ -406,7 +414,7 @@ class BenchmarkStageMixin:
             self.benchmark_child_allows_window_mutation = True
             return proc.returncode or 0
         finally:
-            if proc.poll() is None:
+            if proc is not None and proc.poll() is None:
                 outcome = terminate_and_reap(
                     proc,
                     terminate_timeout=_BENCHMARK_TERMINATE_TIMEOUT,
@@ -416,7 +424,7 @@ class BenchmarkStageMixin:
                 # Reaping a force-killed local srun client does not prove that
                 # its remote Slurm step can no longer write the window.
                 self.benchmark_child_allows_window_mutation = outcome.reaped and not outcome.force_killed
-            elif self.benchmark_child_reaped is False:
+            elif proc is not None and self.benchmark_child_reaped is False:
                 proc.wait()
                 self.benchmark_child_reaped = True
                 self.benchmark_child_allows_window_mutation = True
@@ -424,6 +432,70 @@ class BenchmarkStageMixin:
                 snapshotter.stop()
             if host_sampler is not None:
                 host_sampler.stop()
+            for sampler_proc in remote_samplers:
+                if sampler_proc.poll() is not None:
+                    if sampler_proc.returncode != 0:
+                        # e.g. a bare node without python3: contained, but say so
+                        # instead of letting the gap surface as missing files later.
+                        logger.warning(
+                            "A remote host sampler exited early (rc=%s); see host_sampler_remote*.out",
+                            sampler_proc.returncode,
+                        )
+                    continue
+                # SIGTERM lets the remote sampler flush its final JSONL row;
+                # terminate_and_reap escalates to SIGKILL and logs if it wedges,
+                # so a hung srun can't keep appending rows past the window.
+                terminate_and_reap(sampler_proc, terminate_timeout=10, kill_timeout=5)
+
+    def _start_remote_host_samplers(self) -> list[subprocess.Popen]:
+        """Launch the standalone /proc sampler on every allocated node except this one.
+
+        One persistent srun per het group (not per sample), no container: the
+        sampler is stdlib-only and reads the HOST /proc either way, and the
+        srtctl checkout lives on a shared filesystem the compute nodes see.
+        Best-effort like all host telemetry — a node without python3 logs a
+        failure into host_sampler_remote.out and the benchmark proceeds.
+        """
+        from srtctl.analysis import host_sampler as host_sampler_module
+        from srtctl.analysis.host_sampler import plan_remote_sampler_nodes
+
+        nodes = self.runtime.nodes
+        all_nodes = list(dict.fromkeys([nodes.head, nodes.bench, nodes.infra, *nodes.worker]))
+        targets = plan_remote_sampler_nodes(all_nodes, os.uname().nodename)
+        if not targets:
+            return []
+
+        script = Path(host_sampler_module.__file__).resolve()
+        groups: dict[int | None, list[str]] = {}
+        for node in targets:
+            groups.setdefault(nodes.het_group_for(node), []).append(node)
+
+        procs: list[subprocess.Popen] = []
+        launched_nodes = 0
+        for het_group, group_nodes in sorted(groups.items(), key=lambda kv: (kv[0] is not None, kv[0])):
+            suffix = "" if het_group is None else f".g{het_group}"
+            try:
+                proc = start_srun_process(
+                    command=["python3", str(script), "--log-dir", str(self.runtime.log_dir), "--interval", "2"],
+                    nodes=len(group_nodes),
+                    ntasks=len(group_nodes),
+                    nodelist=group_nodes,
+                    output=str(self.runtime.log_dir / f"host_sampler_remote{suffix}.out"),
+                    srun_options=self.runtime.srun_options,
+                    het_group=het_group,
+                    use_bash_wrapper=False,
+                )
+            except Exception as exc:  # noqa: BLE001 - best effort, never blocks the benchmark
+                logger.warning("Remote host samplers failed to start on %s: %s", group_nodes, exc)
+                continue
+            procs.append(proc)
+            launched_nodes += len(group_nodes)
+        if procs:
+            logger.info(
+                "Remote host samplers started on %d node(s) -> host_samples_<node>.jsonl",
+                launched_nodes,
+            )
+        return procs
 
     def _get_benchmark_profiling_env(
         self,

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1126,6 +1126,11 @@ class ObservabilityConfig:
     enabled: bool = False
     enable_otel: bool = False
     otel_endpoint: str | None = None
+    # Run the /proc host sampler on EVERY allocated node (one persistent srun per
+    # node group, files host_samples_<node>.jsonl), not just the orchestrator
+    # node. Closes the gap where worker nodes — and a dedicated frontend node —
+    # had no per-process host-CPU/scheduler telemetry at all. Follows ``enabled``.
+    host_sampler_all_nodes: bool = True
 
     tachometer: TachometerConfig = field(default_factory=TachometerConfig)
 

--- a/tests/test_host_sampler_all_nodes.py
+++ b/tests/test_host_sampler_all_nodes.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the all-node host sampler: scheduler-contention fields, the
+standalone per-node CLI mode, remote-launch planning, and the multi-file ingest."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from srtctl.analysis import host_sampler
+from srtctl.analysis.host_sampler import _proc_sample, plan_remote_sampler_nodes
+
+
+class TestProcSampleSchedulerFields:
+    def test_own_process_has_scheduler_fields(self):
+        d = _proc_sample(os.getpid())
+        assert d is not None
+        # /proc/<pid>/schedstat: cumulative on-CPU ns and run-queue-wait ns.
+        assert isinstance(d.get("cpu_ns"), int)
+        assert isinstance(d.get("run_delay_ns"), int)
+        # se.nr_migrations from /proc/<pid>/sched.
+        assert isinstance(d.get("nr_migrations"), int)
+        # sched_getaffinity width: the direct pinning-state observable.
+        assert isinstance(d.get("affinity_ncpus"), int) and d["affinity_ncpus"] >= 1
+
+    def test_procs_running_blocked(self):
+        running, blocked = host_sampler._procs_running_blocked()
+        assert isinstance(running, int) and running >= 1
+        assert isinstance(blocked, int) and blocked >= 0
+
+
+class TestPlanRemoteSamplerNodes:
+    def test_excludes_local_and_dedups(self):
+        assert plan_remote_sampler_nodes(["n1", "n2", "n1", "n3"], "n2") == ["n1", "n3"]
+
+    def test_fqdn_vs_short_hostname(self):
+        assert plan_remote_sampler_nodes(["n1.cluster.local", "n2"], "n1") == ["n2"]
+        assert plan_remote_sampler_nodes(["n1", "n2"], "n1.cluster.local") == ["n2"]
+
+    def test_all_local(self):
+        assert plan_remote_sampler_nodes(["n1", "n1"], "n1") == []
+
+
+class TestStandaloneMode:
+    def test_writes_per_node_file_and_exits(self, tmp_path):
+        """python3 host_sampler.py --log-dir D --max-samples 2 writes host_samples_<host>.jsonl."""
+        script = Path(host_sampler.__file__).resolve()
+        r = subprocess.run(
+            [sys.executable, str(script), "--log-dir", str(tmp_path), "--interval", "1", "--max-samples", "2"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert r.returncode == 0, r.stderr
+        out = tmp_path / f"host_samples_{os.uname().nodename}.jsonl"
+        assert out.exists()
+        rows = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+        assert len(rows) >= 2
+        assert rows[0]["host"] == os.uname().nodename
+        assert "t_mono" in rows[0] and "procs_running" in rows[0]
+
+
+class TestRemoteLaunch:
+    def _mixin(self, worker_nodes):
+        from srtctl.cli.mixins.benchmark_stage import BenchmarkStageMixin
+
+        m = BenchmarkStageMixin.__new__(BenchmarkStageMixin)
+        runtime = MagicMock()
+        runtime.nodes.head = worker_nodes[0]
+        runtime.nodes.bench = worker_nodes[0]
+        runtime.nodes.infra = worker_nodes[0]
+        runtime.nodes.worker = tuple(worker_nodes)
+        runtime.nodes.het_group_for.return_value = None
+        runtime.log_dir = Path("/tmp/logs")
+        runtime.srun_options = {}
+        m.runtime = runtime
+        return m
+
+    def test_launches_on_all_nodes_except_local(self):
+        local = os.uname().nodename
+        mixin = self._mixin([local, "nodeB", "nodeC"])
+        with patch("srtctl.cli.mixins.benchmark_stage.start_srun_process") as srun:
+            srun.return_value = MagicMock()
+            procs = mixin._start_remote_host_samplers()
+        assert len(procs) == 1
+        kwargs = srun.call_args.kwargs
+        assert kwargs["nodelist"] == ["nodeB", "nodeC"]
+        assert kwargs["nodes"] == 2 and kwargs["ntasks"] == 2
+        assert kwargs["command"][0] == "python3"
+        assert kwargs["command"][1].endswith("host_sampler.py")
+        assert "--log-dir" in kwargs["command"]
+
+    def test_no_launch_when_only_local(self):
+        mixin = self._mixin([os.uname().nodename])
+        with patch("srtctl.cli.mixins.benchmark_stage.start_srun_process") as srun:
+            procs = mixin._start_remote_host_samplers()
+        assert procs == [] and srun.call_count == 0
+
+
+def _rows():
+    def proc(pid, cpu_j, invol, delay_ns, migr, aff):
+        return {"pid": pid, "name": "dynamo", "cpu_jiffies": cpu_j, "ctx_invol": invol,
+                "run_delay_ns": delay_ns, "nr_migrations": migr, "affinity_ncpus": aff,
+                "rss_kb": 100, "threads": 4, "open_fds": 10}
+
+    return [
+        {"t": 100.0, "host": "nodeB", "cpu_busy_jiffies": 1000, "cpu_total_jiffies": 10000,
+         "procs_running": 5, "procs_blocked": 0, "mem": {"MemTotal": 100, "MemAvailable": 50},
+         "established_conns": 3, "fd_limit": 1024, "procs": [proc(7, 100, 10, 1_000_000_000, 50, 144)]},
+        {"t": 102.0, "host": "nodeB", "cpu_busy_jiffies": 1100, "cpu_total_jiffies": 10200,
+         "procs_running": 8, "procs_blocked": 1, "mem": {"MemTotal": 100, "MemAvailable": 40},
+         "established_conns": 4, "fd_limit": 1024, "procs": [proc(7, 140, 30, 1_200_000_000, 60, 144)]},
+    ]
+
+
+class TestIngestSchedulerSeries:
+    def test_rates_from_rows(self):
+        from src.ingest.ingest import _host_series_from_rows
+
+        s = _host_series_from_rows(_rows())
+        assert s is not None and s["host"] == "nodeB"
+        p = s["procs"]["dynamo:7"]
+        # 200ms of run-queue delta over 2s -> 100 ms/s
+        assert p["run_delay_ms_per_s"] == [[102.0, 100.0]]
+        # 10 migrations over 2s -> 5/s
+        assert p["migrations_rate"] == [[102.0, 5.0]]
+        assert p["affinity_ncpus"] == [[102.0, 144]]
+        assert s["procs_runnable"] == [[102.0, 8]]
+        assert s["procs_blocked"] == [[102.0, 1]]
+
+    def test_rates_prefer_monotonic_clock(self):
+        """A forward NTP step in wall-clock t must not deflate the rates."""
+        from src.ingest.ingest import _host_series_from_rows
+
+        rows = _rows()
+        rows[0]["t_mono"], rows[1]["t_mono"] = 500.0, 502.0
+        rows[1]["t"] = 112.0  # wall clock stepped +10s mid-window
+        s = _host_series_from_rows(rows)
+        # dt = 2s from t_mono, not 12s from t: 200ms delta -> 100 ms/s
+        assert s["procs"]["dynamo:7"]["run_delay_ms_per_s"] == [[112.0, 100.0]]
+
+    def test_multi_file_hosts_map(self, tmp_path):
+        from src.ingest.ingest import run_host_samples
+
+        run_dir, bundle = tmp_path / "run", tmp_path / "bundle"
+        run_dir.mkdir()
+        bundle.mkdir()
+        local = _rows()
+        for r in local:
+            r["host"] = "orchestrator"
+        (run_dir / "host_samples.jsonl").write_text("\n".join(json.dumps(r) for r in local))
+        (run_dir / "host_samples_nodeB.jsonl").write_text("\n".join(json.dumps(r) for r in _rows()))
+        out = run_host_samples(run_dir, bundle)
+        assert out["host"] == "orchestrator"
+        assert "nodeB" in out["hosts"]
+        assert out["hosts"]["nodeB"]["procs"]["dynamo:7"]["run_delay_ms_per_s"] == [[102.0, 100.0]]
+        assert json.loads((bundle / "host_series.json").read_text())["hosts"]["nodeB"]["host"] == "nodeB"
+
+    def test_per_node_files_only(self, tmp_path):
+        """Remote-node files alone (no orchestrator file) still produce a bundle."""
+        from src.ingest.ingest import run_host_samples
+
+        run_dir, bundle = tmp_path / "run", tmp_path / "bundle"
+        run_dir.mkdir()
+        bundle.mkdir()
+        (run_dir / "host_samples_nodeB.jsonl").write_text("\n".join(json.dumps(r) for r in _rows()))
+        out = run_host_samples(run_dir, bundle)
+        assert out["hosts"]["nodeB"]["samples"] == 2


### PR DESCRIPTION
## What

Extends the `/proc` host sampler from orchestrator-node-only to **every allocated node**, and adds the scheduler-level metrics needed to attribute host-CPU interference to a remedy from a single baseline run — the collection half of the pinning-vs-frontend-placement attribution methodology documented in the new `docs/host-attribution-metrics.md`.

## Why

Two independent host-CPU effects are each worth ~1% output throughput at high concurrency on GB300 disaggregated serving (measured on the DSV4 c1010 A/B campaign): worker-rank CPU pinning, and moving frontend+etcd off the prefill node. Neither is visible in throughput/TTFT, and until now srt-slurm had **zero** host-CPU telemetry on worker nodes (and none at all on a dedicated frontend node). Retro-analysis of the c1010 runs showed the frontend-sharing node's ranks run measurably slower (cache-matched +1.3–2.0% median prefill time) and its GPUs 2–3 pp less utilized — signals these collectors now capture live.

## New metrics (per sampled process)

| Field | Diagnoses | Remedy it points at |
|---|---|---|
| `run_delay_ns` (schedstat) | runnable-but-not-running time — scheduler contention | `backend.numa_cpu_bind` |
| `nr_migrations` (/proc/pid/sched) | cross-core churn; ~0 when pinned | `backend.numa_cpu_bind` |
| `affinity_ncpus` (sched_getaffinity) | direct pinning-state observable (144 floating / 36 pinned) | config state |
| `ctx_invol` (existing) + per-proc `cpu_pct` on the shared node | frontend/etcd stealing CPU from co-located ranks | `frontend.dedicated_node` |
| host `procs_running/blocked`, `t_mono` | node run-queue pressure; clock-offset hygiene | — |

## How

- `host_sampler.py`: new fields; stdlib-only standalone CLI mode writing `host_samples_<node>.jsonl` (SIGTERM-clean, exits nonzero if its sampler thread dies, never samples itself)
- `benchmark_stage`: launches the standalone sampler on all non-orchestrator nodes, one `srun --overlap` per het group, no container; best-effort contract (a node without python3 logs and is skipped). Gated by new `observability.host_sampler_all_nodes` (default true, follows `observability.enabled`)
- ingest: `host_series.json` gains a per-node `hosts` map + the new rate series; rate denominators prefer the monotonic clock (NTP-step-proof)
- teardown hardening from a 12-agent adversarial review (8 confirmed findings, all fixed): benchmark proc creation moved inside the try so sampler sruns can't leak on placement/launch errors; `terminate_and_reap` escalation; early-exit logging

`make check`: 1492 passed. 12 new tests (scheduler fields, standalone mode e2e, launch planning, remote-launch mocking, ingest rates incl. NTP-step case, multi-file merge).

## Status: first production evidence in

Round 1 of the validation matrix (baseline vs pinned at c1010) completed with these collectors enabled: **all-node capture worked (13 files/run), and the baseline-only placement fingerprint is real — the frontend-sharing node's worker rank shows a ~100× run-queue-delay asymmetry vs clean peers, while `affinity_ncpus` directly dissociates pinned (72) from unpinned (144) ranks.** Full perf-diff and attribution tables: see the round-1 evidence comment below. Dedicated-frontend variants (C/D incl. the etcd-deconfounded cell) + repeats 2–3 are running to complete the double dissociation and set the rubric thresholds in `docs/host-attribution-metrics.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
