### PR TITLE
Add cluster-wide git_http_version config for intermittent git smart-HTTP failures

### DIFF
--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from srtctl.benchmarks.base import SCRIPTS_DIR
-from srtctl.core.config import get_srtslurm_setting, load_cluster_config
+from srtctl.core.config import get_srtslurm_setting, git_clone_command_prefix, load_cluster_config
 from srtctl.core.git_state import GIT_STATE_FILENAME
 from srtctl.core.lockfile import collect_worker_fingerprints, generate_reproduction_report, write_lockfile
 from srtctl.core.schema import AIAnalysisConfig, S3Config
@@ -525,6 +525,7 @@ export PYTHONPATH={q_root}
         Upload is always attempted if awscli installs successfully. Parsing is
         best-effort so raw logs survive parser/tooling failures.
         """
+        git_cmd = shlex.join(git_clone_command_prefix())
         return f"""
 set -u
 set -o pipefail
@@ -539,7 +540,7 @@ if ! pip install uv awscli; then
 fi
 
 echo "Installing srtlog..."
-if cd /tmp && git clone --depth 1 https://github.com/ishandhanani/srtlog.git && uv pip install --system ./srtlog; then
+if cd /tmp && {git_cmd} clone --depth 1 https://github.com/ishandhanani/srtlog.git && uv pip install --system ./srtlog; then
   echo "Running srtlog parse..."
   cd /logs
   srtlog parse . || PARSE_STATUS=$?

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -591,6 +591,23 @@ def get_srtslurm_setting(key: str, default: Any = None) -> Any:
     return default
 
 
+def git_clone_command_prefix() -> list[str]:
+    """Return the ``git`` invocation every clone/fetch in srtctl should start from.
+
+    Some clusters see intermittent git smart-HTTP failures negotiating HTTP/2
+    against github.com (stalls, or truncated responses that git misreports as
+    "could not read Username" auth-prompt failures) on certain network paths --
+    observed on both a login host and its compute nodes. Setting
+    ``git_http_version: "HTTP/1.1"`` in srtslurm.yaml works around this for
+    every git clone/fetch srtctl performs, cluster-wide, without touching
+    individual recipes or call sites.
+    """
+    version = get_srtslurm_setting("git_http_version")
+    if not version:
+        return ["git"]
+    return ["git", "-c", f"http.version={version}"]
+
+
 def _setdefault_nested(parent: dict, key: str, values: dict) -> None:
     """``parent[key]`` becomes a dict and gains ``values`` without clobbering."""
     child = parent.get(key)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1300,6 +1300,14 @@ def dynamo_cargo_patch_commands(cargo_patches: list[str] | None = None) -> tuple
     return tuple(commands)
 
 
+def _git_clone_cmd() -> str:
+    """Shell-quoted ``git`` invocation for install-script bash strings; see
+    ``srtctl.core.config.git_clone_command_prefix`` for why this exists."""
+    from srtctl.core.config import git_clone_command_prefix
+
+    return shlex.join(git_clone_command_prefix())
+
+
 def _hash_cached_source_install(dynamo_hash: str, cargo_patches: list[str] | None = None) -> str:
     """Bash for hash-pinned source install with a /configs/dynamo-wheels cache.
 
@@ -1347,7 +1355,7 @@ def _hash_cached_source_install(dynamo_hash: str, cargo_patches: list[str] | Non
         f"pip install --break-system-packages --force-reinstall --quiet maturin && "
         # Clone + build the runtime wheel.
         f"DYN_BUILD_DIR=$(mktemp -d) && cd $DYN_BUILD_DIR && "
-        f"git clone https://github.com/ai-dynamo/dynamo.git && "
+        f"{_git_clone_cmd()} clone https://github.com/ai-dynamo/dynamo.git && "
         f"cd dynamo && git checkout {dynamo_hash} && "
         f"{override_cmd}"
         f"cd lib/bindings/python/ && "
@@ -1390,7 +1398,7 @@ def _live_source_install_for_top_of_tree() -> str:
         # Force-reinstall maturin: see _hash_cached_source_install.
         "pip install --break-system-packages --force-reinstall --quiet maturin && "
         "cd /sgl-workspace/ && "
-        "git clone https://github.com/ai-dynamo/dynamo.git && "
+        f"{_git_clone_cmd()} clone https://github.com/ai-dynamo/dynamo.git && "
         "cd dynamo && "
         "cd lib/bindings/python/ && "
         'export RUSTFLAGS="${RUSTFLAGS:-} -C target-cpu=native --cfg tokio_unstable" && '
@@ -1410,7 +1418,7 @@ def _live_source_install_for_top_of_tree() -> str:
         # Force-reinstall maturin: see _hash_cached_source_install.
         "pip install --break-system-packages --force-reinstall --quiet maturin && "
         "ORIG_DIR=$(pwd) && rm -rf /tmp/dynamo_build && mkdir -p /tmp/dynamo_build && cd /tmp/dynamo_build && "
-        "git clone https://github.com/ai-dynamo/dynamo.git && "
+        f"{_git_clone_cmd()} clone https://github.com/ai-dynamo/dynamo.git && "
         "cd dynamo && "
         "cd lib/bindings/python/ && "
         'export RUSTFLAGS="${RUSTFLAGS:-} -C target-cpu=native --cfg tokio_unstable" && '

--- a/src/srtctl/render/direct_stages/runtime_stage.py
+++ b/src/srtctl/render/direct_stages/runtime_stage.py
@@ -18,6 +18,15 @@ from typing import Any
 
 from .common import run_capture, rust_toolchain
 
+# Some clusters see intermittent git smart-HTTP failures negotiating HTTP/2
+# against github.com (stalls, or truncated responses git misreports as
+# "could not read Username" auth-prompt failures). --bash dev-mode can't
+# read srtslurm.yaml's git_http_version (see srtctl.core.config.
+# git_clone_command_prefix, the config-driven equivalent for the real
+# sbatch path); this stdlib-only package applies the workaround
+# unconditionally instead.
+_GIT = ["git", "-c", "http.version=HTTP/1.1"]
+
 
 class RuntimeSetupStageMixin:
     """Install SGLang and Dynamo into the per-run serving environment."""
@@ -164,15 +173,15 @@ class RuntimeSetupStageMixin:
                     build = Path(raw_build)
                     repo = build / "dynamo"
                     self._run_logged(
-                        ["git", "clone", "--no-checkout", "https://github.com/ai-dynamo/dynamo.git", str(repo)],
+                        [*_GIT, "clone", "--no-checkout", "https://github.com/ai-dynamo/dynamo.git", str(repo)],
                         log_name="install-dynamo.log",
                     )
                     self._run_logged(
-                        ["git", "-C", str(repo), "fetch", "--depth", "1", "origin", source_hash],
+                        [*_GIT, "-C", str(repo), "fetch", "--depth", "1", "origin", source_hash],
                         log_name="install-dynamo.log",
                     )
                     self._run_logged(
-                        ["git", "-C", str(repo), "checkout", "--detach", "FETCH_HEAD"], log_name="install-dynamo.log"
+                        [*_GIT, "-C", str(repo), "checkout", "--detach", "FETCH_HEAD"], log_name="install-dynamo.log"
                     )
                     for command in self.plan["dynamo_cargo_patch_commands"]:
                         self._run_logged(["bash", "-lc", str(command)], log_name="install-dynamo.log", cwd=repo)
@@ -221,7 +230,7 @@ class RuntimeSetupStageMixin:
             build = Path(raw_build)
             repo = build / "dynamo"
             self._run_logged(
-                ["git", "clone", "--depth", "1", "https://github.com/ai-dynamo/dynamo.git", str(repo)],
+                [*_GIT, "clone", "--depth", "1", "https://github.com/ai-dynamo/dynamo.git", str(repo)],
                 log_name="install-dynamo.log",
             )
             environment = dict(os.environ)

--- a/srtslurm.yaml.example
+++ b/srtslurm.yaml.example
@@ -11,6 +11,13 @@ default_account: "your-gpu-account"
 default_partition: "gpu"
 default_time_limit: "04:00:00"
 
+# Some clusters see intermittent git smart-HTTP failures negotiating HTTP/2
+# against github.com (stalls, or truncated responses git misreports as
+# "could not read Username" auth-prompt failures) from certain network paths.
+# Set this if srtctl's dynamo-from-source installs or any other git clone/fetch
+# it performs on the real sbatch path fail this way. No effect if unset.
+# git_http_version: "HTTP/1.1"
+
 # Default health check window for jobs that don't override `health_check:`
 # in the recipe. Useful on clusters with slow storage where large MoE models
 # need >30 min to cold-load (the schema default is max_attempts=180, ~30 min).


### PR DESCRIPTION
## Summary
Some clusters see intermittent git smart-HTTP failures negotiating HTTP/2 against github.com -- stalls, or truncated responses git misreports as `could not read Username` auth-prompt failures -- on certain network paths. Observed live on NVIDIA/InferenceMAX PR #271, on both a login host and its compute nodes, across three separate git operations (clone, fetch, and checkout of a partial clone, which does its own lazy blob fetch for missing objects).

- New `srtctl.core.config.git_clone_command_prefix()`, reading an optional `git_http_version` setting from `srtslurm.yaml` (e.g. `"HTTP/1.1"`).
- Wired into every git clone/fetch on the real sbatch path: the dynamo-from-source install scripts in `core/schema.py` (highest-impact site -- used by any recipe with `dynamo.install: true`, not just one feature), and the srtlog post-processing clone (`cli/mixins/postprocess_stage.py`).
- `--bash` dev-mode (`render/direct_stages/`) can't read `srtslurm.yaml` (deliberately stdlib-only, no `srtctl.core` imports) -- applies `http.version=HTTP/1.1` unconditionally there instead of leaving it unfixed.
- Default (`git_http_version` unset) is unchanged -- plain `git`, no behavior change for clusters that don't need this.

## Test plan
- [x] Full suite: `1544 passed, 2 skipped` -- the 2 unrelated failures (`test_fingerprint.py`, `test_apply_mock.py`) are pre-existing macOS-only platform gaps (`os.sched_getaffinity` doesn't exist on macOS), confirmed by reproducing the same failures on a clean `origin/main` checkout.
- [ ] Live validation pending on NVIDIA/InferenceMAX PR #271, which hit this exact failure mode.