### PR TITLE
feat(telemetry): ACPI CPU power Prometheus exporter for AIPerf server-metrics

### DIFF
--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -664,6 +664,14 @@ class BenchmarkStageMixin:
                     host = get_hostname_ip(process.node, self.runtime.network_interface)
                     urls.append(f"http://{host}:{kvbm_port}/metrics")
 
+        # Add ACPI CPU power exporter endpoints (one per worker node) when enabled.
+        cpu_power = getattr(self.config.telemetry, "cpu_power", None)
+        if self.config.telemetry.enabled and cpu_power is not None and cpu_power.enabled and cpu_power.prometheus_port > 0:
+            worker_nodes = sorted({process.node for process in self.backend_processes})
+            for node in worker_nodes:
+                host = get_hostname_ip(node, self.runtime.network_interface)
+                urls.append(f"http://{host}:{cpu_power.prometheus_port}/metrics")
+
         if not urls:
             return {}
         # Custom commands preserve logical topology order; built-in AIPerf

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -303,7 +303,60 @@ class TelemetryStageMixin:
             logger.warning("CPU power collectors did not become ready on every worker node")
         else:
             logger.info("CPU power telemetry ready (artifacts under %s)", cpu_dir)
+
+        if cpu_power.prometheus_port > 0:
+            self._start_cpu_power_prometheus_exporters(registry, worker_nodes, cpu_power.prometheus_port)
+
         return session
+
+    def _start_cpu_power_prometheus_exporters(
+        self, registry: ProcessRegistry, worker_nodes: list[str], port: int
+    ) -> None:
+        """Launch cpu_power_exporter.py on each worker node for AIPerf server-metrics scraping."""
+        exporter_command = [
+            sys.executable,
+            "-m",
+            "srtctl.core.cpu_power_exporter",
+            "--port",
+            str(port),
+        ]
+        if self.runtime.nodes.het:
+            groups: dict[int, list[str]] = {}
+            for node in worker_nodes:
+                group_id = self.runtime.nodes.het_group_for(node)
+                if group_id is None:
+                    raise RuntimeError(f"node {node!r} not in any het component")
+                groups.setdefault(group_id, []).append(node)
+            chunks = sorted(groups.items())
+        else:
+            chunks = [(-1, worker_nodes)]
+
+        for group_id, nodes in chunks:
+            suffix = "" if len(chunks) == 1 else f".g{group_id}"
+            log_file = self.runtime.log_dir / f"telemetry_cpu_power_prom{suffix}.%N.out"
+            try:
+                proc = start_srun_process(
+                    command=exporter_command,
+                    nodes=len(nodes),
+                    ntasks=len(nodes),
+                    nodelist=nodes,
+                    output=str(log_file),
+                    srun_options=self.runtime.srun_options,
+                    het_group=group_id if group_id >= 0 else None,
+                    use_bash_wrapper=False,
+                )
+                name = "telemetry_cpu_power_prom" if len(chunks) == 1 else f"telemetry_cpu_power_prom_g{group_id}"
+                registry.add_process(
+                    ManagedProcess(
+                        name=name,
+                        popen=proc,
+                        log_file=log_file,
+                        node=",".join(nodes),
+                        critical=False,
+                    )
+                )
+            except Exception:
+                logger.exception("CPU power Prometheus exporter launch failed on group %s", group_id)
 
     def power_telemetry_blocks_benchmark(self) -> bool:
         """Whether required-mode telemetry failed startup and must skip the workload.

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -151,8 +151,8 @@ class TelemetryStageMixin:
             return None
 
         exporter_config = telemetry.dcgm_exporter
-        if exporter_config is None:  # guaranteed by schema validation
-            raise ValueError("telemetry.dcgm_exporter is required when telemetry is enabled")
+        if exporter_config is None:
+            return None
 
         worker_nodes = sorted({process.node for process in self.backend_processes})
         power_dir = self.runtime.log_dir / telemetry.storage_subdir

--- a/src/srtctl/core/cpu_power_exporter.py
+++ b/src/srtctl/core/cpu_power_exporter.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal Prometheus exporter for Grace CPU power via ACPI hwmon.
+
+Runs on the host (not inside a container) so /sys/class/hwmon is visible.
+Exposes metrics on :9401/metrics by default, readable by AIPerf's
+DCGMTelemetryCollector or a dedicated CPUPowerTelemetryCollector.
+
+Metric names:
+    cpu_power_acpi_watts{socket, oem_info, source}   -- per-channel power (W)
+
+Usage:
+    python3 -m srtctl.core.cpu_power_exporter --port 9401
+    # or via srun (host step, no container):
+    srun ... python3 -m srtctl.core.cpu_power_exporter --port 9401
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import signal
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+# Channels we surface; others (NVSwitch rails etc.) are collected but labelled separately.
+_OEM_LABELS = {
+    re.compile(r"CPU Power Socket (\d+)", re.IGNORECASE): "cpu",
+    re.compile(r"Grace Power Socket (\d+)", re.IGNORECASE): "grace",
+    re.compile(r"SysIO Power Socket (\d+)", re.IGNORECASE): "sysio",
+}
+
+
+def _find_power_meter_sensors(hwmon_root: Path = Path("/sys/class/hwmon")) -> list[dict[str, Any]]:
+    sensors: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for hwmon_dir in sorted(hwmon_root.glob("hwmon*")):
+        try:
+            if (hwmon_dir / "name").read_text().strip() != "power_meter":
+                continue
+        except OSError:
+            continue
+        for root in (hwmon_dir / "device", hwmon_dir):
+            for avg_path in sorted(root.glob("power*_average")):
+                identity = str(avg_path.resolve()) if avg_path.exists() else str(avg_path)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                if not avg_path.is_file():
+                    continue
+                chan = avg_path.stem.removesuffix("_average")
+                oem = _read_text(root / f"{chan}_oem_info") or _read_text(root / f"{chan}_label") or chan
+                channel_type = "other"
+                socket_id = ""
+                for pattern, kind in _OEM_LABELS.items():
+                    m = pattern.search(oem)
+                    if m:
+                        channel_type = kind
+                        socket_id = m.group(1)
+                        break
+                sensors.append(
+                    {
+                        "path": avg_path,
+                        "oem": oem,
+                        "type": channel_type,
+                        "socket": socket_id,
+                    }
+                )
+    return sensors
+
+
+def _read_text(p: Path) -> str | None:
+    try:
+        v = p.read_text().strip()
+        return v or None
+    except OSError:
+        return None
+
+
+def _read_watts(path: Path) -> float | None:
+    raw = _read_text(path)
+    if raw is None:
+        return None
+    try:
+        w = float(raw) / 1_000_000.0
+        return w if math.isfinite(w) and w >= 0 else None
+    except ValueError:
+        return None
+
+
+def _escape(s: str) -> str:
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _build_metrics(sensors: list[dict[str, Any]]) -> str:
+    lines = [
+        "# HELP cpu_power_acpi_watts Grace CPU power rail reading from ACPI hwmon (W).",
+        "# TYPE cpu_power_acpi_watts gauge",
+    ]
+    for s in sensors:
+        watts = _read_watts(s["path"])
+        if watts is None:
+            continue
+        labels = (
+            f'type="{_escape(s["type"])}",'
+            f'socket="{_escape(s["socket"])}",'
+            f'oem_info="{_escape(s["oem"])}",'
+            f'source="acpi"'
+        )
+        lines.append(f"cpu_power_acpi_watts{{{labels}}} {watts:.6f}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    sensors: list[dict[str, Any]] = []
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path not in ("/metrics", "/health"):
+            self.send_response(404)
+            self.end_headers()
+            return
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok\n")
+            return
+        body = _build_metrics(self.sensors).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        pass  # suppress default access log noise
+
+
+def serve(port: int) -> int:
+    sensors = _find_power_meter_sensors()
+    if not sensors:
+        print("ERROR: no ACPI power_meter hwmon sensors found", file=sys.stderr)
+        return 2
+    print(f"Found {len(sensors)} sensor(s):", file=sys.stderr)
+    for s in sensors:
+        print(f"  [{s['type']}] socket={s['socket']}  {s['oem']}  ({s['path']})", file=sys.stderr)
+
+    _Handler.sensors = sensors
+    server = HTTPServer(("", port), _Handler)
+    stop = threading.Event()
+
+    def _shutdown(_sig: int, _frame: Any) -> None:
+        stop.set()
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    print(f"Listening on :{port}/metrics", file=sys.stderr, flush=True)
+    server.serve_forever()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=9401)
+    args = parser.parse_args()
+    return serve(args.port)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1150,6 +1150,9 @@ class CpuPowerConfig:
     sample_interval_seconds: float = 0.1
     startup_timeout_seconds: float = 30.0
     required: bool = False
+    # When > 0, also launch cpu_power_exporter.py on each worker node so
+    # AIPerf can scrape ACPI power rails via --server-metrics / AIPERF_SERVER_METRICS_URLS.
+    prometheus_port: int = 9401
 
     Schema: ClassVar[type[Schema]] = Schema
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -2442,11 +2442,12 @@ class SrtConfig:
             )
 
     def _validate_telemetry(self):
-        """Validate DCGM power telemetry."""
+        """Validate telemetry config."""
         telemetry = self.telemetry
         if telemetry is None or not telemetry.enabled:
             return
-        self._validate_dcgm_power()
+        if telemetry.dcgm_exporter is not None:
+            self._validate_dcgm_power()
 
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":


### PR DESCRIPTION
## Summary

- Adds a Python-based ACPI CPU power Prometheus exporter that integrates with AIPerf's `--server-metrics` scraping pipeline
- Allows `telemetry.enabled` without a `dcgm_exporter` when only `cpu_power` is configured
- Stacks cleanly on top of Kyle's GPU power limits and DCGM/ACPI Python reader work

## Test plan

- [ ] `cpu_power` exporter launches on worker nodes and serves `/metrics` on the configured Prometheus port
- [ ] `AIPERF_SERVER_METRICS_URLS` is populated with exporter endpoints and scraped during benchmark
- [ ] `telemetry.enabled: true` with `cpu_power` only (no `dcgm_exporter`) does not error
- [ ] Existing GPU power collection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)