### PR TITLE
feat(observability): align the Tachometer capture with the load window

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1264,7 +1264,9 @@ observability:
   enabled: true
 ```
 
-Tachometer scrapes the **complement** of what the benchmark client polls: worker endpoints that appear in `AIPERF_SERVER_METRICS_URLS` are left to the client (a worker endpoint is never double-polled — the extra scrape load has previously made a submission irreproducible), while the frontend, DCGM, and node-exporter endpoints are always Tachometer's. On runs whose benchmark has no aiperf client (sa-bench, lm-eval, serve-only, manual), the complement expands to every endpoint.
+The capture window aligns with the load, the same window the benchmark client's own `AIPERF_SERVER_METRICS_URLS` polling covers: on benchmark runs the scraper starts once the server passes the health gate (bring-up produces only dead-endpoint noise while workers load) and is stopped **gracefully** when the client exits, with a configurable grace period for compacting `final.parquet` before post-processing reads it. Runs without a discrete load window (serve-only, `manual`, eval-only) capture the whole serve session as before. Signal handlers and the critical-process monitor still use the process registry’s existing teardown budget; the benchmark shutdown grace does not override those paths.
+
+Tachometer scrapes all configured worker, frontend, DCGM, and node-exporter endpoints, independently of the benchmark client's `AIPERF_SERVER_METRICS_URLS` polling. This keeps the raw capture complete even when the client also collects metrics.
 
 The legacy in-job Python RAW scraper is retired: a recipe still carrying `scrape_metrics`, `scrape_interval_seconds`, or `scrape_output` fails validation at submit time. Historical `raw_prometheus.jsonl` artifacts remain readable by the post-processing ingest.
 
@@ -1304,6 +1306,7 @@ observability:
 | `binary_path` | string | `tachometer-scraper` | Scraper command or path on the compute nodes |
 | `collect_interval_ms` | int | `1000` | Milliseconds between scrapes of every endpoint; the single cadence knob — it also drives the launched DCGM exporter's `--collect-interval` (an explicit `dcgm_exporter.command` wins) and the host sampler. Values below `1000` speed up DCGM NVML sampling and are warned about at launch: 100ms sampling measured ~2% decode ITL overhead on GB300. Replaces the retired Hz-based `default_frequency` |
 | `sync_interval_secs` | int | `120` | Interval for intermediate Parquet compaction; `0` disables it |
+| `shutdown_grace_secs` | float | `120.0` | Time the scraper gets after SIGTERM to flush and compact `final.parquet` before it is killed; compaction scales with the data accumulated since the last periodic sync |
 | `compaction_threads` | int | `4` | Value passed as `POLARS_MAX_THREADS` |
 | `storage_subdir` | string | `tachometer` | Output directory below the run log directory |
 | `extra_metadata` | dict | `{}` | Static string metadata added to every endpoint |

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -813,9 +813,17 @@ class SweepOrchestrator(
                     self.start_cpu_power_host_telemetry(registry)
                     self.start_incremental_power_report()
 
-            tachometer_procs = self.start_tachometer()
-            for proc in tachometer_procs:
-                registry.add_process(proc)
+            # Tachometer capture aligns with the load window: benchmark runs
+            # start it inside run_benchmark once the server is healthy and
+            # stop it gracefully when the client exits (see
+            # BenchmarkStageMixin.run_benchmark). Only runs WITHOUT a discrete
+            # load window — serve-only, manual, eval-only — keep the
+            # whole-session capture, started here.
+            eval_only = os.environ.get("EVAL_ONLY", "false").lower() == "true"
+            if self.serve_only or eval_only or self.config.benchmark.type == "manual":
+                tachometer_procs = self.start_tachometer()
+                for proc in tachometer_procs:
+                    registry.add_process(proc)
 
             self._print_connection_info()
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -12,7 +12,7 @@ import shlex
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from srtctl.core.fingerprint import format_identity_verification, verify_identity
 from srtctl.core.health import wait_for_model
@@ -33,6 +33,7 @@ _BENCHMARK_KILL_TIMEOUT = 10.0
 
 if TYPE_CHECKING:
     from srtctl.benchmarks.base import BenchmarkRunner
+    from srtctl.cli.mixins.telemetry_stage import TelemetryStageMixin
     from srtctl.core.processes import ProcessRegistry
     from srtctl.core.runtime import RuntimeContext
     from srtctl.core.schema import SrtConfig
@@ -377,9 +378,28 @@ class BenchmarkStageMixin:
 
         logger.info("Running %s benchmark", runner.name)
 
+        # Tachometer scrapes the load window only, the same window the
+        # benchmark client's own AIPERF polling covers. Starting it with the
+        # other telemetry (before the health gate) recorded minutes of
+        # dead-endpoint noise while workers loaded; stopping it with the
+        # registry's hard teardown SIGKILLed the scraper mid-write and
+        # stranded the whole capture in the arrow WAL (hecate job 487539).
+        # The finally attempts a flush when the benchmark script returns or
+        # raises. Signal/monitor cleanup can terminate registered processes
+        # earlier using its existing budget. Both hooks live on
+        # TelemetryStageMixin (same orchestrator object).
+        start_tachometer = getattr(self, "start_tachometer", None)
+        tachometer_procs = start_tachometer() if start_tachometer is not None else []
+        for proc in tachometer_procs:
+            registry.add_process(proc)
+
         # Run the benchmark script
         benchmark_log = self.runtime.log_dir / "benchmark.out"
-        exit_code = self._run_benchmark_script(runner, benchmark_log, stop_event)
+        try:
+            exit_code = self._run_benchmark_script(runner, benchmark_log, stop_event)
+        finally:
+            if tachometer_procs:
+                cast("TelemetryStageMixin", self).stop_tachometer(tachometer_procs)
 
         if exit_code != 0:
             logger.error("Benchmark failed with exit code %d", exit_code)

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -21,7 +21,7 @@ from srtctl.core.power.cpu_session import CpuPowerCollector, CpuPowerSessionSett
 from srtctl.core.power.manifest import ExpectedWindow
 from srtctl.core.power.session import PowerSessionSettings, PowerTelemetrySession
 from srtctl.core.power.topology import build_expected_devices
-from srtctl.core.processes import ManagedProcess, ProcessRegistry
+from srtctl.core.processes import ManagedProcess, ProcessRegistry, terminate_and_reap
 from srtctl.core.schema import TelemetryExporterConfig
 from srtctl.core.slurm import start_srun_process
 from srtctl.core.telemetry import TACHOMETER_STORAGE_PARENT, generate_tachometer_config
@@ -625,9 +625,9 @@ class TelemetryStageMixin:
         if tachometer.sync_interval_secs > 0:
             cmd.extend(["--sync-interval", str(tachometer.sync_interval_secs)])
 
-        env_to_set: dict[str, str] = {}
+        srun_export_env: dict[str, str] = {}
         if tachometer.compaction_threads > 0:
-            env_to_set["POLARS_MAX_THREADS"] = str(tachometer.compaction_threads)
+            srun_export_env["POLARS_MAX_THREADS"] = str(tachometer.compaction_threads)
 
         processes.append(
             ManagedProcess(
@@ -636,7 +636,14 @@ class TelemetryStageMixin:
                     command=cmd,
                     nodelist=[self.runtime.nodes.head],
                     output=str(self.runtime.log_dir / "tachometer.out"),
-                    env_to_set=env_to_set,
+                    # Shell-less on purpose: the scraper compacts final.parquet
+                    # on SIGTERM, and srun forwards signals to the task it
+                    # launched. Under the bash wrapper the task is bash, which
+                    # exits without signaling its child — the scraper then dies
+                    # by step SIGKILL with the capture stranded in the arrow
+                    # WAL (hecate job 487539). Env goes via --export instead.
+                    use_bash_wrapper=False,
+                    srun_export_env=srun_export_env,
                     srun_options=self.runtime.srun_options,
                     het_group=self.runtime.nodes.het_group_for(self.runtime.nodes.head),
                 ),
@@ -650,3 +657,28 @@ class TelemetryStageMixin:
         )
         logger.info("Tachometer started with artifacts under %s", tachometer_dir)
         return processes
+
+    def stop_tachometer(self, processes: list[ManagedProcess]) -> None:
+        """Stop Tachometer gracefully so the scraper compacts final.parquet.
+
+        SIGTERM starts the scraper's flush + compact + upload path; anything
+        harder loses everything since the last periodic sync. The scraper gets
+        ``tachometer.shutdown_grace_secs`` to finish compacting before the
+        SIGKILL escalation; the exporter sidecars are plain daemons and keep
+        the registry's default budget. Already-exited processes are skipped,
+        so the registry's later cleanup pass stays a no-op for these.
+        """
+        grace = self.config.observability.tachometer.shutdown_grace_secs
+        for process in processes:
+            if not process.is_running:
+                continue
+            timeout = grace if process.name == "tachometer" else 10.0
+            outcome = terminate_and_reap(process.popen, terminate_timeout=timeout, kill_timeout=10.0)
+            if outcome.force_killed:
+                logger.warning(
+                    "%s did not exit within %.0fs of SIGTERM and was killed; the capture may be partial",
+                    process.name,
+                    timeout,
+                )
+            else:
+                logger.info("%s stopped gracefully", process.name)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1132,6 +1132,10 @@ class TachometerConfig:
     # ``default_frequency`` (1000ms == the old 1.0 Hz default).
     collect_interval_ms: int = 1000
     sync_interval_secs: int = 120
+    # How long the scraper gets after SIGTERM to flush + compact final.parquet
+    # before the SIGKILL escalation. Compaction time scales with the arrow WAL
+    # accumulated since the last periodic sync.
+    shutdown_grace_secs: float = 120.0
     compaction_threads: int = 4
     storage_subdir: str = "tachometer"
     extra_metadata: dict[str, str] = field(default_factory=dict)

--- a/tests/test_power_collector.py
+++ b/tests/test_power_collector.py
@@ -854,7 +854,10 @@ class TestRequiredReadinessGate:
             exit_code = orchestrator.run()
 
         run_benchmark.assert_not_called()
-        start_tachometer.assert_called_once()
+        # Tachometer aligns with the load window (started inside
+        # run_benchmark); a run whose benchmark was skipped has no window,
+        # so nothing starts the capture.
+        start_tachometer.assert_not_called()
         assert exit_code == 1
 
     def test_eval_only_run_never_starts_power_telemetry(self, tmp_path):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1017,6 +1017,14 @@ class TestTachometerStageMixin:
         ]
         assert "container_image" not in scraper_call.kwargs
         assert "container_mounts" not in scraper_call.kwargs
+        # Shell-less launch is load-bearing for graceful shutdown: srun
+        # forwards SIGTERM to the task it launched, and the scraper only
+        # compacts final.parquet if IT is that task. Under the bash wrapper
+        # the signal dies with bash and the capture is lost to step SIGKILL
+        # (hecate job 487539). Env must ride --export, not a bash `export`.
+        assert scraper_call.kwargs["use_bash_wrapper"] is False
+        assert scraper_call.kwargs["srun_export_env"] == {"POLARS_MAX_THREADS": "4"}
+        assert "env_to_set" not in scraper_call.kwargs
         # Telemetry is best-effort by contract: a dead scraper must never
         # tear down the benchmark via the critical-process check.
         assert procs[-1].name == "tachometer"
@@ -1286,6 +1294,97 @@ class TestTachometerStageMixin:
         for call in exporter_calls:
             assert call.kwargs["nodes"] == 2
             assert call.kwargs["ntasks"] == 2
+
+
+class TestStopTachometer:
+    """Graceful shutdown: SIGTERM first, with the scraper's compaction grace."""
+
+    @staticmethod
+    def _stage(grace: float = 120.0) -> TelemetryStageMixin:
+        stage = TelemetryStageMixin()
+        stage.config = _make_config(tachometer=TachometerConfig(enabled=True, shutdown_grace_secs=grace))
+        return stage
+
+    @patch("srtctl.cli.mixins.telemetry_stage.terminate_and_reap")
+    def test_scraper_gets_the_shutdown_grace_and_exporters_do_not(self, mock_reap):
+        from srtctl.core.processes import ManagedProcess, TerminationOutcome
+
+        mock_reap.return_value = TerminationOutcome(reaped=True, force_killed=False)
+        exporter = ManagedProcess(name="tachometer_node_exporter", popen=_running_exporter(), critical=False)
+        scraper = ManagedProcess(name="tachometer", popen=_running_exporter(), critical=False)
+
+        self._stage(grace=45.0).stop_tachometer([exporter, scraper])
+
+        # The scraper compacts final.parquet after SIGTERM and needs the
+        # configured grace; the exporter sidecars are plain daemons.
+        assert mock_reap.call_args_list[0].kwargs["terminate_timeout"] == 10.0
+        assert mock_reap.call_args_list[1].kwargs["terminate_timeout"] == 45.0
+
+    @patch("srtctl.cli.mixins.telemetry_stage.terminate_and_reap")
+    def test_already_exited_processes_are_skipped(self, mock_reap):
+        from srtctl.core.processes import ManagedProcess
+
+        popen = MagicMock()
+        popen.poll.return_value = 0
+        self._stage().stop_tachometer([ManagedProcess(name="tachometer", popen=popen, critical=False)])
+
+        mock_reap.assert_not_called()
+
+
+class TestBenchmarkWindowTachometerLifecycle:
+    """run_benchmark brackets the load with the Tachometer capture.
+
+    Starting with the other telemetry (before the health gate) records only
+    dead-endpoint noise while workers load; leaving the stop to the registry's
+    hard teardown SIGKILLs the scraper mid-write and strands the capture in
+    the arrow WAL (hecate job 487539). The window contract mirrors the
+    client's own AIPERF polling: scrape while the load runs.
+    """
+
+    @staticmethod
+    def _harness(tmp_path, calls):
+        from srtctl.cli.mixins.benchmark_stage import BenchmarkStageMixin
+        from srtctl.core.processes import ManagedProcess
+
+        class Stage(BenchmarkStageMixin):
+            pass
+
+        stage = Stage()
+        stage.config = _make_config(benchmark=BenchmarkConfig(type="custom", command="echo load", concurrencies=[1]))
+        stage.runtime = MagicMock()
+        stage.runtime.log_dir = tmp_path
+        stage._wait_for_service_ready = lambda stop_event: True
+        scraper = ManagedProcess(name="tachometer", popen=_running_exporter(), critical=False)
+        stage.start_tachometer = MagicMock(side_effect=lambda: (calls.append("start"), [scraper])[1])
+        stage.stop_tachometer = MagicMock(side_effect=lambda procs: calls.append("stop"))
+        return stage, scraper
+
+    def test_capture_brackets_the_benchmark_script(self, tmp_path):
+        import threading
+
+        calls: list[str] = []
+        stage, scraper = self._harness(tmp_path, calls)
+        stage._run_benchmark_script = MagicMock(side_effect=lambda *a, **k: (calls.append("script"), 0)[1])
+        registry = MagicMock()
+
+        exit_code = stage.run_benchmark(registry, threading.Event(), reporter=None)
+
+        assert exit_code == 0
+        assert calls == ["start", "script", "stop"]
+        registry.add_process.assert_called_once_with(scraper)
+        stage.stop_tachometer.assert_called_once_with([scraper])
+
+    def test_capture_stops_even_when_the_script_raises(self, tmp_path):
+        import threading
+
+        calls: list[str] = []
+        stage, _ = self._harness(tmp_path, calls)
+        stage._run_benchmark_script = MagicMock(side_effect=RuntimeError("client crashed"))
+
+        with pytest.raises(RuntimeError, match="client crashed"):
+            stage.run_benchmark(MagicMock(), threading.Event(), reporter=None)
+
+        assert calls == ["start", "stop"]
 
 
 def _running_exporter():


### PR DESCRIPTION
## Changes

On benchmark runs, start Tachometer after health and runner validation, then attempt a graceful stop when the benchmark script returns or raises. The scraper receives SIGTERM directly through a shell-less srun launch, with `POLARS_MAX_THREADS` passed through `--export`. `observability.tachometer.shutdown_grace_secs` defaults to 120 seconds for benchmark shutdown compaction.

Serve-only, manual, and eval-only runs retain session-wide capture. Existing default-on collection, full endpoint coverage, millisecond cadence, and power finalization behavior are preserved. The obsolete health-check test fix is already in main and is omitted from this diff.

Signal handlers and the critical-process monitor retain the registry's existing cleanup timeout; the longer benchmark shutdown grace does not override those paths.

## Validation

- `make check`: 1,959 passed, 2 skipped, 6 deselected; source Ruff lint and formatting passed.
- Focused telemetry, benchmark, power and process tests: 287 passed before the type-only mixin annotation adjustment; the final full suite covers the same tests.
- Full pre-commit was run and compared with unchanged main: both report 40 lint findings (one auto-fix) and format the same 10 unrelated files. Those unrelated edits are excluded. The two findings on PR-touched files are pre-existing UP038 findings in untouched code.
- The nine non-blocking `ty` diagnostics match unchanged main; the lifecycle call adds none.
- `git diff --check` passed. No new SLURM run or end-to-end parquet-compaction verification was performed for this conflict resolution.
