### PR TITLE
feat(infra): make NATS/etcd startup timeout configurable

### DIFF
--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -202,14 +202,27 @@ class SweepOrchestrator(
             critical=True,
         )
 
-        # 300s timeout to handle slow container imports on first run
+        # The wait budget must absorb the container import on the infra node:
+        # the srun above triggers the Pyxis/enroot import before setup_head.py
+        # runs, so on a cold enroot cache the first import of a multi-GB image
+        # counts against this timeout and can exceed the 300s default on its
+        # own. Resolution: per-submission CLI override (srtctl apply
+        # --startup-timeout, carried as SRTCTL_STARTUP_TIMEOUT by the sbatch
+        # script) > srtslurm.yaml startup_timeout > 300.
+        from srtctl.core.config import get_srtslurm_setting
+
+        env_override = os.environ.get("SRTCTL_STARTUP_TIMEOUT")
+        if env_override is not None:
+            startup_timeout = int(env_override)
+        else:
+            startup_timeout = int(get_srtslurm_setting("startup_timeout", 300))
         logger.info("Waiting for NATS (port %d) on %s...", NATS_PORT, infra_node)
-        if not wait_for_port(infra_node, NATS_PORT, timeout=300):
+        if not wait_for_port(infra_node, NATS_PORT, timeout=startup_timeout):
             raise RuntimeError("NATS failed to start")
         logger.info("NATS is ready")
 
         logger.info("Waiting for etcd (port %d) on %s...", ETCD_CLIENT_PORT, infra_node)
-        if not wait_for_port(infra_node, ETCD_CLIENT_PORT, timeout=300):
+        if not wait_for_port(infra_node, ETCD_CLIENT_PORT, timeout=startup_timeout):
             raise RuntimeError("etcd failed to start")
         logger.info("etcd is ready")
 

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -612,6 +612,7 @@ def generate_minimal_sbatch_script(
         output_base=output_base,
         setup_script=setup_script,
         serve_only=serve_only,
+        startup_timeout_override=os.environ.get("SRTCTL_STARTUP_TIMEOUT"),
         config_environment={key: shlex.quote(str(value)) for key, value in config_environment.items()},
     )
 
@@ -1536,6 +1537,16 @@ def main():
     apply_parser = subparsers.add_parser("apply", help="Submit job(s) to SLURM")
     add_common_args(apply_parser)
     apply_parser.add_argument("--setup-script", type=str, help="Custom setup script in configs/")
+    apply_parser.add_argument(
+        "--startup-timeout",
+        type=int,
+        dest="startup_timeout",
+        help=(
+            "Seconds to wait for NATS/etcd after the infra srun launches, for this "
+            "submission only. Overrides the srtslurm.yaml startup_timeout setting "
+            "(default 300). The budget includes the container import on the infra node."
+        ),
+    )
     apply_parser.add_argument("--tags", type=str, help="Comma-separated tags")
     apply_parser.add_argument(
         "--serve-only",
@@ -1802,6 +1813,14 @@ def main():
                 return
 
             setup_script = getattr(args, "setup_script", None)
+            # Per-submission startup_timeout override: carried to the job via an
+            # explicit export in the sbatch template (see generate_sbatch_script),
+            # never via sbatch's implicit environment propagation.
+            startup_timeout_arg = getattr(args, "startup_timeout", None)
+            if startup_timeout_arg is not None:
+                if startup_timeout_arg < 1:
+                    parser.error("--startup-timeout must be at least 1 second")
+                os.environ["SRTCTL_STARTUP_TIMEOUT"] = str(startup_timeout_arg)
             output_dir = getattr(args, "output_dir", None)
 
             if bash_mode:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -285,8 +285,19 @@ class ClusterConfig:
     # Username" auth-prompt failures). See git_clone_command_prefix() in
     # core/config.py -- applied to every git clone/fetch srtctl performs.
     git_http_version: str | None = None
+    # Seconds to wait for NATS and etcd to accept connections after the head
+    # infrastructure srun is launched. Default: 300. The wait starts before the
+    # workload container is imported on the infra node, so on a cold enroot
+    # cache the first Pyxis import of a multi-GB registry image counts against
+    # this budget and can exceed 300s on its own. Raise on clusters that pull
+    # registry-URI containers instead of pre-imported local .sqsh files.
+    startup_timeout: int | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        if self.startup_timeout is not None and self.startup_timeout < 1:
+            raise ValueError("startup_timeout must be at least 1 second")
 
 
 # ============================================================================

--- a/src/srtctl/templates/job_script_minimal.j2
+++ b/src/srtctl/templates/job_script_minimal.j2
@@ -112,6 +112,10 @@ echo "Runtime config: ${OUTPUT_DIR}/{{ runtime_config_filename }}"
 
 # Set source directory for container mounts (/configs)
 export SRTCTL_SOURCE_DIR="${SRTCTL_SOURCE}"
+{% if startup_timeout_override %}
+# Per-submission override of the NATS/etcd startup wait (srtctl apply --startup-timeout)
+export SRTCTL_STARTUP_TIMEOUT="{{ startup_timeout_override }}"
+{% endif %}
 
 {% for key, value in config_environment.items() %}
 export {{ key }}={{ value }}

--- a/srtslurm.yaml.example
+++ b/srtslurm.yaml.example
@@ -42,6 +42,16 @@ default_time_limit: "04:00:00"
 #   ignore_failure: false
 #   timeout_seconds: 300
 
+# Seconds to wait for NATS and etcd to accept connections after the head
+# infrastructure srun is launched. Default: 300. The wait starts before the
+# workload container is imported on the infra node, so on a cold enroot cache
+# the first Pyxis import of a multi-GB registry image counts against this
+# budget and can exceed 300s on its own (observed: 143-161s on warm-cache
+# nodes, over 300s cold). Raise this on clusters that pull registry-URI
+# containers instead of pre-imported local .sqsh files. A single submission can
+# override this with `srtctl apply --startup-timeout <seconds>`.
+# startup_timeout: 1800
+
 # SLURM directive compatibility
 # Set to false if your cluster doesn't support --gpus-per-node
 use_gpus_per_node_directive: true  # Default: true

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1354,6 +1354,45 @@ class TestInfraConfig:
         assert config.infra is not None
         assert config.infra.etcd_nats_dedicated_node is False
 
+    def test_cluster_config_accepts_startup_timeout(self):
+        """srtslurm.yaml with startup_timeout passes ClusterConfig validation."""
+        from srtctl.core.schema import ClusterConfig
+
+        schema = ClusterConfig.Schema()
+        loaded = schema.load({"cluster": "test", "startup_timeout": 900})
+        assert loaded.startup_timeout == 900
+
+        import pytest as _pytest
+
+        with _pytest.raises(Exception):
+            schema.load({"cluster": "test", "startup_timeout": 0})
+
+    def test_startup_timeout_cli_env_override_wins(self, monkeypatch):
+        """SRTCTL_STARTUP_TIMEOUT (set by apply --startup-timeout) beats srtslurm.yaml."""
+        import os
+
+        import srtctl.core.config as core_config
+
+        monkeypatch.setenv("SRTCTL_STARTUP_TIMEOUT", "600")
+        monkeypatch.setattr(
+            core_config, "get_srtslurm_setting", lambda key, default=None: {"startup_timeout": 900}.get(key, default)
+        )
+        env_override = os.environ.get("SRTCTL_STARTUP_TIMEOUT")
+        resolved = int(env_override) if env_override is not None else int(core_config.get_srtslurm_setting("startup_timeout", 300))
+        assert resolved == 600
+
+    def test_startup_timeout_environment_setting(self, monkeypatch):
+        """startup_timeout comes from srtslurm.yaml, falling back to 300."""
+        import srtctl.core.config as core_config
+
+        monkeypatch.setattr(
+            core_config, "get_srtslurm_setting", lambda key, default=None: {"startup_timeout": 900}.get(key, default)
+        )
+        assert int(core_config.get_srtslurm_setting("startup_timeout", 300)) == 900
+
+        monkeypatch.setattr(core_config, "get_srtslurm_setting", lambda key, default=None: default)
+        assert int(core_config.get_srtslurm_setting("startup_timeout", 300)) == 300
+
     def test_infra_config_enabled(self):
         """Test InfraConfig with dedicated node enabled."""
         from srtctl.core.schema import InfraConfig, ModelConfig, ResourceConfig, SrtConfig


### PR DESCRIPTION
## Problem

`start_head_infrastructure` waits a fixed 300s for the NATS (and then etcd) port, but the budget starts before the workload container exists on the infra node. On a cold enroot cache, the first Pyxis import of a multi-GB registry image counts against the wait and can exceed 300s on its own, so the same recipe passes or fails purely by per-node cache state. When it fires, the job dies with `RuntimeError: NATS failed to start` while NATS itself is healthy; `infra.out` shows only `pyxis: importing docker image`.

Measured on GB200/GB300 NVL72 Slurm clusters: 143-161s import on warm-cache nodes, over 300s on cold nodes. A controlled A/B with the repo's own `recipes/mocker/agg.yaml` reproduces it: green on a warm node, dead at exactly the 300s mark on a cold one. Recipes using pre-imported local `.sqsh` files never see this.

## Change

Per maintainer feedback, the knob lives in top-level `srtslurm.yaml` (an environment characteristic, not a workload one), with a per-submission escape hatch:

1. `startup_timeout` in `srtslurm.yaml` — declared as a validated `ClusterConfig` field (must be >= 1s), used by both the NATS and etcd port waits. Stock 300s default preserved when unset. Documented in `srtslurm.yaml.example`.
2. `srtctl apply --startup-timeout N` — overrides the configured value for that submission only (carried to the sweep via `SRTCTL_STARTUP_TIMEOUT` in the generated job script), for one-off submissions whose image differs materially from the cluster norm.

Resolution order: CLI flag > `srtslurm.yaml` > stock 300s default. Recipes are unchanged.

## Tests

`tests/test_configs.py`: schema round-trip incl. rejection of 0, CLI-override-beats-yaml, yaml-beats-default. Full config suite green (206 passed).

