### PR TITLE
feat(glm5): add validated GB300 OCI-AGA recipes

### DIFF
--- a/CrossCluster_Recipes/GLM5/gb300/16k_512/hightpt/glm5-gb300-fp8-stp-hightpt-10p8d-bs1280-conc1300.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/16k_512/hightpt/glm5-gb300-fp8-stp-hightpt-10p8d-bs1280-conc1300.yaml
@@ -1,0 +1,153 @@
+# Derived for 16K/512 from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_hightpt[2]
+# STP only. Topology: 10 prefill + 8 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-16k512-hightpt-10p8d-bs1280-conc1300
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 10
+  prefill_workers: 10
+  decode_nodes: 8
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 160
+      cuda-graph-max-bs-decode: 160
+      mem-fraction-static: 0.7
+      context-length: 16896
+      chunked-prefill-size: 65536
+      max-prefill-tokens: 16384
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 16896
+      tensor-parallel-size: 32
+      data-parallel-size: 32
+      expert-parallel-size: 32
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 32
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 1280
+      cuda-graph-max-bs-decode: 40
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 16384
+  osl: 512
+  concurrencies: "1300"

--- a/CrossCluster_Recipes/GLM5/gb300/16k_512/hightpt/glm5-gb300-fp8-stp-hightpt-12p6d-bs1680-conc1700.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/16k_512/hightpt/glm5-gb300-fp8-stp-hightpt-12p6d-bs1680-conc1700.yaml
@@ -1,0 +1,153 @@
+# Derived for 16K/512 from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_hightpt[1]
+# STP only. Topology: 12 prefill + 6 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-16k512-hightpt-12p6d-bs1680-conc1700
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 12
+  prefill_workers: 12
+  decode_nodes: 6
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 160
+      cuda-graph-max-bs-decode: 160
+      mem-fraction-static: 0.7
+      context-length: 16896
+      chunked-prefill-size: 65536
+      max-prefill-tokens: 16384
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 16896
+      tensor-parallel-size: 24
+      data-parallel-size: 24
+      expert-parallel-size: 24
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 32
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 1680
+      cuda-graph-max-bs-decode: 70
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 16384
+  osl: 512
+  concurrencies: "1700"

--- a/CrossCluster_Recipes/GLM5/gb300/16k_512/hightpt/glm5-gb300-fp8-stp-hightpt-14p4d-bs2800-conc2800.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/16k_512/hightpt/glm5-gb300-fp8-stp-hightpt-14p4d-bs2800-conc2800.yaml
@@ -1,0 +1,153 @@
+# Derived for 16K/512 from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_hightpt[0]
+# STP only. Topology: 14 prefill + 4 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-16k512-hightpt-14p4d-bs2800-conc2800
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 14
+  prefill_workers: 14
+  decode_nodes: 4
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 160
+      cuda-graph-max-bs-decode: 160
+      mem-fraction-static: 0.7
+      context-length: 16896
+      chunked-prefill-size: 65536
+      max-prefill-tokens: 16384
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 16896
+      tensor-parallel-size: 16
+      data-parallel-size: 16
+      expert-parallel-size: 16
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 32
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 2800
+      cuda-graph-max-bs-decode: 175
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 16384
+  osl: 512
+  concurrencies: "2800"

--- a/CrossCluster_Recipes/GLM5/gb300/16k_512/hightpt/glm5-gb300-fp8-stp-hightpt-8p10d-bs880-conc900.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/16k_512/hightpt/glm5-gb300-fp8-stp-hightpt-8p10d-bs880-conc900.yaml
@@ -1,0 +1,153 @@
+# Derived for 16K/512 from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_hightpt[3]
+# STP only. Topology: 8 prefill + 10 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-16k512-hightpt-8p10d-bs880-conc900
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 8
+  prefill_workers: 8
+  decode_nodes: 10
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 160
+      cuda-graph-max-bs-decode: 160
+      mem-fraction-static: 0.7
+      context-length: 16896
+      chunked-prefill-size: 65536
+      max-prefill-tokens: 16384
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 16896
+      tensor-parallel-size: 40
+      data-parallel-size: 40
+      expert-parallel-size: 40
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 24
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 880
+      cuda-graph-max-bs-decode: 22
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 16384
+  osl: 512
+  concurrencies: "900"

--- a/CrossCluster_Recipes/GLM5/gb300/16k_512/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p17d-bs8-conc128x64x32.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/16k_512/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p17d-bs8-conc128x64x32.yaml
@@ -1,0 +1,142 @@
+# Derived for 16K/512 from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_lowlat[1]
+# STP only. Topology: 1 prefill + 17 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-16k512-lowlatency-1p17d-bs8-conc128x64x32
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "04:00:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 17
+  decode_workers: 17
+
+frontend:
+  type: dynamo
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 160
+      cuda-graph-max-bs-decode: 160
+      mem-fraction-static: 0.7
+      context-length: 16896
+      chunked-prefill-size: 65536
+      max-prefill-tokens: 16384
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 16896
+      tensor-parallel-size: 4
+      data-parallel-size: 1
+      expert-parallel-size: 1
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      max-running-requests: 8
+      cuda-graph-max-bs-decode: 8
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 16384
+  osl: 512
+  concurrencies: "128x64x32"

--- a/CrossCluster_Recipes/GLM5/gb300/16k_512/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p9d-bs15-conc150.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/16k_512/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p9d-bs15-conc150.yaml
@@ -1,0 +1,142 @@
+# Derived for 16K/512 from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_lowlat[0]
+# STP only. Topology: 1 prefill + 9 decode nodes = 10 nodes / 40 GPUs.
+name: glm5-gb300-fp8-stp-16k512-lowlatency-1p9d-bs15-conc150
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 9
+  decode_workers: 9
+
+frontend:
+  type: dynamo
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 160
+      cuda-graph-max-bs-decode: 160
+      mem-fraction-static: 0.7
+      context-length: 16896
+      chunked-prefill-size: 65536
+      max-prefill-tokens: 16384
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 16896
+      tensor-parallel-size: 4
+      data-parallel-size: 1
+      expert-parallel-size: 1
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      max-running-requests: 15
+      cuda-graph-max-bs-decode: 15
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 16384
+  osl: 512
+  concurrencies: "150"

--- a/CrossCluster_Recipes/GLM5/gb300/1k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-4p14d-bs5600-conc5700.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/1k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-4p14d-bs5600-conc5700.yaml
@@ -1,0 +1,153 @@
+# Expanded from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_1k1k_hightpt[4]
+# STP only. Topology: 4 prefill + 14 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-1k1k-hightpt-4p14d-bs5600-conc5700
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 4
+  prefill_workers: 4
+  decode_nodes: 14
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 256
+      cuda-graph-max-bs-decode: 256
+      mem-fraction-static: 0.7
+      context-length: 9600
+      chunked-prefill-size: 32768
+      max-prefill-tokens: 8192
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 9600
+      tensor-parallel-size: 56
+      data-parallel-size: 56
+      expert-parallel-size: 56
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 24
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 5600
+      cuda-graph-max-bs-decode: 100
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 1024
+  osl: 1024
+  concurrencies: "5700"

--- a/CrossCluster_Recipes/GLM5/gb300/1k_1k/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p17d-bs32-conc512x256x128x64.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/1k_1k/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p17d-bs32-conc512x256x128x64.yaml
@@ -1,0 +1,142 @@
+# Expanded from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_1k1k_lowlat[0]
+# STP only. Topology: 1 prefill + 17 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-1k1k-lowlatency-1p17d-bs32-conc512x256x128x64
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "04:00:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 17
+  decode_workers: 17
+
+frontend:
+  type: dynamo
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 256
+      cuda-graph-max-bs-decode: 256
+      mem-fraction-static: 0.7
+      context-length: 9600
+      chunked-prefill-size: 32768
+      max-prefill-tokens: 8192
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 9600
+      tensor-parallel-size: 4
+      data-parallel-size: 1
+      expert-parallel-size: 1
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      max-running-requests: 32
+      cuda-graph-max-bs-decode: 32
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 1024
+  osl: 1024
+  concurrencies: "512x256x128x64"

--- a/CrossCluster_Recipes/GLM5/gb300/8k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-10p8d-bs1280-conc1300.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/8k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-10p8d-bs1280-conc1300.yaml
@@ -1,0 +1,153 @@
+# Expanded from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_hightpt[2]
+# STP only. Topology: 10 prefill + 8 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-8k1k-hightpt-10p8d-bs1280-conc1300
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 10
+  prefill_workers: 10
+  decode_nodes: 8
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 256
+      cuda-graph-max-bs-decode: 256
+      mem-fraction-static: 0.7
+      context-length: 9600
+      chunked-prefill-size: 32768
+      max-prefill-tokens: 8192
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 9600
+      tensor-parallel-size: 32
+      data-parallel-size: 32
+      expert-parallel-size: 32
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 32
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 1280
+      cuda-graph-max-bs-decode: 40
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 8192
+  osl: 1024
+  concurrencies: "1300"

--- a/CrossCluster_Recipes/GLM5/gb300/8k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-12p6d-bs1680-conc1700.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/8k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-12p6d-bs1680-conc1700.yaml
@@ -1,0 +1,153 @@
+# Expanded from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_hightpt[1]
+# STP only. Topology: 12 prefill + 6 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-8k1k-hightpt-12p6d-bs1680-conc1700
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 12
+  prefill_workers: 12
+  decode_nodes: 6
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 256
+      cuda-graph-max-bs-decode: 256
+      mem-fraction-static: 0.7
+      context-length: 9600
+      chunked-prefill-size: 32768
+      max-prefill-tokens: 8192
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 9600
+      tensor-parallel-size: 24
+      data-parallel-size: 24
+      expert-parallel-size: 24
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 32
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 1680
+      cuda-graph-max-bs-decode: 70
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 8192
+  osl: 1024
+  concurrencies: "1700"

--- a/CrossCluster_Recipes/GLM5/gb300/8k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-14p4d-bs2800-conc2800.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/8k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-14p4d-bs2800-conc2800.yaml
@@ -1,0 +1,153 @@
+# Expanded from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_hightpt[0]
+# STP only. Topology: 14 prefill + 4 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-8k1k-hightpt-14p4d-bs2800-conc2800
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 14
+  prefill_workers: 14
+  decode_nodes: 4
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 256
+      cuda-graph-max-bs-decode: 256
+      mem-fraction-static: 0.7
+      context-length: 9600
+      chunked-prefill-size: 32768
+      max-prefill-tokens: 8192
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 9600
+      tensor-parallel-size: 16
+      data-parallel-size: 16
+      expert-parallel-size: 16
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 32
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 2800
+      cuda-graph-max-bs-decode: 175
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 8192
+  osl: 1024
+  concurrencies: "2800"

--- a/CrossCluster_Recipes/GLM5/gb300/8k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-8p10d-bs880-conc900.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/8k_1k/hightpt/glm5-gb300-fp8-stp-hightpt-8p10d-bs880-conc900.yaml
@@ -1,0 +1,153 @@
+# Expanded from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_hightpt[3]
+# STP only. Topology: 8 prefill + 10 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-8k1k-hightpt-8p10d-bs880-conc900
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 8
+  prefill_workers: 8
+  decode_nodes: 10
+  decode_workers: 1
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 9
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    # Scale-out DeepEP uses NVSHMEM HCA names, not the UCX/NCCL rdma_* aliases.
+    NVSHMEM_HCA_LIST: "mlx5_8:1,mlx5_17:1"
+    NVSHMEM_ENABLE_NIC_PE_MAPPING: "1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 256
+      cuda-graph-max-bs-decode: 256
+      mem-fraction-static: 0.7
+      context-length: 9600
+      chunked-prefill-size: 32768
+      max-prefill-tokens: 8192
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 9600
+      tensor-parallel-size: 40
+      data-parallel-size: 40
+      expert-parallel-size: 40
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      moe-dense-tp-size: 1
+      ep-num-redundant-experts: 24
+      ep-dispatch-algorithm: static
+      moe-a2a-backend: deepep
+      deepep-mode: low_latency
+      deepep-config: /configs/deepep_config.json
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      max-running-requests: 880
+      cuda-graph-max-bs-decode: 22
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 8192
+  osl: 1024
+  concurrencies: "900"

--- a/CrossCluster_Recipes/GLM5/gb300/8k_1k/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p17d-bs8-conc128x64x32.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/8k_1k/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p17d-bs8-conc128x64x32.yaml
@@ -1,0 +1,142 @@
+# Expanded from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_lowlat[1]
+# STP only. Topology: 1 prefill + 17 decode nodes = 18 nodes / 72 GPUs.
+name: glm5-gb300-fp8-stp-8k1k-lowlatency-1p17d-bs8-conc128x64x32
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "04:00:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 17
+  decode_workers: 17
+
+frontend:
+  type: dynamo
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 256
+      cuda-graph-max-bs-decode: 256
+      mem-fraction-static: 0.7
+      context-length: 9600
+      chunked-prefill-size: 32768
+      max-prefill-tokens: 8192
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 9600
+      tensor-parallel-size: 4
+      data-parallel-size: 1
+      expert-parallel-size: 1
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      max-running-requests: 8
+      cuda-graph-max-bs-decode: 8
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 8192
+  osl: 1024
+  concurrencies: "128x64x32"

--- a/CrossCluster_Recipes/GLM5/gb300/8k_1k/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p9d-bs15-conc150.yaml
+++ b/CrossCluster_Recipes/GLM5/gb300/8k_1k/lowlatency/glm5-gb300-fp8-stp-lowlatency-1p9d-bs15-conc150.yaml
@@ -1,0 +1,142 @@
+# Expanded from NVIDIA recipes/gb300-fp8/glm5.yaml:zip_override_8k1k_lowlat[0]
+# STP only. Topology: 1 prefill + 9 decode nodes = 10 nodes / 40 GPUs.
+name: glm5-gb300-fp8-stp-8k1k-lowlatency-1p9d-bs15-conc150
+
+model:
+  path: glm5-fp8
+  container: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  precision: fp8
+
+identity:
+  model:
+    repo: zai-org/GLM-5-FP8
+    revision: 4f96cc5eec29dcee5d6ded54f7ffe889438f9516
+  container:
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
+  frameworks:
+    dynamo: 1.3.0
+    sglang: 0.5.14
+
+slurm:
+  time_limit: "01:30:00"
+
+resources:
+  gpu_type: gb300
+  gpus_per_node: 4
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 9
+  decode_workers: 9
+
+frontend:
+  type: dynamo
+
+dynamo:
+  version: 1.3.0
+  install: false
+
+backend:
+  prefill_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+
+  decode_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+    UCX_MODULE_DIR: "/usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx"
+    UCX_TLS: "rc,cuda_copy,cuda_ipc"
+    UCX_NET_DEVICES: "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1"
+    PYTHONUNBUFFERED: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    MC_TE_METRIC: "true"
+    MC_FORCE_MNNVL: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: "0"
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: "1"
+    DYN_REQUEST_PLANE: nats
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "512"
+
+  sglang_config:
+    prefill:
+      port: 6500
+      disaggregation-bootstrap-port: 6600
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: prefill
+      disaggregation-transfer-backend: nixl
+      max-running-requests: 256
+      cuda-graph-max-bs-decode: 256
+      mem-fraction-static: 0.7
+      context-length: 9600
+      chunked-prefill-size: 32768
+      max-prefill-tokens: 8192
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 1
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      load-balance-method: total_tokens
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      disable-radix-cache: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+    decode:
+      port: 6500
+      served-model-name: GLM-5-FP8
+      trust-remote-code: true
+      skip-tokenizer-init: true
+      quantization: fp8
+      kv-cache-dtype: fp8_e4m3
+      disaggregation-mode: decode
+      disaggregation-transfer-backend: nixl
+      mem-fraction-static: 0.8
+      context-length: 9600
+      tensor-parallel-size: 4
+      data-parallel-size: 1
+      expert-parallel-size: 1
+      dsa-decode-backend: trtllm
+      dsa-prefill-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      flashinfer-allreduce-fusion-backend: auto
+      max-running-requests: 15
+      cuda-graph-max-bs-decode: 15
+      disable-radix-cache: true
+      stream-interval: 30
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+
+health_check:
+  max_attempts: 360
+  interval_seconds: 10
+
+benchmark:
+  type: sa-bench
+  req_rate: inf
+  isl: 8192
+  osl: 1024
+  concurrencies: "150"

--- a/src/srtctl/cli/install.py
+++ b/src/srtctl/cli/install.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 _SAFE_MODEL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _SAFE_HF_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+_SAFE_HF_REVISION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
 _SAFE_MODEL_ALIAS_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
 _SAFE_CONTAINER_IMAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@:+-]*$")
 
@@ -51,6 +52,11 @@ def add_install_parser(subparsers: argparse._SubParsersAction) -> argparse.Argum
         "--hf-repo-id",
         required=True,
         help="Hugging Face repo id to download, e.g. nvidia/GLM-5-NVFP4",
+    )
+    parser.add_argument(
+        "--hf-revision",
+        default=None,
+        help="Optional Hugging Face revision to download; use an immutable commit SHA for reproducibility",
     )
     parser.add_argument(
         "--model-alias",
@@ -126,6 +132,7 @@ def _resolve_spec(args: argparse.Namespace) -> ModelInstallSpec:
     spec = ModelInstallSpec(
         name=args.model,
         hf_repo_id=args.hf_repo_id,
+        hf_revision=args.hf_revision,
         model_alias=args.model_alias,
         container_image=args.container_image,
         default_recipe="",
@@ -144,6 +151,10 @@ def _validate_spec(spec: ModelInstallSpec) -> None:
     if not _SAFE_HF_REPO_RE.fullmatch(spec.hf_repo_id):
         raise ValueError(
             f"Invalid hf repo id {spec.hf_repo_id!r}. Expected format 'org/repo' with safe URL characters."
+        )
+    if spec.hf_revision and not _SAFE_HF_REVISION_RE.fullmatch(spec.hf_revision):
+        raise ValueError(
+            f"Invalid hf revision {spec.hf_revision!r}. Allowed characters: letters, numbers, /, dot, underscore, hyphen."
         )
     if not _SAFE_MODEL_ALIAS_RE.fullmatch(spec.model_alias):
         raise ValueError(

--- a/src/srtctl/install/registry.py
+++ b/src/srtctl/install/registry.py
@@ -45,6 +45,9 @@ class ModelInstallSpec:
 
     description: str = ""
 
+    hf_revision: str | None = None
+    """Optional Hugging Face revision passed to ``snapshot_download`` (prefer a commit SHA)."""
+
 
 REGISTRY: dict[str, ModelInstallSpec] = {
     "glm5": ModelInstallSpec(

--- a/src/srtctl/install/slurm.py
+++ b/src/srtctl/install/slurm.py
@@ -82,7 +82,22 @@ def build_sbatch_script(
     account = _require(cluster_config, "default_account")
     partition = _require(cluster_config, "default_partition")
     time_limit = _require(cluster_config, "default_time_limit")
-    use_exclusive = bool((cluster_config or {}).get("use_exclusive_sbatch_directive", False))
+    config = cluster_config or {}
+    use_exclusive = bool(config.get("use_exclusive_sbatch_directive", False))
+    use_gpus_per_node = bool(config.get("use_gpus_per_node_directive", False))
+    gpus_per_node = config.get("gpus_per_node")
+
+    if use_gpus_per_node:
+        try:
+            gpus_per_node = int(gpus_per_node)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "srtslurm.yaml enables use_gpus_per_node_directive but has no valid gpus_per_node value."
+            ) from exc
+        if gpus_per_node < 1:
+            raise RuntimeError(
+                "srtslurm.yaml enables use_gpus_per_node_directive but gpus_per_node must be positive."
+            )
 
     model_dir = install_base / "models" / model_storage_dirname(spec.hf_repo_id)
     container_path = install_base / "containers" / container_filename(spec.container_image)
@@ -99,6 +114,8 @@ def build_sbatch_script(
         f"#SBATCH --output={log_path}",
         f"#SBATCH --error={log_path}",
     ]
+    if use_gpus_per_node:
+        directives.append(f"#SBATCH --gpus-per-node={gpus_per_node}")
     if use_exclusive:
         directives.append("#SBATCH --exclusive")
 
@@ -147,12 +164,13 @@ def build_sbatch_script(
         f'MODEL_DIR="{model_dir}"',
         'mkdir -p "${MODEL_DIR}"',
         "",
-        f'echo "Downloading {spec.hf_repo_id} -> ${{MODEL_DIR}}"',
+        f'echo "Downloading {spec.hf_repo_id}{" @ " + spec.hf_revision if spec.hf_revision else ""} -> ${{MODEL_DIR}}"',
         "python3 - <<'PYEOF'",
         "import os",
         "from huggingface_hub import snapshot_download",
         "snapshot_download(",
         f"    repo_id={spec.hf_repo_id!r},",
+        *([f"    revision={spec.hf_revision!r},"] if spec.hf_revision else []),
         f"    local_dir={str(model_dir)!r},",
         '    token=os.environ["HF_TOKEN"],',
         "    max_workers=8,",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -259,10 +259,11 @@ def test_import_container_allows_non_nvcr_without_credentials(tmp_path: Path):
 # ----------------------------- slurm sbatch builder -------------------
 
 
-def _make_spec(name: str = "glm5") -> _MIS:
+def _make_spec(name: str = "glm5", hf_revision: str | None = None) -> _MIS:
     return _MIS(
         name=name,
         hf_repo_id="nvidia/GLM-5-NVFP4",
+        hf_revision=hf_revision,
         model_alias="nvidia/GLM5-NVFP4",
         container_image="nvcr.io/test/img:1.0",
         default_recipe="recipes/test/x.yaml",
@@ -276,6 +277,8 @@ def test_build_sbatch_script_uses_cluster_config():
         "default_account": "my_account",
         "default_partition": "gpu_partition",
         "default_time_limit": "06:00:00",
+        "gpus_per_node": 4,
+        "use_gpus_per_node_directive": True,
         "use_exclusive_sbatch_directive": True,
     }
     script = build_sbatch_script(
@@ -289,6 +292,7 @@ def test_build_sbatch_script_uses_cluster_config():
     assert "#SBATCH --account=my_account" in script
     assert "#SBATCH --partition=gpu_partition" in script
     assert "#SBATCH --time=06:00:00" in script
+    assert "#SBATCH --gpus-per-node=4" in script
     assert "#SBATCH --exclusive" in script
     assert '#SBATCH --job-name="srtctl-install-glm5"' in script
     # Inline format: model + container + alias-register all live in this single script.
@@ -314,6 +318,24 @@ def test_build_sbatch_script_uses_cluster_config():
             raise AssertionError(f"sbatch script invokes srtctl as a command: {line!r}")
     # Activates the user-supplied venv path.
     assert 'source "/repo/.venv/bin/activate"' in script
+
+
+def test_build_sbatch_script_pins_hf_revision():
+    cluster = {
+        "default_account": "a",
+        "default_partition": "p",
+        "default_time_limit": "01:00:00",
+    }
+    revision = "4f96cc5eec29dcee5d6ded54f7ffe889438f9516"
+    script = build_sbatch_script(
+        spec=_make_spec(hf_revision=revision),
+        srtctl_root=Path("/repo"),
+        install_base=Path("/repo/install"),
+        log_path=Path("/repo/install/install_glm5_%j.log"),
+        venv_path=Path("/repo/.venv"),
+        cluster_config=cluster,
+    )
+    assert f"revision='{revision}'" in script
 
 
 def test_build_sbatch_script_omits_exclusive_when_false():
@@ -427,6 +449,7 @@ def test_resolve_spec_requires_explicit_fields():
     args = SimpleNamespace(
         model="glm5",
         hf_repo_id=None,
+        hf_revision=None,
         model_alias=None,
         container_image=None,
         strict_auth_preflight=False,
@@ -441,6 +464,7 @@ def test_resolve_spec_supports_generic_model():
     args = SimpleNamespace(
         model="my-model",
         hf_repo_id="org/repo",
+        hf_revision="4f96cc5eec29dcee5d6ded54f7ffe889438f9516",
         model_alias="org/repo-alias",
         container_image="docker.io/org/image:1.0",
         strict_auth_preflight=False,
@@ -448,6 +472,7 @@ def test_resolve_spec_supports_generic_model():
     spec = _resolve_spec(args)
     assert spec.name == "my-model"
     assert spec.hf_repo_id == "org/repo"
+    assert spec.hf_revision == "4f96cc5eec29dcee5d6ded54f7ffe889438f9516"
     assert spec.model_alias == "org/repo-alias"
     assert spec.container_image == "docker.io/org/image:1.0"
 
@@ -458,6 +483,7 @@ def test_resolve_spec_rejects_unsafe_values():
     args = SimpleNamespace(
         model="my-model",
         hf_repo_id="org/repo",
+        hf_revision=None,
         model_alias="bad\"alias",
         container_image="docker.io/org/image:1.0",
         strict_auth_preflight=False,


### PR DESCRIPTION
## Summary

Adds the validated GLM-5 GB300 OCI-AGA recipes using the SGLang Dynamo runtime for the 26.10 release.

## Included configurations

- 1K/1K: concurrency 64, 128, 256, 512, and 5700
- 8K/1K: concurrency 32, 64, 128, 150, 900, 1300, 1700, and 2800
- 16K/512: concurrency 32, 64, 128, 150, 900, 1300, 1700, and 2800
- Runtime image: `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0`



