### PR TITLE
fix(telemetry): publish SA-Bench measurement window

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1124,7 +1124,7 @@ telemetry:
 | `storage_subdir` | string | `power` | Output directory below the run log directory |
 | `required` | bool | `false` | Fail the benchmark when publishable power artifacts cannot be produced |
 | `startup_timeout_seconds` | float | `30.0` | Exporter readiness timeout |
-| `request_timeout_seconds` | float | `2.0` | Per-request exporter timeout |
+| `request_timeout_seconds` | float | `5.0` | Per-request exporter timeout |
 | `collector_join_timeout_seconds` | float/null | `null` | Shutdown join timeout; defaults from `request_timeout_seconds` |
 
 ---

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -55,6 +55,7 @@ from backend_request_func import (
     get_tokenizer as get_sa_bench_tokenizer,
 )
 from datasets import load_dataset
+from measurement_window import MeasurementWindow
 from PIL.Image import Image
 from tqdm.asyncio import tqdm
 from transformers import PreTrainedTokenizerBase
@@ -726,6 +727,7 @@ async def benchmark(
     slow_down_sleep_time: float = 1.0,
     slow_down_wait_time: float = 60.0,
     request_session: aiohttp.ClientSession | None = None,
+    measurement_window: MeasurementWindow | None = None,
 ):
     if backend in ASYNC_REQUEST_FUNCS:
         request_func = ASYNC_REQUEST_FUNCS[backend]
@@ -834,6 +836,9 @@ async def benchmark(
             return await request_func(request_func_input=request_func_input, pbar=pbar)
 
     benchmark_start_time = time.perf_counter()
+    benchmark_start_time_unix = time.time()
+    if measurement_window is not None:
+        measurement_window.mark_running(benchmark_start_time_unix)
     tasks: list[asyncio.Task] = []
     try:
         async for request in get_request(input_requests, request_rate, burstiness):
@@ -857,7 +862,16 @@ async def benchmark(
             )
             tasks.append(asyncio.create_task(limited_request_func(request_func_input=request_func_input, pbar=pbar)))
         outputs: list[RequestFuncOutput] = await asyncio.gather(*tasks)
-    except BaseException:
+    except BaseException as error:
+        benchmark_end_time_unix = time.time()
+        benchmark_duration = time.perf_counter() - benchmark_start_time
+        if measurement_window is not None:
+            measurement_window.mark_failed(
+                start_unix=benchmark_start_time_unix,
+                end_unix=benchmark_end_time_unix,
+                duration=benchmark_duration,
+                reason=f"{type(error).__name__}: {error}",
+            )
         if backend == "dynamo" and request_session is not None:
             # A shared pool must outlive every request using it. Preserve the
             # historical task behavior when connection reuse is disabled.
@@ -894,6 +908,13 @@ async def benchmark(
         pbar.close()
 
     benchmark_duration = time.perf_counter() - benchmark_start_time
+    benchmark_end_time_unix = time.time()
+    if measurement_window is not None:
+        measurement_window.record_boundary(
+            start_unix=benchmark_start_time_unix,
+            end_unix=benchmark_end_time_unix,
+            duration=benchmark_duration,
+        )
     if backend == "dynamo" and request_session is not None and not request_session.closed:
         await request_session.close()
         # Allow asyncio to finish closing pooled transports before CPU-heavy metrics.
@@ -923,6 +944,8 @@ async def benchmark(
 
     result = {
         "duration": benchmark_duration,
+        "benchmark_start_time_unix": benchmark_start_time_unix,
+        "benchmark_end_time_unix": benchmark_end_time_unix,
         "completed": metrics.completed,
         "total_input_tokens": metrics.total_input,
         "total_output_tokens": metrics.total_output,
@@ -978,6 +1001,13 @@ async def benchmark(
     process_one_metric("e2el", "E2EL", "End-to-end Latency")
 
     print("=" * 50)
+
+    if measurement_window is not None:
+        measurement_window.mark_completed(
+            start_unix=benchmark_start_time_unix,
+            end_unix=benchmark_end_time_unix,
+            duration=benchmark_duration,
+        )
 
     return result
 
@@ -1239,6 +1269,13 @@ def main(args: argparse.Namespace):
     gc.collect()
     gc.freeze()
 
+    measurement_window = MeasurementWindow.create(
+        save_result=args.save_result,
+        result_dir=args.result_dir,
+        result_filename=args.result_filename,
+        concurrency=args.max_concurrency,
+    )
+
     benchmark_result = asyncio.run(
         run_benchmark_with_cleanup(
             reuse_http_connections=args.reuse_http_connections,
@@ -1264,6 +1301,7 @@ def main(args: argparse.Namespace):
             slow_down_servers=args.slow_down_servers,
             slow_down_sleep_time=args.slow_down_sleep_time,
             slow_down_wait_time=args.slow_down_wait_time,
+            measurement_window=measurement_window,
         )
     )
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1134,7 +1134,7 @@ class TelemetryConfig:
     storage_subdir: str = "power"
     required: bool = False
     startup_timeout_seconds: float = 30.0
-    request_timeout_seconds: float = 2.0
+    request_timeout_seconds: float = 5.0
     # None derives a safe shutdown budget from request_timeout_seconds.
     collector_join_timeout_seconds: float | None = None
 

--- a/tests/test_sa_bench_http_session.py
+++ b/tests/test_sa_bench_http_session.py
@@ -331,6 +331,126 @@ def test_session_is_closed_before_metrics(monkeypatch):
     assert request_sessions == [sessions[0], sessions[0], sessions[0]]
 
 
+def test_benchmark_writes_completed_measurement_window(monkeypatch, tmp_path):
+    _import_sa_bench_module("backend_request_func")
+    module = _import_sa_bench_module("benchmark_serving")
+    windows_dir = tmp_path / "power" / "windows"
+    result_dir = tmp_path / "results"
+    windows_dir.mkdir(parents=True)
+    result_dir.mkdir()
+    window = module.MeasurementWindow.create(
+        save_result=True,
+        result_dir=str(result_dir),
+        result_filename="results_concurrency_2_gpus_2.json",
+        concurrency=2,
+        window_dir=str(windows_dir),
+        log_root=str(tmp_path),
+    )
+    assert window is not None
+
+    async def fake_request(request_func_input, pbar=None):
+        return module.RequestFuncOutput(
+            success=True,
+            output_tokens=1,
+            prompt_len=request_func_input.prompt_len,
+            start_time=1.0,
+            ttft=0.01,
+            latency=0.02,
+        )
+
+    monkeypatch.setitem(module.ASYNC_REQUEST_FUNCS, "dynamo", fake_request)
+
+    result = asyncio.run(
+        module.benchmark(
+            backend="dynamo",
+            api_url="http://localhost:8000/v1/completions",
+            base_url="http://localhost:8000",
+            model_id="model",
+            model_name="model",
+            tokenizer=object(),
+            input_requests=[("prompt", 1, 1, None), ("prompt", 1, 1, None)],
+            logprobs=None,
+            best_of=1,
+            request_rate=float("inf"),
+            burstiness=1.0,
+            disable_tqdm=True,
+            profile=False,
+            selected_percentile_metrics=[],
+            selected_percentiles=[50.0],
+            ignore_eos=True,
+            goodput_config_dict={},
+            max_concurrency=2,
+            lora_modules=None,
+            measurement_window=window,
+        )
+    )
+
+    payload = module.json.loads((windows_dir / "results_concurrency_2_gpus_2.json").read_text())
+    assert payload["status"] == "completed"
+    assert payload["benchmark_start_time_unix"] == result["benchmark_start_time_unix"]
+    assert payload["benchmark_end_time_unix"] == result["benchmark_end_time_unix"]
+    assert payload["duration"] == result["duration"]
+
+
+def test_benchmark_writes_failed_measurement_window(monkeypatch, tmp_path):
+    _import_sa_bench_module("backend_request_func")
+    module = _import_sa_bench_module("benchmark_serving")
+    windows_dir = tmp_path / "power" / "windows"
+    result_dir = tmp_path / "results"
+    windows_dir.mkdir(parents=True)
+    result_dir.mkdir()
+    window = module.MeasurementWindow.create(
+        save_result=True,
+        result_dir=str(result_dir),
+        result_filename="results_concurrency_1_gpus_1.json",
+        concurrency=1,
+        window_dir=str(windows_dir),
+        log_root=str(tmp_path),
+    )
+    assert window is not None
+    calls = 0
+
+    async def fail_after_probe(request_func_input, pbar=None):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return module.RequestFuncOutput(success=True, output_tokens=1, prompt_len=1)
+        raise RuntimeError("request failed")
+
+    monkeypatch.setitem(module.ASYNC_REQUEST_FUNCS, "dynamo", fail_after_probe)
+
+    with pytest.raises(RuntimeError, match="request failed"):
+        asyncio.run(
+            module.benchmark(
+                backend="dynamo",
+                api_url="http://localhost:8000/v1/completions",
+                base_url="http://localhost:8000",
+                model_id="model",
+                model_name="model",
+                tokenizer=object(),
+                input_requests=[("prompt", 1, 1, None)],
+                logprobs=None,
+                best_of=1,
+                request_rate=float("inf"),
+                burstiness=1.0,
+                disable_tqdm=True,
+                profile=False,
+                selected_percentile_metrics=[],
+                selected_percentiles=[50.0],
+                ignore_eos=True,
+                goodput_config_dict={},
+                max_concurrency=1,
+                lora_modules=None,
+                measurement_window=window,
+            )
+        )
+
+    payload = module.json.loads((windows_dir / "results_concurrency_1_gpus_1.json").read_text())
+    assert payload["status"] == "failed"
+    assert payload["benchmark_end_time_unix"] >= payload["benchmark_start_time_unix"]
+    assert payload["reason"] == "RuntimeError: request failed"
+
+
 @pytest.mark.parametrize("failure", [RuntimeError("probe failed"), asyncio.CancelledError()])
 def test_benchmark_wrapper_closes_session_on_failure(monkeypatch, failure):
     _import_sa_bench_module("backend_request_func")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -110,9 +110,9 @@ class TestDcgmPowerConfig:
         assert defaults.default_frequency == 1.0
         assert defaults.required is False
         assert defaults.startup_timeout_seconds == 30.0
-        assert defaults.request_timeout_seconds == 2.0
+        assert defaults.request_timeout_seconds == 5.0
         assert defaults.collector_join_timeout_seconds is None
-        assert defaults.resolved_collector_join_timeout_seconds == 12.0
+        assert defaults.resolved_collector_join_timeout_seconds == 24.0
 
     def test_join_timeout_default_tracks_request_timeout(self):
         config = _make_config(


### PR DESCRIPTION
## Problem this solves

SA-Bench could collect power telemetry without publishing the formal measurement-window markers expected by downstream processing, leaving otherwise successful runs with incomplete power results. Failures during the measured request phase also lost the window boundary needed to interpret partial runs. This change aligns SA-Bench's measured request phase, result timestamps, and telemetry window lifecycle.

## Summary
- publish the formal SA-Bench measurement window around the measured request gather
- record failed windows when the request phase raises
- expose matching benchmark wall-clock boundaries in result JSON
- raise the native power endpoint timeout default from 2s to 5s

## Validation
- focused telemetry/SA-Bench suite: 115 passed
- full suite: 1432 passed, 2 skipped, 6 deselected; 5 existing macOS/path-assumption failures
- real 8x B200 InferenceX run reproduced the missing-window failure before this fix
