### PR TITLE
fix(profiling): preserve workers during timed nsys capture

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -800,7 +800,7 @@ class ProfilingConfig:
 
     type: str = "none"  # "none", "nsys", "nsys-time", or "torch"
 
-    # Extra arguments passed to nsys profile (appended before `-o`; see get_nsys_prefix)
+    # Extra arguments passed to nsys profile, or to nsys start for nsys-time.
     extra_nsys_args: list[str] | None = None
 
     # Phase-specific profiling step configs (not used for nsys-time)
@@ -808,9 +808,9 @@ class ProfilingConfig:
     decode: ProfilingPhaseConfig | None = None
     aggregated: ProfilingPhaseConfig | None = None
 
-    # nsys-time fields: time-based capture window, same on all workers
-    delay_secs: int | None = None  # nsys --delay: seconds from worker launch before capture starts
-    duration_secs: int | None = None  # nsys --duration: seconds to capture after delay
+    # nsys-time fields: named-session capture window, same on all workers
+    delay_secs: int | None = None  # Seconds from worker launch before collection starts
+    duration_secs: int | None = None  # Seconds to collect before finalizing the report
     benchmark_duration_secs: int = 300  # total traffic generation duration (must cover delay + duration)
 
     @property
@@ -825,7 +825,7 @@ class ProfilingConfig:
 
     @property
     def is_nsys_time(self) -> bool:
-        """Check if using time-based nsys capture (--delay/--duration instead of cudaProfilerApi)."""
+        """Check if using a wall-clock nsys capture instead of cudaProfilerApi."""
         return self.type == "nsys-time"
 
     @property
@@ -897,21 +897,10 @@ class ProfilingConfig:
         """Get nsys command prefix for TRTLLM workers.
 
         Supports both iteration-based (cudaProfilerApi trigger via TLLM_PROFILE_START_STOP)
-        and time-based (--delay/--duration) capture modes.
+        and wall-clock named-session capture modes.
         """
         if self.is_nsys_time:
-            cmd = [
-                self.nsys_binary,
-                "profile",
-                "-t",
-                "cuda,nvtx,ucx",
-                "--sample=none",
-                "--cuda-graph-trace=node",
-            ]
-            if self.delay_secs is not None:
-                cmd += ["--delay", str(self.delay_secs)]
-            if self.duration_secs is not None:
-                cmd += ["--duration", str(self.duration_secs)]
+            return self._get_nsys_time_prefix(output_file, trace="cuda-sw,nvtx,ucx")
         else:
             # Iteration-based: TLLM_PROFILE_START_STOP env var triggers cudaProfilerStart/Stop
             cmd = [
@@ -942,6 +931,26 @@ class ProfilingConfig:
         ]
         return cmd
 
+    def _get_nsys_time_prefix(self, output_file: str, *, trace: str) -> list[str]:
+        """Launch a named session whose collection window does not own worker lifetime."""
+        if self.delay_secs is None or self.duration_secs is None:
+            raise ValueError("nsys-time requires delay_secs and duration_secs")
+        identity = hashlib.sha256(output_file.encode()).hexdigest()[:16]
+        session_seed = f"srt_{identity}"
+        cmd = [
+            "/srtctl-runtime/nsys_time_session.sh",
+            self.nsys_binary,
+            session_seed,
+            str(self.delay_secs),
+            str(self.duration_secs),
+            trace,
+            output_file,
+        ]
+        if self.extra_nsys_args:
+            cmd.extend(self.extra_nsys_args)
+        cmd.append("--")
+        return cmd
+
     def get_nsys_prefix(
         self, output_file: str, *, frontend_type: str | None = None, backend_type: str | None = None
     ) -> list[str]:
@@ -963,31 +972,10 @@ class ProfilingConfig:
         if backend_type == "trtllm":
             return self._get_nsys_prefix_trtllm(output_file)
 
-        # Time-based capture for non-TRTLLM backends (vllm, sglang). Required
-        # for vllm+dynamo because dynamo's HTTP frontend doesn't proxy
-        # /start_profile to the vllm worker (returns 404), so cudaProfilerApi
-        # capture can't be triggered from the bench client — we drive capture
-        # purely by --delay/--duration instead.
+        # Named-session capture for non-TRTLLM backends (vllm, sglang). This
+        # path is independent of framework HTTP endpoints and profiler APIs.
         if self.is_nsys_time:
-            cmd = [
-                self.nsys_binary,
-                "profile",
-                "-t",
-                "cuda,nvtx",
-                "--cuda-graph-trace=node",
-                "--force-overwrite",
-                "true",
-            ]
-            if self.delay_secs is not None:
-                cmd += ["--delay", str(self.delay_secs)]
-            if self.duration_secs is not None:
-                cmd += ["--duration", str(self.duration_secs)]
-            if self.extra_nsys_args:
-                cmd.extend(self.extra_nsys_args)
-            cmd.extend(["-o", output_file])
-            if frontend_type == "dynamo":
-                cmd.insert(-2, "--trace-fork-before-exec=true")
-            return cmd
+            return self._get_nsys_time_prefix(output_file, trace="cuda-sw,nvtx")
 
         # SGLang / default path — keep existing behavior
         cmd = [
@@ -1921,11 +1909,8 @@ class SrtConfig:
         if prof.is_torch and backend_type == "trtllm":
             raise ValidationError("torch profiling is not supported for the trtllm backend; use nsys instead")
 
-        # nsys-time (time-based capture via nsys --delay/--duration) is supported
-        # for all backends. get_nsys_prefix() emits a time-based command for the
-        # non-TRTLLM (vllm/sglang) path too, which is the only option for
-        # vllm+dynamo where /start_profile returns 404 and cudaProfilerApi-triggered
-        # capture can't fire.
+        # nsys-time uses a named launch/start/stop session for every backend. It
+        # does not depend on a framework profiling endpoint or CUDA profiler API.
 
         # nsys-time uses top-level delay/duration — no per-phase step configs needed
         if prof.is_nsys_time:
@@ -1933,6 +1918,10 @@ class SrtConfig:
                 raise ValidationError(
                     "profiling.delay_secs and profiling.duration_secs are required for nsys-time mode"
                 )
+            if prof.delay_secs < 0:
+                raise ValidationError("profiling.delay_secs must be non-negative")
+            if prof.duration_secs <= 0:
+                raise ValidationError("profiling.duration_secs must be positive")
             return
 
         r = self.resources

--- a/src/srtctl/runtime_scripts/nsys_time_session.sh
+++ b/src/srtctl/runtime_scripts/nsys_time_session.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run a serving worker in a named Nsight session, collect one bounded window,
+# and keep the launch process tied to the real server lifetime. `nsys stop`
+# finalizes the report without ending the server; SRT remains teardown owner.
+set -euo pipefail
+
+if [ "$#" -lt 8 ]; then
+    echo "usage: $0 NSYS SESSION DELAY DURATION TRACE OUTPUT [START_ARGS...] -- APPLICATION [ARGS...]" >&2
+    exit 2
+fi
+
+nsys_binary="$1"
+session_seed="$2"
+delay_seconds="$3"
+duration_seconds="$4"
+trace="$5"
+output_file="$6"
+shift 6
+
+session_name="${session_seed}_${SLURM_PROCID:-0}_$(hostname)"
+
+start_args=()
+while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+    start_args+=("$1")
+    shift
+done
+if [ "$#" -lt 2 ]; then
+    echo "nsys-time session requires an application after --" >&2
+    exit 2
+fi
+shift
+
+launch_pid=""
+cleanup() {
+    if [ -n "$launch_pid" ] && kill -0 "$launch_pid" 2>/dev/null; then
+        "$nsys_binary" shutdown --session="$session_name" --kill sigterm >/dev/null 2>&1 || true
+    fi
+}
+terminate() {
+    trap - EXIT
+    cleanup
+    exit 143
+}
+trap cleanup EXIT
+trap terminate INT TERM
+
+"$nsys_binary" launch \
+    --session-new="$session_name" \
+    --trace="$trace" \
+    --cuda-graph-trace=node \
+    "$@" &
+launch_pid=$!
+
+sleep "$delay_seconds"
+if ! kill -0 "$launch_pid" 2>/dev/null; then
+    wait "$launch_pid"
+    exit $?
+fi
+
+start_command=(
+    "$nsys_binary" start
+    "--session=$session_name"
+    "--sample=none"
+    "--cpuctxsw=none"
+    "--force-overwrite=true"
+    "--output=$output_file"
+)
+if [ "${#start_args[@]}" -gt 0 ]; then
+    start_command+=("${start_args[@]}")
+fi
+
+# A zero delay can race session registration. Retry only while the launch is
+# alive; run once more without stderr suppression to retain a useful failure.
+started=false
+for ((attempt = 0; attempt < 50; attempt++)); do
+    if "${start_command[@]}" 2>/dev/null; then
+        started=true
+        break
+    fi
+    if ! kill -0 "$launch_pid" 2>/dev/null; then
+        wait "$launch_pid"
+        exit $?
+    fi
+    sleep 0.1
+done
+if [ "$started" != true ]; then
+    "${start_command[@]}"
+fi
+sleep "$duration_seconds"
+"$nsys_binary" stop --session="$session_name"
+
+wait "$launch_pid"

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -3,6 +3,10 @@
 
 """Tests for profiling configuration, validation, and benchmark runner."""
 
+import os
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from srtctl.benchmarks import get_runner
@@ -81,8 +85,7 @@ class TestProfilingConfig:
 
     def test_nsys_time_vllm_dynamo_path(self, monkeypatch):
         """nsys-time on a non-TRTLLM backend (vllm) drives capture purely via
-        --delay/--duration (no cudaProfilerApi range), and adds
-        --trace-fork-before-exec for the dynamo frontend."""
+        a named start/stop session (no cudaProfilerApi range)."""
         from srtctl.core.schema import ProfilingConfig
 
         monkeypatch.delenv("SRTCTL_NSYS_BIN", raising=False)
@@ -90,20 +93,19 @@ class TestProfilingConfig:
         assert profiling.is_nsys_time is True
 
         prefix = profiling.get_nsys_prefix("/out/w0", frontend_type="dynamo", backend_type="vllm")
-        assert prefix[0] == "nsys"
-        assert "profile" in prefix
-        assert "--delay" in prefix and "120" in prefix
-        assert "--duration" in prefix and "30" in prefix
+        assert prefix[0] == "/srtctl-runtime/nsys_time_session.sh"
+        assert prefix[1] == "nsys"
+        assert prefix[2].startswith("srt_")
+        assert "%q" not in prefix[2]
+        assert prefix[3:5] == ["120", "30"]
+        assert prefix[5] == "cuda-sw,nvtx"
+        assert prefix[-1] == "--"
         # Time-based capture — no cudaProfilerApi capture-range trigger.
         assert "cudaProfilerApi" not in prefix
         assert "--capture-range-end" not in prefix
-        assert "--trace-fork-before-exec=true" in prefix
-        # Output file is the last token (-o <output>).
-        assert prefix[-1] == "/out/w0"
-
-        # sglangrouter / non-dynamo frontend omits the fork flag.
+        # Frontend choice does not change the session mechanism.
         prefix_router = profiling.get_nsys_prefix("/out/w0", frontend_type="sglangrouter", backend_type="vllm")
-        assert "--trace-fork-before-exec=true" not in prefix_router
+        assert prefix_router == prefix
 
     def test_nsys_binary_override(self, monkeypatch):
         """SRTCTL_NSYS_BIN overrides the nsys executable across every code path."""
@@ -116,9 +118,62 @@ class TestProfilingConfig:
         time_prefix = ProfilingConfig(type="nsys-time", delay_secs=1, duration_secs=1).get_nsys_prefix(
             "/out/w0", backend_type="vllm"
         )
-        assert time_prefix[0] == "/opt/nsight/nsys"
+        assert time_prefix[:2] == [
+            "/srtctl-runtime/nsys_time_session.sh",
+            "/opt/nsight/nsys",
+        ]
         # trtllm path
         assert ProfilingConfig(type="nsys").get_nsys_prefix("/out/w0", backend_type="trtllm")[0] == "/opt/nsight/nsys"
+
+    def test_nsys_time_session_preserves_application_lifetime(self, tmp_path):
+        """Stopping collection must not stop the serving application."""
+        log_path = tmp_path / "nsys.log"
+        application_done = tmp_path / "application.done"
+        fake_nsys = tmp_path / "nsys"
+        fake_nsys.write_text(
+            """#!/bin/bash
+set -euo pipefail
+command="$1"
+shift
+if [ "$command" = start ] && [ ! -f "$NSYS_TEST_READY" ]; then
+    exit 1
+fi
+printf '%s\\n' "$command" >> "$NSYS_TEST_LOG"
+if [ "$command" = launch ]; then
+    touch "$NSYS_TEST_READY"
+    while [[ "$1" == --* ]]; do shift; done
+    exec "$@"
+fi
+"""
+        )
+        fake_nsys.chmod(0o755)
+        application = tmp_path / "application"
+        application.write_text(f"#!/bin/bash\nsleep 0.2\nprintf done > {application_done!s}\n")
+        application.chmod(0o755)
+        wrapper = Path(__file__).parents[1] / "src/srtctl/runtime_scripts/nsys_time_session.sh"
+
+        subprocess.run(
+            [
+                wrapper,
+                fake_nsys,
+                "test-session",
+                "0",
+                "0.05",
+                "cuda-sw,nvtx",
+                str(tmp_path / "profile"),
+                "--",
+                application,
+            ],
+            check=True,
+            env={
+                **os.environ,
+                "NSYS_TEST_LOG": str(log_path),
+                "NSYS_TEST_READY": str(tmp_path / "nsys.ready"),
+            },
+        )
+
+        assert log_path.read_text().splitlines() == ["launch", "start", "stop"]
+        assert application_done.read_text() == "done"
 
     def test_torch_profiling(self):
         """Test torch profiling configuration."""
@@ -326,6 +381,30 @@ class TestProfilingValidation:
         )
         assert config.profiling.is_nsys_time
         assert config.backend.type != "trtllm"
+
+    @pytest.mark.parametrize(
+        ("delay_secs", "duration_secs", "message"),
+        [(-1, 1, "delay_secs must be non-negative"), (0, 0, "duration_secs must be positive")],
+    )
+    def test_nsys_time_rejects_invalid_window(self, delay_secs, duration_secs, message):
+        """A named-session window must have a valid wall-clock interval."""
+        from marshmallow import ValidationError
+
+        from srtctl.core.schema import ModelConfig, ProfilingConfig, ResourceConfig, SrtConfig
+
+        with pytest.raises(ValidationError, match=message):
+            SrtConfig(
+                name="test",
+                model=ModelConfig(path="/model", container="/container", precision="fp8"),
+                resources=ResourceConfig(
+                    gpu_type="gb200",
+                    prefill_nodes=1,
+                    decode_nodes=1,
+                    prefill_workers=1,
+                    decode_workers=1,
+                ),
+                profiling=ProfilingConfig(type="nsys-time", delay_secs=delay_secs, duration_secs=duration_secs),
+            )
 
     def test_vllm_profiler_config_in_vllm_config_rejected(self):
         """profiler-config.* in vllm_config conflicts with the auto-injected one."""


### PR DESCRIPTION
## Summary

- replace `nsys profile --delay/--duration` worker ownership with named `nsys launch/start/stop` sessions
- keep the serving worker alive after a bounded collection window so SRT-Slurm remains lifecycle owner
- use the same time-capture wrapper for vLLM, SGLang, and TensorRT-LLM
- use `cuda-sw` for delayed CUDA collection on Blackwell and export the requested report after `nsys stop`
- validate the capture window and cover session registration, shutdown, and application lifetime in tests

## Why

The previous duration-based wrapper either terminated the serving process when collection ended or allowed the surrounding Slurm/Pyxis step to tear it down when `nsys` exited. Framework HTTP profiling endpoints also differ or are unavailable. A named Nsight session makes collection independent of framework APIs and separates profiler lifetime from worker lifetime.

## Validation

- focused SRT-Slurm profiling tests: 29 passed
- `ruff` and shell syntax checks: passed
- full `make check`: 1,433 passed, 2 skipped; five existing macOS/worktree-specific failures remained (mock Slurm process behavior, sa-bench's adjacent `lib/profiling.sh` fixture, and Linux-only CPU-affinity coverage)
- integrated B200 cluster runs on `nsc-svg-slurm-1`: vLLM, SGLang, and TensorRT-LLM each completed AIPerf after the Nsight report finalized and produced a non-empty report/SQLite export with CUDA kernels

## Dependency

This commit is consumed by lights-out-inference MR !855, which adds the deterministic AIPerf profile-capture task and artifact validation.
