### PR TITLE
feat(trtllm): allow overriding the served model name

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -87,27 +87,21 @@ class TRTLLMProtocol:
 
     trtllm_config: TRTLLMServerConfig | None = None
 
-    # The name dynamo.trtllm advertises the model under (`--served-model-name`),
-    # which is the string clients must put in the "model" field of a request.
+    # The name clients must use in a request's "model" field.
     # Defaults to the checkpoint directory name.
-    #
-    # This is a top-level field rather than a `trtllm_config` key on purpose:
-    # trtllm_config is written out verbatim as the engine YAML, and
-    # served-model-name is a dynamo.trtllm CLI flag with no LlmArgs field, so a
-    # YAML key would only inject an unknown option into the engine config. The
-    # MLPerf submission templates make the same split, carrying MODEL_PATH and
-    # SERVED_MODEL_NAME beside the engine YAML rather than inside it.
     #
     #     backend:
     #       type: trtllm
     #       served_model_name: "deepseek-ai/deepseek-r1"
     #
-    # Set it when the client cannot be told which name to ask for. A benchmark
-    # client that takes the name as a flag (agentperf) is handed srtctl's value
-    # and needs nothing here; one that hardcodes it as part of its definition
-    # (the MLPerf harness, where model identity is what makes results
-    # comparable) can only be met by naming the model its way. Without that the
-    # request 404s with the weights loaded and serving.
+    # Set it when the client cannot be told which name to ask for. agentperf
+    # takes the name as a flag, so it never needs this; the MLPerf harness has
+    # it fixed in the benchmark definition, so the server must match or every
+    # request 404s.
+    #
+    # Top-level rather than a trtllm_config key because trtllm_config is dumped
+    # straight into the engine's YAML file, and this is a launcher flag the
+    # engine does not recognise.
     served_model_name: str | None = None
 
     # Whether dynamo.trtllm workers pass `--publish-events-and-metrics`.

--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -87,6 +87,29 @@ class TRTLLMProtocol:
 
     trtllm_config: TRTLLMServerConfig | None = None
 
+    # The name dynamo.trtllm advertises the model under (`--served-model-name`),
+    # which is the string clients must put in the "model" field of a request.
+    # Defaults to the checkpoint directory name.
+    #
+    # This is a top-level field rather than a `trtllm_config` key on purpose:
+    # trtllm_config is written out verbatim as the engine YAML, and
+    # served-model-name is a dynamo.trtllm CLI flag with no LlmArgs field, so a
+    # YAML key would only inject an unknown option into the engine config. The
+    # MLPerf submission templates make the same split, carrying MODEL_PATH and
+    # SERVED_MODEL_NAME beside the engine YAML rather than inside it.
+    #
+    #     backend:
+    #       type: trtllm
+    #       served_model_name: "deepseek-ai/deepseek-r1"
+    #
+    # Set it when the client cannot be told which name to ask for. A benchmark
+    # client that takes the name as a flag (agentperf) is handed srtctl's value
+    # and needs nothing here; one that hardcodes it as part of its definition
+    # (the MLPerf harness, where model identity is what makes results
+    # comparable) can only be met by naming the model its way. Without that the
+    # request 404s with the weights loaded and serving.
+    served_model_name: str | None = None
+
     # Whether dynamo.trtllm workers pass `--publish-events-and-metrics`.
     # Enables the worker to publish KV-cache events (add/evict) + metrics, which
     # the dynamo frontend consumes for KV-cache-aware routing (router-mode: kv).
@@ -187,9 +210,8 @@ class TRTLLMProtocol:
         return {}
 
     def get_served_model_name(self, default: str) -> str:
-        """Get served model name from TRTLLM config, or return default."""
-        # TRTLLM doesn't have served-model-name in config, just use default
-        return default
+        """Get the configured served model name, or return default."""
+        return self.served_model_name or default
 
     def allocate_endpoints(
         self,
@@ -322,7 +344,7 @@ class TRTLLMProtocol:
             "--model-path",
             model_arg,
             "--served-model-name",
-            runtime.model_path.name,
+            self.get_served_model_name(runtime.model_path.name),
         ]
 
         # Only add disaggregation mode for prefill/decode, not for agg

--- a/tests/test_trtllm_served_model_name.py
+++ b/tests/test_trtllm_served_model_name.py
@@ -7,12 +7,11 @@ from srtctl.backends.trtllm import TRTLLMProtocol, TRTLLMServerConfig
 
 
 class TestTRTLLMServedModelName:
-    """`--served-model-name` is what a client must put in a request's "model" field.
+    """The name clients must use in a request's "model" field.
 
-    It defaults to the checkpoint directory name, which is fine when the client
-    can be told what to ask for. A client that hardcodes the name — the MLPerf
-    harness treats model identity as part of the benchmark definition — can only
-    be met by naming the model its way.
+    Defaults to the checkpoint directory name. That is fine when the client can
+    be told what to ask for; a client with the name baked in (the MLPerf
+    harness) needs the server to match it instead.
     """
 
     def test_defaults_to_the_checkpoint_directory_name(self):
@@ -23,12 +22,12 @@ class TestTRTLLMServedModelName:
         assert backend.get_served_model_name("deepseek_r1-torch-fp4-v2") == "deepseek-ai/deepseek-r1"
 
     def test_empty_string_falls_back_to_the_default(self):
-        """An unset-but-present key should not serve the model under an empty name."""
+        """An empty value in a recipe should not serve the model under an empty name."""
         assert TRTLLMProtocol(served_model_name="").get_served_model_name("ckpt") == "ckpt"
 
     def test_is_not_written_into_the_engine_yaml(self):
-        """It is a dynamo.trtllm CLI flag; leaking it into the engine config would
-        inject an option TRT-LLM's LlmArgs does not define."""
+        """trtllm_config becomes the engine's YAML file, and this is a launcher
+        flag, so it must not leak in there."""
         backend = TRTLLMProtocol(
             served_model_name="deepseek-ai/deepseek-r1",
             trtllm_config=TRTLLMServerConfig(aggregated={"tensor_parallel_size": 4}),
@@ -39,7 +38,7 @@ class TestTRTLLMServedModelName:
         assert rendered == {"tensor_parallel_size": 4}
 
     def test_reaches_the_worker_command(self):
-        """The flag the worker is launched with must reflect the override."""
+        """The worker must actually be launched with the configured name."""
         from pathlib import Path
         from unittest.mock import MagicMock
 

--- a/tests/test_trtllm_served_model_name.py
+++ b/tests/test_trtllm_served_model_name.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TRT-LLM's served model name override."""
+
+from srtctl.backends.trtllm import TRTLLMProtocol, TRTLLMServerConfig
+
+
+class TestTRTLLMServedModelName:
+    """`--served-model-name` is what a client must put in a request's "model" field.
+
+    It defaults to the checkpoint directory name, which is fine when the client
+    can be told what to ask for. A client that hardcodes the name — the MLPerf
+    harness treats model identity as part of the benchmark definition — can only
+    be met by naming the model its way.
+    """
+
+    def test_defaults_to_the_checkpoint_directory_name(self):
+        assert TRTLLMProtocol().get_served_model_name("deepseek_r1-torch-fp4-v2") == "deepseek_r1-torch-fp4-v2"
+
+    def test_configured_name_wins(self):
+        backend = TRTLLMProtocol(served_model_name="deepseek-ai/deepseek-r1")
+        assert backend.get_served_model_name("deepseek_r1-torch-fp4-v2") == "deepseek-ai/deepseek-r1"
+
+    def test_empty_string_falls_back_to_the_default(self):
+        """An unset-but-present key should not serve the model under an empty name."""
+        assert TRTLLMProtocol(served_model_name="").get_served_model_name("ckpt") == "ckpt"
+
+    def test_is_not_written_into_the_engine_yaml(self):
+        """It is a dynamo.trtllm CLI flag; leaking it into the engine config would
+        inject an option TRT-LLM's LlmArgs does not define."""
+        backend = TRTLLMProtocol(
+            served_model_name="deepseek-ai/deepseek-r1",
+            trtllm_config=TRTLLMServerConfig(aggregated={"tensor_parallel_size": 4}),
+        )
+        rendered = backend.get_config_for_mode("agg")
+        assert "served_model_name" not in rendered
+        assert "served-model-name" not in rendered
+        assert rendered == {"tensor_parallel_size": 4}
+
+    def test_reaches_the_worker_command(self):
+        """The flag the worker is launched with must reflect the override."""
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        backend = TRTLLMProtocol(served_model_name="deepseek-ai/deepseek-r1")
+        runtime = MagicMock()
+        runtime.model_path = Path("/models/deepseek_r1-torch-fp4-v2")
+        runtime.request_plane = "nats"
+
+        process = MagicMock()
+        process.endpoint_mode = "agg"
+        cmd = backend.build_worker_command(process, [process], runtime)
+
+        assert "--served-model-name" in cmd
+        assert cmd[cmd.index("--served-model-name") + 1] == "deepseek-ai/deepseek-r1"


### PR DESCRIPTION
#### Overview:

`dynamo.trtllm` already accepts `--served-model-name` and srt-slurm already passes it — but hardcoded to the checkpoint directory name, with a comment stating TRT-LLM has no way to configure it:

```python
def get_served_model_name(self, default: str) -> str:
    """Get served model name from TRTLLM config, or return default."""
    # TRTLLM doesn't have served-model-name in config, just use default
    return default
```

It does. Nothing was reading a config. This adds `served_model_name` to `TRTLLMProtocol` and routes the flag through the existing `get_served_model_name` accessor — exactly what the SGLang and vLLM backends already do.

#### Details:

That name is the string a client must put in the `"model"` field of a request; the server 404s anything else. So the checkpoint-directory default only works when the client can be *told* what to ask for.

| client | how it gets the name | affected? |
|---|---|---|
| agentperf | `--model`, handed srtctl's value | no — it has no opinion |
| MLPerf harness (`nv_mlpinf`) | `HF_MODEL_REPO`, fixed in the benchmark module | **yes — cannot be told** |

The MLPerf harness hardcodes it deliberately: for a submission, model identity is part of what makes two results comparable, so a harness that let you rename the model under test would be the wrong design.

**Measured on hecate.** DeepSeek-R1 NVFP4 loaded across 4 GPUs and registered as `deepseek_r1-torch-fp4-v2` — the checkpoint directory, reached through a symlink from the path the recipe named. The harness asked for `deepseek-ai/deepseek-r1`. The request 404'd against a fully healthy server with the weights resident.

**NVIDIA's own MLPerf submission templates solve this from the server side, for this exact reason.** `closed/NVIDIA/scaleout/sflow/templates/dynamo_disagg_loadgen.yaml` passes the flag to both worker roles:

```yaml
trtllm-llmapi-launch python3 -m dynamo.trtllm
  --model-path        ${{ variables.MODEL_PATH }}
  --served-model-name ${{ variables.SERVED_MODEL_NAME }}
```

and the per-system configs carry the two as separate values, with the comment saying so:

```yaml
# Model resolution for the dynamo.trtllm workers. Passed straight to
# --model-path / --served-model-name (no nv_mlpinf config lookup).
MODEL_PATH:         /home/mlperf_inference_storage/models/gpt-oss/gpt-oss-120b
SERVED_MODEL_NAME:  openai/gpt-oss-120b
```

One is *where the weights are*; the other is *what the model is called*. This PR makes that split expressible in a recipe:

```yaml
backend:
  type: trtllm
  served_model_name: "deepseek-ai/deepseek-r1"
```

**Why a top-level field and not a `trtllm_config` key.** `trtllm_config` is written out verbatim as the engine YAML, and `served-model-name` is a `dynamo.trtllm` CLI flag with no `LlmArgs` field — a YAML key would only inject an option the engine does not define. SGLang and vLLM read it from their engine configs because for those engines it genuinely is an engine option. A test asserts it does not leak into the rendered YAML.

#### Where should the reviewer start?

- `src/srtctl/backends/trtllm.py` — the field, and the one-line change routing the worker command through the accessor rather than `runtime.model_path.name`.
- `tests/test_trtllm_served_model_name.py` — 5 tests: default, override, empty-string fallback, absence from the rendered engine YAML, and that the flag actually reaches the worker command.

**Validated on hardware.** hecate job 514983, 4× GR100 Vera Rubin, DeepSeek-R1 NVFP4 served by Dynamo + TRT-LLM through `srtctl apply`:

```
Registered base model 'deepseek-ai/deepseek-r1'      # was 'deepseek_r1-torch-fp4-v2'
404 responses: 0                                     # was every request
Completed tokens per second: 1402.10
```

Before this change the same recipe 404'd every request against a fully healthy server with the weights resident. With `served_model_name: "deepseek-ai/deepseek-r1"` set, the MLPerf harness reached the model and LoadGen produced a complete summary.

5 new tests; full suite 1506 passed (the 6 failures are pre-existing on this machine — git commit signing inside temp repos, `os.sched_getaffinity` on macOS, and a 3s health-check timeout — all unrelated). Behaviour is unchanged when the field is unset: `served_model_name or default`.

Found while getting MLPerf LoadGen running against an srt-slurm-deployed Dynamo cluster (#365), but it isn't MLPerf-specific — any client with a fixed model identity hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
