### PR TITLE
feat(observability): tachometer on by default for every run

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1112,7 +1112,7 @@ infra:
 
 ## observability
 
-`observability.enabled` turns on the server metrics and trace surfaces and collects them with the native Tachometer scraper for the whole run:
+Tachometer collection is **on by default for every run** (no configuration needed; `observability.tachometer.enabled: false` opts out). `observability.enabled` turns on the server metrics *content* (the TRT-LLM publish flag and engine statistics) and the trace surfaces:
 
 ```yaml
 observability:
@@ -1155,7 +1155,7 @@ observability:
 
 | Tachometer field | Type | Default | Description |
 | ---------------- | ---- | ------- | ----------- |
-| `enabled` | bool/null | `null` | `null` follows `observability.enabled`; explicit `false` opts out; explicit `true` without `observability.enabled` is a validation error |
+| `enabled` | bool/null | `null` | `null` means ON for every run (decoupled from `observability.enabled`); explicit `false` opts out |
 | `binary_path` | string | `tachometer-scraper` | Scraper command or path on the compute nodes |
 | `default_frequency` | float | `1.0` | Scrape frequency in Hz |
 | `sync_interval_secs` | int | `120` | Interval for intermediate Parquet compaction; `0` disables it |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1132,7 +1132,7 @@ The legacy in-job Python RAW scraper is retired: a recipe still carrying `scrape
 
 The component perf dashboard is **not** configured here. It is built in post-processing on every run; `enabled` decides which capture legs exist and therefore which tabs the page carries. See [Component Performance Dashboard](component-dashboard.md).
 
-Tachometer collects every worker rank and frontend metrics by default (minus the client-polled complement described above). DCGM and node exporters are optional additions:
+Tachometer collects every worker rank, frontend, DCGM, and node metrics by default (minus the client-polled complement described above) — the exporters launch from pinned multi-arch registry images with no configuration. Air-gapped clusters override the images via the `containers:` alias map in `srtslurm.yaml`; `default_exporters: false` disables the built-ins:
 
 ```yaml
 observability:
@@ -1162,8 +1162,9 @@ observability:
 | `compaction_threads` | int | `4` | Value passed as `POLARS_MAX_THREADS` |
 | `storage_subdir` | string | `tachometer` | Output directory below the run log directory |
 | `extra_metadata` | dict | `{}` | Static string metadata added to every endpoint |
-| `dcgm_exporter` | object/null | `null` | Optional DCGM exporter image, port, and command |
-| `node_exporter` | object/null | `null` | Optional node exporter image, port, and command |
+| `default_exporters` | bool | `true` | Launch the built-in DCGM + node exporters when no explicit blocks are set (sweep path only) |
+| `dcgm_exporter` | object/null | built-in | Defaults to `nvcr.io#nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04` on port 9401; an explicit block overrides |
+| `node_exporter` | object/null | built-in | Defaults to `quay.io#prometheus/node-exporter:v1.8.2` on port 9101; an explicit block overrides |
 
 `make setup ARCH=<compute_arch>` downloads and checksum-verifies the matching Tachometer binary from the latest srt-slurm release. The scraper runs as a native `srun` process on the head node; configured exporters remain containerized on worker nodes. Run `make tachometer-scraper` to build from source instead.
 

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -307,7 +307,7 @@ class TelemetryStageMixin:
             )
 
         power_telemetry = self.config.telemetry
-        dcgm_exporter = power_telemetry.dcgm_exporter if power_telemetry.enabled else tachometer.dcgm_exporter
+        dcgm_exporter = power_telemetry.dcgm_exporter if power_telemetry.enabled else tachometer.resolved_dcgm_exporter
         topology = self._compute_frontend_topology()
         config_path = self.runtime.log_dir / "tachometer_config.toml"
         config_path.write_text(
@@ -336,10 +336,10 @@ class TelemetryStageMixin:
         # must never tear down the benchmark. Verified the hard way: a
         # bash-wrapped node-exporter (FROM scratch) died with execve() ENOENT
         # and, as a critical process, killed a 7-node run at startup.
-        if not power_telemetry.enabled and tachometer.dcgm_exporter is not None:
+        if not power_telemetry.enabled and tachometer.resolved_dcgm_exporter is not None:
             processes.extend(
                 self._start_exporter_container(
-                    exporter_config=tachometer.dcgm_exporter,
+                    exporter_config=tachometer.resolved_dcgm_exporter,
                     name="tachometer_dcgm_exporter",
                     nodelist=worker_nodes,
                     log_file=self.runtime.log_dir / "tachometer_dcgm_exporter.out",
@@ -348,10 +348,10 @@ class TelemetryStageMixin:
                     critical=False,
                 )
             )
-        if tachometer.node_exporter is not None:
+        if tachometer.resolved_node_exporter is not None:
             processes.extend(
                 self._start_exporter_container(
-                    exporter_config=tachometer.node_exporter,
+                    exporter_config=tachometer.resolved_node_exporter,
                     name="tachometer_node_exporter",
                     nodelist=worker_nodes,
                     log_file=self.runtime.log_dir / "tachometer_node_exporter.out",

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -390,6 +390,14 @@ def show_config_details(config: SrtConfig) -> None:
             details.add_row("observability", "storage_subdir", tachometer.storage_subdir)
             details.add_row("observability", "frequency", str(tachometer.default_frequency))
             details.add_row("observability", "binary_path", tachometer.binary_path)
+            if config.telemetry.enabled:
+                details.add_row("observability", "dcgm_exporter", "shared with power telemetry")
+            elif tachometer.resolved_dcgm_exporter is not None:
+                dcgm = tachometer.resolved_dcgm_exporter
+                details.add_row("observability", "dcgm_exporter", f"{dcgm.container_image} :{dcgm.port}")
+            if tachometer.resolved_node_exporter is not None:
+                node = tachometer.resolved_node_exporter
+                details.add_row("observability", "node_exporter", f"{node.container_image} :{node.port}")
 
         if config.telemetry.enabled:
             exporter = config.telemetry.dcgm_exporter

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1033,6 +1033,25 @@ class TelemetryExporterConfig:
     Schema: ClassVar[type[Schema]] = Schema
 
 
+# Built-in exporter defaults (sweep path only; the --bash lifecycle keys on the
+# raw recipe fields and never launches exporter containers). Pinned multi-arch
+# registry URIs, so pyxis pulls the node's architecture with zero setup; both
+# pins are production-verified on GB300 (all 19 DCGM families; 125 node
+# families incl. meminfo, no host /proc mount needed). Ports are deliberately
+# offset from the conventional 9400/9100 — managed clusters may already run
+# host-level exporters there. Air-gapped or version-pinning clusters override
+# the image through the srtslurm.yaml ``containers:`` alias map, which already
+# resolves these fields.
+DEFAULT_DCGM_EXPORTER = TelemetryExporterConfig(
+    container_image="nvcr.io#nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04",
+    port=9401,
+)
+DEFAULT_NODE_EXPORTER = TelemetryExporterConfig(
+    container_image="quay.io#prometheus/node-exporter:v1.8.2",
+    port=9101,
+)
+
+
 @dataclass(frozen=True)
 class TachometerConfig:
     """Native Tachometer collection for an observability-enabled run.
@@ -1042,7 +1061,13 @@ class TachometerConfig:
     explicit ``false`` opts out. Note that without ``observability.enabled``
     the TRT-LLM worker endpoints may have no engine metrics to serve (the
     observability expansion is what turns their content on); the frontend
-    and any configured exporters are always worth capturing.
+    and the exporters are always worth capturing.
+
+    DCGM and node exporters default ON via the ``resolved_*`` properties
+    (sweep path only): an explicit ``dcgm_exporter``/``node_exporter`` block
+    always wins, ``default_exporters: false`` disables the built-ins, and the
+    raw fields stay ``None`` unless the recipe set them — which is what the
+    power-telemetry sharing validation and the --bash gate key on.
     """
 
     enabled: bool | None = None
@@ -1052,10 +1077,25 @@ class TachometerConfig:
     compaction_threads: int = 4
     storage_subdir: str = "tachometer"
     extra_metadata: dict[str, str] = field(default_factory=dict)
+    default_exporters: bool = True
     dcgm_exporter: TelemetryExporterConfig | None = None
     node_exporter: TelemetryExporterConfig | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
+
+    @property
+    def resolved_dcgm_exporter(self) -> TelemetryExporterConfig | None:
+        """User-configured DCGM exporter, else the built-in default."""
+        if self.dcgm_exporter is not None:
+            return self.dcgm_exporter
+        return DEFAULT_DCGM_EXPORTER if self.default_exporters else None
+
+    @property
+    def resolved_node_exporter(self) -> TelemetryExporterConfig | None:
+        """User-configured node exporter, else the built-in default."""
+        if self.node_exporter is not None:
+            return self.node_exporter
+        return DEFAULT_NODE_EXPORTER if self.default_exporters else None
 
 
 @dataclass(frozen=True)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1037,12 +1037,12 @@ class TelemetryExporterConfig:
 class TachometerConfig:
     """Native Tachometer collection for an observability-enabled run.
 
-    ``enabled`` is tri-state: ``None`` (the default) follows
-    ``observability.enabled``, so an observability run collects Tachometer
-    data with no ``tachometer:`` block at all; an explicit ``false`` opts
-    out; an explicit ``true`` under ``observability.enabled: false`` is a
-    validation error (Tachometer's targets only have content when the
-    observability expansion ran).
+    ``enabled`` is tri-state: ``None`` (the default) means ON — every run
+    collects Tachometer data with no ``tachometer:`` block at all; an
+    explicit ``false`` opts out. Note that without ``observability.enabled``
+    the TRT-LLM worker endpoints may have no engine metrics to serve (the
+    observability expansion is what turns their content on); the frontend
+    and any configured exporters are always worth capturing.
     """
 
     enabled: bool | None = None
@@ -1133,8 +1133,14 @@ class ObservabilityConfig:
 
     @property
     def tachometer_enabled(self) -> bool:
-        """Resolved Tachometer enablement (tri-state ``tachometer.enabled``)."""
-        return self.enabled if self.tachometer.enabled is None else self.tachometer.enabled
+        """Resolved Tachometer enablement (tri-state ``tachometer.enabled``).
+
+        Tachometer is on by default for every run — server-side capture is
+        not an opt-in special occasion, and its cost is bounded (1 Hz,
+        best-effort, complement of the client's polling). ``enabled: false``
+        opts out; ``observability.enabled`` no longer gates it.
+        """
+        return True if self.tachometer.enabled is None else self.tachometer.enabled
 
 
 @dataclass(frozen=True)
@@ -2299,8 +2305,6 @@ class SrtConfig:
         """Validate Tachometer collection under observability."""
         observability = self.observability
         tachometer = observability.tachometer
-        if tachometer.enabled is True and not observability.enabled:
-            raise ValidationError("observability.tachometer requires observability.enabled: true")
         if not observability.tachometer_enabled:
             return
         if self.telemetry.enabled and tachometer.dcgm_exporter is not None:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1045,6 +1045,10 @@ class TelemetryExporterConfig:
 DEFAULT_DCGM_EXPORTER = TelemetryExporterConfig(
     container_image="nvcr.io#nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04",
     port=9401,
+    # 100ms collection (the power-telemetry template's interval) costs ~2% ITL
+    # p50 on GB300 decode; 5000ms is measured at parity with no telemetry.
+    # Values repeat across consecutive 1 Hz scrapes, which panels tolerate.
+    command="dcgm-exporter --collect-interval=5000 --address :{port}",
 )
 DEFAULT_NODE_EXPORTER = TelemetryExporterConfig(
     container_image="quay.io#prometheus/node-exporter:v1.8.2",

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -58,8 +58,8 @@ def generate_tachometer_config(
     node-exporter endpoints are never excluded: the frontend scrape is cheap
     and Tachometer is the only whole-window, per-replica capture of it.
     """
-    dcgm_exporter = dcgm_exporter or tachometer.dcgm_exporter
-    node_exporter = tachometer.node_exporter
+    dcgm_exporter = dcgm_exporter or tachometer.resolved_dcgm_exporter
+    node_exporter = tachometer.resolved_node_exporter
     endpoints: list[TelemetryEndpoint] = []
     physical_nodes: dict[str, list[Process]] = {}
     for process in processes:

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1482,13 +1482,18 @@ class TestRunPostEval:
             FrontendConfig,
             HealthCheckConfig,
             ModelConfig,
+            ObservabilityConfig,
             ResourceConfig,
             SrtConfig,
+            TachometerConfig,
         )
 
         config = SrtConfig(
             name="test",
             model=ModelConfig(path="/model/test-model", container="/image", precision="fp4"),
+            # These tests exercise the eval flow, not telemetry; opt out of the
+            # default-on Tachometer so run() needs no scraper mocks.
+            observability=ObservabilityConfig(tachometer=TachometerConfig(enabled=False)),
             resources=ResourceConfig(
                 gpu_type="h100",
                 gpus_per_node=8,

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -272,6 +272,11 @@ class TestDryRunExecutionExtensions:
         assert "tachometer" in output
         assert "enabled" in output
         assert "storage_subdir" in output
+        # Built-in exporters are part of the default and must be visible.
+        assert "dcgm_exporter" in output
+        assert "node_exporter" in output
+        assert ":9401" in output
+        assert ":9101" in output
 
     def test_dcgm_power_telemetry_details_shown(self, capsys):
         config = _make_config(

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -225,11 +225,22 @@ class TestExpandObservability:
         with pytest.raises(ValidationError, match="scrape_metrics"):
             SrtConfig.Schema().load(cfg)
 
-    def test_tachometer_requires_master_observability_knob(self):
+    def test_tachometer_no_longer_requires_master_observability_knob(self):
+        """Tachometer is decoupled from observability.enabled: explicit true
+        without the master knob is valid, and the default is on for every run."""
         cfg = _trtllm_config(enabled=False, tachometer={"enabled": True})
+        loaded = SrtConfig.Schema().load(cfg)
+        assert loaded.observability.tachometer_enabled is True
 
-        with pytest.raises(ValidationError, match="requires observability.enabled"):
-            SrtConfig.Schema().load(cfg)
+    def test_tachometer_is_on_by_default_without_observability(self):
+        cfg = _trtllm_config(enabled=False)
+        loaded = SrtConfig.Schema().load(cfg)
+        assert loaded.observability.tachometer_enabled is True
+
+    def test_tachometer_explicit_false_still_opts_out(self):
+        cfg = _trtllm_config(enabled=False, tachometer={"enabled": False})
+        loaded = SrtConfig.Schema().load(cfg)
+        assert loaded.observability.tachometer_enabled is False
 
     def test_telemetry_rejects_tachometer_fields(self):
         cfg = {

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -84,6 +84,26 @@ class TestTachometerConfig:
         assert config.observability.tachometer.dcgm_exporter is None
         assert config.observability.tachometer.node_exporter is None
 
+    def test_exporters_resolve_to_built_in_defaults(self):
+        """No exporter blocks needed: pinned multi-arch registry defaults."""
+        tachometer = TachometerConfig()
+        assert tachometer.dcgm_exporter is None  # raw stays None (power/--bash gates)
+        assert tachometer.resolved_dcgm_exporter.port == 9401
+        assert "dcgm-exporter" in tachometer.resolved_dcgm_exporter.container_image
+        assert tachometer.resolved_node_exporter.port == 9101
+        assert "node-exporter" in tachometer.resolved_node_exporter.container_image
+
+    def test_default_exporters_false_disables_built_ins(self):
+        tachometer = TachometerConfig(default_exporters=False)
+        assert tachometer.resolved_dcgm_exporter is None
+        assert tachometer.resolved_node_exporter is None
+
+    def test_explicit_exporter_block_wins_over_default(self):
+        custom = TelemetryExporterConfig(container_image="/containers/dcgm.sqsh", port=9500)
+        tachometer = TachometerConfig(dcgm_exporter=custom)
+        assert tachometer.resolved_dcgm_exporter is custom
+        assert tachometer.resolved_node_exporter.port == 9101
+
     def test_default_frequency_is_one_hz(self):
         """1 Hz matches the retired RAW scraper's cadence; 5 Hz produced ~9M
         rows in a 25-minute run with no analysis consuming the extra
@@ -460,7 +480,7 @@ class TestTachometerConfigGeneration:
 
     @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
     def test_generate_config_without_exporters_targets_servers_only(self, _mock_get_hostname_ip):
-        tachometer = TachometerConfig(enabled=True)
+        tachometer = TachometerConfig(enabled=True, default_exporters=False)
         runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
         runtime.log_dir = Path("/runs/12345/logs")
         processes = [
@@ -668,6 +688,9 @@ class TestTachometerStageMixin:
                 self.runtime.run_name = "test_12345"
                 self.runtime.network_interface = "eth0"
                 self.runtime.nodes.head = "node-a"
+                self.runtime.nodes.het = False
+                self.runtime.srun_options = {}
+                self.runtime.container_mounts = {Path(tmp_path): Path("/logs")}
                 self._backend_processes = [
                     Process(
                         node="node-a",
@@ -698,7 +721,12 @@ class TestTachometerStageMixin:
 
         procs = harness.start_tachometer()
 
-        assert [proc.name for proc in procs] == ["tachometer"]
+        # Built-in exporters launch by default alongside the scraper.
+        assert [proc.name for proc in procs] == [
+            "tachometer_dcgm_exporter",
+            "tachometer_node_exporter",
+            "tachometer",
+        ]
         assert (tmp_path / "tachometer_config.toml").exists()
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
@@ -765,8 +793,8 @@ class TestTachometerStageMixin:
 
         processes = Harness().start_tachometer()
 
-        assert [process.name for process in processes] == ["tachometer"]
-        assert mock_srun.call_count == 1
+        assert [process.name for process in processes] == ["tachometer_node_exporter", "tachometer"]
+        assert mock_srun.call_count == 2
         assert 'name = "dcgm_node-a"' in (tmp_path / "tachometer_config.toml").read_text()
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -93,6 +93,25 @@ class TestTachometerConfig:
         assert tachometer.resolved_node_exporter.port == 9101
         assert "node-exporter" in tachometer.resolved_node_exporter.container_image
 
+    def test_default_dcgm_exporter_samples_gently(self):
+        """The built-in DCGM exporter must NOT inherit the power-telemetry
+        template's 100ms collect interval: 10 Hz NVML sampling measured ~2%
+        ITL p50 overhead on GB300 decode, while 5000ms measured at parity
+        with no telemetry (A/B/C/D/E isolation runs, 2026-09-06). The power
+        path keeps 100ms — high-rate sampling is its purpose."""
+        from srtctl.cli.mixins.telemetry_stage import (
+            DCGM_EXPORTER_COMMAND_TEMPLATE,
+            resolve_exporter_command,
+        )
+
+        tachometer = TachometerConfig()
+        cmd = resolve_exporter_command(
+            tachometer.resolved_dcgm_exporter, DCGM_EXPORTER_COMMAND_TEMPLATE
+        )
+        assert "--collect-interval=5000" in cmd
+        assert ":9401" in cmd
+        assert "--collect-interval=100 " in DCGM_EXPORTER_COMMAND_TEMPLATE
+
     def test_default_exporters_false_disables_built_ins(self):
         tachometer = TachometerConfig(default_exporters=False)
         assert tachometer.resolved_dcgm_exporter is None


### PR DESCRIPTION
## What

`observability.tachometer.enabled: null` (the default) now resolves to **ON for every run**, decoupled from `observability.enabled`; the requires-master-knob validation is removed. Explicit `enabled: false` still opts out. `observability.enabled` keeps gating what it always gated: worker metrics *content* (TRT-LLM publish flag + engine stats) and the trace/request-trace/host-sampler legs.

## Why draft

Held until a real production A/B rerun proves the default costs nothing: same recipe, no `observability:` block, current main (tachometer off) vs this branch (tachometer on), comparing client-side TTFT/ITL/throughput. Plan is ready; will attach results before marking ready-for-review.

## Cost argument (to be validated by the run)

1 Hz default (#352), best-effort scraper + sidecars (never critical), complement of the client's URL list (no worker double-polling), and without `observability.enabled` the TRT-LLM worker endpoints serve little/nothing — the capture is dominated by the frontend endpoint plus any recipe-configured exporters.

## Notes

- `validate-setup` already requires `bin/tachometer-scraper` unconditionally, so the default-on flip adds no new setup burden.
- Eval-flow integration tests opt out explicitly (they exercise eval, not telemetry).
- `make check`: 1508 passed; the one failure (`TestRunPostEval::test_eval_only_successful`) reproduces on clean origin/main — pre-existing, unrelated (health-mock path, likely from a recent merge).