### PR TITLE
fix(sweep): filter invalid vLLM GPU topologies

### DIFF
--- a/src/srtctl/core/sweep.py
+++ b/src/srtctl/core/sweep.py
@@ -11,7 +11,63 @@ expanding all combinations of sweep parameters.
 
 import copy
 import itertools
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _parallel_size(config: dict[str, Any], name: str) -> int:
+    """Return a positive parallel size from kebab- or snake-case config."""
+    value = config.get(name, config.get(name.replace("-", "_"), 1))
+    try:
+        size = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"vLLM {name} must be a positive integer; got {value!r}") from exc
+    if size < 1:
+        raise ValueError(f"vLLM {name} must be a positive integer; got {value!r}")
+    return size
+
+
+def _vllm_parallelism_fits_allocation(config: dict[str, Any]) -> bool:
+    """Return whether a vLLM variant fits every active worker allocation.
+
+    TP-only vLLM workers may intentionally use fewer GPUs than a reserved node.
+    Distributed DP workers, however, require their complete DP*TP*PP*PCP world
+    to match the endpoint allocation exactly.
+    """
+    backend = config.get("backend", {})
+    if backend.get("type") != "vllm":
+        return True
+
+    from srtctl.core.schema import ResourceConfig
+
+    resources = ResourceConfig.Schema().load(config.get("resources", {}))
+    vllm_config = backend.get("vllm_config") or {}
+    frontend_type = (config.get("frontend") or {}).get("type", "dynamo")
+    modes = (
+        ("prefill", resources.num_prefill, resources.gpus_per_prefill),
+        ("decode", resources.num_decode, resources.gpus_per_decode),
+        ("aggregated", resources.num_agg, resources.gpus_per_agg),
+    )
+
+    for mode, worker_count, allocated_gpus in modes:
+        if worker_count < 1:
+            continue
+        mode_config = vllm_config.get(mode) or {}
+        dp_size = _parallel_size(mode_config, "data-parallel-size")
+        required_gpus = (
+            dp_size
+            * _parallel_size(mode_config, "tensor-parallel-size")
+            * _parallel_size(mode_config, "pipeline-parallel-size")
+            * _parallel_size(mode_config, "prefill-context-parallel-size")
+        )
+        if required_gpus > allocated_gpus:
+            return False
+        if frontend_type != "vllm" and dp_size > 1 and required_gpus != allocated_gpus:
+            return False
+
+    return True
 
 
 def expand_template(template: Any, values: dict[str, Any]) -> Any:
@@ -74,6 +130,7 @@ def generate_sweep_configs(sweep_config: dict) -> list[tuple[dict, dict]]:
     param_values_list = [sweep_params[name] for name in param_names]
 
     configs = []
+    filtered_count = 0
     for values in itertools.product(*param_values_list):
         # Create parameter dict for this combination
         params = dict(zip(param_names, values, strict=False))
@@ -84,6 +141,14 @@ def generate_sweep_configs(sweep_config: dict) -> list[tuple[dict, dict]]:
 
         # Expand all template placeholders
         config = expand_template(config, params)
+
+        # A Cartesian vLLM topology sweep can request a larger parallel world
+        # than the GPUs allocated to a worker. Drop those variants before full
+        # schema validation so one impossible combination does not abort the
+        # entire sweep (notably for vllm-router, which validates DP eagerly).
+        if not _vllm_parallelism_fits_allocation(config):
+            filtered_count += 1
+            continue
 
         # Generate a unique name for this config
         param_str = "_".join(f"{k}{v}" for k, v in params.items())
@@ -97,5 +162,13 @@ def generate_sweep_configs(sweep_config: dict) -> list[tuple[dict, dict]]:
         config = schema.dump(validated)
 
         configs.append((config, params))
+
+    if filtered_count:
+        logger.warning(
+            "Filtered %d vLLM sweep combination(s) incompatible with worker GPU allocations",
+            filtered_count,
+        )
+    if filtered_count and not configs:
+        raise ValueError("Sweep has no runnable configurations after filtering vLLM parallelism")
 
     return configs

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -108,6 +108,28 @@ class TestExpandTemplate:
 class TestGenerateSweepConfigs:
     """Tests for generate_sweep_configs function."""
 
+    @staticmethod
+    def _vllm_config(sweep: dict, aggregated: dict) -> dict:
+        return {
+            "name": "vllm-sweep",
+            "model": {
+                "path": "model",
+                "container": "container.sqsh",
+                "precision": "fp8",
+            },
+            "resources": {
+                "gpu_type": "h100",
+                "gpus_per_node": 8,
+                "agg_nodes": 1,
+                "agg_workers": 1,
+            },
+            "backend": {
+                "type": "vllm",
+                "vllm_config": {"aggregated": aggregated},
+            },
+            "sweep": sweep,
+        }
+
     def test_missing_sweep_section_raises(self):
         """Test that missing sweep section raises ValueError."""
         config = {"name": "test", "model": {}}
@@ -287,3 +309,95 @@ class TestGenerateSweepConfigs:
 
         assert prefill1["mem-fraction-static"] == "0.85"
         assert prefill2["mem-fraction-static"] == "0.9"
+
+    def test_vllm_sweep_filters_parallelism_larger_than_worker(self):
+        """TP/PP variants larger than the worker allocation are omitted."""
+        config = self._vllm_config(
+            sweep={"tp": [1, 2, 4, 8], "pp": [1, 2, 4, 8]},
+            aggregated={
+                "tensor-parallel-size": "{tp}",
+                "pipeline-parallel-size": "{pp}",
+            },
+        )
+
+        results = generate_sweep_configs(config)
+        params = [result[1] for result in results]
+
+        assert len(results) == 10
+        assert {"tp": 4, "pp": 2} in params
+        assert {"tp": 8, "pp": 8} not in params
+        assert all(item["tp"] * item["pp"] <= 8 for item in params)
+
+    def test_vllm_sweep_preserves_valid_combined_dp_topologies(self):
+        """DP/TP combinations matching the endpoint world size are retained."""
+        config = self._vllm_config(
+            sweep={"tp": [1, 2, 4, 8], "dp": [1, 2, 4, 8]},
+            aggregated={
+                "tensor-parallel-size": "{tp}",
+                "data-parallel-size": "{dp}",
+            },
+        )
+
+        results = generate_sweep_configs(config)
+        params = [result[1] for result in results]
+
+        assert {"tp": 4, "dp": 2} in params
+        assert {"tp": 8, "dp": 8} not in params
+        assert all(item["tp"] * item["dp"] <= 8 for item in params)
+        assert all(item["dp"] == 1 or item["tp"] * item["dp"] == 8 for item in params)
+
+    def test_vllm_router_filters_before_eager_topology_validation(self):
+        """An oversized router variant does not abort the valid variants."""
+        config = self._vllm_config(
+            sweep={"dp": [8, 16]},
+            aggregated={
+                "tensor-parallel-size": 1,
+                "data-parallel-size": "{dp}",
+            },
+        )
+        config["frontend"] = {"type": "vllm-router"}
+
+        results = generate_sweep_configs(config)
+
+        assert [result[1] for result in results] == [{"dp": 8}]
+
+    def test_non_vllm_sweep_keeps_cartesian_product(self):
+        """Backend-specific vLLM filtering does not change SGLang sweeps."""
+        config = {
+            "name": "sglang-sweep",
+            "model": {
+                "path": "model",
+                "container": "container.sqsh",
+                "precision": "fp8",
+            },
+            "resources": {
+                "gpu_type": "h100",
+                "gpus_per_node": 8,
+                "agg_nodes": 1,
+                "agg_workers": 1,
+            },
+            "backend": {
+                "type": "sglang",
+                "sglang_config": {
+                    "aggregated": {
+                        "tp-size": "{tp}",
+                        "dp-size": "{dp}",
+                    }
+                },
+            },
+            "sweep": {"tp": [4, 8], "dp": [4, 8]},
+        }
+
+        results = generate_sweep_configs(config)
+
+        assert len(results) == 4
+
+    def test_vllm_sweep_raises_when_all_topologies_are_invalid(self):
+        """An entirely incompatible sweep fails instead of submitting no jobs."""
+        config = self._vllm_config(
+            sweep={"tp": [16, 32]},
+            aggregated={"tensor-parallel-size": "{tp}"},
+        )
+
+        with pytest.raises(ValueError, match="no runnable configurations"):
+            generate_sweep_configs(config)


### PR DESCRIPTION
## Summary

- filter vLLM sweep variants whose TP × PP × PCP × DP world cannot run within the GPUs allocated to each worker
- preserve valid mixed topologies such as TP4/DP2 on an eight-GPU worker
- keep intentional TP-only configurations that use fewer GPUs than the reserved node
- apply the guard before full schema validation so one oversized vLLM Router variant does not abort the entire sweep
- leave SGLang and TensorRT-LLM expansion unchanged because their parallel dimensions have different semantics

## Motivation

Cartesian topology sweeps in `srt-slurm-recipes` currently expand combinations such as TP8/PP8/DP8 on an eight-GPU node. Those jobs cannot run, but constraining the recipes to TP8/PP1 also removes useful coverage such as TP4/DP2.

This addresses the root cause requested in [NVIDIA/srt-slurm-recipes#9](https://github.com/NVIDIA/srt-slurm-recipes/pull/9) by filtering incompatible vLLM variants during sweep generation.

## Validation

- `pytest tests/ -q` on Linux: 1551 passed, 2 skipped, 6 deselected
- `pytest tests/test_sweep.py -q` on Linux and Windows: 25 passed
- `ruff check src/srtctl/`
- `ruff format --check src/srtctl/`
- `ty check src/srtctl/core/sweep.py`
- expanded all six recipes from srt-slurm-recipes PR #9:
  - DeepSeek-R1 and Nemotron retain TP4/DP2 and cap retained worlds at eight GPUs
  - MiniMax retains its allocation-compatible DP8 variant

## Checklist

- [x] Added regression coverage for oversized TP/PP, mixed TP/DP, vLLM Router, non-vLLM isolation, and fully invalid sweeps
- [x] Commit includes a DCO sign-off
