### PR TITLE
feat(observability): make INFO JSONL the default

### DIFF
--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -173,7 +173,7 @@ and loses Overview.
 | **Metrics** | `observability.enabled` (Tachometer), else the client's own export | `<log_dir>/tachometer/raw/scrape/*.parquet`, else historical `<log_dir>/raw_prometheus.jsonl`, else `<log_dir>/agentic/*/…/server_metrics_export.json(l)` | `server_metrics_export.jsonl` | every time-series panel |
 | **Request trace** | `observability.enabled` | `<log_dir>/dynamo-request-trace` | `request_trace.jsonl` | per-request card, per-session view, the waterfall's KV-transfer band |
 | **Per-iteration** | `print_iter_log: true` in the engine config | `SPAN`-free lines in `<log_dir>/*_w*.out` | `iter_bins.json` | batch composition, host/device step time |
-| **Traces** | `observability.enabled` **and** an AIPerf benchmark | `SPAN_CLOSED` lines in `<log_dir>/*.out` | `tempo_traces/<xid>.json` | Overview, routing outcome on the card |
+| **Traces** | `observability.debug_spans` **and** an AIPerf benchmark | `SPAN_CLOSED` lines in `<log_dir>/*.out` | `tempo_traces/<xid>.json` | Overview, routing outcome on the card |
 | **Client** | an AIPerf benchmark at export level `records` (default) | `<log_dir>/agentic/*/aiperf_artifacts/` or `artifacts/*/` | `profile_export.jsonl` | Overview, warmup filtering |
 | **Engine config** | TRT-LLM backend | `<log_dir>/trtllm_config_*.yaml` | copied verbatim | in-flight-batch ceilings |
 | **Frontend log** | *nothing* — always written | `<log_dir>/<node>_frontend_<i>.out` | *(read directly)* | Log analysis |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1152,6 +1152,7 @@ infra:
 ```yaml
 observability:
   enabled: true
+  debug_spans: false
 ```
 
 Tachometer scrapes the **complement** of what the benchmark client polls: worker endpoints that appear in `AIPERF_SERVER_METRICS_URLS` are left to the client (a worker endpoint is never double-polled — the extra scrape load has previously made a submission irreproducible), while the frontend, DCGM, and node-exporter endpoints are always Tachometer's. On runs whose benchmark has no aiperf client (sa-bench, lm-eval, serve-only, manual), the complement expands to every endpoint.
@@ -1160,7 +1161,8 @@ The legacy in-job Python RAW scraper is retired: a recipe still carrying `scrape
 
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
-| `enabled` | bool | `false` | Enable server-side metrics/traces, Tachometer collection, and host sampling |
+| `enabled` | bool | `false` | Enable INFO JSONL component logs, frontend request tracing, server metrics, Tachometer collection, and host sampling |
+| `debug_spans` | bool | `false` | Add DEBUG-level `SPAN_CLOSED` records for exact router-span debugging |
 | `enable_otel` | bool | `false` | Inject OTEL tracing environment variables |
 | `otel_endpoint` | string/null | `null` | OTEL collector endpoint |
 | `tachometer` | object | `enabled: null` | Native Tachometer collection settings; `enabled: null` follows `observability.enabled`, explicit `false` opts out |

--- a/src/ingest/traces_spanlog.py
+++ b/src/ingest/traces_spanlog.py
@@ -16,7 +16,8 @@ the debugged gotcha). Emits per-request Tempo-format JSON that L3
 
 On an srt-slurm run the input logs are the job's ``<node>_<mode>_w<i>.out`` and
 ``<node>_frontend_<i>.out`` files, which carry SPAN_CLOSED lines whenever
-``observability.enabled`` is set (see ``ANALYTICS_SPAN_ENV`` in ``srtctl.core.schema``).
+``observability.debug_spans`` is set (see ``ANALYTICS_DEBUG_SPAN_ENV`` in
+``srtctl.core.schema``).
 
 SPAN_CLOSED line grammar (verified on real perf-on data):
   <label>: {"time":"<ISO Z>", "message":"SPAN_CLOSED", "span_name":..., "span_id":...,

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -751,6 +751,7 @@ class SweepOrchestrator(
             logger.info("Cleanup")
             # NOTE: finalize before registry.cleanup() so samples and manifest are durable.
             exit_code = self.finalize_power_telemetry(exit_code, interrupted=stop_event.is_set())
+            self.finalize_tachometer(registry)
             stop_event.set()
             registry.cleanup()
             if exit_code != 0:

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import os
 import shlex
+import subprocess
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -20,7 +21,7 @@ from srtctl.core.power.topology import build_expected_devices
 from srtctl.core.processes import ManagedProcess, ProcessRegistry
 from srtctl.core.schema import TelemetryExporterConfig
 from srtctl.core.slurm import start_srun_process
-from srtctl.core.telemetry import TACHOMETER_STORAGE_PARENT, generate_tachometer_config
+from srtctl.core.telemetry import TACHOMETER_STORAGE_LEAF, TACHOMETER_STORAGE_PARENT, generate_tachometer_config
 
 if TYPE_CHECKING:
     from srtctl.core.runtime import RuntimeContext
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DCGM_EXPORTER_COMMAND_TEMPLATE = "dcgm-exporter --collect-interval=100 --address :{port}"
+TACHOMETER_COMPACT_TIMEOUT_SECONDS = 30 * 60
 
 
 def resolve_exporter_command(exporter_config: TelemetryExporterConfig, default_template: str) -> str:
@@ -399,3 +401,69 @@ class TelemetryStageMixin:
         )
         logger.info("Tachometer started with artifacts under %s", tachometer_dir)
         return processes
+
+    def finalize_tachometer(self, registry: ProcessRegistry) -> bool:
+        """Stop Tachometer and explicitly compact its durable local shards.
+
+        Terminating a local ``srun`` client can cause Slurm to kill the remote
+        step before the scraper handles SIGTERM. The periodic shards remain
+        durable, but the scraper never publishes ``final.parquet``. Run the
+        idempotent compact subcommand after the scraper step exits so
+        post-processing always sees the authoritative final artifact.
+        """
+        observability = self.config.observability
+        if not observability.tachometer_enabled:
+            return True
+
+        scraper = registry.get_process("tachometer")
+        if scraper is None:
+            logger.debug("No registered Tachometer scraper to finalize")
+            return True
+        if scraper.is_running:
+            logger.info("Stopping Tachometer before final compaction")
+            scraper.terminate(timeout=30.0)
+
+        tachometer = observability.tachometer
+        tachometer_dir = self.runtime.log_dir / tachometer.storage_subdir
+        local_dir = tachometer_dir / "local"
+        storage_leaf = tachometer_dir / TACHOMETER_STORAGE_PARENT / TACHOMETER_STORAGE_LEAF
+        compact_log = self.runtime.log_dir / "tachometer_compact.out"
+        command = [
+            self._resolve_tachometer_binary(tachometer.binary_path),
+            "compact",
+            str(local_dir),
+            "--output",
+            f"file://{storage_leaf}",
+        ]
+        env_to_set: dict[str, str] = {}
+        if tachometer.compaction_threads > 0:
+            env_to_set["POLARS_MAX_THREADS"] = str(tachometer.compaction_threads)
+
+        logger.info("Compacting Tachometer artifacts to %s", storage_leaf / "final.parquet")
+        proc = start_srun_process(
+            command=command,
+            nodelist=[self.runtime.nodes.head],
+            output=str(compact_log),
+            env_to_set=env_to_set,
+            srun_options=self.runtime.srun_options,
+            het_group=self.runtime.nodes.het_group_for(self.runtime.nodes.head),
+        )
+        try:
+            return_code = proc.wait(timeout=TACHOMETER_COMPACT_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "Tachometer final compaction timed out after %ds; see %s",
+                TACHOMETER_COMPACT_TIMEOUT_SECONDS,
+                compact_log,
+            )
+            proc.kill()
+            proc.wait()
+            return False
+        if return_code != 0:
+            logger.error("Tachometer final compaction exited %d; see %s", return_code, compact_log)
+            return False
+        if not (storage_leaf / "final.parquet").is_file():
+            logger.error("Tachometer compaction returned success without %s", storage_leaf / "final.parquet")
+            return False
+        logger.info("Tachometer final compaction complete")
+        return True

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -385,6 +385,13 @@ def show_config_details(config: SrtConfig) -> None:
             details.add_row("benchmark", "container_image", config.benchmark.container_image)
 
         tachometer = config.observability.tachometer
+        if config.observability.enabled:
+            details.add_row(
+                "observability",
+                "logging",
+                "DEBUG JSONL + span events" if config.observability.debug_spans else "INFO JSONL",
+            )
+            details.add_row("observability", "request_trace", "frontend-only metadata")
         if config.observability.tachometer_enabled:
             details.add_row("observability", "tachometer", "enabled")
             details.add_row("observability", "storage_subdir", tachometer.storage_subdir)

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -606,29 +606,34 @@ def expand_observability(cfg: dict) -> dict:
     No-op unless ``observability.enabled`` is truthy.
     """
     from srtctl.core.schema import (
+        ANALYTICS_DEBUG_SPAN_ENV,
         ANALYTICS_ENGINE_CONFIG,
+        ANALYTICS_INFO_ENV,
         ANALYTICS_REQUEST_TRACE_ENV,
-        ANALYTICS_SPAN_ENV,
     )
 
     observability = cfg.get("observability")
     if not isinstance(observability, dict) or not observability.get("enabled"):
         return cfg
 
-    # --- traces leg: SPAN_CLOSED lines on prefill, decode and frontend -------
+    # --- structured logging on prefill, decode and frontend ------------------
+    component_log_env = dict(ANALYTICS_INFO_ENV)
+    if observability.get("debug_spans"):
+        component_log_env.update(ANALYTICS_DEBUG_SPAN_ENV)
+
     backend = cfg.get("backend")
     if not isinstance(backend, dict):
         backend = {}
         cfg["backend"] = backend
 
     for mode in ("prefill", "decode", "aggregated"):
-        _setdefault_nested(backend, f"{mode}_environment", ANALYTICS_SPAN_ENV)
+        _setdefault_nested(backend, f"{mode}_environment", component_log_env)
 
     frontend = cfg.get("frontend")
     if not isinstance(frontend, dict):
         frontend = {}
         cfg["frontend"] = frontend
-    _setdefault_nested(frontend, "env", ANALYTICS_SPAN_ENV)
+    _setdefault_nested(frontend, "env", component_log_env)
 
     # --- request-trace leg: per-request phase timings, frontend only ---------
     # Complements the span leg rather than duplicating it. Spans decompose the
@@ -664,8 +669,9 @@ def expand_observability(cfg: dict) -> dict:
                 _setdefault_nested(trtllm_config, mode, ANALYTICS_ENGINE_CONFIG)
 
     logger.info(
-        "observability.enabled: expanded span-event env (prefill/decode/frontend), "
-        "publish_events_and_metrics and per-iteration engine stats"
+        "observability.enabled: expanded INFO JSONL env and frontend request trace, "
+        "publish_events_and_metrics and per-iteration engine stats%s",
+        " with DEBUG span events" if observability.get("debug_spans") else "",
     )
     return cfg
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1060,7 +1060,7 @@ class TachometerConfig:
 
 @dataclass(frozen=True)
 class ObservabilityConfig:
-    """Observability configuration for OTEL tracing.
+    """Observability configuration for structured logs, metrics, and tracing.
 
     When enable_otel is True, OTEL environment variables (DYN_LOGGING_JSONL,
     OTEL_EXPORT_ENABLED, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_SERVICE_NAME)
@@ -1080,8 +1080,13 @@ class ObservabilityConfig:
     * ``enable_iter_perf_stats`` + ``return_perf_metrics`` on every engine
       config -- the ``trtllm_kv_cache_*`` occupancy gauges and per-request
       histograms appear on that surface.
-    * ``DYN_LOGGING_SPAN_EVENTS`` / ``DYN_LOGGING_JSONL`` / ``DYN_LOG=debug`` on
-      prefill, decode and frontend -- per-request ``SPAN_CLOSED`` trace lines.
+    * ``DYN_LOGGING_JSONL=true`` / ``DYN_LOG=info`` on prefill, decode and
+      frontend -- lightweight structured component logs.
+    * ``DYN_REQUEST_TRACE=1`` on the frontend only -- metadata-only per-request
+      timing and routing records, persisted below the run log directory.
+
+    Setting ``debug_spans`` additionally enables ``DYN_LOGGING_SPAN_EVENTS``
+    and changes the default log level to DEBUG for exact router-span analysis.
 
     and, for the run's server-side capture:
 
@@ -1109,6 +1114,8 @@ class ObservabilityConfig:
 
     Attributes:
         enabled: Master analytics knob. Default: False.
+        debug_spans: Emit DEBUG-level span events for exact router debugging.
+            Default: False.
         enable_otel: If True, inject OTEL environment variables into all workers
             and frontends. Requires otel_endpoint to be set. Default: False.
         otel_endpoint: OTEL collector endpoint (e.g. "http://10.0.0.1:4317").
@@ -1124,6 +1131,7 @@ class ObservabilityConfig:
     """
 
     enabled: bool = False
+    debug_spans: bool = False
     enable_otel: bool = False
     otel_endpoint: str | None = None
 
@@ -1178,13 +1186,16 @@ def build_otel_env(observability: ObservabilityConfig, component: str) -> dict[s
     }
 
 
-# Env that makes Dynamo emit one JSONL ``SPAN_CLOSED`` line per closed span on
-# the component's stdout. This is the *only* source for the per-request trace
-# leg of the offline perf tooling; without it those panels have no input.
-# DYN_LOG=debug is required because the span events are emitted at DEBUG level.
-ANALYTICS_SPAN_ENV: dict[str, str] = {
-    "DYN_LOGGING_SPAN_EVENTS": "true",
+# Lightweight structured logging used for every observability-enabled run.
+ANALYTICS_INFO_ENV: dict[str, str] = {
     "DYN_LOGGING_JSONL": "true",
+    "DYN_LOG": "info",
+}
+
+# Optional exact router-span debugging. Span events are emitted at DEBUG level,
+# so both settings are required when observability.debug_spans is enabled.
+ANALYTICS_DEBUG_SPAN_ENV: dict[str, str] = {
+    "DYN_LOGGING_SPAN_EVENTS": "true",
     "DYN_LOG": "debug",
 }
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -263,6 +263,8 @@ class TestDryRunExecutionExtensions:
         assert "binary_path" in output
         assert "tachometer-scraper" in output
         assert "storage_subdir" in output
+        assert "INFO JSONL" in output
+        assert "frontend-only metadata" in output
 
     def test_tachometer_details_shown_without_explicit_block(self, capsys):
         """observability.enabled alone implies Tachometer; dry-run must say so."""

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -49,8 +49,19 @@ class TestExpandObservability:
         cfg = expand_observability(_trtllm_config())
         assert "publish_events_and_metrics" not in cfg["backend"]
 
-    def test_enabled_expands_span_env_on_all_three_roles(self):
+    def test_enabled_expands_info_jsonl_without_debug_spans(self):
         cfg = expand_observability(_trtllm_config(enabled=True))
+        for env in (
+            cfg["backend"]["prefill_environment"],
+            cfg["backend"]["decode_environment"],
+            cfg["frontend"]["env"],
+        ):
+            assert env["DYN_LOGGING_JSONL"] == "true"
+            assert env["DYN_LOG"] == "info"
+            assert "DYN_LOGGING_SPAN_EVENTS" not in env
+
+    def test_debug_spans_expands_debug_span_env_on_all_three_roles(self):
+        cfg = expand_observability(_trtllm_config(enabled=True, debug_spans=True))
         for env in (
             cfg["backend"]["prefill_environment"],
             cfg["backend"]["decode_environment"],
@@ -58,7 +69,6 @@ class TestExpandObservability:
         ):
             assert env["DYN_LOGGING_SPAN_EVENTS"] == "true"
             assert env["DYN_LOGGING_JSONL"] == "true"
-            # SPAN_CLOSED is emitted at DEBUG; anything higher yields no traces.
             assert env["DYN_LOG"] == "debug"
 
     def test_enabled_expands_request_trace_env_on_the_frontend_only(self):
@@ -90,12 +100,14 @@ class TestExpandObservability:
 
     def test_explicit_recipe_values_win(self):
         """setdefault semantics: an explicit recipe value must never be clobbered."""
-        cfg = _trtllm_config(enabled=True)
-        cfg["backend"]["decode_environment"]["DYN_LOG"] = "info"
+        cfg = _trtllm_config(enabled=True, debug_spans=True)
+        cfg["backend"]["decode_environment"]["DYN_LOG"] = "warn"
+        cfg["frontend"]["env"]["DYN_LOGGING_JSONL"] = "false"
         cfg["backend"]["trtllm_config"]["decode"]["return_perf_metrics"] = False
         cfg["backend"]["publish_events_and_metrics"] = False
         out = expand_observability(cfg)
-        assert out["backend"]["decode_environment"]["DYN_LOG"] == "info"
+        assert out["backend"]["decode_environment"]["DYN_LOG"] == "warn"
+        assert out["frontend"]["env"]["DYN_LOGGING_JSONL"] == "false"
         assert out["backend"]["trtllm_config"]["decode"]["return_perf_metrics"] is False
         assert out["backend"]["publish_events_and_metrics"] is False
 
@@ -104,12 +116,13 @@ class TestExpandObservability:
         assert cfg["backend"]["prefill_environment"]["TLLM_LOG_LEVEL"] == "INFO"
         assert cfg["frontend"]["env"]["DYN_TOKENIZER"] == "fastokens"
 
-    def test_non_trtllm_backend_keeps_span_env_but_no_engine_keys(self):
+    def test_non_trtllm_backend_keeps_logging_env_but_no_engine_keys(self):
         cfg = dict(BASE_CONFIG)
         cfg["backend"] = {"type": "sglang"}
         cfg["observability"] = {"enabled": True}
         out = expand_observability(cfg)
-        assert out["backend"]["prefill_environment"]["DYN_LOGGING_SPAN_EVENTS"] == "true"
+        assert out["backend"]["prefill_environment"]["DYN_LOG"] == "info"
+        assert "DYN_LOGGING_SPAN_EVENTS" not in out["backend"]["prefill_environment"]
         assert "publish_events_and_metrics" not in out["backend"]
 
     def test_missing_sections_are_created(self):
@@ -248,6 +261,7 @@ class TestObservabilitySchema:
     def test_defaults_are_off(self):
         cfg = SrtConfig.Schema().load(BASE_CONFIG)
         assert cfg.observability.enabled is False
+        assert cfg.observability.debug_spans is False
         assert cfg.observability.enable_otel is False
 
     def test_knob_exposes_no_benchmark_client_fields(self):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -654,6 +654,46 @@ class TestTachometerStageMixin:
         assert stage._resolve_tachometer_binary("tachometer-scraper") == str(binary)
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
+    def test_finalize_tachometer_stops_scraper_and_compacts(self, mock_srun, tmp_path):
+        class Harness(TelemetryStageMixin):
+            def __init__(self):
+                self.config = _make_config(tachometer=TachometerConfig(enabled=True))
+                self.runtime = MagicMock()
+                self.runtime.log_dir = tmp_path
+                self.runtime.nodes.head = "node-a"
+                self.runtime.nodes.het_group_for.return_value = None
+                self.runtime.srun_options = {}
+
+        local_dir = tmp_path / "tachometer" / "local"
+        storage_leaf = tmp_path / "tachometer" / "raw" / "scrape"
+        local_dir.mkdir(parents=True)
+        storage_leaf.mkdir(parents=True)
+
+        scraper = MagicMock()
+        scraper.is_running = True
+        registry = MagicMock()
+        registry.get_process.return_value = scraper
+
+        compact = MagicMock()
+        compact.wait.return_value = 0
+        mock_srun.return_value = compact
+        harness = Harness()
+        harness._resolve_tachometer_binary = lambda binary_path: binary_path
+
+        # The real compact process creates this before returning success.
+        compact.wait.side_effect = lambda timeout: (storage_leaf / "final.parquet").touch() or 0
+
+        assert harness.finalize_tachometer(registry) is True
+        scraper.terminate.assert_called_once_with(timeout=30.0)
+        assert mock_srun.call_args.kwargs["command"] == [
+            "tachometer-scraper",
+            "compact",
+            str(local_dir),
+            "--output",
+            f"file://{storage_leaf}",
+        ]
+
+    @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
     def test_tachometer_auto_starts_under_observability_enabled(self, mock_srun, tmp_path):
         """observability.enabled alone starts Tachometer — no tachometer: block needed."""
         import dataclasses


### PR DESCRIPTION
## Summary
- default observability-enabled components to INFO-level JSONL logging
- keep metadata-only request tracing on frontend replicas and Tachometer at 1 Hz
- add observability.debug_spans for opt-in DEBUG SPAN_CLOSED records
- surface the active logging and request-trace mode in dry-run output

## Tests
- uv run pytest -q tests/test_observability.py tests/test_dry_run.py

The full suite was also started under the required Nix C++ runtime; it reached the long-running integration-status section with no failures before the local command timeout.