### PR TITLE
Fix: register git_http_version on ClusterConfig (was read-only, not declared)

### DIFF
--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -280,6 +280,11 @@ class ClusterConfig:
     # When set, applied to job configs that omit ``frontend.nginx_raise_ulimit``.
     # Clusters that disallow raising nofile for nginx containers should use false.
     nginx_raise_ulimit: bool | None = None
+    # Works around intermittent git smart-HTTP/HTTP2 failures cloning github.com
+    # (stalls, or truncated responses git misreports as "could not read
+    # Username" auth-prompt failures). See git_clone_command_prefix() in
+    # core/config.py -- applied to every git clone/fetch srtctl performs.
+    git_http_version: str | None = None
 
     Schema: ClassVar[type[Schema]] = Schema
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -56,6 +56,26 @@ class TestConfigLoading:
                 print(f"  - {err}")
 
 
+class TestClusterConfigGitHttpVersion:
+    """srtslurm.yaml is schema-validated, and a failure there silently drops
+    every cluster default (model_paths, containers, etc.) -- so a new key
+    has to be declared in ClusterConfig, not just read via
+    get_srtslurm_setting(). See TestHostSetup.test_cluster_schema_accepts_the_key
+    for the same lesson applied to an earlier field."""
+
+    def test_cluster_schema_accepts_the_key(self):
+        from srtctl.core.schema import ClusterConfig
+
+        loaded = ClusterConfig.Schema().load({"git_http_version": "HTTP/1.1"})
+        assert loaded.git_http_version == "HTTP/1.1"
+
+    def test_unset_defaults_to_none(self):
+        from srtctl.core.schema import ClusterConfig
+
+        loaded = ClusterConfig.Schema().load({})
+        assert loaded.git_http_version is None
+
+
 class TestSrtConfigStructure:
     """Tests for SrtConfig dataclass structure."""
 


### PR DESCRIPTION
## Summary
#376 added `git_clone_command_prefix()` reading `git_http_version` via `get_srtslurm_setting()`, but never declared the key on `ClusterConfig`. `srtslurm.yaml` is schema-validated, and an unknown top-level key fails that validation and **silently drops every cluster default for the whole config**, not just the unrecognized key.

Confirmed live on NVIDIA/InferenceMAX PR #271: `Failed to load or validate srtslurm.yaml: {'git_http_version': ['Unknown field.']}`, which also broke `model_paths` resolution as collateral damage (`FileNotFoundError` on a literal `"deepseek-v4-pro"` path instead of the aliased `/scratch/...` path).

Same lesson `TestHostSetup.test_cluster_schema_accepts_the_key` already captured for an earlier field -- #376 needed the same test and didn't have it.

## Test plan
- [x] New tests confirm `ClusterConfig.Schema()` accepts `git_http_version` and defaults to `None` when unset.
- [x] Full suite: same 2 pre-existing macOS-only failures as `main` (`os.sched_getaffinity`), nothing new.