### PR TITLE
feat(infra): make NATS/etcd startup timeout configurable

### DIFF
--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -202,14 +202,19 @@ class SweepOrchestrator(
             critical=True,
         )
 
-        # 300s timeout to handle slow container imports on first run
+        # The wait budget must absorb the container import on the infra node:
+        # the srun above triggers the Pyxis/enroot import before setup_head.py
+        # runs, so on a cold enroot cache the first import of a multi-GB image
+        # counts against this timeout and can exceed the 300s default on its
+        # own. Configurable via infra.startup_timeout.
+        startup_timeout = self.config.infra.startup_timeout
         logger.info("Waiting for NATS (port %d) on %s...", NATS_PORT, infra_node)
-        if not wait_for_port(infra_node, NATS_PORT, timeout=300):
+        if not wait_for_port(infra_node, NATS_PORT, timeout=startup_timeout):
             raise RuntimeError("NATS failed to start")
         logger.info("NATS is ready")
 
         logger.info("Waiting for etcd (port %d) on %s...", ETCD_CLIENT_PORT, infra_node)
-        if not wait_for_port(infra_node, ETCD_CLIENT_PORT, timeout=300):
+        if not wait_for_port(infra_node, ETCD_CLIENT_PORT, timeout=startup_timeout):
             raise RuntimeError("etcd failed to start")
         logger.info("etcd is ready")
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1731,10 +1731,18 @@ class InfraConfig:
         nats_max_payload_mb: Maximum NATS message payload in MB. Default: None (uses
             NATS default of 1MB). Set to 24+ for disaggregated serving with long ISL
             (e.g. 65K+ tokens where prompt data exceeds 1MB in NATS messages).
+        startup_timeout: Seconds to wait for NATS and etcd to accept connections
+            after the infra srun is launched. Default: 300. The wait starts before
+            the container is imported, so on a node with a cold enroot cache the
+            first Pyxis import of a multi-GB image counts against this budget and
+            can exceed 300s on its own (observed: 156-161s warm-ish, >300s cold).
+            Raise this when using registry-URI containers that are not pre-imported
+            as local .sqsh files.
     """
 
     etcd_nats_dedicated_node: bool = False
     nats_max_payload_mb: int | None = None
+    startup_timeout: int = 300
 
     Schema: ClassVar[type[Schema]] = Schema
 


### PR DESCRIPTION
## Problem

`start_head_infrastructure` waits a fixed 300s for the NATS port (and etcd), but the budget starts before the workload container exists on the infra node. On a cold enroot cache, the first Pyxis import of a multi-GB registry image counts against that budget and can exceed it on its own. When the timeout fires, `infra.out` contains only `pyxis: importing docker image: ...` and the sweep dies with `RuntimeError: NATS failed to start`, although NATS itself is healthy.

Measured across repeated runs on GB200/GB300 NVL72 Slurm clusters: imports take ~143-161s on warm-cache nodes and exceed 300s on cold nodes (one observed import took over an hour), so the same recipe passes or fails purely by per-node cache state. A controlled A/B with the repo's own smoke test (`recipes/mocker/agg.yaml`) reproduces it deterministically: green on a warm node, dead at exactly the 300s mark on a cold one. Recipes using pre-imported local `.sqsh` files never see this, which is likely why it went unreported.

## Change

1. New `infra.startup_timeout` config field (default 300, stock behavior unchanged), documented as including container import time for registry-URI containers.
2. The NATS and etcd port waits in `do_sweep.py` use it instead of the hardcoded constant.

Minimal and backward compatible. Verified end to end: with the field set, previously flaky recipes complete green on cold nodes across both cluster generations.

## Follow-up (happy to build if wanted)

The deeper fix is to start the clock only once the container entrypoint is actually running (a sentinel written by `setup_head.py`), so import time never counts against service startup and no fixed number needs sizing. Our data shows any fixed timeout eventually loses to a slow-enough import; the sentinel design is the durable variant. I kept this PR minimal per the discussion, and can follow up with the sentinel as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)