### PR TITLE
WIP feat(cpu-power): Rust ACPI/DCGM exporter with Python fallback for AIPerf server-metrics

### DIFF
--- a/.github/workflows/cpu-power-exporter.yaml
+++ b/.github/workflows/cpu-power-exporter.yaml
@@ -1,0 +1,71 @@
+name: CPU Power Exporter
+
+on:
+  pull_request:
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - src/cpu-power-exporter/**
+      - docker/Dockerfile.cpu-power-exporter
+      - .dockerignore
+  push:
+    branches: [main, master]
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - src/cpu-power-exporter/**
+      - docker/Dockerfile.cpu-power-exporter
+      - .dockerignore
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cpu-power-exporter-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run tests
+        run: cargo test --workspace --locked
+
+  # The released binaries are the cross-compiled musl ones, so a native cargo
+  # build would not catch a linker or target regression. Both release targets
+  # are built here, through the same Dockerfile the release workflow uses.
+  release-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - uses: actions/checkout@v4
+
+      # No QEMU: the Dockerfile builds on $BUILDPLATFORM and cross-links, and
+      # the artifact stage only copies the result.
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build cpu-power-exporter binary
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform "${{ matrix.platform }}" \
+            --file docker/Dockerfile.cpu-power-exporter \
+            --target artifact \
+            --output type=local,dest=build/cpu-power-exporter \
+            .
+          test -s build/cpu-power-exporter/cpu-power-exporter

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,11 @@ jobs:
     outputs:
       tag: ${{ steps.ver.outputs.tag }}
       target: ${{ github.event.pull_request.merge_commit_sha }}
-      tachometer_changed: ${{ steps.tachometer.outputs.changed }}
+      tachometer_changed: ${{ steps.changed.outputs.tachometer }}
+      cpu_power_exporter_changed: ${{ steps.changed.outputs.cpu_power_exporter }}
     steps:
-      - name: Detect Tachometer changes
-        id: tachometer
+      - name: Detect changed binaries
+        id: changed
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -34,13 +35,22 @@ jobs:
         run: |
           set -euo pipefail
           files=$(gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename')
-          if printf '%s\n' "$files" | grep -Eq '^(Cargo\.(toml|lock)|rust-toolchain\.toml|src/tachometer/|docker/Dockerfile\.tachometer-scraper$|\.dockerignore$)'; then
-            changed=true
+
+          if printf '%s\n' "$files" | grep -Eq '^(Cargo\.(toml|lock)|rust-toolchain\.toml|src/tachometer/|docker/Dockerfile\.tachometer-scraper$|\.dockerignore$|\.github/workflows/release\.yaml$)'; then
+            tachometer=true
           else
-            changed=false
+            tachometer=false
           fi
-          echo "Tachometer changed: $changed"
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "Tachometer changed: $tachometer"
+          echo "tachometer=$tachometer" >> "$GITHUB_OUTPUT"
+
+          if printf '%s\n' "$files" | grep -Eq '^(Cargo\.(toml|lock)|rust-toolchain\.toml|src/cpu-power-exporter/|docker/Dockerfile\.cpu-power-exporter$|\.dockerignore$|\.github/workflows/release\.yaml$)'; then
+            cpu_power_exporter=true
+          else
+            cpu_power_exporter=false
+          fi
+          echo "cpu-power-exporter changed: $cpu_power_exporter"
+          echo "cpu_power_exporter=$cpu_power_exporter" >> "$GITHUB_OUTPUT"
 
       - name: Compute next version
         id: ver
@@ -114,12 +124,55 @@ jobs:
           path: dist/
           retention-days: 7
 
+  build-cpu-power-exporter:
+    needs: version
+    if: needs.version.outputs.cpu_power_exporter_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            asset: cpu-power-exporter-x86_64-unknown-linux-musl
+          - platform: linux/arm64
+            asset: cpu-power-exporter-aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.target }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build cpu-power-exporter binary
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform "${{ matrix.platform }}" \
+            --file docker/Dockerfile.cpu-power-exporter \
+            --target artifact \
+            --output type=local,dest=build/cpu-power-exporter \
+            .
+          mkdir -p dist
+          mv build/cpu-power-exporter/cpu-power-exporter "dist/${{ matrix.asset }}"
+          chmod +x "dist/${{ matrix.asset }}"
+          (cd dist && sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256")
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: dist/
+          retention-days: 7
+
   release:
-    needs: [version, build-tachometer-scraper]
+    needs: [version, build-tachometer-scraper, build-cpu-power-exporter]
     if: >-
       always() &&
       needs.version.result == 'success' &&
-      (needs.build-tachometer-scraper.result == 'success' || needs.build-tachometer-scraper.result == 'skipped')
+      (needs.build-tachometer-scraper.result == 'success' || needs.build-tachometer-scraper.result == 'skipped') &&
+      (needs.build-cpu-power-exporter.result == 'success' || needs.build-cpu-power-exporter.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -131,27 +184,53 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Reuse scraper binaries from the previous release
-        if: needs.version.outputs.tachometer_changed != 'true'
+      - uses: actions/download-artifact@v4
+        if: needs.version.outputs.cpu_power_exporter_changed == 'true'
+        with:
+          pattern: cpu-power-exporter-*
+          path: dist
+          merge-multiple: true
+
+      - name: Carry forward unchanged binaries from the previous release
+        if: needs.version.outputs.tachometer_changed != 'true' || needs.version.outputs.cpu_power_exporter_changed != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          TACHOMETER_CHANGED: ${{ needs.version.outputs.tachometer_changed }}
+          CPU_POWER_EXPORTER_CHANGED: ${{ needs.version.outputs.cpu_power_exporter_changed }}
         run: |
           set -euo pipefail
           previous=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' | sort -V | tail -n1)
-          if [ -z "$previous" ]; then
-            echo "No previous release contains Tachometer scraper binaries"
-            exit 1
-          fi
           mkdir -p dist
-          gh release download "$previous" --pattern 'tachometer-scraper-*' --dir dist
+          # Every merge cuts a release, so an unchanged binary is re-uploaded
+          # from the previous one to keep each release self-contained. A gap is
+          # a warning, not a failure: the first-ever release has nothing to
+          # carry forward, and a binary added later is absent from older ones.
+          carry() {
+            if [ -z "$previous" ]; then
+              echo "::warning::No previous release to carry $1 forward from; this release omits it"
+              return 0
+            fi
+            if ! gh release download "$previous" --pattern "$1-*" --dir dist; then
+              echo "::warning::Previous release $previous has no $1 assets; this release omits them"
+            fi
+          }
+          [ "$TACHOMETER_CHANGED" = "true" ] || carry tachometer-scraper
+          [ "$CPU_POWER_EXPORTER_CHANGED" = "true" ] || carry cpu-power-exporter
 
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.version.outputs.tag }}
+          TARGET: ${{ needs.version.outputs.target }}
         run: |
-          gh release create "${{ needs.version.outputs.tag }}" dist/* \
-            --target "${{ needs.version.outputs.target }}" \
-            --title "${{ needs.version.outputs.tag }}" \
+          set -euo pipefail
+          shopt -s nullglob
+          # An unexpanded dist/* glob would be passed through as a literal path.
+          assets=(dist/*)
+          echo "Publishing $TAG with ${#assets[@]} asset(s)"
+          gh release create "$TAG" "${assets[@]}" \
+            --target "$TARGET" \
+            --title "$TAG" \
             --generate-notes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpu-power-exporter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "libloading",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +1668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lexical-core"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1735,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -3262,6 +3291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,6 +3641,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "thrift"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,6 +3871,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "src/tachometer/tachometer-writer",
     "src/tachometer/tachometer-scraper",
+    "src/cpu-power-exporter",
 ]
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: lint test test-cov ci check setup cleanup gb200-fp8 gb200-fp4 tachometer-scraper tachometer-scraper-download
+.PHONY: lint test test-cov ci check setup cleanup gb200-fp8 gb200-fp4 tachometer-scraper tachometer-scraper-download cpu-power-exporter cpu-power-exporter-download
 
 NATS_VERSION ?= v2.10.28
 ETCD_VERSION ?= v3.5.21
 LOGS_DIR ?= logs
 ARCH ?= $(shell uname -m)
 TACHOMETER_RELEASE ?= latest
+CPU_POWER_EXPORTER_RELEASE ?= latest
 
 default:
 	./run_dashboard.sh
@@ -54,6 +55,35 @@ tachometer-scraper-download:
 	install -Dm755 "$$tmp_dir/$$asset" bin/tachometer-scraper; \
 	echo "Installed Tachometer scraper at bin/tachometer-scraper"
 
+cpu-power-exporter:
+	cargo build --release --locked --bin cpu-power-exporter
+	install -Dm755 target/release/cpu-power-exporter bin/cpu-power-exporter
+
+cpu-power-exporter-download:
+	@set -eu; \
+	case "$(ARCH)" in \
+		x86_64)  asset="cpu-power-exporter-x86_64-unknown-linux-musl"; file_pattern="x86-64" ;; \
+		aarch64) asset="cpu-power-exporter-aarch64-unknown-linux-musl"; file_pattern="aarch64" ;; \
+		*) echo "Unsupported architecture: $(ARCH)"; exit 1 ;; \
+	esac; \
+	if [ -f bin/cpu-power-exporter ] && file bin/cpu-power-exporter | grep -q "$$file_pattern"; then \
+		echo "cpu-power-exporter already installed at bin/cpu-power-exporter ($(ARCH))"; \
+		exit 0; \
+	fi; \
+	if [ "$(CPU_POWER_EXPORTER_RELEASE)" = "latest" ]; then \
+		base_url="https://github.com/NVIDIA/srt-slurm/releases/latest/download"; \
+	else \
+		base_url="https://github.com/NVIDIA/srt-slurm/releases/download/$(CPU_POWER_EXPORTER_RELEASE)"; \
+	fi; \
+	tmp_dir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp_dir"' EXIT; \
+	echo "Downloading $$asset from srt-slurm $(CPU_POWER_EXPORTER_RELEASE)"; \
+	curl --fail --location --retry 3 --retry-delay 2 "$$base_url/$$asset" --output "$$tmp_dir/$$asset"; \
+	curl --fail --location --retry 3 --retry-delay 2 "$$base_url/$$asset.sha256" --output "$$tmp_dir/$$asset.sha256"; \
+	(cd "$$tmp_dir" && sha256sum --check "$$asset.sha256"); \
+	install -Dm755 "$$tmp_dir/$$asset" bin/cpu-power-exporter; \
+	echo "Installed cpu-power-exporter at bin/cpu-power-exporter"
+
 # Runners
 gb200-fp8:
 	srtctl apply -f recipes/gb200-fp8/1k1k/low-latency.yaml
@@ -70,7 +100,7 @@ gb200-fp4:
 	srtctl apply -f recipes/gb200-fp4/8k1k/max-tpt.yaml
 	srtctl apply -f recipes/gb200-fp4/8k1k/mid-curve.yaml
 
-setup: tachometer-scraper-download
+setup: tachometer-scraper-download cpu-power-exporter-download
 	@echo "📦 Setting up configs and logs directories..."
 	@mkdir -p logs
 	@echo "🖥️  Using architecture: $(ARCH)"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test test-cov ci check setup cleanup gb200-fp8 gb200-fp4 tachometer-scraper tachometer-scraper-download cpu-power-exporter cpu-power-exporter-download
+.PHONY: lint test test-cov ci check setup cleanup gb200-fp8 gb200-fp4 tachometer-scraper tachometer-scraper-download cpu-power-exporter cpu-power-exporter-download cpu-power-exporter-setup
 
 NATS_VERSION ?= v2.10.28
 ETCD_VERSION ?= v3.5.21
@@ -58,6 +58,9 @@ tachometer-scraper-download:
 cpu-power-exporter:
 	cargo build --release --locked --bin cpu-power-exporter
 	install -Dm755 target/release/cpu-power-exporter bin/cpu-power-exporter
+	@# A locally built binary is not a release. Leaving the marker behind would
+	@# tell a later pinned download that the tag is already installed.
+	rm -f bin/.cpu-power-exporter.release
 
 cpu-power-exporter-download:
 	@set -eu; \
@@ -66,14 +69,25 @@ cpu-power-exporter-download:
 		aarch64) asset="cpu-power-exporter-aarch64-unknown-linux-musl"; file_pattern="aarch64" ;; \
 		*) echo "Unsupported architecture: $(ARCH)"; exit 1 ;; \
 	esac; \
-	if [ -f bin/cpu-power-exporter ] && file bin/cpu-power-exporter | grep -q "$$file_pattern"; then \
-		echo "cpu-power-exporter already installed at bin/cpu-power-exporter ($(ARCH))"; \
-		exit 0; \
+	marker=bin/.cpu-power-exporter.release; \
+	installed=$$(cat "$$marker" 2>/dev/null || echo ""); \
+	if [ -f bin/cpu-power-exporter ]; then \
+		if ! command -v file >/dev/null 2>&1; then \
+			echo "Cannot check the architecture of bin/cpu-power-exporter: file(1) is not installed"; \
+			echo "Downloading the $(ARCH) asset rather than trusting or deleting it"; \
+		elif ! file bin/cpu-power-exporter | grep -q "$$file_pattern"; then \
+			echo "Removing bin/cpu-power-exporter: not a $(ARCH) binary"; \
+			rm -f bin/cpu-power-exporter "$$marker"; \
+		elif [ "$(CPU_POWER_EXPORTER_RELEASE)" = "latest" ] || [ "$$installed" = "$(CPU_POWER_EXPORTER_RELEASE)" ]; then \
+			echo "cpu-power-exporter $$installed already installed at bin/cpu-power-exporter ($(ARCH))"; \
+			exit 0; \
+		fi; \
 	fi; \
 	if [ "$(CPU_POWER_EXPORTER_RELEASE)" = "latest" ]; then \
 		base_url="https://github.com/NVIDIA/srt-slurm/releases/latest/download"; \
 	else \
 		base_url="https://github.com/NVIDIA/srt-slurm/releases/download/$(CPU_POWER_EXPORTER_RELEASE)"; \
+		rm -f bin/cpu-power-exporter "$$marker"; \
 	fi; \
 	tmp_dir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmp_dir"' EXIT; \
@@ -82,7 +96,17 @@ cpu-power-exporter-download:
 	curl --fail --location --retry 3 --retry-delay 2 "$$base_url/$$asset.sha256" --output "$$tmp_dir/$$asset.sha256"; \
 	(cd "$$tmp_dir" && sha256sum --check "$$asset.sha256"); \
 	install -Dm755 "$$tmp_dir/$$asset" bin/cpu-power-exporter; \
-	echo "Installed cpu-power-exporter at bin/cpu-power-exporter"
+	printf '%s' "$(CPU_POWER_EXPORTER_RELEASE)" > "$$marker"; \
+	echo "Installed cpu-power-exporter $(CPU_POWER_EXPORTER_RELEASE) at bin/cpu-power-exporter"
+
+cpu-power-exporter-setup:
+	@set -eu; \
+	if [ "$(CPU_POWER_EXPORTER_RELEASE)" = "latest" ]; then \
+		$(MAKE) --no-print-directory cpu-power-exporter-download || \
+		  echo "Warning: cpu-power-exporter download failed (optional for non-CPU-power recipes)"; \
+	else \
+		$(MAKE) --no-print-directory cpu-power-exporter-download; \
+	fi
 
 # Runners
 gb200-fp8:
@@ -100,7 +124,7 @@ gb200-fp4:
 	srtctl apply -f recipes/gb200-fp4/8k1k/max-tpt.yaml
 	srtctl apply -f recipes/gb200-fp4/8k1k/mid-curve.yaml
 
-setup: tachometer-scraper-download cpu-power-exporter-download
+setup: tachometer-scraper-download cpu-power-exporter-setup
 	@echo "📦 Setting up configs and logs directories..."
 	@mkdir -p logs
 	@echo "🖥️  Using architecture: $(ARCH)"

--- a/configs/cpu-power-test.yaml
+++ b/configs/cpu-power-test.yaml
@@ -1,0 +1,73 @@
+# Exercises the ACPI CPU power leg end to end on Grace hardware:
+# cpu-power-exporter on every worker node, the head-node collector writing
+# logs/<run>/cpu_power/{samples.csv,manifest.json}, and AIPerf consuming the
+# same endpoints via --server-metrics.
+#
+# benchmark.type must be one that actually reads AIPERF_SERVER_METRICS_URLS.
+# sa-bench does not, so it would launch the exporters with no consumer and
+# prove nothing about the AIPerf integration.
+#
+# Qwen3.5-27B BF16 (not FP4) keeps startup under 2 min by avoiding the
+# 8-minute fp4_gemm JIT autotuning pass that DeepSeek-R1 FP4 requires.
+name: "cpu-power-exporter-test"
+
+model:
+  path: "/lustre/share/core_dlfw_ci/models/Qwen3.5-27B"
+  container: "/lustre/fsw/coreai_comparch_inferencex/yangminl/containers/lmsysorg+sglang+nightly-dev-20260818-c0b6474b.sqsh"
+  precision: "bf16"
+
+dynamo:
+  wheel: "1.4.0"
+
+resources:
+  gpu_type: "gb200"
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_node: 4
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+  sglang_config:
+    prefill:
+      served-model-name: "Qwen/Qwen3.5-27B"
+      trust-remote-code: true
+      disaggregation-mode: "prefill"
+      mem-fraction-static: 0.88
+      tensor-parallel-size: 4
+      disaggregation-bootstrap-port: 30001
+      disaggregation-transfer-backend: nixl
+      page-size: 64
+    decode:
+      served-model-name: "Qwen/Qwen3.5-27B"
+      trust-remote-code: true
+      disaggregation-mode: "decode"
+      mem-fraction-static: 0.88
+      tensor-parallel-size: 4
+      disaggregation-bootstrap-port: 30001
+      disaggregation-transfer-backend: nixl
+      page-size: 64
+
+benchmark:
+  type: "trace-replay"
+  trace_file: "/configs/cpu-power-test-trace.jsonl"
+  concurrencies: [8, 16]
+  aiperf_package: "aiperf"
+  aiperf_args:
+    request-count: 50
+    tokenizer: "/model"
+    extra-inputs: "max_tokens:128,enable_thinking:false"
+
+telemetry:
+  enabled: true
+  cpu_power:
+    enabled: true
+    # ACPI is mandatory here: the point of the recipe is to prove the rails are
+    # collected, so a node without them must fail rather than quietly skip.
+    source: "acpi"
+    required: true
+    prometheus_port: 9405

--- a/docker/Dockerfile.cpu-power-exporter
+++ b/docker/Dockerfile.cpu-power-exporter
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM rust:1.90-slim-bookworm AS builder
+
+ARG TARGETARCH
+
+WORKDIR /app
+
+# musl-tools supplies x86_64-musl-gcc for the amd64 target.
+# arm64 uses the GNU cross-toolchain to link a musl target; it is not ideal
+# but works for fully Rust-native crates with no cc build-scripts.
+RUN apt-get update \
+    && if [ "$TARGETARCH" = "arm64" ]; then \
+        apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu; \
+    else \
+        apt-get install -y --no-install-recommends musl-tools; \
+    fi \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rust-toolchain.toml ./
+COPY Cargo.toml Cargo.lock ./
+COPY src/tachometer/tachometer-writer/Cargo.toml src/tachometer/tachometer-writer/Cargo.toml
+COPY src/tachometer/tachometer-scraper/Cargo.toml src/tachometer/tachometer-scraper/Cargo.toml
+COPY src/cpu-power-exporter/Cargo.toml src/cpu-power-exporter/Cargo.toml
+# Empty sibling sources satisfy the workspace without compiling them.
+RUN mkdir -p src/tachometer/tachometer-writer/src src/tachometer/tachometer-scraper/src \
+    && echo 'pub fn stub(){}' > src/tachometer/tachometer-writer/src/lib.rs \
+    && echo 'fn main(){}' > src/tachometer/tachometer-scraper/src/main.rs
+
+COPY src/cpu-power-exporter/src src/cpu-power-exporter/src
+
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        rustup target add aarch64-unknown-linux-musl; \
+    else \
+        rustup target add x86_64-unknown-linux-musl; \
+    fi
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target,id=cpu-power-target-$TARGETARCH,sharing=locked \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        export CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc \
+        && export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc \
+        && cargo build --release --locked --bin cpu-power-exporter --target aarch64-unknown-linux-musl \
+        && cp target/aarch64-unknown-linux-musl/release/cpu-power-exporter /cpu-power-exporter; \
+    else \
+        cargo build --release --locked --bin cpu-power-exporter --target x86_64-unknown-linux-musl \
+        && cp target/x86_64-unknown-linux-musl/release/cpu-power-exporter /cpu-power-exporter; \
+    fi
+
+FROM scratch AS artifact
+COPY --from=builder /cpu-power-exporter /cpu-power-exporter

--- a/src/cpu-power-exporter/Cargo.toml
+++ b/src/cpu-power-exporter/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "cpu-power-exporter"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+# Not `tokio.workspace = true`: the workspace default is `features = ["full"]`,
+# and this binary ships as a standalone release asset. The trim only holds when
+# the crate is built on its own (`--bin cpu-power-exporter`), which is what
+# docker/Dockerfile.cpu-power-exporter and `make cpu-power-exporter` do.
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time"] }
+clap = { workspace = true }
+anyhow.workspace = true
+tracing.workspace = true
+# No `env-filter`: it pulls regex back in via `matchers`, and its default
+# directive is ERROR, which silences every startup log unless RUST_LOG is set.
+# Without it `fmt::init()` still honours RUST_LOG but defaults to INFO.
+tracing-subscriber = { workspace = true, features = ["fmt"] }
+# Dynamic loading for optional DCGM dependency — libdcgm.so is not present on
+# every host, so linking at build time would prevent the binary from starting
+# on ACPI-only systems.
+libloading = "0.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/cpu-power-exporter/src/dcgm.rs
+++ b/src/cpu-power-exporter/src/dcgm.rs
@@ -1,0 +1,571 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! DCGM CPU power reader via dynamic loading of libdcgm.so.
+//!
+//! Field 1130 (DCGM_FI_DEV_CPU_POWER_WATTS / DCGM_FI_DEV_CPU_POWER_UTIL_CURRENT) is a watched
+//! field, not a live-data field.  The correct setup sequence is:
+//!   1. dcgmInit / dcgmStartEmbedded  — initialise the library and get a handle.
+//!   2. dcgmGetEntityGroupEntities    — enumerate DCGM_FE_CPU entity IDs.
+//!   3. dcgmGroupCreate + dcgmGroupAddEntity × N — build an entity group.
+//!   4. dcgmFieldGroupCreate          — name a field group containing field 1130.
+//!   5. dcgmWatchFields               — register the watch on that entity+field group.
+//!   6. dcgmUpdateAllFields(true)     — seed the first sample.
+//!   7. dcgmEntitiesGetLatestValues with flags=0 — read cached values on every tick.
+//!
+//! Passing DCGM_FV_FLAG_LIVE_DATA (0x1) to step 7 bypasses the cache and returns
+//! blank/stale data for watched fields — that is the bug Kyle's c1c0028 fixed.
+//!
+//! All symbols are resolved at runtime so the binary starts on hosts that lack
+//! DCGM; unavailability is a soft `DcgmUnavailable` error, not a link failure.
+
+use std::ffi::CString;
+use std::fmt;
+
+// ── Constants derived from dcgm_fields.h / dcgm_structs.h ────────────────────
+
+/// DCGM_FI_DEV_CPU_POWER_WATTS (alias DCGM_FI_DEV_CPU_POWER_UTIL_CURRENT).
+const CPU_POWER_FIELD_ID: u16 = 1130;
+
+/// DCGM_FE_CPU: entity group for Grace CPU nodes.
+const DCGM_FE_CPU: u32 = 7;
+
+/// DCGM_GROUP_EMPTY: create an empty entity group.
+const DCGM_GROUP_EMPTY: i32 = 1;
+
+/// DCGM_OPERATION_MODE_AUTO: collect data automatically.
+const DCGM_OPERATION_MODE_AUTO: i32 = 1;
+
+/// DCGM_GEGE_FLAG_ONLY_SUPPORTED: filter to entities supported on this system.
+const DCGM_GEGE_FLAG_ONLY_SUPPORTED: u32 = 0x00000001;
+
+/// DCGM_ST_OK: success return code.
+const DCGM_ST_OK: i32 = 0;
+
+/// dcgmFieldValue_version2 = MAKE_DCGM_VERSION(dcgmFieldValue_v2, 2)
+/// = sizeof(dcgmFieldValue_v2) | (2 << 24). Callers must pre-set this in
+/// each output struct before calling dcgmEntitiesGetLatestValues so DCGM
+/// knows the struct size and populates the fields correctly.
+const DCGM_FIELD_VALUE_V2_VERSION: u32 = 0x02001020;
+
+/// Upper bound on CPU entity count (Grace has 2 sockets; 64 is more than enough).
+const MAX_CPU_ENTITIES: usize = 64;
+
+/// DCGM_MAX_STR_LENGTH from dcgm_structs.h.
+const DCGM_MAX_STR_LENGTH: usize = 256;
+
+/// DCGM_MAX_BLOB_LENGTH from dcgm_structs.h.
+const DCGM_MAX_BLOB_LENGTH: usize = 4096;
+
+// ── C ABI types ──────────────────────────────────────────────────────────────
+
+/// dcgmHandle_t / dcgmGpuGrp_t / dcgmFieldGrp_t are all `uintptr_t`.
+type Handle = usize;
+
+/// dcgmGroupEntityPair_t — entity group + entity ID pair.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct GroupEntityPair {
+    entity_group_id: u32,
+    entity_id: u32,
+}
+
+/// dcgmFieldValue_v2.  Layout verified against dcgm_structs.h:
+///   version (u32) + entityGroupId (u32) + entityId (u32) + fieldId (u16) +
+///   fieldType (u16) + status (i32) + unused (u32) + ts (i64) +
+///   value union (4096 bytes) = 4128 bytes total.
+#[repr(C)]
+struct FieldValueV2 {
+    version: u32,
+    entity_group_id: u32,
+    entity_id: u32,
+    field_id: u16,
+    field_type: u16,
+    status: i32,
+    _unused: u32,
+    ts: i64,
+    val: FieldValueUnion,
+}
+
+#[repr(C)]
+union FieldValueUnion {
+    i64: i64,
+    dbl: f64,
+    str_val: [u8; DCGM_MAX_STR_LENGTH],
+    blob: [u8; DCGM_MAX_BLOB_LENGTH],
+}
+
+// ── Function pointer types (verbatim from dcgm_agent.h) ──────────────────────
+
+type FnDcgmInit = unsafe extern "C" fn() -> i32;
+type FnDcgmShutdown = unsafe extern "C" fn() -> i32;
+type FnDcgmConnect =
+    unsafe extern "C" fn(ip_address: *const libc_c_char, handle: *mut Handle) -> i32;
+type FnDcgmDisconnect = unsafe extern "C" fn(handle: Handle) -> i32;
+type FnDcgmStartEmbedded = unsafe extern "C" fn(op_mode: i32, handle: *mut Handle) -> i32;
+type FnDcgmStopEmbedded = unsafe extern "C" fn(handle: Handle) -> i32;
+type FnDcgmGetEntityGroupEntities = unsafe extern "C" fn(
+    handle: Handle,
+    entity_group: u32,
+    entities: *mut u32,
+    num_entities: *mut i32,
+    flags: u32,
+) -> i32;
+type FnDcgmGroupCreate = unsafe extern "C" fn(
+    handle: Handle,
+    group_type: i32,
+    name: *const libc_c_char,
+    group_id: *mut Handle,
+) -> i32;
+type FnDcgmGroupAddEntity = unsafe extern "C" fn(
+    handle: Handle,
+    group_id: Handle,
+    entity_group_id: u32,
+    entity_id: u32,
+) -> i32;
+type FnDcgmGroupDestroy = unsafe extern "C" fn(handle: Handle, group_id: Handle) -> i32;
+type FnDcgmFieldGroupCreate = unsafe extern "C" fn(
+    handle: Handle,
+    num_field_ids: i32,
+    field_ids: *const u16,
+    name: *const libc_c_char,
+    field_group_id: *mut Handle,
+) -> i32;
+type FnDcgmFieldGroupDestroy = unsafe extern "C" fn(handle: Handle, field_group_id: Handle) -> i32;
+type FnDcgmWatchFields = unsafe extern "C" fn(
+    handle: Handle,
+    group_id: Handle,
+    field_group_id: Handle,
+    update_freq_usec: i64,
+    max_keep_age_secs: f64,
+    max_keep_samples: i32,
+) -> i32;
+type FnDcgmUpdateAllFields = unsafe extern "C" fn(handle: Handle, wait_for_update: i32) -> i32;
+type FnDcgmEntitiesGetLatestValues = unsafe extern "C" fn(
+    handle: Handle,
+    entities: *const GroupEntityPair,
+    entity_count: u32,
+    fields: *const u16,
+    field_count: u32,
+    flags: u32,
+    values: *mut FieldValueV2,
+) -> i32;
+
+// c_char is i8 on x86_64 and u8 on aarch64; use the stdlib alias so the fn
+// pointer types match CString::as_ptr() on both architectures.
+#[allow(non_camel_case_types)]
+type libc_c_char = std::os::raw::c_char;
+
+// ── Loaded library ────────────────────────────────────────────────────────────
+
+/// Owns the open `libdcgm.so` handle and all resolved function pointers.
+///
+/// Function pointers are valid for as long as `_lib` is alive.  Because `DcgmLib`
+/// is only ever accessed through `DcgmReader` (which holds it exclusively), no
+/// cross-thread aliasing occurs.
+struct DcgmLib {
+    _lib: libloading::Library,
+    init: FnDcgmInit,
+    shutdown: FnDcgmShutdown,
+    connect: FnDcgmConnect,
+    disconnect: FnDcgmDisconnect,
+    start_embedded: FnDcgmStartEmbedded,
+    stop_embedded: FnDcgmStopEmbedded,
+    get_entity_group_entities: FnDcgmGetEntityGroupEntities,
+    group_create: FnDcgmGroupCreate,
+    group_add_entity: FnDcgmGroupAddEntity,
+    group_destroy: FnDcgmGroupDestroy,
+    field_group_create: FnDcgmFieldGroupCreate,
+    field_group_destroy: FnDcgmFieldGroupDestroy,
+    watch_fields: FnDcgmWatchFields,
+    update_all_fields: FnDcgmUpdateAllFields,
+    entities_get_latest_values: FnDcgmEntitiesGetLatestValues,
+}
+
+// SAFETY: all fn pointers are derived from a loaded shared library and are
+// plain C function addresses; they carry no thread-local state.
+unsafe impl Send for DcgmLib {}
+
+impl DcgmLib {
+    /// Try the standard DCGM library names in version order.
+    fn load() -> Result<Self, DcgmUnavailable> {
+        let lib = Self::open_lib()?;
+        // SAFETY: `_lib` remains alive for the lifetime of this struct, keeping
+        // the resolved symbols valid.  Each symbol is transmuted from a
+        // `libloading::Symbol<T>` to `T`, which is sound because Symbol<T>
+        // implements `Deref<Target = T>` and fn pointers are Copy.
+        unsafe {
+            macro_rules! sym {
+                ($name:literal, $ty:ty) => {
+                    *lib.get::<$ty>($name).map_err(|e| {
+                        DcgmUnavailable(format!("symbol {}: {e}", stringify!($name)))
+                    })?
+                };
+            }
+            Ok(Self {
+                init: sym!(b"dcgmInit\0", FnDcgmInit),
+                shutdown: sym!(b"dcgmShutdown\0", FnDcgmShutdown),
+                connect: sym!(b"dcgmConnect\0", FnDcgmConnect),
+                disconnect: sym!(b"dcgmDisconnect\0", FnDcgmDisconnect),
+                start_embedded: sym!(b"dcgmStartEmbedded\0", FnDcgmStartEmbedded),
+                stop_embedded: sym!(b"dcgmStopEmbedded\0", FnDcgmStopEmbedded),
+                get_entity_group_entities: sym!(
+                    b"dcgmGetEntityGroupEntities\0",
+                    FnDcgmGetEntityGroupEntities
+                ),
+                group_create: sym!(b"dcgmGroupCreate\0", FnDcgmGroupCreate),
+                group_add_entity: sym!(b"dcgmGroupAddEntity\0", FnDcgmGroupAddEntity),
+                group_destroy: sym!(b"dcgmGroupDestroy\0", FnDcgmGroupDestroy),
+                field_group_create: sym!(b"dcgmFieldGroupCreate\0", FnDcgmFieldGroupCreate),
+                field_group_destroy: sym!(b"dcgmFieldGroupDestroy\0", FnDcgmFieldGroupDestroy),
+                watch_fields: sym!(b"dcgmWatchFields\0", FnDcgmWatchFields),
+                update_all_fields: sym!(b"dcgmUpdateAllFields\0", FnDcgmUpdateAllFields),
+                entities_get_latest_values: sym!(
+                    b"dcgmEntitiesGetLatestValues\0",
+                    FnDcgmEntitiesGetLatestValues
+                ),
+                _lib: lib,
+            })
+        }
+    }
+
+    fn open_lib() -> Result<libloading::Library, DcgmUnavailable> {
+        let names: &[&str] = &["libdcgm.so.4", "libdcgm.so.3", "libdcgm.so"];
+        let mut last_err = String::new();
+        for &name in names {
+            match unsafe { libloading::Library::new(name) } {
+                Ok(lib) => return Ok(lib),
+                Err(e) => last_err = e.to_string(),
+            }
+        }
+        Err(DcgmUnavailable(format!("libdcgm not found: {last_err}")))
+    }
+}
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// DCGM is not available on this host or the operation failed.
+#[derive(Debug)]
+pub struct DcgmUnavailable(pub String);
+
+impl fmt::Display for DcgmUnavailable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for DcgmUnavailable {}
+
+fn check(ret: i32, context: &str) -> Result<(), DcgmUnavailable> {
+    if ret == DCGM_ST_OK {
+        Ok(())
+    } else {
+        Err(DcgmUnavailable(format!("{context}: DCGM error {ret}")))
+    }
+}
+
+// ── Reader ────────────────────────────────────────────────────────────────────
+
+/// How we obtained the DCGM handle — determines which teardown call to use.
+enum HandleSource {
+    /// Connected to an already-running daemon via `dcgmConnect`.
+    Connected,
+    /// We started our own in-process daemon via `dcgmStartEmbedded`.
+    Embedded,
+}
+
+/// Per-socket CPU power reading via DCGM field 1130.
+///
+/// `Drop` cleans up the entity group, field group, embedded handle, and library
+/// in the reverse order of construction.
+pub struct DcgmReader {
+    lib: DcgmLib,
+    handle: Handle,
+    handle_source: HandleSource,
+    group_id: Handle,
+    field_group_id: Handle,
+    entities: Vec<GroupEntityPair>,
+    /// CPU entity IDs in enumeration order (index == socket position).
+    pub cpu_ids: Vec<u32>,
+}
+
+// SAFETY: DcgmLib is Send; all other fields are plain integers / Vecs.
+unsafe impl Send for DcgmReader {}
+
+impl DcgmReader {
+    /// Load libdcgm, try connecting to a running daemon first, then fall back to
+    /// starting an embedded instance.  Enumerates CPU entities, registers the
+    /// field watch, and seeds the first sample.
+    pub fn new() -> Result<Self, DcgmUnavailable> {
+        let lib = DcgmLib::load()?;
+
+        // Library init — must be called once before any other DCGM function.
+        check(unsafe { (lib.init)() }, "dcgmInit")?;
+
+        // Try connecting to an already-running privileged daemon first.
+        // nv-hostengine listens on TCP 5555 by default; if one is present it has
+        // root access and its field watches return real hardware values.
+        let connect_result = Self::try_connect(&lib);
+        let (handle, handle_source) = match connect_result {
+            Ok(h) => {
+                tracing::info!("connected to existing DCGM daemon (root-level access)");
+                (h, HandleSource::Connected)
+            }
+            Err(e) => {
+                tracing::info!(reason = %e, "no running DCGM daemon; starting embedded instance");
+                let mut h: Handle = 0;
+                let ret = unsafe { (lib.start_embedded)(DCGM_OPERATION_MODE_AUTO, &mut h) };
+                if ret != DCGM_ST_OK {
+                    unsafe { (lib.shutdown)() };
+                    return Err(DcgmUnavailable(format!("dcgmStartEmbedded: error {ret}")));
+                }
+                (h, HandleSource::Embedded)
+            }
+        };
+
+        match Self::setup(lib, handle, handle_source) {
+            Ok(reader) => Ok(reader),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Try `dcgmConnect` to a daemon at the default nv-hostengine address.
+    fn try_connect(lib: &DcgmLib) -> Result<Handle, DcgmUnavailable> {
+        let addr = CString::new("127.0.0.1").unwrap();
+        let mut handle: Handle = 0;
+        let ret = unsafe { (lib.connect)(addr.as_ptr(), &mut handle) };
+        if ret == DCGM_ST_OK {
+            Ok(handle)
+        } else {
+            Err(DcgmUnavailable(format!("dcgmConnect: error {ret}")))
+        }
+    }
+
+    fn setup(lib: DcgmLib, handle: Handle, handle_source: HandleSource) -> Result<Self, DcgmUnavailable> {
+        // Enumerate supported CPU entities.
+        let mut raw_ids = vec![0u32; MAX_CPU_ENTITIES];
+        let mut count: i32 = MAX_CPU_ENTITIES as i32;
+        check(
+            unsafe {
+                (lib.get_entity_group_entities)(
+                    handle,
+                    DCGM_FE_CPU,
+                    raw_ids.as_mut_ptr(),
+                    &mut count,
+                    DCGM_GEGE_FLAG_ONLY_SUPPORTED,
+                )
+            },
+            "dcgmGetEntityGroupEntities",
+        )?;
+
+        if count <= 0 {
+            return Err(DcgmUnavailable(
+                "no supported DCGM CPU entities on this host".into(),
+            ));
+        }
+        let cpu_ids: Vec<u32> = raw_ids[..count as usize].to_vec();
+
+        // Unique suffix prevents name collisions across concurrent processes.
+        let suffix = format!("{}_{}", std::process::id(), {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0)
+        });
+        let group_name = CString::new(format!("cpu_power_entities_{suffix}")).unwrap();
+        let field_group_name = CString::new(format!("cpu_power_fields_{suffix}")).unwrap();
+
+        // Create an empty entity group and add each CPU entity.
+        let mut group_id: Handle = 0;
+        check(
+            unsafe {
+                (lib.group_create)(handle, DCGM_GROUP_EMPTY, group_name.as_ptr(), &mut group_id)
+            },
+            "dcgmGroupCreate",
+        )?;
+
+        for &cpu_id in &cpu_ids {
+            check(
+                unsafe { (lib.group_add_entity)(handle, group_id, DCGM_FE_CPU, cpu_id) },
+                "dcgmGroupAddEntity",
+            )?;
+        }
+
+        // Create a field group containing only field 1130.
+        let field_ids: [u16; 1] = [CPU_POWER_FIELD_ID];
+        let mut field_group_id: Handle = 0;
+        check(
+            unsafe {
+                (lib.field_group_create)(
+                    handle,
+                    1,
+                    field_ids.as_ptr(),
+                    field_group_name.as_ptr(),
+                    &mut field_group_id,
+                )
+            },
+            "dcgmFieldGroupCreate",
+        )?;
+
+        // Register the watch: 100 ms interval, keep 60 s of history, 600 max samples.
+        check(
+            unsafe { (lib.watch_fields)(handle, group_id, field_group_id, 100_000, 60.0, 600) },
+            "dcgmWatchFields",
+        )?;
+
+        // Force the first watched update so the initial read returns real data
+        // rather than a blank sample.  waitForUpdate=1 blocks until done.
+        check(
+            unsafe { (lib.update_all_fields)(handle, 1) },
+            "dcgmUpdateAllFields",
+        )?;
+
+        let entities: Vec<GroupEntityPair> = cpu_ids
+            .iter()
+            .map(|&id| GroupEntityPair {
+                entity_group_id: DCGM_FE_CPU,
+                entity_id: id,
+            })
+            .collect();
+
+        Ok(Self {
+            lib,
+            handle,
+            handle_source,
+            group_id,
+            field_group_id,
+            entities,
+            cpu_ids,
+        })
+    }
+
+    /// Read the latest cached power value for each CPU entity.
+    ///
+    /// Returns one `(cpu_id, watts)` pair per entity.  `None` means the DCGM
+    /// status for that entity was not `DCGM_ST_OK` or the value was not finite.
+    pub fn read_watts(&mut self) -> Result<Vec<(u32, Option<f64>)>, DcgmUnavailable> {
+        // Force a fresh hardware sample before reading cached values.  The initial
+        // update in new() can return 0.0 if the first hardware poll hasn't
+        // completed yet; calling here ensures every scrape gets real data.
+        check(
+            unsafe { (self.lib.update_all_fields)(self.handle, 1) },
+            "dcgmUpdateAllFields",
+        )?;
+
+        let n = self.entities.len();
+        let mut values: Vec<FieldValueV2> = (0..n)
+            .map(|_| FieldValueV2 {
+                version: DCGM_FIELD_VALUE_V2_VERSION,
+                entity_group_id: 0,
+                entity_id: 0,
+                field_id: 0,
+                field_type: 0,
+                status: 0,
+                _unused: 0,
+                ts: 0,
+                val: FieldValueUnion { i64: 0 },
+            })
+            .collect();
+
+        let field_ids: [u16; 1] = [CPU_POWER_FIELD_ID];
+
+        check(
+            unsafe {
+                (self.lib.entities_get_latest_values)(
+                    self.handle,
+                    self.entities.as_ptr(),
+                    n as u32,
+                    field_ids.as_ptr(),
+                    1,
+                    0, // flags=0: use cached data — DCGM_FV_FLAG_LIVE_DATA breaks watched fields
+                    values.as_mut_ptr(),
+                )
+            },
+            "dcgmEntitiesGetLatestValues",
+        )?;
+
+        let result: Vec<(u32, Option<f64>)> = values
+            .iter()
+            .map(|v| {
+                let watts = if v.status == DCGM_ST_OK {
+                    // SAFETY: field 1130 is a double field; union variant is valid.
+                    let w = unsafe { v.val.dbl };
+                    tracing::debug!(entity_id = v.entity_id, w, "DCGM raw value");
+                    if w.is_finite() && w > 0.0 {
+                        Some(w)
+                    } else {
+                        None
+                    }
+                } else {
+                    tracing::debug!(
+                        entity_id = v.entity_id,
+                        status = v.status,
+                        "DCGM non-OK status for entity; skipping"
+                    );
+                    None
+                };
+                (v.entity_id, watts)
+            })
+            .collect();
+
+        Ok(result)
+    }
+}
+
+impl Drop for DcgmReader {
+    fn drop(&mut self) {
+        // Best-effort cleanup in reverse-construction order.
+        // Errors are swallowed — a failed unwatch must not panic at shutdown.
+        unsafe {
+            (self.lib.watch_fields)(
+                self.handle,
+                self.group_id,
+                self.field_group_id,
+                0, // updateFreq=0 means unwatch
+                0.0,
+                0,
+            );
+            (self.lib.field_group_destroy)(self.handle, self.field_group_id);
+            (self.lib.group_destroy)(self.handle, self.group_id);
+            match self.handle_source {
+                HandleSource::Connected => {
+                    (self.lib.disconnect)(self.handle);
+                }
+                HandleSource::Embedded => {
+                    (self.lib.stop_embedded)(self.handle);
+                }
+            }
+            (self.lib.shutdown)();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_value_v2_size() {
+        // Verify our struct matches the C layout: 32 bytes of header + 4096 byte union.
+        assert_eq!(std::mem::size_of::<FieldValueV2>(), 4128);
+        assert_eq!(std::mem::align_of::<FieldValueV2>(), 8);
+    }
+
+    #[test]
+    fn group_entity_pair_size() {
+        assert_eq!(std::mem::size_of::<GroupEntityPair>(), 8);
+    }
+
+    #[test]
+    fn dcgm_unavailable_on_missing_lib() {
+        // On hosts without libdcgm.so this must be a soft error, not a panic.
+        match DcgmReader::new() {
+            Ok(_) => {}
+            Err(e) => {
+                // Must not be empty — callers log this message.
+                assert!(!e.0.is_empty(), "DcgmUnavailable must carry a message");
+            }
+        }
+    }
+}

--- a/src/cpu-power-exporter/src/main.rs
+++ b/src/cpu-power-exporter/src/main.rs
@@ -1,0 +1,814 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Grace CPU power exporter for Prometheus / AIPerf server-metrics.
+//!
+//! Two back-ends are supported and selected via `--source`:
+//!
+//! - `acpi` (default fallback): reads `/sys/class/hwmon/hwmon*/power*_average` and
+//!   exposes `cpu_power_acpi_watts{sensor,type,socket,oem_info,source="acpi"}`.
+//!   Firmware-averaged; available without DCGM.
+//!
+//! - `dcgm`: reads DCGM field 1130 (`DCGM_FI_DEV_CPU_POWER_WATTS`) via the DCGM
+//!   C API and exposes `cpu_power_dcgm_watts{socket,source="dcgm"}`.
+//!   Instantaneous; requires `libdcgm.so` and a system running the DCGM embedded
+//!   host engine.
+//!
+//! - `auto` (default): tries DCGM first; falls back to ACPI if `libdcgm.so` is
+//!   absent or no CPU entities are found.
+//!
+//! Endpoints:
+//!   GET /metrics  — Prometheus text format
+//!   GET /health   — "ok\n"
+
+mod dcgm;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::collections::btree_map::{BTreeMap, Entry};
+use std::fmt::Write as _;
+use std::io::ErrorKind;
+use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, RwLock};
+use std::{fs, process};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::signal;
+use tokio::signal::unix::{signal as unix_signal, SignalKind};
+use tokio::sync::oneshot;
+use tokio::task::JoinSet;
+use tokio::time::{timeout, Duration};
+
+/// Channels we surface. Matched against the hwmon OEM string in this order;
+/// the socket ID must follow the phrase directly, so "Grace Power Socket 1"
+/// stays `grace` even when the string also mentions CPU power elsewhere.
+const OEM_KINDS: [(&str, &str); 3] = [
+    ("cpu power socket ", "cpu"),
+    ("grace power socket ", "grace"),
+    ("sysio power socket ", "sysio"),
+];
+
+const READ_TIMEOUT: Duration = Duration::from_secs(5);
+const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+const ACCEPT_BACKOFF_MIN: Duration = Duration::from_millis(10);
+const ACCEPT_BACKOFF_MAX: Duration = Duration::from_secs(1);
+/// A wedged sysfs read must not hold a scrape open longer than the client waits.
+const COLLECT_TIMEOUT: Duration = Duration::from_secs(3);
+const MAX_REQUEST_BYTES: usize = 8192;
+/// Backpressure, not a happy-path size: a scrape target sees ~1 request/s.
+const MAX_CONNECTIONS: usize = 64;
+/// How often the background thread re-reads ACPI sysfs sensors.
+/// Each read blocks ~150 ms waiting for firmware; 6 sensors × 150 ms = ~900 ms,
+/// so a 1 s interval keeps the cache fresh without falling behind.
+const ACPI_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(clap::ValueEnum, Clone, Debug, Default)]
+enum SourceMode {
+    Acpi,
+    Dcgm,
+    #[default]
+    Auto,
+}
+
+#[derive(Parser)]
+#[command(
+    version,
+    about = "Grace CPU power exporter for Prometheus / AIPerf server-metrics"
+)]
+struct Args {
+    /// TCP port to listen on.
+    #[arg(long, default_value_t = 9405)]
+    port: u16,
+
+    /// Address to bind.
+    #[arg(long, default_value = "0.0.0.0")]
+    bind: IpAddr,
+
+    /// Root of hwmon sysfs (override for testing).
+    #[arg(long, default_value = "/sys/class/hwmon")]
+    hwmon_root: PathBuf,
+
+    /// Power reading back-end.
+    ///
+    /// `auto` tries DCGM first and falls back to ACPI when libdcgm.so is
+    /// absent or reports no CPU entities.
+    #[arg(long, default_value = "auto")]
+    source: SourceMode,
+}
+
+struct Sensor {
+    path: PathBuf,
+    /// `<hwmon node>/<channel>`: the one label guaranteed distinct per rail,
+    /// so two rails sharing an OEM string are still two Prometheus series.
+    id: String,
+    oem_info: String,
+    kind: &'static str,
+    socket: String,
+    /// Escaped `sensor=..,type=..,socket=..,oem_info=..` rendered once at discovery.
+    labels: String,
+}
+
+/// One `power*_average` file before alias resolution picks a winner.
+struct Candidate {
+    path: PathBuf,
+    node: String,
+    chan: String,
+    oem_info: Option<String>,
+}
+
+/// Live state shared across connection handlers.
+#[derive(Clone)]
+enum MetricsState {
+    /// Pre-rendered Prometheus text, refreshed every `ACPI_POLL_INTERVAL` by a
+    /// background OS thread.  Scrapes read from this cache and return instantly.
+    Acpi(Arc<RwLock<String>>),
+    Dcgm(Arc<Mutex<dcgm::DcgmReader>>),
+}
+
+fn read_text(p: &Path) -> Option<String> {
+    fs::read_to_string(p)
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+fn classify_oem(oem: &str) -> (&'static str, String) {
+    let lower = oem.to_lowercase();
+    for (needle, kind) in OEM_KINDS {
+        let Some((_, rest)) = lower.split_once(needle) else {
+            continue;
+        };
+        let socket: String = rest.chars().take_while(char::is_ascii_digit).collect();
+        if !socket.is_empty() {
+            return (kind, socket);
+        }
+    }
+    ("other", String::new())
+}
+
+fn escape_label(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+/// Channel `*_average` files under one hwmon directory.
+///
+/// A missing `device/` alias is normal. Any other I/O error means rails we
+/// cannot see, so it is reported rather than silently shortening the list.
+fn average_paths(dir: &Path) -> Vec<PathBuf> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Vec::new(),
+        Err(e) => {
+            tracing::warn!(error = %e, dir = %dir.display(), "hwmon directory unreadable; its rails are not exported");
+            return Vec::new();
+        }
+    };
+
+    let mut paths = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(entry) => {
+                let path = entry.path();
+                let is_average = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("power") && n.ends_with("_average"));
+                if is_average && path.is_file() {
+                    paths.push(path);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, dir = %dir.display(), "hwmon entry unreadable; a rail may be missing")
+            }
+        }
+    }
+    paths.sort();
+    paths
+}
+
+fn discover_sensors(hwmon_root: &Path) -> Result<Vec<Sensor>> {
+    let entries =
+        fs::read_dir(hwmon_root).with_context(|| format!("list {}", hwmon_root.display()))?;
+    let mut dirs = Vec::new();
+    for entry in entries {
+        let entry = entry.with_context(|| format!("list {}", hwmon_root.display()))?;
+        dirs.push(entry.path());
+    }
+    dirs.sort();
+
+    // `hwmonN/` and `hwmonN/device/` alias the same files, so dedup on the
+    // resolved path; distinct channels are never collapsed. The alias that
+    // carries the channel's metadata wins regardless of scan order.
+    let mut by_identity: BTreeMap<PathBuf, Candidate> = BTreeMap::new();
+
+    for hwmon_dir in dirs {
+        let Some(node) = hwmon_dir.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !node.starts_with("hwmon") {
+            continue;
+        }
+        if read_text(&hwmon_dir.join("name")).as_deref() != Some("power_meter") {
+            continue;
+        }
+        let node = node.to_owned();
+
+        for root in [hwmon_dir.clone(), hwmon_dir.join("device")] {
+            for path in average_paths(&root) {
+                let Some(chan) = path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .and_then(|s| s.strip_suffix("_average"))
+                    .map(str::to_owned)
+                else {
+                    continue;
+                };
+                let oem_info = read_text(&root.join(format!("{chan}_oem_info")))
+                    .or_else(|| read_text(&root.join(format!("{chan}_label"))));
+                let identity = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                let candidate = Candidate {
+                    path,
+                    node: node.clone(),
+                    chan,
+                    oem_info,
+                };
+                match by_identity.entry(identity) {
+                    Entry::Vacant(slot) => {
+                        slot.insert(candidate);
+                    }
+                    Entry::Occupied(mut slot) => {
+                        if slot.get().oem_info.is_none() && candidate.oem_info.is_some() {
+                            slot.insert(candidate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut candidates: Vec<Candidate> = by_identity.into_values().collect();
+    candidates.sort_by(|a, b| (&a.node, &a.chan).cmp(&(&b.node, &b.chan)));
+
+    Ok(candidates
+        .into_iter()
+        .map(|c| {
+            let id = format!("{}/{}", c.node, c.chan);
+            let oem_info = c.oem_info.unwrap_or(c.chan);
+            let (kind, socket) = classify_oem(&oem_info);
+            let labels = format!(
+                "sensor=\"{}\",type=\"{kind}\",socket=\"{socket}\",oem_info=\"{}\"",
+                escape_label(&id),
+                escape_label(&oem_info),
+            );
+            Sensor {
+                path: c.path,
+                id,
+                oem_info,
+                kind,
+                socket,
+                labels,
+            }
+        })
+        .collect())
+}
+
+fn read_acpi_watts(path: &Path) -> Option<f64> {
+    let raw = read_text(path)?;
+    let microwatts: f64 = raw.parse().ok()?;
+    let watts = microwatts / 1_000_000.0;
+    if watts.is_finite() && watts >= 0.0 {
+        Some(watts)
+    } else {
+        None
+    }
+}
+
+fn build_metrics(sensors: &[Sensor]) -> String {
+    let mut out = String::from(
+        "# HELP cpu_power_acpi_watts Grace CPU power rail reading from ACPI hwmon (W).\n\
+         # TYPE cpu_power_acpi_watts gauge\n",
+    );
+    for s in sensors {
+        match read_acpi_watts(&s.path) {
+            Some(watts) => {
+                let _ = writeln!(
+                    out,
+                    "cpu_power_acpi_watts{{{},source=\"acpi\"}} {watts:.6}",
+                    s.labels
+                );
+            }
+            // Every scrape re-reads, so a persistently bad channel would warn
+            // forever; the gap in the series is the signal a consumer acts on.
+            None => {
+                tracing::debug!(path = %s.path.display(), "unreadable channel; skipping sample")
+            }
+        }
+    }
+    out
+}
+
+fn build_metrics_dcgm(reader: &Arc<Mutex<dcgm::DcgmReader>>) -> String {
+    let mut out = String::from(
+        "# HELP cpu_power_dcgm_watts Grace CPU instantaneous power via DCGM field 1130 (W).\n\
+         # TYPE cpu_power_dcgm_watts gauge\n",
+    );
+    match reader.lock() {
+        Err(_) => {
+            tracing::error!("DCGM reader mutex poisoned; skipping scrape");
+        }
+        Ok(mut r) => match r.read_watts() {
+            Err(e) => tracing::warn!(error = %e, "DCGM read failed; skipping scrape"),
+            Ok(readings) => {
+                for (cpu_id, watts) in readings {
+                    if let Some(w) = watts {
+                        let _ = writeln!(
+                            out,
+                            "cpu_power_dcgm_watts{{socket=\"{cpu_id}\",source=\"dcgm\"}} {w:.6}",
+                        );
+                    } else {
+                        tracing::debug!(cpu_id, "no DCGM sample for entity; skipping");
+                    }
+                }
+            }
+        },
+    }
+    out
+}
+
+/// Reads until the end of the request headers, so a request split across
+/// segments is not mistaken for a request for `/`.
+///
+/// The timeout bounds the whole header, not each read: a client dribbling one
+/// byte at a time must not hold a connection slot open indefinitely.
+async fn read_request(stream: &mut TcpStream) -> Option<String> {
+    let read_headers = async {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut chunk).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                return String::from_utf8(buf).ok();
+            }
+            if buf.len() > MAX_REQUEST_BYTES {
+                return None;
+            }
+        }
+    };
+    timeout(READ_TIMEOUT, read_headers).await.ok()?
+}
+
+async fn handle_connection(mut stream: TcpStream, state: MetricsState) {
+    let Some(req) = read_request(&mut stream).await else {
+        return;
+    };
+    let mut request_line = req.split_whitespace();
+    let method = request_line.next().unwrap_or("");
+    // `/metrics?collect[]=x` addresses the same endpoint; the query is not part of it.
+    let path = request_line
+        .next()
+        .unwrap_or("")
+        .split('?')
+        .next()
+        .unwrap_or("");
+
+    let mut extra_headers = "";
+    let (status, content_type, body) = match (method, path) {
+        // /health deliberately touches no sensor: it must still answer while
+        // the collection thread is stuck on a firmware read.
+        ("GET" | "HEAD", "/health") => ("200 OK", "text/plain", "ok\n".to_owned()),
+        ("GET" | "HEAD", "/metrics") => {
+            let body = match &state {
+                MetricsState::Acpi(cache) => cache.read().unwrap().clone(),
+                MetricsState::Dcgm(reader) => build_metrics_dcgm(reader),
+            };
+            ("200 OK", "text/plain; version=0.0.4; charset=utf-8", body)
+        }
+        ("GET" | "HEAD", _) => ("404 Not Found", "text/plain", "Not Found\n".to_owned()),
+        _ => {
+            extra_headers = "Allow: GET, HEAD\r\n";
+            (
+                "405 Method Not Allowed",
+                "text/plain",
+                "Method Not Allowed\n".to_owned(),
+            )
+        }
+    };
+
+    // HEAD carries exactly the headers its GET would, and no body.
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\n{extra_headers}Connection: close\r\n\r\n{}",
+        body.len(),
+        if method == "HEAD" { "" } else { body.as_str() },
+    );
+    match timeout(WRITE_TIMEOUT, stream.write_all(response.as_bytes())).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::debug!(error = %e, "response write failed"),
+        Err(_) => tracing::debug!("response write timed out"),
+    }
+}
+
+/// Accepts one connection, backing off while the listener keeps erroring.
+///
+/// `select!` drops this future on a shutdown signal, so a backoff sleep can
+/// never delay shutdown.
+async fn accept(listener: &TcpListener, backoff: &mut Duration) -> TcpStream {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _)) => {
+                *backoff = Duration::ZERO;
+                return stream;
+            }
+            Err(e) => {
+                *backoff = (*backoff * 2).clamp(ACCEPT_BACKOFF_MIN, ACCEPT_BACKOFF_MAX);
+                tracing::warn!(error = %e, backoff_ms = backoff.as_millis(), "accept failed");
+                tokio::time::sleep(*backoff).await;
+            }
+        }
+    }
+}
+
+fn init_metrics_state(args: &Args) -> Result<MetricsState> {
+    let want_dcgm = matches!(args.source, SourceMode::Dcgm | SourceMode::Auto);
+    let want_acpi = matches!(args.source, SourceMode::Acpi | SourceMode::Auto);
+
+    if want_dcgm {
+        match dcgm::DcgmReader::new() {
+            Ok(mut reader) => {
+                tracing::info!(
+                    cpu_count = reader.cpu_ids.len(),
+                    cpu_ids = ?reader.cpu_ids,
+                    "DCGM reader initialised"
+                );
+                // Probe: if every entity returns zero/None the embedded daemon
+                // lacks hardware access (common when running without root while a
+                // system dcgm-exporter holds the DCGM session as root).  In Auto
+                // mode this is a silent fallback to ACPI; in Dcgm mode it is a
+                // hard failure because the caller explicitly requested DCGM.
+                let probe = reader.read_watts();
+                let any_live = probe
+                    .as_ref()
+                    .map(|v| v.iter().any(|(_, w)| w.is_some()))
+                    .unwrap_or(false);
+                if !any_live {
+                    let reason = match probe {
+                        Err(ref e) => format!("read error: {e}"),
+                        Ok(_) => "all entities returned zero watts".into(),
+                    };
+                    if matches!(args.source, SourceMode::Dcgm) {
+                        anyhow::bail!("DCGM yielded no live data: {reason}");
+                    }
+                    tracing::info!(%reason, "DCGM yielded no live data; falling back to ACPI");
+                } else {
+                    return Ok(MetricsState::Dcgm(Arc::new(Mutex::new(reader))));
+                }
+            }
+            Err(e) => {
+                if matches!(args.source, SourceMode::Dcgm) {
+                    anyhow::bail!("DCGM unavailable: {e}");
+                }
+                tracing::info!(reason = %e, "DCGM unavailable; falling back to ACPI");
+            }
+        }
+    }
+
+    if want_acpi {
+        let sensors: &'static [Sensor] = Vec::leak(discover_sensors(&args.hwmon_root)?);
+        if sensors.is_empty() {
+            anyhow::bail!(
+                "no ACPI power_meter hwmon sensors found under {}",
+                args.hwmon_root.display()
+            );
+        }
+        tracing::info!(count = sensors.len(), "discovered ACPI sensors");
+        for s in sensors {
+            tracing::debug!(
+                sensor = %s.id, kind = s.kind,
+                socket = %s.socket, oem_info = %s.oem_info,
+                path = %s.path.display(), "sensor"
+            );
+        }
+
+        // Seed the cache synchronously so the first scrape after startup is not empty.
+        let initial = build_metrics(sensors);
+        let cache = Arc::new(RwLock::new(initial));
+        let cache_bg = Arc::clone(&cache);
+
+        // Background OS thread: re-reads all sensors every ACPI_POLL_INTERVAL so
+        // HTTP scrapes serve cached data and return in <1 ms.
+        std::thread::Builder::new()
+            .name("acpi-poller".to_owned())
+            .spawn(move || loop {
+                std::thread::sleep(ACPI_POLL_INTERVAL);
+                let snapshot = build_metrics(sensors);
+                *cache_bg.write().unwrap() = snapshot;
+            })
+            .context("spawn acpi-poller thread")?;
+
+        return Ok(MetricsState::Acpi(cache));
+    }
+
+    unreachable!("one of want_dcgm or want_acpi must be true");
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Without the `env-filter` feature this honours RUST_LOG via `Targets` and
+    // defaults to INFO. With it, the default directive would be ERROR, which
+    // silently drops every line below unless the caller sets RUST_LOG.
+    tracing_subscriber::fmt::init();
+
+    let args = Args::parse();
+    let state = init_metrics_state(&args)?;
+
+    let addr = SocketAddr::new(args.bind, args.port);
+    let listener = TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("bind {addr}"))?;
+    // Consumers (AIPerf discovers its endpoints once at startup) treat this
+    // line as readiness, so it is emitted only after the port is accepting.
+    tracing::info!(%addr, "listening");
+
+    let mut sigterm = unix_signal(SignalKind::terminate())?;
+    let mut conns = JoinSet::new();
+    let mut backoff = Duration::ZERO;
+    loop {
+        let at_capacity = conns.len() >= MAX_CONNECTIONS;
+        tokio::select! {
+            // Reaping stays inside the select! so a signal is honoured while
+            // the exporter is sitting at its connection limit.
+            Some(_) = conns.join_next(), if at_capacity => {}
+            stream = accept(&listener, &mut backoff), if !at_capacity => {
+                conns.spawn(handle_connection(stream, state.clone()));
+            }
+            _ = signal::ctrl_c() => {
+                tracing::info!("received SIGINT, shutting down");
+                break;
+            }
+            _ = sigterm.recv() => {
+                tracing::info!("received SIGTERM, shutting down");
+                break;
+            }
+        }
+    }
+
+    // Let in-flight scrapes finish rather than truncating a response mid-write.
+    if timeout(DRAIN_TIMEOUT, async {
+        while conns.join_next().await.is_some() {}
+    })
+    .await
+    .is_err()
+    {
+        // A handler blocked in a sysfs read reaches no await point, so dropping
+        // its task would not bound anything. Exiting does.
+        tracing::warn!("timed out draining in-flight connections; exiting");
+        process::exit(0);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_hwmon(root: &Path, node: &str, sensors: &[(&str, Option<&str>, &str)]) -> PathBuf {
+        let hwmon = root.join(node);
+        fs::create_dir_all(&hwmon).unwrap();
+        fs::write(hwmon.join("name"), "power_meter").unwrap();
+        for (chan, oem, microwatts) in sensors {
+            fs::write(hwmon.join(format!("{chan}_average")), microwatts).unwrap();
+            if let Some(oem) = oem {
+                fs::write(hwmon.join(format!("{chan}_oem_info")), oem).unwrap();
+            }
+        }
+        hwmon
+    }
+
+    #[test]
+    fn discover_sensors_finds_power_meter_channels() {
+        let dir = TempDir::new().unwrap();
+        write_hwmon(
+            dir.path(),
+            "hwmon0",
+            &[
+                ("power1", Some("CPU Power Socket 0"), "150000000"),
+                ("power2", Some("Grace Power Socket 1"), "80000000"),
+            ],
+        );
+        let sensors = discover_sensors(dir.path()).unwrap();
+        assert_eq!(sensors.len(), 2);
+        assert_eq!((sensors[0].kind, sensors[0].socket.as_str()), ("cpu", "0"));
+        assert_eq!(
+            (sensors[1].kind, sensors[1].socket.as_str()),
+            ("grace", "1")
+        );
+    }
+
+    #[test]
+    fn alias_dedup_keeps_the_side_that_carries_the_metadata() {
+        let dir = TempDir::new().unwrap();
+        let hwmon = write_hwmon(dir.path(), "hwmon0", &[("power1", None, "100000000")]);
+        // Real Grace nodes publish the reading on the hwmon node and the OEM
+        // string only under device/. The bare hwmon side is scanned first and
+        // must not win, or every rail would be labelled "power1".
+        let device = hwmon.join("device");
+        fs::create_dir_all(&device).unwrap();
+        std::os::unix::fs::symlink(hwmon.join("power1_average"), device.join("power1_average"))
+            .unwrap();
+        fs::write(device.join("power1_oem_info"), "CPU Power Socket 0").unwrap();
+
+        let sensors = discover_sensors(dir.path()).unwrap();
+        assert_eq!(sensors.len(), 1, "an alias is one sensor, not two");
+        assert_eq!(sensors[0].oem_info, "CPU Power Socket 0");
+        assert_eq!(sensors[0].kind, "cpu");
+    }
+
+    #[test]
+    fn distinct_rails_get_distinct_series_without_usable_metadata() {
+        let dir = TempDir::new().unwrap();
+        // Duplicated OEM text on one node and no metadata at all on another:
+        // both collapse to one Prometheus series unless `sensor` disambiguates.
+        write_hwmon(
+            dir.path(),
+            "hwmon0",
+            &[
+                ("power1", Some("CPU Power"), "100000000"),
+                ("power2", Some("CPU Power"), "110000000"),
+            ],
+        );
+        write_hwmon(dir.path(), "hwmon1", &[("power1", None, "120000000")]);
+
+        let output = build_metrics(&discover_sensors(dir.path()).unwrap());
+        let series: Vec<&str> = output
+            .lines()
+            .filter(|line| line.starts_with("cpu_power_acpi_watts{"))
+            .collect();
+        assert_eq!(series.len(), 3, "{output}");
+        let identities: std::collections::HashSet<&str> = series
+            .iter()
+            .map(|line| line.split_once(' ').unwrap().0)
+            .collect();
+        assert_eq!(identities.len(), 3, "duplicate label sets: {output}");
+    }
+
+    #[test]
+    fn classify_oem_requires_a_socket_id_adjacent_to_the_rail_name() {
+        assert_eq!(classify_oem("CPU Power Socket 0"), ("cpu", "0".into()));
+        // Rail name wins by adjacency, not by scan order.
+        assert_eq!(
+            classify_oem("Grace Power Socket 1 CPU Power"),
+            ("grace", "1".into())
+        );
+        // No numeric socket ID -> unclassified, so no unescaped text reaches a label.
+        assert_eq!(
+            classify_oem("CPU Power Socket \"x"),
+            ("other", String::new())
+        );
+        assert_eq!(classify_oem("Module Socket A"), ("other", String::new()));
+    }
+
+    #[test]
+    fn build_metrics_formats_and_escapes_prometheus_text() {
+        let dir = TempDir::new().unwrap();
+        write_hwmon(
+            dir.path(),
+            "hwmon0",
+            &[
+                ("power1", Some("CPU Power Socket 0"), "150000000"),
+                ("power2", Some("Odd \"rail\""), "not-a-number"),
+            ],
+        );
+        let sensors = discover_sensors(dir.path()).unwrap();
+        let output = build_metrics(&sensors);
+        assert!(output.contains("# TYPE cpu_power_acpi_watts gauge"));
+        assert!(output.contains(
+            "cpu_power_acpi_watts{sensor=\"hwmon0/power1\",type=\"cpu\",socket=\"0\",oem_info=\"CPU Power Socket 0\",source=\"acpi\"} 150.000000\n"
+        ), "{output}");
+        assert!(
+            !output.contains("not-a-number"),
+            "unparseable channel must be skipped"
+        );
+        assert!(sensors
+            .iter()
+            .any(|s| s.labels.contains(r#"oem_info="Odd \"rail\"""#)));
+    }
+
+    #[test]
+    fn discover_sensors_reports_an_unreadable_root() {
+        let dir = TempDir::new().unwrap();
+        assert!(discover_sensors(&dir.path().join("absent")).is_err());
+    }
+
+    async fn request(addr: SocketAddr, head: &str) -> String {
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        // Split across writes: a correct reader waits for the header terminator.
+        client.write_all(head.as_bytes()).await.unwrap();
+        client.write_all(b"Host: localhost\r\n\r\n").await.unwrap();
+        let mut resp = String::new();
+        client.read_to_string(&mut resp).await.unwrap();
+        resp
+    }
+
+    #[tokio::test]
+    async fn serves_metrics_health_and_rejects_unsupported_methods() {
+        let dir = TempDir::new().unwrap();
+        write_hwmon(
+            dir.path(),
+            "hwmon0",
+            &[("power1", Some("CPU Power Socket 0"), "150000000")],
+        );
+        let sensors: &'static [Sensor] = Vec::leak(discover_sensors(dir.path()).unwrap());
+        let state = MetricsState::Acpi(Arc::new(RwLock::new(build_metrics(sensors))));
+
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                handle_connection(stream, state.clone()).await;
+            }
+        });
+
+        for (head, expected) in [
+            ("GET /health HTTP/1.1\r\n", "200 OK"),
+            // A query string addresses the same endpoint.
+            ("GET /metrics?collect%5B%5D=x HTTP/1.1\r\n", "200 OK"),
+            ("GET /nope HTTP/1.1\r\n", "404 Not Found"),
+            ("POST /metrics HTTP/1.1\r\n", "405 Method Not Allowed"),
+        ] {
+            let resp = request(addr, head).await;
+            assert!(
+                resp.starts_with(&format!("HTTP/1.1 {expected}")),
+                "{head}: {resp}"
+            );
+        }
+
+        let get = request(addr, "GET /metrics HTTP/1.1\r\n").await;
+        let head = request(addr, "HEAD /metrics HTTP/1.1\r\n").await;
+        let body = "cpu_power_acpi_watts{sensor=\"hwmon0/power1\"";
+        assert!(get.contains(body), "{get}");
+        assert!(!head.contains(body), "HEAD must carry no body: {head}");
+        // Same Content-Length as the GET it mirrors.
+        let length = |resp: &str| {
+            resp.lines()
+                .find(|l| l.starts_with("Content-Length:"))
+                .unwrap()
+                .to_owned()
+        };
+        assert_eq!(length(&get), length(&head));
+
+        let rejected = request(addr, "POST /metrics HTTP/1.1\r\n").await;
+        assert!(rejected.contains("Allow: GET, HEAD"), "{rejected}");
+    }
+
+    /// Accepts serially, so a handler that blocked its thread would stall the next request.
+    async fn serve(collector: &'static Collector) -> SocketAddr {
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                handle_connection(stream, collector).await;
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn a_wedged_collector_degrades_metrics_without_blocking_the_runtime() {
+        // A collector whose thread never answers stands in for a sysfs read
+        // stuck in the kernel: /metrics must give up, and /health must not care.
+        let (requests, inbox) = mpsc::sync_channel::<CollectRequest>(MAX_CONNECTIONS);
+        let stuck = thread::spawn(move || {
+            let held: Vec<CollectRequest> = inbox.into_iter().collect();
+            drop(held);
+        });
+        let collector: &'static Collector = Box::leak(Box::new(Collector { requests }));
+        let addr = serve(collector).await;
+
+        let metrics = tokio::time::timeout(
+            COLLECT_TIMEOUT * 2,
+            request(addr, "GET /metrics HTTP/1.1\r\n"),
+        )
+        .await
+        .expect("handler must not hold the connection open indefinitely");
+        assert!(
+            metrics.starts_with("HTTP/1.1 503 Service Unavailable"),
+            "{metrics}"
+        );
+
+        let health = request(addr, "GET /health HTTP/1.1\r\n").await;
+        assert!(health.starts_with("HTTP/1.1 200 OK"), "{health}");
+        let _ = stuck;
+    }
+}

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from srtctl.core.fingerprint import format_identity_verification, verify_identity
+from srtctl.core.ip_utils import url_host
 from srtctl.core.health import wait_for_model
 from srtctl.core.lockfile import collect_worker_fingerprints
 from srtctl.core.power.contract import (
@@ -676,7 +677,7 @@ class BenchmarkStageMixin:
             worker_nodes = sorted({process.node for process in self.backend_processes})
             for node in worker_nodes:
                 host = get_hostname_ip(node, self.runtime.network_interface)
-                urls.append(f"http://{host}:{cpu_power.prometheus_port}/metrics")
+                urls.append(f"http://{url_host(host)}:{cpu_power.prometheus_port}/metrics")
 
         return {"AIPERF_SERVER_METRICS_URLS": ",".join(urls)}
 

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -669,6 +669,15 @@ class BenchmarkStageMixin:
         # Custom commands preserve logical topology order; built-in AIPerf
         # runners retain their historical sorted physical-process list.
         urls = list(dict.fromkeys(urls)) if logical_workers_only else sorted(set(urls))
+
+        # Add ACPI CPU power exporter endpoints (one per worker node) when enabled.
+        cpu_power = getattr(self.config.telemetry, "cpu_power", None)
+        if self.config.telemetry.enabled and cpu_power is not None and cpu_power.enabled and cpu_power.prometheus_port > 0:
+            worker_nodes = sorted({process.node for process in self.backend_processes})
+            for node in worker_nodes:
+                host = get_hostname_ip(node, self.runtime.network_interface)
+                urls.append(f"http://{host}:{cpu_power.prometheus_port}/metrics")
+
         return {"AIPERF_SERVER_METRICS_URLS": ",".join(urls)}
 
     def _client_polled_metric_urls(self) -> frozenset[str]:

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -157,12 +157,6 @@ class TelemetryStageMixin:
         worker_nodes = sorted({process.node for process in self.backend_processes})
         power_dir = self.runtime.log_dir / telemetry.storage_subdir
         command = resolve_exporter_command(exporter_config, DCGM_EXPORTER_COMMAND_TEMPLATE)
-        gpus_per_node = self.config.resources.gpus_per_node
-        permitted_device_keys = (
-            [(node, gpu_index) for node in worker_nodes for gpu_index in range(gpus_per_node)]
-            if isinstance(gpus_per_node, int) and gpus_per_node > 0
-            else None
-        )
 
         session = PowerTelemetrySession(
             settings=PowerSessionSettings(
@@ -187,7 +181,6 @@ class TelemetryStageMixin:
                 for concurrency in self.config.benchmark.get_concurrency_list()
             ],
             nodes=worker_nodes,
-            permitted_device_keys=permitted_device_keys,
         )
         # NOTE: stored before initialize() so a raise mid-startup still leaves a finalizable session.
         self._power_session = session
@@ -229,7 +222,7 @@ class TelemetryStageMixin:
             return None
 
         worker_nodes = sorted({process.node for process in self.backend_processes})
-        cpu_dir = self.runtime.log_dir / telemetry.storage_subdir / "cpu"
+        cpu_dir = self.runtime.log_dir / cpu_power.storage_subdir
         session = CpuPowerTelemetrySession(
             CpuPowerSessionSettings(
                 cpu_dir=cpu_dir,

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -313,11 +313,13 @@ class TelemetryStageMixin:
         self, registry: ProcessRegistry, worker_nodes: list[str], port: int
     ) -> None:
         """Launch cpu-power-exporter on each worker node for AIPerf server-metrics scraping."""
-        exporter_command = [
-            self._resolve_bundled_binary("cpu-power-exporter"),
-            "--port",
-            str(port),
-        ]
+        resolved = self._resolve_bundled_binary("cpu-power-exporter")
+        if Path(resolved).is_file() and os.access(resolved, os.X_OK):
+            exporter_command = [resolved, "--port", str(port)]
+            logger.info("CPU power exporter: using Rust binary %s", resolved)
+        else:
+            exporter_command = ["python3", "-m", "srtctl.core.cpu_power_exporter", "--port", str(port)]
+            logger.info("CPU power exporter: Rust binary not found, falling back to Python exporter")
         if self.runtime.nodes.het:
             groups: dict[int, list[str]] = {}
             for node in worker_nodes:

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -151,8 +151,8 @@ class TelemetryStageMixin:
             return None
 
         exporter_config = telemetry.dcgm_exporter
-        if exporter_config is None:  # guaranteed by schema validation
-            raise ValueError("telemetry.dcgm_exporter is required when telemetry is enabled")
+        if exporter_config is None:
+            return None
 
         worker_nodes = sorted({process.node for process in self.backend_processes})
         power_dir = self.runtime.log_dir / telemetry.storage_subdir
@@ -303,7 +303,58 @@ class TelemetryStageMixin:
             logger.warning("CPU power collectors did not become ready on every worker node")
         else:
             logger.info("CPU power telemetry ready (artifacts under %s)", cpu_dir)
+
+        if cpu_power.prometheus_port > 0:
+            self._start_cpu_power_prometheus_exporters(registry, worker_nodes, cpu_power.prometheus_port)
+
         return session
+
+    def _start_cpu_power_prometheus_exporters(
+        self, registry: ProcessRegistry, worker_nodes: list[str], port: int
+    ) -> None:
+        """Launch cpu-power-exporter on each worker node for AIPerf server-metrics scraping."""
+        exporter_command = [
+            self._resolve_bundled_binary("cpu-power-exporter"),
+            "--port",
+            str(port),
+        ]
+        if self.runtime.nodes.het:
+            groups: dict[int, list[str]] = {}
+            for node in worker_nodes:
+                group_id = self.runtime.nodes.het_group_for(node)
+                if group_id is None:
+                    raise RuntimeError(f"node {node!r} not in any het component")
+                groups.setdefault(group_id, []).append(node)
+            chunks = sorted(groups.items())
+        else:
+            chunks = [(-1, worker_nodes)]
+
+        for group_id, nodes in chunks:
+            suffix = "" if len(chunks) == 1 else f".g{group_id}"
+            log_file = self.runtime.log_dir / f"telemetry_cpu_power_prom{suffix}.%N.out"
+            try:
+                proc = start_srun_process(
+                    command=exporter_command,
+                    nodes=len(nodes),
+                    ntasks=len(nodes),
+                    nodelist=nodes,
+                    output=str(log_file),
+                    srun_options=self.runtime.srun_options,
+                    het_group=group_id if group_id >= 0 else None,
+                    use_bash_wrapper=False,
+                )
+                name = "telemetry_cpu_power_prom" if len(chunks) == 1 else f"telemetry_cpu_power_prom_g{group_id}"
+                registry.add_process(
+                    ManagedProcess(
+                        name=name,
+                        popen=proc,
+                        log_file=log_file,
+                        node=",".join(nodes),
+                        critical=False,
+                    )
+                )
+            except Exception:
+                logger.exception("CPU power Prometheus exporter launch failed on group %s", group_id)
 
     def power_telemetry_blocks_benchmark(self) -> bool:
         """Whether required-mode telemetry failed startup and must skip the workload.
@@ -385,25 +436,32 @@ class TelemetryStageMixin:
             return 1
         return exit_code
 
-    def _resolve_tachometer_binary(self, binary_path: str) -> str:
-        """Resolve the default bare binary name against the checkout's bin/.
+    def _resolve_bundled_binary(self, name: str) -> str:
+        """Resolve a bare binary name against the checkout's ``bin/``.
 
-        An explicit ``binary_path`` is always respected verbatim. The default
-        bare name used to rely on ``$PATH`` inside the srun step, while
-        ``make setup`` installs the binary to ``<srtctl_root>/bin/`` — the
-        same place ``validate_setup`` checks and the --bash lifecycle uses.
+        ``make setup`` installs the released binaries to ``<srtctl_root>/bin/``
+        — the same place ``validate_setup`` checks and the --bash lifecycle
+        uses. Falling back to the bare name keeps ``$PATH`` working for ad-hoc
+        installs inside the srun step.
         """
-        if binary_path != "tachometer-scraper":
-            return binary_path
         candidates = []
         source_dir = os.environ.get("SRTCTL_SOURCE_DIR")
         if source_dir:
-            candidates.append(Path(source_dir) / "bin" / binary_path)
-        candidates.append(Path(__file__).resolve().parents[4] / "bin" / binary_path)
+            candidates.append(Path(source_dir) / "bin" / name)
+        candidates.append(Path(__file__).resolve().parents[4] / "bin" / name)
         for candidate in candidates:
             if candidate.is_file() and os.access(candidate, os.X_OK):
                 return str(candidate)
-        return binary_path
+        return name
+
+    def _resolve_tachometer_binary(self, binary_path: str) -> str:
+        """Resolve the default bare binary name against the checkout's bin/.
+
+        An explicit ``binary_path`` is always respected verbatim.
+        """
+        if binary_path != "tachometer-scraper":
+            return binary_path
+        return self._resolve_bundled_binary(binary_path)
 
     def start_tachometer(self) -> list[ManagedProcess]:
         """Start Tachometer collection (follows ``observability.enabled``)."""

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -482,6 +482,8 @@ def validate_setup(srtctl_source: Path) -> None:
         missing.append("bin/uv (compute-arch uv)")
     if not (srtctl_source / "bin" / "tachometer-scraper").exists():
         missing.append("bin/tachometer-scraper (compute-arch Tachometer scraper)")
+    if not (srtctl_source / "bin" / "cpu-power-exporter").exists():
+        missing.append("bin/cpu-power-exporter (compute-arch ACPI CPU power exporter)")
 
     if missing:
         console.print(f"\n[red bold]ERROR:[/] Required binaries not found in {srtctl_source}:")

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -60,6 +60,7 @@ from srtctl.core.schema import SrtConfig, installs_dynamo
 from srtctl.core.status import create_job_record
 from srtctl.core.validation import preflight_config_variants
 from srtctl.ports import MOONCAKE_MASTER_PORT
+from srtctl.runtime_scripts.dynamo_wheels import arch_from_binary, detect_target_arch
 from srtctl.render.direct_plan import (
     build_direct_plan_context,
     render_direct_container_shim,
@@ -465,11 +466,37 @@ def show_config_details(config: SrtConfig) -> None:
         console.print(Panel(details, border_style="blue"))
 
 
-def validate_setup(srtctl_source: Path) -> None:
+def _cpu_power_exporter_problem(srtctl_source: Path) -> str | None:
+    """Why the installed exporter could not run on the compute nodes, if it could not.
+
+    Existence alone is not enough: a partial download leaves a file srun cannot
+    execute, and a checkout carried between architectures leaves one built for
+    the wrong machine. Either way the failure surfaces only once the allocation
+    is already running. The intended architecture is the compute architecture
+    make setup ARCH= installed, not this submit host, which is routinely a
+    different machine; when neither can be read, nothing is claimed.
+    """
+    label = "bin/cpu-power-exporter (compute-arch ACPI CPU power exporter)"
+    exporter = srtctl_source / "bin" / "cpu-power-exporter"
+    if not exporter.is_file():
+        return label
+    if not os.access(exporter, os.X_OK):
+        return f"{label} — present but not executable"
+    installed = arch_from_binary(exporter)
+    target = detect_target_arch(srtctl_source)
+    if installed is not None and installed != target:
+        return f"{label} — built for {installed}, but the compute nodes are {target}"
+    return None
+
+
+def validate_setup(srtctl_source: Path, config: SrtConfig | None = None) -> None:
     """Validate that make setup has been run and required binaries exist.
 
     Checks for NATS, etcd, Tachometer, and compute-arch uv binaries. Raises SystemExit
     with a clear error message if anything is missing.
+
+    cpu-power-exporter is only required by recipes that enable
+    telemetry.cpu_power; every other recipe submits without it.
     """
     missing = []
 
@@ -482,8 +509,11 @@ def validate_setup(srtctl_source: Path) -> None:
         missing.append("bin/uv (compute-arch uv)")
     if not (srtctl_source / "bin" / "tachometer-scraper").exists():
         missing.append("bin/tachometer-scraper (compute-arch Tachometer scraper)")
-    if not (srtctl_source / "bin" / "cpu-power-exporter").exists():
-        missing.append("bin/cpu-power-exporter (compute-arch ACPI CPU power exporter)")
+    cpu_power_enabled = config is not None and config.telemetry.enabled and config.telemetry.cpu_power.enabled
+    if cpu_power_enabled:
+        problem = _cpu_power_exporter_problem(srtctl_source)
+        if problem is not None:
+            missing.append(problem)
 
     if missing:
         console.print(f"\n[red bold]ERROR:[/] Required binaries not found in {srtctl_source}:")

--- a/src/srtctl/core/cpu_power_exporter.py
+++ b/src/srtctl/core/cpu_power_exporter.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal Prometheus exporter for Grace CPU power via ACPI hwmon.
+
+Runs on the host (not inside a container) so /sys/class/hwmon is visible.
+Exposes metrics on :9405/metrics by default, readable by AIPerf's
+DCGMTelemetryCollector or a dedicated CPUPowerTelemetryCollector.
+
+Metric names:
+    cpu_power_acpi_watts{socket, oem_info, source}   -- per-channel power (W)
+
+Usage:
+    python3 -m srtctl.core.cpu_power_exporter --port 9405
+    # or via srun (host step, no container):
+    srun ... python3 -m srtctl.core.cpu_power_exporter --port 9405
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import signal
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+# Channels we surface; others (NVSwitch rails etc.) are collected but labelled separately.
+_OEM_LABELS = {
+    re.compile(r"CPU Power Socket (\d+)", re.IGNORECASE): "cpu",
+    re.compile(r"Grace Power Socket (\d+)", re.IGNORECASE): "grace",
+    re.compile(r"SysIO Power Socket (\d+)", re.IGNORECASE): "sysio",
+}
+
+
+def _find_power_meter_sensors(hwmon_root: Path = Path("/sys/class/hwmon")) -> list[dict[str, Any]]:
+    sensors: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for hwmon_dir in sorted(hwmon_root.glob("hwmon*")):
+        try:
+            if (hwmon_dir / "name").read_text().strip() != "power_meter":
+                continue
+        except OSError:
+            continue
+        for root in (hwmon_dir / "device", hwmon_dir):
+            for avg_path in sorted(root.glob("power*_average")):
+                identity = str(avg_path.resolve()) if avg_path.exists() else str(avg_path)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                if not avg_path.is_file():
+                    continue
+                chan = avg_path.stem.removesuffix("_average")
+                oem = _read_text(root / f"{chan}_oem_info") or _read_text(root / f"{chan}_label") or chan
+                channel_type = "other"
+                socket_id = ""
+                for pattern, kind in _OEM_LABELS.items():
+                    m = pattern.search(oem)
+                    if m:
+                        channel_type = kind
+                        socket_id = m.group(1)
+                        break
+                sensors.append(
+                    {
+                        "path": avg_path,
+                        "oem": oem,
+                        "type": channel_type,
+                        "socket": socket_id,
+                    }
+                )
+    return sensors
+
+
+def _read_text(p: Path) -> str | None:
+    try:
+        v = p.read_text().strip()
+        return v or None
+    except OSError:
+        return None
+
+
+def _read_watts(path: Path) -> float | None:
+    raw = _read_text(path)
+    if raw is None:
+        return None
+    try:
+        w = float(raw) / 1_000_000.0
+        return w if math.isfinite(w) and w >= 0 else None
+    except ValueError:
+        return None
+
+
+def _escape(s: str) -> str:
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _build_metrics(sensors: list[dict[str, Any]]) -> str:
+    lines = [
+        "# HELP cpu_power_acpi_watts Grace CPU power rail reading from ACPI hwmon (W).",
+        "# TYPE cpu_power_acpi_watts gauge",
+    ]
+    for s in sensors:
+        watts = _read_watts(s["path"])
+        if watts is None:
+            continue
+        labels = (
+            f'type="{_escape(s["type"])}",'
+            f'socket="{_escape(s["socket"])}",'
+            f'oem_info="{_escape(s["oem"])}",'
+            f'source="acpi"'
+        )
+        lines.append(f"cpu_power_acpi_watts{{{labels}}} {watts:.6f}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    sensors: list[dict[str, Any]] = []
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path not in ("/metrics", "/health"):
+            self.send_response(404)
+            self.end_headers()
+            return
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok\n")
+            return
+        body = _build_metrics(self.sensors).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        pass  # suppress default access log noise
+
+
+def serve(port: int) -> int:
+    sensors = _find_power_meter_sensors()
+    if not sensors:
+        print("ERROR: no ACPI power_meter hwmon sensors found", file=sys.stderr)
+        return 2
+    print(f"Found {len(sensors)} sensor(s):", file=sys.stderr)
+    for s in sensors:
+        print(f"  [{s['type']}] socket={s['socket']}  {s['oem']}  ({s['path']})", file=sys.stderr)
+
+    _Handler.sensors = sensors
+    server = HTTPServer(("", port), _Handler)
+    stop = threading.Event()
+
+    def _shutdown(_sig: int, _frame: Any) -> None:
+        stop.set()
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    print(f"Listening on :{port}/metrics", file=sys.stderr, flush=True)
+    server.serve_forever()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=9405)
+    args = parser.parse_args()
+    return serve(args.port)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/srtctl/core/ip_utils/__init__.py
+++ b/src/srtctl/core/ip_utils/__init__.py
@@ -7,6 +7,7 @@ IP address resolution utilities.
 This module provides:
 - get_node_ip(): Get IP address for a remote SLURM node (via srun)
 - get_local_ip(): Get local IP address
+- url_host(): Spell an address the way a URL authority needs it
 """
 
 import logging
@@ -17,6 +18,16 @@ logger = logging.getLogger(__name__)
 
 # Path to the bash scripts directory
 SCRIPTS_DIR = Path(__file__).parent
+
+
+def url_host(address: str) -> str:
+    """Spell ``address`` the way a URL authority needs it.
+
+    An IPv6 literal must be bracketed, or the colons inside the address are
+    read as the port separator and the URL is malformed. A hostname or an IPv4
+    address is handed back unchanged.
+    """
+    return f"[{address.replace('%', '%25')}]" if ":" in address else address
 
 
 def _run_bash_function(

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 _BENCHMARK_TYPE_SA_BENCH = "sa-bench"
 _DCGM_POWER_MAX_SAMPLE_GAP_SECONDS = 3.0
 _DCGM_POWER_COLLECT_CYCLE_TIMEOUT_GRACE_SECONDS = 1.0
+_CPU_POWER_MAX_SAMPLE_GAP_SECONDS = 3.0
 
 
 def _is_safe_relative_subpath(value: str) -> bool:
@@ -1143,18 +1144,48 @@ class ObservabilityConfig:
 
 @dataclass(frozen=True)
 class CpuPowerConfig:
-    """Host CPU-power collection alongside the DCGM GPU power artifact."""
+    """Host CPU-power collection alongside the DCGM GPU power artifact.
+
+    ACPI is the only implemented provider: ``cpu-power-exporter`` runs on every
+    worker node, publishes ``cpu_power_acpi_watts`` from ``/sys/class/hwmon``,
+    and the head-node session scrapes it on the same clock as the DCGM leg. The
+    same endpoints are handed to AIPerf via ``AIPERF_SERVER_METRICS_URLS``.
+
+    Attributes:
+        enabled: Master switch for the CPU power leg. Default: False.
+        source: Which provider to use. ``acpi`` names it explicitly and makes it
+            mandatory; ``auto`` is best-effort -- a node with no ACPI power
+            rails simply contributes no CPU samples instead of failing the run.
+        sample_interval_seconds: Scrape period, in seconds.
+        startup_timeout_seconds: How long to wait for the exporters to serve
+            ``/metrics`` before giving up on the leg.
+        required: Fail the job when the leg does not start or does not produce a
+            valid publication. Implies the ``acpi`` provider is mandatory.
+        prometheus_port: Port ``cpu-power-exporter`` listens on, on every worker
+            node. Must not collide with ``telemetry.dcgm_exporter.port``.
+        storage_subdir: Directory below the run log directory that holds the CPU
+            samples and manifest.
+    """
 
     enabled: bool = False
-    source: Literal["auto", "acpi", "dcgm"] = "auto"
+    source: Literal["auto", "acpi"] = "auto"
     sample_interval_seconds: float = 0.1
     startup_timeout_seconds: float = 30.0
     required: bool = False
-    # When > 0, also launch the cpu-power-exporter binary on each worker node so
-    # AIPerf can scrape ACPI power rails via --server-metrics / AIPERF_SERVER_METRICS_URLS.
     prometheus_port: int = 9405
+    storage_subdir: str = "cpu_power"
 
     Schema: ClassVar[type[Schema]] = Schema
+
+    @property
+    def acpi_mandatory(self) -> bool:
+        """Whether an absent or unhealthy ACPI exporter must fail the run.
+
+        ``auto`` is best-effort, so a cluster without ACPI power rails still
+        runs. Naming ``acpi`` explicitly, or asking for fail-closed behaviour
+        with ``required``, makes exporter readiness mandatory.
+        """
+        return self.source == "acpi" or self.required
 
 
 @dataclass(frozen=True)
@@ -2350,7 +2381,7 @@ class SrtConfig:
         if not 1 <= exporter.port <= 65535:
             raise ValidationError("telemetry.dcgm_exporter.port must be in 1..65535")
 
-        for name in ("default_frequency", "startup_timeout_seconds", "request_timeout_seconds"):
+        for name in ("default_frequency", "startup_timeout_seconds"):
             if not _is_finite_positive(getattr(telemetry, name)):
                 raise ValidationError(f"telemetry.{name} must be finite and positive")
         if telemetry.default_frequency > _DCGM_POWER_MAX_SAMPLE_GAP_SECONDS:
@@ -2359,19 +2390,6 @@ class SrtConfig:
                 f"{_DCGM_POWER_MAX_SAMPLE_GAP_SECONDS}s max sample gap the power validator accepts; "
                 "every window would fail sample_gap_exceeded. Set it to the intended collector "
                 "period (e.g. 1.0)."
-            )
-        worst_case_join_seconds = 2 * (
-            2 * telemetry.request_timeout_seconds + _DCGM_POWER_COLLECT_CYCLE_TIMEOUT_GRACE_SECONDS
-        )
-        collector_join_timeout_seconds = telemetry.resolved_collector_join_timeout_seconds
-        if (
-            not _is_finite_positive(collector_join_timeout_seconds)
-            or collector_join_timeout_seconds <= worst_case_join_seconds
-        ):
-            raise ValidationError(
-                "telemetry.collector_join_timeout_seconds must be finite, positive, "
-                "and greater than two full collector cycles "
-                "(2 * (2 * telemetry.request_timeout_seconds + 1 second))"
             )
 
         if not _is_safe_relative_subpath(telemetry.storage_subdir):
@@ -2402,6 +2420,113 @@ class SrtConfig:
         if not concurrencies or len(set(concurrencies)) != len(concurrencies) or any(c <= 0 for c in concurrencies):
             raise ValidationError("telemetry requires a non-empty list of unique positive benchmark.concurrencies")
 
+    def _dynamo_system_ports(self) -> set[int]:
+        """System-status ports that backend launches actually bind on worker nodes."""
+        if self.frontend.type != "dynamo":
+            return set()
+
+        resources = self.resources
+        nodes = [f"validation-worker-{index}" for index in range(self.total_nodes)]
+        endpoints = self.backend.allocate_endpoints(
+            num_prefill=resources.num_prefill,
+            num_decode=resources.num_decode,
+            num_agg=resources.num_agg,
+            gpus_per_prefill=resources.gpus_per_prefill,
+            gpus_per_decode=resources.gpus_per_decode,
+            gpus_per_agg=resources.gpus_per_agg,
+            gpus_per_node=resources.gpus_per_node,
+            available_nodes=nodes,
+            spread_workers=resources.spread_workers,
+        )
+        processes = self.backend.endpoints_to_processes(
+            endpoints,
+            frontend_type=self.frontend.type,
+            dynamo_sidecar=self.dynamo.sidecar,
+        )
+        if self.backend.get_srun_config().launch_per_endpoint:
+            processes = [process for process in processes if process.node_rank == 0]
+        return {process.sys_port for process in processes}
+
+    def _validate_collector_budget(self) -> None:
+        """Validate the scrape and join budget every enabled leg's collector uses.
+
+        Both the DCGM and CPU legs poll with ``request_timeout_seconds`` and are
+        joined with ``collector_join_timeout_seconds``, so a leg running alone
+        needs these checked just as much as the pair does.
+        """
+        telemetry = self.telemetry
+        if not _is_finite_positive(telemetry.request_timeout_seconds):
+            raise ValidationError("telemetry.request_timeout_seconds must be finite and positive")
+        worst_case_join_seconds = 2 * (
+            2 * telemetry.request_timeout_seconds + _DCGM_POWER_COLLECT_CYCLE_TIMEOUT_GRACE_SECONDS
+        )
+        collector_join_timeout_seconds = telemetry.resolved_collector_join_timeout_seconds
+        if (
+            not _is_finite_positive(collector_join_timeout_seconds)
+            or collector_join_timeout_seconds <= worst_case_join_seconds
+        ):
+            raise ValidationError(
+                "telemetry.collector_join_timeout_seconds must be finite, positive, "
+                "and greater than two full collector cycles "
+                "(2 * (2 * telemetry.request_timeout_seconds + 1 second))"
+            )
+
+    def _validate_cpu_power(self) -> None:
+        """Validate the host CPU power leg."""
+        cpu_power = self.telemetry.cpu_power
+        if not 1 <= cpu_power.prometheus_port <= 65535:
+            raise ValidationError("telemetry.cpu_power.prometheus_port must be in 1..65535")
+
+        neighbours = [("telemetry.dcgm_exporter", self.telemetry.dcgm_exporter)]
+        if self.observability.tachometer_enabled:
+            tachometer = self.observability.tachometer
+            neighbours += [
+                ("observability.tachometer.dcgm_exporter", tachometer.dcgm_exporter),
+                ("observability.tachometer.node_exporter", tachometer.node_exporter),
+            ]
+        for name, exporter in neighbours:
+            if exporter is not None and exporter.port == cpu_power.prometheus_port:
+                raise ValidationError(
+                    f"telemetry.cpu_power.prometheus_port={cpu_power.prometheus_port} collides with "
+                    f"{name}.port; both run on every worker node"
+                )
+
+        if cpu_power.prometheus_port in self._dynamo_system_ports():
+            raise ValidationError(
+                f"telemetry.cpu_power.prometheus_port={cpu_power.prometheus_port} collides with a Dynamo system port "
+                "assigned to a backend process on a worker node"
+            )
+
+        for name in ("sample_interval_seconds", "startup_timeout_seconds"):
+            if not _is_finite_positive(getattr(cpu_power, name)):
+                raise ValidationError(f"telemetry.cpu_power.{name} must be finite and positive")
+        if cpu_power.sample_interval_seconds > _CPU_POWER_MAX_SAMPLE_GAP_SECONDS:
+            raise ValidationError(
+                f"telemetry.cpu_power.sample_interval_seconds={cpu_power.sample_interval_seconds} exceeds the "
+                f"{_CPU_POWER_MAX_SAMPLE_GAP_SECONDS}s max sample gap; every window would fail sample_gap_exceeded"
+            )
+
+        if not _is_safe_relative_subpath(cpu_power.storage_subdir):
+            raise ValidationError(
+                "telemetry.cpu_power.storage_subdir must be a safe relative path below the run log directory"
+            )
+        if cpu_power.storage_subdir == self.telemetry.storage_subdir:
+            raise ValidationError(
+                "telemetry.cpu_power.storage_subdir must differ from telemetry.storage_subdir; "
+                "the two legs write their own samples and manifest"
+            )
+
+    def _reject_inert_cpu_power_demand(self) -> None:
+        """Reject mandatory CPU power semantics that nothing will act on."""
+        cpu_power = self.telemetry.cpu_power
+        if cpu_power.required:
+            raise ValidationError("telemetry.cpu_power.required has no effect unless telemetry.cpu_power.enabled")
+        if cpu_power.source == "acpi":
+            raise ValidationError(
+                'telemetry.cpu_power.source: "acpi" has no effect unless telemetry.cpu_power.enabled; '
+                "it names a mandatory provider for a leg that will not run"
+            )
+
     def _validate_observability(self):
         """Validate Tachometer collection under observability."""
         observability = self.observability
@@ -2410,7 +2535,7 @@ class SrtConfig:
             raise ValidationError("observability.tachometer requires observability.enabled: true")
         if not observability.tachometer_enabled:
             return
-        if self.telemetry.enabled and tachometer.dcgm_exporter is not None:
+        if self.telemetry.enabled and self.telemetry.dcgm_exporter is not None and tachometer.dcgm_exporter is not None:
             raise ValidationError(
                 "configure the shared DCGM exporter under telemetry, not observability.tachometer, "
                 "when DCGM power telemetry is enabled"
@@ -2442,12 +2567,34 @@ class SrtConfig:
             )
 
     def _validate_telemetry(self):
-        """Validate telemetry config."""
+        """Validate telemetry config.
+
+        The two legs are independent: a recipe may enable CPU power without a
+        DCGM exporter, or either alone.
+        """
         telemetry = self.telemetry
         if telemetry is None or not telemetry.enabled:
+            if telemetry is not None and telemetry.cpu_power.enabled:
+                raise ValidationError("telemetry.cpu_power.enabled requires telemetry.enabled")
+            if telemetry is not None:
+                self._reject_inert_cpu_power_demand()
             return
+        if telemetry.cpu_power.enabled:
+            if not _is_safe_relative_subpath(telemetry.storage_subdir):
+                raise ValidationError(
+                    "telemetry.storage_subdir must be a safe relative path below the run log directory"
+                )
+            self._validate_cpu_power()
+        else:
+            self._reject_inert_cpu_power_demand()
         if telemetry.dcgm_exporter is not None:
             self._validate_dcgm_power()
+        elif not telemetry.cpu_power.enabled:
+            raise ValidationError(
+                "telemetry.enabled requires telemetry.dcgm_exporter or telemetry.cpu_power.enabled; "
+                "otherwise there is nothing to collect"
+            )
+        self._validate_collector_budget()
 
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1150,6 +1150,9 @@ class CpuPowerConfig:
     sample_interval_seconds: float = 0.1
     startup_timeout_seconds: float = 30.0
     required: bool = False
+    # When > 0, also launch the cpu-power-exporter binary on each worker node so
+    # AIPerf can scrape ACPI power rails via --server-metrics / AIPERF_SERVER_METRICS_URLS.
+    prometheus_port: int = 9405
 
     Schema: ClassVar[type[Schema]] = Schema
 
@@ -2439,11 +2442,12 @@ class SrtConfig:
             )
 
     def _validate_telemetry(self):
-        """Validate DCGM power telemetry."""
+        """Validate telemetry config."""
         telemetry = self.telemetry
         if telemetry is None or not telemetry.enabled:
             return
-        self._validate_dcgm_power()
+        if telemetry.dcgm_exporter is not None:
+            self._validate_dcgm_power()
 
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":

--- a/src/srtctl/runtime_scripts/dynamo_wheels.py
+++ b/src/srtctl/runtime_scripts/dynamo_wheels.py
@@ -40,6 +40,19 @@ def _describe_file(path: Path) -> str:
     return result.stdout.strip()
 
 
+def arch_from_binary(path: Path) -> str | None:
+    """The architecture an installed binary was built for, when it can be read."""
+    if not path.exists():
+        return None
+
+    description = _describe_file(path)
+    if "aarch64" in description or "ARM aarch64" in description:
+        return "aarch64"
+    if "x86-64" in description or "x86_64" in description:
+        return "x86_64"
+    return None
+
+
 def arch_from_uv_binary(source_dir: Path) -> str | None:
     """Infer compute arch from the uv binary installed by make setup ARCH=..."""
     uv_bin = source_dir / "bin" / "uv"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -461,6 +461,56 @@ class TestTachometerConfigGeneration:
         # The frontend endpoint is never excluded (whole-window coverage).
         assert 'url = "http://10.0.0.1:8000/metrics"' in config_text
 
+    @patch("srtctl.core.telemetry.get_hostname_ip", return_value="2001:db8::1")
+    def test_ipv6_backend_and_frontend_targets_are_bracketed(self, _mock_get_hostname_ip):
+        tachometer = TachometerConfig(enabled=True)
+        runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
+        runtime.log_dir = Path("/runs/12345/logs")
+        process = Process(
+            node="node-a",
+            gpu_indices=frozenset({0}),
+            sys_port=8081,
+            http_port=30000,
+            endpoint_mode="prefill",
+            endpoint_index=0,
+            node_rank=0,
+        )
+        topology = FrontendTopology(nginx_node=None, frontend_nodes=["node-a"], frontend_port=8000, public_port=8000)
+
+        config_text = generate_tachometer_config(
+            processes=[process], frontend_topology=topology, runtime=runtime, tachometer=tachometer
+        )
+
+        assert 'url = "http://[2001:db8::1]:8081/metrics"' in config_text
+        assert 'url = "http://[2001:db8::1]:8000/metrics"' in config_text
+
+    @patch("srtctl.core.telemetry.get_hostname_ip", return_value="2001:db8::1")
+    def test_bracketed_aiperf_ipv6_url_excludes_the_backend_target(self, _mock_get_hostname_ip):
+        tachometer = TachometerConfig(enabled=True)
+        runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
+        runtime.log_dir = Path("/runs/12345/logs")
+        process = Process(
+            node="node-a",
+            gpu_indices=frozenset({0}),
+            sys_port=8081,
+            http_port=30000,
+            endpoint_mode="prefill",
+            endpoint_index=0,
+            node_rank=0,
+        )
+        topology = FrontendTopology(nginx_node=None, frontend_nodes=["node-a"], frontend_port=8000, public_port=8000)
+
+        config_text = generate_tachometer_config(
+            processes=[process],
+            frontend_topology=topology,
+            runtime=runtime,
+            tachometer=tachometer,
+            exclude_urls={"http://[2001:db8::1]:8081/metrics"},
+        )
+
+        assert 'name = "backend_prefill0_rank0"' not in config_text
+        assert 'url = "http://[2001:db8::1]:8000/metrics"' in config_text
+
     @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
     def test_backend_targets_cover_every_rank(self, _mock_get_hostname_ip):
         """Every worker rank is a scrape target (vLLM agg followers excepted);
@@ -809,8 +859,63 @@ class TestTachometerStageMixin:
         assert 'name = "dcgm_node-a"' in (tmp_path / "tachometer_config.toml").read_text()
 
     @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
+    def test_cpu_only_telemetry_leaves_tachometers_dcgm_exporter_running(self, mock_srun, tmp_path):
+        """The CPU leg configures no DCGM exporter, so there is nothing to reuse."""
+
+        class Harness(TelemetryStageMixin):
+            def __init__(self):
+                self.config = _make_config(
+                    tachometer=TachometerConfig(
+                        enabled=True,
+                        dcgm_exporter=TelemetryExporterConfig(container_image="dcgm:latest", port=9400),
+                    ),
+                    telemetry=TelemetryConfig(enabled=True, cpu_power=CpuPowerConfig(enabled=True)),
+                )
+                self.runtime = MagicMock()
+                self.runtime.log_dir = tmp_path
+                self.runtime.job_id = "12345"
+                self.runtime.run_name = "test_12345"
+                self.runtime.network_interface = "eth0"
+                self.runtime.nodes.head = "node-a"
+                self.runtime.nodes.het = False
+                self.runtime.srun_options = {}
+                self.runtime.container_mounts = {Path(tmp_path): Path("/logs")}
+                self._backend_processes = [
+                    Process(
+                        node="node-a",
+                        gpu_indices=frozenset({0}),
+                        sys_port=8081,
+                        http_port=30000,
+                        endpoint_mode="agg",
+                        endpoint_index=0,
+                        node_rank=0,
+                    )
+                ]
+
+            @property
+            def backend_processes(self):
+                return self._backend_processes
+
+            def _compute_frontend_topology(self):
+                return FrontendTopology(
+                    nginx_node=None,
+                    frontend_nodes=["node-a"],
+                    frontend_port=8000,
+                    public_port=8000,
+                )
+
+        mock_srun.return_value = _running_exporter()
+        harness = Harness()
+        harness._resolve_tachometer_binary = lambda binary_path: binary_path
+
+        processes = harness.start_tachometer()
+
+        assert [process.name for process in processes] == ["tachometer_dcgm_exporter", "tachometer"]
+        assert 'name = "dcgm_node-a"' in (tmp_path / "tachometer_config.toml").read_text()
+
+    @patch("srtctl.cli.mixins.telemetry_stage.start_srun_process")
     @patch("srtctl.cli.mixins.telemetry_stage.generate_tachometer_config", return_value='storage = "/run/tachometer"\n')
-    def test_multinode_exporters_request_one_node_per_task(self, _mock_config, mock_srun, tmp_path):
+    def test_multinode_exporters_request_one_node_per_taskdef test_multinode_exporters_request_one_node_per_task(self, _mock_config, mock_srun, tmp_path):
         """srun rejects --nodes 1 with a longer --nodelist, so the exporter launch
         must size --nodes to the worker set."""
 

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -3,12 +3,33 @@
 
 """Tests for validate_setup pre-flight check and Makefile arch detection."""
 
+import platform
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
 from srtctl.cli.submit import validate_setup
+from srtctl.core.schema import (
+    BenchmarkConfig,
+    CpuPowerConfig,
+    ModelConfig,
+    ResourceConfig,
+    SrtConfig,
+    TelemetryConfig,
+)
+
+# Minimal ELF headers: just enough for `file` to identify the architecture
+# ELF magic + class(64-bit) + data(little-endian) + version + OS/ABI + padding + type + machine
+ELF_X86_64 = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8 + b"\x02\x00\x3e\x00" + b"\x00" * 44
+ELF_AARCH64 = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8 + b"\x02\x00\xb7\x00" + b"\x00" * 44
+
+
+def _install(path: Path, image: bytes) -> None:
+    """Write an executable binary of a known architecture, as make setup does."""
+    path.write_bytes(image)
+    path.chmod(0o755)
 
 
 class TestValidateSetup:
@@ -75,6 +96,86 @@ class TestValidateSetup:
         with pytest.raises(SystemExit):
             validate_setup(tmp_path)
 
+    @staticmethod
+    def _setup_tree(tmp_path: Path) -> None:
+        (tmp_path / "configs").mkdir()
+        (tmp_path / "configs" / "nats-server").touch()
+        (tmp_path / "configs" / "etcd").touch()
+        (tmp_path / "bin").mkdir()
+        (tmp_path / "bin" / "uv").touch()
+        (tmp_path / "bin" / "tachometer-scraper").touch()
+
+    @staticmethod
+    def _config(cpu_power_enabled: bool) -> SrtConfig:
+        return SrtConfig(
+            name="test",
+            model=ModelConfig(path="/model", container="/image", precision="fp4"),
+            resources=ResourceConfig(gpu_type="h100"),
+            benchmark=BenchmarkConfig(type="manual"),
+            telemetry=TelemetryConfig(
+                enabled=cpu_power_enabled,
+                cpu_power=CpuPowerConfig(enabled=cpu_power_enabled),
+            ),
+        )
+
+    def test_cpu_power_exporter_is_not_required_when_disabled(self, tmp_path: Path):
+        """Recipes that never scrape ACPI rails must not need the exporter."""
+        self._setup_tree(tmp_path)
+
+        validate_setup(tmp_path, self._config(cpu_power_enabled=False))
+
+    def test_cpu_power_exporter_is_required_when_enabled(self, tmp_path: Path):
+        """A recipe that enables CPU power cannot run without the exporter."""
+        self._setup_tree(tmp_path)
+
+        with pytest.raises(SystemExit):
+            validate_setup(tmp_path, self._config(cpu_power_enabled=True))
+
+    @staticmethod
+    def _foreign_arch() -> tuple[bytes, str]:
+        """An architecture that is deliberately not this host's.
+
+        make setup targets the compute nodes, which are routinely a different
+        machine than the one submitting, so the check must follow bin/uv.
+        """
+        if platform.machine() == "aarch64":
+            return ELF_X86_64, "x86_64"
+        return ELF_AARCH64, "aarch64"
+
+    def test_cpu_power_enabled_passes_once_the_exporter_is_installed(self, tmp_path: Path):
+        """The compute architecture is bin/uv's, not the submit host's."""
+        if shutil.which("file") is None:
+            pytest.skip("file(1) is not installed")
+        self._setup_tree(tmp_path)
+        image, _arch = self._foreign_arch()
+        _install(tmp_path / "bin" / "uv", image)
+        _install(tmp_path / "bin" / "cpu-power-exporter", image)
+
+        validate_setup(tmp_path, self._config(cpu_power_enabled=True))
+
+    def test_an_exporter_that_cannot_be_executed_is_rejected(self, tmp_path: Path):
+        """A partial download leaves a file srun cannot start mid-allocation."""
+        self._setup_tree(tmp_path)
+        exporter = tmp_path / "bin" / "cpu-power-exporter"
+        exporter.write_bytes(ELF_X86_64)
+        exporter.chmod(0o644)
+
+        with pytest.raises(SystemExit):
+            validate_setup(tmp_path, self._config(cpu_power_enabled=True))
+
+    def test_an_exporter_built_for_another_architecture_is_rejected(self, tmp_path: Path):
+        """A checkout carried between clusters keeps a binary that cannot run."""
+        if shutil.which("file") is None:
+            pytest.skip("file(1) is not installed")
+        self._setup_tree(tmp_path)
+        compute_image, _arch = self._foreign_arch()
+        other = ELF_AARCH64 if compute_image is ELF_X86_64 else ELF_X86_64
+        _install(tmp_path / "bin" / "uv", compute_image)
+        _install(tmp_path / "bin" / "cpu-power-exporter", other)
+
+        with pytest.raises(SystemExit):
+            validate_setup(tmp_path, self._config(cpu_power_enabled=True))
+
 
 class TestMakefileArchDetection:
     """Test that the file | grep pattern used in Makefile matches correctly.
@@ -84,21 +185,23 @@ class TestMakefileArchDetection:
     the pattern works by creating minimal ELF binaries and checking `file` output.
     """
 
-    # Minimal ELF headers: just enough for `file` to identify the architecture
-    # ELF magic + class(64-bit) + data(little-endian) + version + OS/ABI + padding + type + machine
-    ELF_X86_64 = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8 + b"\x02\x00\x3e\x00"
-    ELF_AARCH64 = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8 + b"\x02\x00\xb7\x00"
-
     @staticmethod
     def _file_description(path: Path) -> str:
-        """Get just the description part of file(1) output (after the colon)."""
+        """Get just the description part of file(1) output (after the colon).
+
+        These tests assert what file(1) says, so a host without it has nothing
+        to assert against -- skipping is the honest answer, and the assertions
+        below are untouched wherever it is installed.
+        """
+        if shutil.which("file") is None:
+            pytest.skip("file(1) is not installed")
         result = subprocess.run(["file", str(path)], capture_output=True, text=True, check=False)
         return result.stdout.split(":", 1)[1] if ":" in result.stdout else result.stdout
 
     def test_file_detects_x86_64(self, tmp_path: Path):
         """file(1) description for x86_64 ELF contains 'x86-64' (hyphen, not underscore)."""
         binary = tmp_path / "fake_bin"
-        binary.write_bytes(self.ELF_X86_64 + b"\x00" * 44)
+        binary.write_bytes(ELF_X86_64)
         desc = self._file_description(binary)
         assert "x86-64" in desc, f"Expected 'x86-64' in: {desc}"
         assert "x86_64" not in desc, f"file uses hyphen not underscore: {desc}"
@@ -106,20 +209,20 @@ class TestMakefileArchDetection:
     def test_file_detects_aarch64(self, tmp_path: Path):
         """file(1) description for aarch64 ELF contains 'aarch64'."""
         binary = tmp_path / "fake_bin"
-        binary.write_bytes(self.ELF_AARCH64 + b"\x00" * 44)
+        binary.write_bytes(ELF_AARCH64)
         desc = self._file_description(binary)
         assert "aarch64" in desc, f"Expected 'aarch64' in: {desc}"
 
     def test_x86_64_not_matched_by_aarch64_pattern(self, tmp_path: Path):
         """An x86_64 binary must not match the aarch64 pattern."""
         binary = tmp_path / "fake_bin"
-        binary.write_bytes(self.ELF_X86_64 + b"\x00" * 44)
+        binary.write_bytes(ELF_X86_64)
         desc = self._file_description(binary)
         assert "aarch64" not in desc
 
     def test_aarch64_not_matched_by_x86_pattern(self, tmp_path: Path):
         """An aarch64 binary must not match the x86-64 pattern."""
         binary = tmp_path / "fake_bin"
-        binary.write_bytes(self.ELF_AARCH64 + b"\x00" * 44)
+        binary.write_bytes(ELF_AARCH64)
         desc = self._file_description(binary)
         assert "x86-64" not in desc


### PR DESCRIPTION
## Summary

Grafts the Rust `cpu-power-exporter` binary onto Kyle's CPU power branch, with the original Python exporter retained as a fallback.

- **Rust exporter** (primary): aarch64-native, reads ACPI hwmon + DCGM CPU power via FFI, background poller, port 9405
- **Python exporter** (fallback): stdlib-only, used when the Rust binary is absent or not executable
- Kyle's Python ACPI/DCGM readers (`cpu_power.py`, `cpu_power_session.py`, `gpu_power_limit.py`) are preserved — they own `samples.csv` / `manifest.json` artifact collection
- Wiring in `telemetry_stage.py` tries the Rust binary first, falls back to Python module
- Port 9405 throughout (default in both Rust and Python)

## Test plan

- [ ] Rust binary launches and serves `/metrics` on aarch64 GB200 nodes
- [ ] DCGM auto-fallback to ACPI when no DCGM daemon running
- [ ] Python fallback launches when binary absent
- [ ] `AIPERF_SERVER_METRICS_URLS` populated and scraped during benchmark
- [ ] Kyle's `samples.csv` / `manifest.json` artifacts still written correctly
- [ ] `test_cpu_power.py` and `test_gpu_power_limit.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)