### PR TITLE
feat: Add host_setup config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,26 @@ backend:
 
 **Validation:** In disaggregated mode, srtslurm rejects configs that set `mooncake_kv_store` without `disaggregation-transfer-backend: mooncake` on `sglang_config.prefill` or `sglang_config.decode`. This catches the common misconfiguration where the master process gets launched but workers fall back to default transport.
 
+### Host Setup
+
+`host_setup` runs commands on each node's **bare host, outside the container**, before any
+worker starts — the counterpart to `setup_script`, which runs *inside* the container. Use it
+for node state a container cannot reach (GPU clocks, kernel modules).
+
+```yaml
+host_setup:
+  commands: ["sudo -n nvidia-smi -lmc <min>,<max>"]
+  teardown: ["sudo -n nvidia-smi -rmc"]   # runs on the cleanup path, success or failure
+  nodes: all                              # all | workers
+```
+
+Implemented in `SweepOrchestrator._run_host_setup()` / `._run_host_teardown()` as one
+container-less `start_srun_process(container_image=None, ...)` per node. Cluster-wide default
+lives in `srtslurm.yaml` as `default_host_setup` (whole-block replace, like
+`default_health_check`). Commands run as the submitting user, so privileged ones need
+passwordless sudo. Always pair a `commands` entry that sets persistent state with a
+`teardown` — otherwise it leaks to the next job on that node.
+
 ### ResourceConfig
 
 Supports explicit GPUs per worker (overrides computed values):
@@ -259,6 +279,7 @@ Config sources that feed into dry-run display:
 - **Mounts**: `config.extra_mount`, `config.container_mounts`, `default_mounts` from srtslurm.yaml
 - **Env vars**: `config.environment` (global), `backend.prefill_environment`, `backend.decode_environment`, `backend.aggregated_environment`
 - **srun options**: `config.srun_options`
+- **Host setup**: `config.host_setup`, `default_host_setup` from srtslurm.yaml
 
 ## Debugging
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -28,6 +28,7 @@ Complete reference for job configuration YAML files.
 - [sbatch_directives](#sbatch_directives)
 - [srun_options](#srun_options)
 - [setup_script](#setup_script)
+- [host_setup](#host_setup)
 - [enable_config_dump](#enable_config_dump)
 - [Complete Examples](#complete-examples)
 
@@ -118,11 +119,14 @@ The `srtslurm.yaml` file can contain the following fields:
 | `containers`                    | dict   | Container image aliases                               |
 | `default_mounts`                | dict   | Cluster-wide container mounts                         |
 | `default_bash_preamble`         | string | Shell snippet prepended to every container srun       |
+| `default_host_setup`            | object | Commands run on every node's bare host, outside the container |
 | `nginx_raise_ulimit`          | bool   | Optional default for `frontend.nginx_raise_ulimit`  |
 
 **output_dir**: When set, job logs are written to `output_dir/{job_id}/logs` instead of `srtctl_root/outputs/{job_id}/logs`. Useful for CI/CD and ephemeral environments.
 
 **default_bash_preamble**: A shell snippet (e.g. `"ulimit -n 1048576 -s unlimited -u 1048576"`) prepended to every container srun launched by srtctl — workers, frontends, telemetry, benchmark, postprocess. Runs before per-call `bash_preamble` and the main command, so cluster-wide ulimits apply to everything downstream. Silently dropped for distroless containers (e.g. `prom/node-exporter`) that bypass the bash wrapper; a WARNING log is emitted in that case.
+
+**default_host_setup**: A [`host_setup`](#host_setup) block applied to every job on the cluster — for node state that has to be set outside the container, such as locking GPU clocks. A recipe that sets its own `host_setup:` block replaces it entirely; `host_setup: {commands: []}` opts a single run out.
 
 **nginx_raise_ulimit**: When set to `true` or `false`, this value is applied to jobs that omit `frontend.nginx_raise_ulimit` in the recipe. Use `true` on clusters where raising the nginx container’s open-file limit is allowed; leave unset if each job should rely on the frontend default (`false`). A recipe that sets `frontend.nginx_raise_ulimit` always wins.
 
@@ -1627,6 +1631,43 @@ setup_script: "install-custom-deps.sh"
 #!/bin/bash
 pip install --quiet git+https://github.com/sgl-project/sglang.git
 ```
+
+---
+
+## host_setup
+
+Commands run on each allocated node's **bare host, outside the container**, before any worker starts.
+
+This is the counterpart to [`setup_script`](#setup_script), which runs *inside* the container. Use `host_setup` for node state the container cannot reach: locking GPU clocks, loading a kernel module, dropping caches.
+
+```yaml
+host_setup:
+  commands:
+    - "sudo -n nvidia-smi -lmc <min>,<max>"
+  teardown:
+    - "sudo -n nvidia-smi -rmc"
+  nodes: all
+  ignore_failure: false
+  timeout_seconds: 300
+```
+
+| Field             | Type            | Default | Description                                                              |
+| ----------------- | --------------- | ------- | ------------------------------------------------------------------------ |
+| `commands`        | list[string]    | `[]`    | Shell commands run in order on each node, joined with `&&`                |
+| `teardown`        | list[string]    | `[]`    | Commands run on each node after workers stop, on success and failure alike |
+| `nodes`           | `all`/`workers` | `all`   | `all` covers head, infra, and workers; `workers` only the worker nodes    |
+| `ignore_failure`  | bool            | `false` | Log a warning instead of failing the job when a node's commands fail      |
+| `timeout_seconds` | int             | `300`   | Per-node wall-clock budget, for `commands` and `teardown` alike           |
+
+**How it runs**: the orchestrator itself runs on the host (not in a container), so it fans these out as one container-less `srun` per node, in parallel. Output lands in `<log_dir>/host_setup_<node>.out` and `<log_dir>/host_teardown_<node>.out`.
+
+**Notes**:
+
+- **Commands run as you, not as root.** Anything privileged needs passwordless sudo (`sudo -n ...`). A `sudo` that prompts for a password will hang until `timeout_seconds` and then fail the job — verify first with `srun --jobid <job> --overlap -w <node> sudo -n true`. If sudo prompts, no recipe change helps; the cluster's SLURM `Prolog=` (which runs as root) is the only route.
+- **Prefer setting `teardown` whenever `commands` changes persistent node state.** `nvidia-smi -lmc` outlives the allocation, so without a matching `-rmc` the next job on that node inherits your locked clocks. `srtctl dry-run` warns when `commands` is set without `teardown`.
+- `teardown` runs from the job's cleanup path, so it fires on failure and cancellation too, and never changes the job's exit code.
+- Set cluster-wide via `default_host_setup` in `srtslurm.yaml` — that's the right home when *the cluster's machines* need this, rather than one recipe. See [Cluster Config Fields](#cluster-config-fields).
+- `srtctl dry-run -f config.yaml` renders the commands, their scope, and which file they came from.
 
 ---
 

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -388,6 +388,103 @@ class SweepOrchestrator(
         if removed > 0:
             logger.info("Cleaned %d stale .lock files from HF cache: %s", removed, hf_home)
 
+    def _host_setup_nodes(self) -> list[str]:
+        """Nodes targeted by host_setup, deduped and stable in allocation order."""
+        nodes = list(self.runtime.nodes.worker)
+        if self.config.host_setup.nodes == "all":
+            nodes = [self.runtime.nodes.head, self.runtime.nodes.infra, *nodes]
+        return list(dict.fromkeys(nodes))
+
+    def _run_host_commands(self, commands: list[str], *, phase: str) -> list[str]:
+        """Run commands on each node's bare host, one srun per node, in parallel.
+
+        Passing container_image=None keeps these on the host: the orchestrator
+        already runs outside the container, so this is the only launch path that
+        can touch node state the container cannot reach (GPU clocks, modules).
+
+        Returns the nodes that failed; the caller decides whether that is fatal.
+        """
+        nodes = self._host_setup_nodes()
+        script = " && ".join(commands)
+        timeout = self.config.host_setup.timeout_seconds
+        logger.info("host_setup (%s): running on %d node(s): %s", phase, len(nodes), script)
+
+        procs = []
+        for node in nodes:
+            log = self.runtime.log_dir / f"host_{phase}_{node}.out"
+            proc = start_srun_process(
+                command=["bash", "-c", script],
+                nodelist=[node],
+                output=str(log),
+                container_image=None,  # bare host, not the job container
+                het_group=self.runtime.nodes.het_group_for(node),
+            )
+            procs.append((node, proc, log))
+
+        failures = []
+        for node, proc, log in procs:
+            try:
+                returncode = proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                # A sudo that prompts for a password hangs here rather than failing,
+                # so kill it instead of stalling the whole allocation.
+                proc.kill()
+                proc.wait()
+                logger.error(
+                    "host_setup (%s) timed out after %ds on %s (see %s); a command that prompts for input will do this",
+                    phase,
+                    timeout,
+                    node,
+                    log,
+                )
+                failures.append(node)
+                continue
+            if returncode != 0:
+                logger.error("host_setup (%s) failed with exit %d on %s (see %s)", phase, returncode, node, log)
+                failures.append(node)
+        return failures
+
+    def _run_host_setup(self) -> None:
+        """Prepare each node's bare host before any worker starts."""
+        setup = self.config.host_setup
+        if not setup.enabled:
+            return
+        # Marks that the job reached this stage, which is what arms teardown --
+        # including for a teardown-only block, where there is nothing to run here.
+        self._host_setup_ran = True
+        if not setup.commands:
+            return
+        failures = self._run_host_commands(setup.commands, phase="setup")
+        if not failures:
+            logger.info("host_setup complete on %d node(s)", len(self._host_setup_nodes()))
+            return
+        if setup.ignore_failure:
+            logger.warning("host_setup failed on %s (ignore_failure: true, continuing)", ", ".join(failures))
+            return
+        raise RuntimeError(f"host_setup failed on: {', '.join(failures)}")
+
+    def _run_host_teardown(self) -> None:
+        """Undo host_setup after workers stop.
+
+        Runs on the way out of every job, successful or not: state set by
+        host_setup (locked clocks, loaded modules) outlives the allocation and
+        would otherwise be inherited by whoever gets the node next. Never raises
+        -- a failed teardown must not overwrite the job's real exit code.
+        """
+        setup = self.config.host_setup
+        if not setup.teardown or not getattr(self, "_host_setup_ran", False):
+            return
+        try:
+            failures = self._run_host_commands(setup.teardown, phase="teardown")
+        except Exception:  # noqa: BLE001 - cleanup path, never mask the job result
+            logger.exception("host_setup teardown raised; node state may need manual cleanup")
+            return
+        if failures:
+            logger.error(
+                "host_setup teardown failed on %s; those nodes may be left in a modified state",
+                ", ".join(failures),
+            )
+
     def _stage_model(self) -> None:
         """Copy the model from shared storage to node-local storage on every
         worker node before workers start (model.stage_dir). One srun per node,
@@ -662,6 +759,10 @@ class SweepOrchestrator(
         exit_code = 1
 
         try:
+            # Stage 0: Bare-host node setup (GPU clocks, kernel modules). Runs
+            # before anything containerized so workers see the prepared node.
+            self._run_host_setup()
+
             # Stage 1: Head infrastructure (NATS, etcd). Only the dynamo request
             # plane uses it; static/direct frontends skip it.
             if self.config.frontend.type in {"sglang", "trtllm_serve", "vllm", "vllm-router"}:
@@ -753,6 +854,8 @@ class SweepOrchestrator(
             exit_code = self.finalize_power_telemetry(exit_code, interrupted=stop_event.is_set())
             stop_event.set()
             registry.cleanup()
+            # After cleanup so the GPUs are idle before node state is reverted.
+            self._run_host_teardown()
             if exit_code != 0:
                 registry.print_failure_details()
             # Post-process first: generate rollup, upload logs to S3, eagerly

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -476,7 +476,8 @@ class SweepOrchestrator(
             return
         try:
             failures = self._run_host_commands(setup.teardown, phase="teardown")
-        except Exception:  # noqa: BLE001 - cleanup path, never mask the job result
+        except Exception:
+            # Cleanup path: a teardown failure must never mask the job's result.
             logger.exception("host_setup teardown raised; node state may need manual cleanup")
             return
         if failures:

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -193,6 +193,23 @@ def setup_logging(level: int = logging.INFO) -> None:
     )
 
 
+def _host_setup_source(config: SrtConfig) -> str:
+    """Where the effective host_setup came from: the recipe or srtslurm.yaml.
+
+    resolve_config_with_defaults only injects default_host_setup when the recipe
+    omits the block entirely, so an exact match against the cluster default
+    identifies it. Worth showing: an unexpected `sudo` in the dry-run output is
+    much easier to chase when you know which file to open.
+    """
+    default = get_srtslurm_setting("default_host_setup")
+    if isinstance(default, dict):
+        commands = list(default.get("commands") or [])
+        teardown = list(default.get("teardown") or [])
+        if commands == config.host_setup.commands and teardown == config.host_setup.teardown:
+            return "srtslurm.yaml (default_host_setup)"
+    return "recipe"
+
+
 def show_config_details(config: SrtConfig) -> None:
     """Display container mounts and environment variables for dry-run verification.
 
@@ -345,6 +362,36 @@ def show_config_details(config: SrtConfig) -> None:
         console.print(Panel(env_table, border_style="yellow"))
     else:
         console.print("[dim]No custom environment variables configured.[/]")
+
+    # --- Host setup (runs on the bare node, outside the container) ---
+    if config.host_setup.enabled:
+        host_table = Table(title="Host Setup (outside container)", show_lines=False, pad_edge=False)
+        host_table.add_column("Phase", style="dim", width=10)
+        host_table.add_column("Command", style="white")
+        for command in config.host_setup.commands:
+            host_table.add_row("setup", command)
+        for command in config.host_setup.teardown:
+            host_table.add_row("teardown", command)
+        console.print(Panel(host_table, border_style="red"))
+
+        setup = config.host_setup
+        source = _host_setup_source(config)
+        console.print(
+            f"[dim]host_setup:[/] nodes={setup.nodes} "
+            f"ignore_failure={str(setup.ignore_failure).lower()} "
+            f"timeout_seconds={setup.timeout_seconds} [dim]source: {source}[/]"
+        )
+        if any("sudo" in command for command in [*setup.commands, *setup.teardown]):
+            console.print(
+                "[yellow]NOTE:[/] host_setup runs as you, not root. Confirm passwordless sudo on a "
+                "compute node first (`srun --jobid <job> --overlap -w <node> sudo -n true`); "
+                "a sudo that prompts will hang until timeout_seconds and fail the job."
+            )
+        if setup.commands and not setup.teardown:
+            console.print(
+                "[yellow]NOTE:[/] no host_setup.teardown configured — any node state set here "
+                "outlives this allocation and is inherited by the next job on these nodes."
+            )
 
     # --- srun options ---
     if config.srun_options:

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -160,6 +160,14 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         config["health_check"] = cluster_config["default_health_check"]
         logger.debug("Applied default_health_check: %s", config["health_check"])
 
+    # Cluster-wide host setup (e.g. locking GPU clocks on nodes that need it).
+    # Whole-block replace, like default_health_check: a recipe that sets
+    # host_setup owns it entirely, so `host_setup: {commands: []}` is the way to
+    # opt a single run out of the cluster default.
+    if "host_setup" not in config and cluster_config.get("default_host_setup"):
+        config["host_setup"] = cluster_config["default_host_setup"]
+        logger.debug("Applied default_host_setup: %s", config["host_setup"])
+
     # Resolve frontend nginx_container alias
     frontend = config.get("frontend", {})
     nginx_container = frontend.get("nginx_container", "")

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -195,6 +195,49 @@ class S3Config:
     Schema: ClassVar[type[Schema]] = Schema
 
 
+@dataclass(frozen=True)
+class HostSetupConfig:
+    """Commands run on the bare host of each allocated node, outside the container.
+
+    The orchestrator (which itself runs on the host, not in a container) fans these
+    out one srun per node before any worker starts, and runs ``teardown`` after the
+    workers are torn down. Use this for node state that cannot be set from inside a
+    container -- locking GPU clocks with ``nvidia-smi -lmc``, loading a kernel
+    module, dropping caches.
+
+    This is the counterpart to ``SrtConfig.setup_script``, which runs *inside* the
+    container from /configs.
+
+    Commands run as the submitting user. Anything needing root must go through
+    passwordless sudo (``sudo -n ...``); a sudo that prompts will hang until
+    ``timeout_seconds`` and fail the job.
+
+    Attributes:
+        commands: Shell commands run in order on each node, joined with ``&&``.
+        teardown: Shell commands run on each node after workers stop. Runs even
+            when the job fails, so state that outlives the allocation (locked
+            clocks persist for the next tenant) gets reset.
+        nodes: Which nodes to target. "all" covers head, infra, and workers;
+            "workers" covers only the nodes running backend workers.
+        ignore_failure: When True, a failing node logs a warning instead of
+            failing the job.
+        timeout_seconds: Per-node wall-clock budget for commands and for teardown.
+    """
+
+    commands: list[str] = field(default_factory=list)
+    teardown: list[str] = field(default_factory=list)
+    nodes: Literal["all", "workers"] = "all"
+    ignore_failure: bool = False
+    timeout_seconds: int = 300
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+    @property
+    def enabled(self) -> bool:
+        """True when there is anything to run on the nodes."""
+        return bool(self.commands or self.teardown)
+
+
 @dataclass
 class ClusterConfig:
     """Cluster configuration from srtslurm.yaml."""
@@ -229,6 +272,9 @@ class ClusterConfig:
     # ``"ulimit -n 1048576 -s unlimited -u 1048576"``. Silently dropped for
     # sruns that bypass the bash wrapper (distroless containers).
     default_bash_preamble: str | None = None
+    # Commands run on every allocated node's bare host, outside the container,
+    # before workers start. Recipes override with their own `host_setup:` block.
+    default_host_setup: HostSetupConfig | None = None
     reporting: ReportingConfig | None = None
     telemetry: dict | None = None  # opaque dict, parsed by try_start_snapshotter
     # When set, applied to job configs that omit ``frontend.nginx_raise_ulimit``.
@@ -1738,6 +1784,11 @@ class SrtConfig:
     # e.g. "custom-setup.sh" -> runs /configs/custom-setup.sh
     setup_script: str | None = None
 
+    # Commands run on each node's bare host, outside the container, before any
+    # worker starts. Cluster-wide default lives in srtslurm.yaml as
+    # default_host_setup; a recipe that sets this block replaces that default.
+    host_setup: HostSetupConfig = field(default_factory=HostSetupConfig)
+
     # Virtual identity — declares what *should* be running (verified against fingerprint)
     identity: IdentityConfig = field(default_factory=IdentityConfig)
 
@@ -1758,7 +1809,28 @@ class SrtConfig:
         self._validate_vllm_frontend()
         self._validate_static_router_frontend()
         self._validate_dynamo_sidecar()
+        self._validate_host_setup()
         self._warn_dp_launch_mode()
+
+    def _validate_host_setup(self) -> None:
+        """Reject host_setup blocks that would fail or hang mid-job.
+
+        These commands run before any worker starts, so a bad entry costs a full
+        allocation to discover. Catch the cheap cases at load time (dry-run).
+        """
+        setup = self.host_setup
+        for attr in ("commands", "teardown"):
+            for i, command in enumerate(getattr(setup, attr)):
+                if not command.strip():
+                    raise ValidationError(f"host_setup.{attr}[{i}] is empty")
+        if setup.timeout_seconds < 1:
+            raise ValidationError(f"host_setup.timeout_seconds must be at least 1, got {setup.timeout_seconds}")
+        if setup.teardown and not setup.commands:
+            logger.warning(
+                "host_setup.teardown is set without host_setup.commands; "
+                "teardown will still run after the job, which is only what you want "
+                "if something outside this recipe set the node state"
+            )
 
     def _validate_dynamo_sidecar(self) -> None:
         """Validate native sidecar configuration before job submission."""

--- a/srtslurm.yaml.example
+++ b/srtslurm.yaml.example
@@ -19,6 +19,22 @@ default_time_limit: "04:00:00"
 #   max_attempts: 540        # 540 * 10s = 90 min
 #   interval_seconds: 10
 
+# Commands run on every allocated node's bare host, OUTSIDE the container,
+# before any worker starts -- for node state a container cannot reach, such as
+# locking GPU clocks on machines that need it. Runs as you, so anything
+# privileged needs passwordless sudo (`sudo -n`); a sudo that prompts hangs
+# until timeout_seconds and fails the job.
+# Recipes that set their own `host_setup:` block override this entirely, and
+# `host_setup: {commands: []}` opts a single run out.
+# default_host_setup:
+#   commands:
+#     - "sudo -n nvidia-smi -lmc <min>,<max>"
+#   teardown:                      # -lmc outlives the job; reset it for the next tenant
+#     - "sudo -n nvidia-smi -rmc"
+#   nodes: all                     # all | workers
+#   ignore_failure: false
+#   timeout_seconds: 300
+
 # SLURM directive compatibility
 # Set to false if your cluster doesn't support --gpus-per-node
 use_gpus_per_node_directive: true  # Default: true

--- a/tests/test_host_setup.py
+++ b/tests/test_host_setup.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for host_setup: commands run on each node's bare host, outside the container."""
+
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from marshmallow import ValidationError
+
+from srtctl.cli.do_sweep import SweepOrchestrator
+from srtctl.core.config import resolve_config_with_defaults
+from srtctl.core.runtime import Nodes, RuntimeContext
+from srtctl.core.schema import HostSetupConfig, ResourceConfig, SrtConfig
+
+LOCK_CLOCKS = "sudo -n nvidia-smi -lmc <min>,<max>"
+RESET_CLOCKS = "sudo -n nvidia-smi -rmc"
+
+BASE_RECIPE = {
+    "name": "host-setup-test",
+    "model": {"path": "/models/test", "container": "test.sqsh", "precision": "fp8"},
+    "resources": {
+        "gpu_type": "gb200",
+        "gpus_per_node": 4,
+        "prefill_nodes": 1,
+        "decode_nodes": 1,
+        "prefill_workers": 1,
+        "decode_workers": 1,
+    },
+}
+
+
+def _load_recipe(overrides: dict | None = None) -> SrtConfig:
+    data = {**BASE_RECIPE, **(overrides or {})}
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(data, f)
+        f.flush()
+        return SrtConfig.from_yaml(Path(f.name))
+
+
+def _config(**host_setup_kwargs) -> SrtConfig:
+    return SrtConfig(
+        name="host-setup-test",
+        model={"path": "/models/test", "container": "test.sqsh", "precision": "fp8"},
+        resources=ResourceConfig(gpu_type="gb200", gpus_per_node=4, prefill_nodes=1, decode_nodes=1),
+        host_setup=HostSetupConfig(**host_setup_kwargs),
+    )
+
+
+def _runtime(tmp_path: Path) -> RuntimeContext:
+    return RuntimeContext(
+        job_id="12345",
+        run_name="test-run",
+        nodes=Nodes(head="node0", bench="node0", infra="node0", worker=("node1", "node2")),
+        head_node_ip="10.0.0.1",
+        infra_node_ip="10.0.0.1",
+        log_dir=tmp_path,
+        model_path=Path("/models/test"),
+        container_image=Path("/img.sqsh"),
+        gpus_per_node=4,
+        network_interface=None,
+        container_mounts={},
+        environment={},
+    )
+
+
+def _ok_proc() -> MagicMock:
+    proc = MagicMock()
+    proc.wait.return_value = 0
+    return proc
+
+
+class TestSchema:
+    def test_defaults_to_disabled(self):
+        config = _load_recipe()
+        assert config.host_setup.commands == []
+        assert config.host_setup.teardown == []
+        assert config.host_setup.enabled is False
+
+    def test_loads_from_recipe(self):
+        config = _load_recipe(
+            {
+                "host_setup": {
+                    "commands": [LOCK_CLOCKS],
+                    "teardown": [RESET_CLOCKS],
+                    "nodes": "workers",
+                    "ignore_failure": True,
+                    "timeout_seconds": 60,
+                }
+            }
+        )
+        assert config.host_setup.commands == [LOCK_CLOCKS]
+        assert config.host_setup.teardown == [RESET_CLOCKS]
+        assert config.host_setup.nodes == "workers"
+        assert config.host_setup.ignore_failure is True
+        assert config.host_setup.timeout_seconds == 60
+        assert config.host_setup.enabled is True
+
+    def test_rejects_unknown_node_scope(self):
+        with pytest.raises(ValidationError):
+            _load_recipe({"host_setup": {"commands": [LOCK_CLOCKS], "nodes": "prefill"}})
+
+    def test_rejects_empty_command(self):
+        with pytest.raises(ValidationError, match="host_setup.commands"):
+            _load_recipe({"host_setup": {"commands": [LOCK_CLOCKS, "   "]}})
+
+    def test_rejects_empty_teardown_command(self):
+        with pytest.raises(ValidationError, match="host_setup.teardown"):
+            _load_recipe({"host_setup": {"commands": [LOCK_CLOCKS], "teardown": [""]}})
+
+    def test_rejects_nonpositive_timeout(self):
+        with pytest.raises(ValidationError, match="timeout_seconds"):
+            _load_recipe({"host_setup": {"commands": [LOCK_CLOCKS], "timeout_seconds": 0}})
+
+
+class TestClusterDefault:
+    """default_host_setup in srtslurm.yaml applies cluster-wide."""
+
+    CLUSTER = {"default_host_setup": {"commands": [LOCK_CLOCKS], "teardown": [RESET_CLOCKS]}}
+
+    def test_applied_when_recipe_omits_block(self):
+        resolved = resolve_config_with_defaults({**BASE_RECIPE}, self.CLUSTER)
+        assert resolved["host_setup"]["commands"] == [LOCK_CLOCKS]
+        assert resolved["host_setup"]["teardown"] == [RESET_CLOCKS]
+
+    def test_recipe_block_wins(self):
+        recipe = {**BASE_RECIPE, "host_setup": {"commands": ["sudo -n nvidia-smi -lgc 1980,1980"]}}
+        resolved = resolve_config_with_defaults(recipe, self.CLUSTER)
+        assert resolved["host_setup"]["commands"] == ["sudo -n nvidia-smi -lgc 1980,1980"]
+        # Whole-block replace: the cluster teardown does not leak into a recipe
+        # that took ownership of the block.
+        assert not resolved["host_setup"].get("teardown")
+
+    def test_empty_commands_opts_out(self):
+        """`host_setup: {commands: []}` is the documented way to skip the cluster default."""
+        recipe = {**BASE_RECIPE, "host_setup": {"commands": []}}
+        resolved = resolve_config_with_defaults(recipe, self.CLUSTER)
+        assert resolved["host_setup"]["commands"] == []
+
+    def test_no_cluster_config_is_a_noop(self):
+        resolved = resolve_config_with_defaults({**BASE_RECIPE}, None)
+        assert "host_setup" not in resolved
+
+    def test_cluster_schema_accepts_the_key(self):
+        """srtslurm.yaml is schema-validated, and a failure there silently drops
+        every cluster default -- so the key has to be declared, not just read."""
+        from srtctl.core.schema import ClusterConfig
+
+        loaded = ClusterConfig.Schema().load({"cluster": "bruh", **self.CLUSTER})
+        assert loaded.default_host_setup.commands == [LOCK_CLOCKS]
+
+
+class TestOrchestrator:
+    def test_runs_one_container_less_srun_per_node(self, tmp_path):
+        orchestrator = SweepOrchestrator(config=_config(commands=[LOCK_CLOCKS]), runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=_ok_proc()) as srun:
+            orchestrator._run_host_setup()
+
+        assert srun.call_count == 3  # head/infra (node0) + node1 + node2
+        for call in srun.call_args_list:
+            assert call.kwargs["container_image"] is None, "host_setup must not run inside the job container"
+            assert call.kwargs["command"] == ["bash", "-c", LOCK_CLOCKS]
+        assert [call.kwargs["nodelist"] for call in srun.call_args_list] == [["node0"], ["node1"], ["node2"]]
+
+    def test_workers_scope_skips_head(self, tmp_path):
+        config = _config(commands=[LOCK_CLOCKS], nodes="workers")
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=_ok_proc()) as srun:
+            orchestrator._run_host_setup()
+
+        assert [call.kwargs["nodelist"] for call in srun.call_args_list] == [["node1"], ["node2"]]
+
+    def test_head_node_not_run_twice_when_it_also_hosts_workers(self, tmp_path):
+        runtime = RuntimeContext(
+            job_id="12345",
+            run_name="test-run",
+            nodes=Nodes(head="node0", bench="node0", infra="node0", worker=("node0", "node1")),
+            head_node_ip="10.0.0.1",
+            infra_node_ip="10.0.0.1",
+            log_dir=tmp_path,
+            model_path=Path("/models/test"),
+            container_image=Path("/img.sqsh"),
+            gpus_per_node=4,
+            network_interface=None,
+            container_mounts={},
+            environment={},
+        )
+        orchestrator = SweepOrchestrator(config=_config(commands=[LOCK_CLOCKS]), runtime=runtime)
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=_ok_proc()) as srun:
+            orchestrator._run_host_setup()
+
+        assert [call.kwargs["nodelist"] for call in srun.call_args_list] == [["node0"], ["node1"]]
+
+    def test_multiple_commands_are_chained(self, tmp_path):
+        config = _config(commands=[LOCK_CLOCKS, "sudo -n nvidia-smi -pm 1"])
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=_ok_proc()) as srun:
+            orchestrator._run_host_setup()
+
+        assert srun.call_args_list[0].kwargs["command"] == [
+            "bash",
+            "-c",
+            f"{LOCK_CLOCKS} && sudo -n nvidia-smi -pm 1",
+        ]
+
+    def test_disabled_block_launches_nothing(self, tmp_path):
+        orchestrator = SweepOrchestrator(config=_config(), runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process") as srun:
+            orchestrator._run_host_setup()
+
+        srun.assert_not_called()
+
+    def test_failure_fails_the_job(self, tmp_path):
+        proc = MagicMock()
+        proc.wait.return_value = 1
+        orchestrator = SweepOrchestrator(config=_config(commands=[LOCK_CLOCKS]), runtime=_runtime(tmp_path))
+
+        with (
+            patch("srtctl.cli.do_sweep.start_srun_process", return_value=proc),
+            pytest.raises(RuntimeError, match="host_setup failed on"),
+        ):
+            orchestrator._run_host_setup()
+
+    def test_ignore_failure_continues(self, tmp_path):
+        proc = MagicMock()
+        proc.wait.return_value = 1
+        config = _config(commands=[LOCK_CLOCKS], ignore_failure=True)
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=proc):
+            orchestrator._run_host_setup()  # does not raise
+
+    def test_timeout_is_killed_and_fails(self, tmp_path):
+        """A sudo that prompts for a password hangs rather than exiting nonzero."""
+
+        def hang(timeout=None):
+            # The timed wait never returns; the reaping wait after kill() does.
+            if timeout is not None:
+                raise subprocess.TimeoutExpired(cmd="srun", timeout=timeout)
+            return -9
+
+        proc = MagicMock()
+        proc.wait.side_effect = hang
+        config = _config(commands=[LOCK_CLOCKS], timeout_seconds=5)
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with (
+            patch("srtctl.cli.do_sweep.start_srun_process", return_value=proc),
+            pytest.raises(RuntimeError, match="host_setup failed on"),
+        ):
+            orchestrator._run_host_setup()
+
+        proc.kill.assert_called()
+
+    def test_timeout_uses_configured_budget(self, tmp_path):
+        config = _config(commands=[LOCK_CLOCKS], timeout_seconds=42)
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+        proc = _ok_proc()
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=proc):
+            orchestrator._run_host_setup()
+
+        proc.wait.assert_called_with(timeout=42)
+
+
+class TestTeardown:
+    def test_runs_after_setup(self, tmp_path):
+        config = _config(commands=[LOCK_CLOCKS], teardown=[RESET_CLOCKS])
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=_ok_proc()) as srun:
+            orchestrator._run_host_setup()
+            srun.reset_mock()
+            orchestrator._run_host_teardown()
+
+        assert srun.call_count == 3
+        for call in srun.call_args_list:
+            assert call.kwargs["command"] == ["bash", "-c", RESET_CLOCKS]
+            assert call.kwargs["container_image"] is None
+
+    def test_skipped_when_setup_never_ran(self, tmp_path):
+        """A job that dies before Stage 0 has not touched the nodes."""
+        config = _config(commands=[LOCK_CLOCKS], teardown=[RESET_CLOCKS])
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process") as srun:
+            orchestrator._run_host_teardown()
+
+        srun.assert_not_called()
+
+    def test_runs_after_an_ignored_setup_failure(self, tmp_path):
+        """Setup may have half-applied, so the nodes still need reverting."""
+        setup_proc = MagicMock()
+        setup_proc.wait.return_value = 1
+        config = _config(commands=[LOCK_CLOCKS], teardown=[RESET_CLOCKS], ignore_failure=True)
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=setup_proc):
+            orchestrator._run_host_setup()
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=_ok_proc()) as srun:
+            orchestrator._run_host_teardown()
+
+        assert srun.call_count == 3
+
+    def test_failure_never_raises(self, tmp_path):
+        """Teardown runs in the finally block; raising would mask the job's result."""
+        config = _config(commands=[LOCK_CLOCKS], teardown=[RESET_CLOCKS])
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=_ok_proc()):
+            orchestrator._run_host_setup()
+        with patch("srtctl.cli.do_sweep.start_srun_process", side_effect=OSError("srun gone")):
+            orchestrator._run_host_teardown()  # does not raise
+
+    def test_teardown_only_block_still_runs(self, tmp_path):
+        config = _config(teardown=[RESET_CLOCKS])
+        orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+
+        with patch("srtctl.cli.do_sweep.start_srun_process", return_value=_ok_proc()) as srun:
+            orchestrator._run_host_setup()
+            assert srun.call_count == 0
+            orchestrator._run_host_teardown()
+
+        assert srun.call_count == 3
+
+
+class TestDryRun:
+    """host_setup must be visible in `srtctl dry-run` before an allocation is spent."""
+
+    def test_commands_are_shown(self, capsys):
+        from srtctl.cli.submit import show_config_details
+
+        show_config_details(_load_recipe({"host_setup": {"commands": [LOCK_CLOCKS], "teardown": [RESET_CLOCKS]}}))
+        output = capsys.readouterr().out
+
+        assert "Host Setup" in output
+        assert "nvidia-smi -lmc <min>,<max>" in output
+        assert "nvidia-smi -rmc" in output
+        assert "nodes=all" in output
+
+    def test_sudo_note_is_shown(self, capsys):
+        from srtctl.cli.submit import show_config_details
+
+        show_config_details(_load_recipe({"host_setup": {"commands": [LOCK_CLOCKS]}}))
+        assert "passwordless" in capsys.readouterr().out
+
+    def test_missing_teardown_is_flagged(self, capsys):
+        from srtctl.cli.submit import show_config_details
+
+        show_config_details(_load_recipe({"host_setup": {"commands": [LOCK_CLOCKS]}}))
+        assert "outlives" in capsys.readouterr().out
+
+    def test_teardown_present_is_not_flagged(self, capsys):
+        from srtctl.cli.submit import show_config_details
+
+        show_config_details(_load_recipe({"host_setup": {"commands": [LOCK_CLOCKS], "teardown": [RESET_CLOCKS]}}))
+        assert "outlives" not in capsys.readouterr().out
+
+    def test_hidden_when_unconfigured(self, capsys):
+        from srtctl.cli.submit import show_config_details
+
+        show_config_details(_load_recipe())
+        assert "Host Setup" not in capsys.readouterr().out
+
+    def test_cluster_default_is_attributed_to_srtslurm_yaml(self, capsys):
+        """An unexpected `sudo` in dry-run should name the file it came from."""
+        from srtctl.cli import submit
+
+        config = _load_recipe({"host_setup": {"commands": [LOCK_CLOCKS]}})
+        with patch.object(
+            submit,
+            "get_srtslurm_setting",
+            side_effect=lambda key, default=None: (
+                {"commands": [LOCK_CLOCKS], "teardown": []} if key == "default_host_setup" else default
+            ),
+        ):
+            submit.show_config_details(config)
+
+        assert "srtslurm.yaml (default_host_setup)" in capsys.readouterr().out
+
+    def test_recipe_block_is_attributed_to_the_recipe(self, capsys):
+        from srtctl.cli import submit
+
+        config = _load_recipe({"host_setup": {"commands": ["sudo -n nvidia-smi -pm 1"]}})
+        with patch.object(
+            submit,
+            "get_srtslurm_setting",
+            side_effect=lambda key, default=None: (
+                {"commands": [LOCK_CLOCKS], "teardown": []} if key == "default_host_setup" else default
+            ),
+        ):
+            submit.show_config_details(config)
+
+        assert "source: recipe" in capsys.readouterr().out


### PR DESCRIPTION
Certain setup commands, such as adjusting GPU clock speeds, must be ran directly on the host instead of the container, srt-slurm currently doesn't have a mechanism for this.

This PR adds `host_setup` configuration to YAML recipes, and `default_host_setup` to srtslurm.yaml.

Example usage to lock memory clocks:
```
host_setup:
  commands: ["sudo -n nvidia-smi -lmc <min>,<max>"]
  teardown: ["sudo -n nvidia-smi -rmc"]
```