### PR TITLE
feat(postprocess): exclude AIPerf inputs.json from uploaded artifacts.

### DIFF
--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -66,7 +66,7 @@ class _QuarantinedArtifact:
     quarantined_path: Path
 
 
-_AIPERF_ARTIFACT_EXCLUSIONS = (_ArtifactExclusion(pattern="artifacts/**/inputs.json"),)
+_AIPERF_ARTIFACT_EXCLUSIONS = (_ArtifactExclusion(pattern="**/inputs.json"),)
 
 
 class PostProcessStageMixin:

--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -20,12 +20,17 @@ import os
 import shlex
 import shutil
 import subprocess
+import tempfile
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from srtctl.benchmarks.base import SCRIPTS_DIR
+from srtctl.benchmarks import get_runner
+from srtctl.benchmarks.base import SCRIPTS_DIR, AIPerfBenchmarkRunner
 from srtctl.core.config import get_srtslurm_setting, load_cluster_config
 from srtctl.core.git_state import GIT_STATE_FILENAME
 from srtctl.core.lockfile import collect_worker_fingerprints, generate_reproduction_report, write_lockfile
@@ -43,6 +48,25 @@ logger = logging.getLogger(__name__)
 POSTPROCESS_PARSE_FAILED_EXIT = 20
 POSTPROCESS_UPLOAD_FAILED_EXIT = 11
 NODE_METRICS_EXPORT_TIMEOUT_SEC = 600
+
+
+@dataclass(frozen=True)
+class _ArtifactExclusion:
+    """A postprocess rule for omitting files from saved artifacts."""
+
+    pattern: str
+    min_size_bytes: int | None = None
+
+
+@dataclass(frozen=True)
+class _QuarantinedArtifact:
+    """An artifact temporarily moved out of the upload tree."""
+
+    original_path: Path
+    quarantined_path: Path
+
+
+_AIPERF_ARTIFACT_EXCLUSIONS = (_ArtifactExclusion(pattern="artifacts/**/inputs.json"),)
 
 
 class PostProcessStageMixin:
@@ -154,16 +178,17 @@ class PostProcessStageMixin:
         """Run post-processing after benchmark completion.
 
         Handles:
-        1. Copy config YAML into log directory (for S3 upload)
-        2. Rollup generation (benchmark-specific normalization)
-        3. Benchmark result extraction (reads rollup or falls back to raw)
-        4. srtlog parsing + S3 upload (if S3 configured)
-        5. Eager push of ``logs_url`` to the status API right after the S3 sync
+        1. Benchmark-specific artifact exclusions
+        2. Copy config YAML into log directory (for S3 upload)
+        3. Rollup generation (benchmark-specific normalization)
+        4. Benchmark result extraction (reads rollup or falls back to raw)
+        5. srtlog parsing + S3 upload (if S3 configured)
+        6. Eager push of ``logs_url`` to the status API right after the S3 sync
            completes, so downstream consumers can fetch results from S3 even
            if later stages below fail or hang.
-        6. Stash ``logs_url`` on self so the caller's final
+        7. Stash ``logs_url`` on self so the caller's final
            ``report_completed`` PUT in do_sweep can reassert the pointer.
-        7. AI-powered failure analysis (only on failures, if enabled).
+        8. AI-powered failure analysis (only on failures, if enabled).
 
         Benchmark results themselves are NOT pushed to the status API — S3 is
         the source of truth for artifacts. The collector only stores pointers.
@@ -171,9 +196,15 @@ class PostProcessStageMixin:
         Args:
             exit_code: Exit code from the benchmark run
             reporter: Optional StatusReporter for eager mid-run pushes. When
-                provided, ``logs_url`` is PUT as soon as it's known (step 5);
+                provided, ``logs_url`` is PUT as soon as it's known (step 6);
                 when None, only the stash path is used.
         """
+        with self._quarantine_excluded_artifacts():
+            self._run_postprocess_steps(exit_code, reporter)
+
+    def _run_postprocess_steps(self, exit_code: int, reporter: "StatusReporter | None") -> None:
+        """Run postprocessing while excluded artifacts are quarantined."""
+
         # Copy config into log directory so it's included in S3 upload
         self._copy_config_to_logs()
 
@@ -230,6 +261,101 @@ class PostProcessStageMixin:
             if ai_config and ai_config.enabled:
                 logger.info("Running AI-powered failure analysis...")
                 self._run_ai_analysis(ai_config)
+
+    @contextmanager
+    def _quarantine_excluded_artifacts(self) -> Iterator[None]:
+        """Temporarily move excluded artifacts out of the postprocess tree."""
+        try:
+            runner = get_runner(self.config.benchmark.type)
+        except ValueError:
+            exclusions = ()
+        else:
+            exclusions = _AIPERF_ARTIFACT_EXCLUSIONS if isinstance(runner, AIPerfBenchmarkRunner) else ()
+        with self._quarantine_artifacts(exclusions):
+            yield
+
+    @contextmanager
+    def _quarantine_artifacts(self, exclusions: tuple[_ArtifactExclusion, ...]) -> Iterator[None]:
+        """Move matching files to a temporary sibling and restore them on exit."""
+        log_dir = self.runtime.log_dir
+        paths: set[Path] = set()
+        for exclusion in exclusions:
+            for path in log_dir.glob(exclusion.pattern):
+                if not path.is_file():
+                    continue
+                if exclusion.min_size_bytes is not None and path.stat().st_size < exclusion.min_size_bytes:
+                    continue
+                paths.add(path)
+
+        if not paths:
+            yield
+            return
+
+        quarantine_root = Path(
+            tempfile.mkdtemp(
+                prefix=".postprocess-quarantine-",
+                dir=log_dir.parent,
+            )
+        )
+        quarantined: list[_QuarantinedArtifact] = []
+        try:
+            for original_path in sorted(paths):
+                relative_path = original_path.relative_to(log_dir)
+                quarantined_path = quarantine_root / relative_path
+                quarantined_path.parent.mkdir(parents=True, exist_ok=True)
+                original_path.replace(quarantined_path)
+                quarantined.append(
+                    _QuarantinedArtifact(
+                        original_path=original_path,
+                        quarantined_path=quarantined_path,
+                    )
+                )
+                logger.info("Quarantined excluded benchmark artifact %s", original_path)
+            yield
+        finally:
+            self._restore_quarantined_artifacts(quarantine_root, quarantined)
+
+    def _restore_quarantined_artifacts(
+        self,
+        quarantine_root: Path,
+        artifacts: list[_QuarantinedArtifact],
+    ) -> None:
+        """Restore quarantined files without overwriting newly created files."""
+        all_restored = True
+        for artifact in reversed(artifacts):
+            try:
+                if artifact.original_path.exists():
+                    all_restored = False
+                    logger.error(
+                        "Cannot restore excluded artifact %s because it already exists; "
+                        "quarantined copy retained at %s",
+                        artifact.original_path,
+                        artifact.quarantined_path,
+                    )
+                    continue
+                artifact.original_path.parent.mkdir(parents=True, exist_ok=True)
+                artifact.quarantined_path.replace(artifact.original_path)
+                logger.info("Restored excluded benchmark artifact %s", artifact.original_path)
+            except OSError as error:
+                all_restored = False
+                logger.error(
+                    "Failed to restore excluded artifact %s; quarantined copy retained at %s: %s",
+                    artifact.original_path,
+                    artifact.quarantined_path,
+                    error,
+                )
+
+        if all_restored:
+            try:
+                shutil.rmtree(quarantine_root)
+            except OSError as error:
+                logger.warning(
+                    "Failed to remove empty artifact quarantine %s: %s",
+                    quarantine_root,
+                    error,
+                )
+        else:
+            logger.error("Artifact quarantine retained at %s", quarantine_root)
 
     def _normalize_ruter(self) -> None:
         """Best-effort Dynamo post-processing shared with the direct Bash lifecycle."""

--- a/src/srtctl/cli/mixins/postprocess_stage.py
+++ b/src/srtctl/cli/mixins/postprocess_stage.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from srtctl.benchmarks import get_runner
-from srtctl.benchmarks.base import SCRIPTS_DIR, AIPerfBenchmarkRunner
+from srtctl.benchmarks.base import SCRIPTS_DIR, AIPerfBenchmarkRunner, BenchmarkRunner
 from srtctl.core.config import get_srtslurm_setting, git_clone_command_prefix, load_cluster_config
 from srtctl.core.git_state import GIT_STATE_FILENAME
 from srtctl.core.lockfile import collect_worker_fingerprints, generate_reproduction_report, write_lockfile
@@ -67,6 +67,13 @@ class _QuarantinedArtifact:
 
 
 _AIPERF_ARTIFACT_EXCLUSIONS = (_ArtifactExclusion(pattern="**/inputs.json"),)
+
+
+def _artifact_exclusions_for(runner: BenchmarkRunner) -> tuple[_ArtifactExclusion, ...]:
+    """Return postprocess artifact exclusions for a benchmark runner."""
+    if isinstance(runner, AIPerfBenchmarkRunner):
+        return _AIPERF_ARTIFACT_EXCLUSIONS
+    return ()
 
 
 class PostProcessStageMixin:
@@ -270,7 +277,7 @@ class PostProcessStageMixin:
         except ValueError:
             exclusions = ()
         else:
-            exclusions = _AIPERF_ARTIFACT_EXCLUSIONS if isinstance(runner, AIPerfBenchmarkRunner) else ()
+            exclusions = _artifact_exclusions_for(runner)
         with self._quarantine_artifacts(exclusions):
             yield
 

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -231,6 +231,8 @@ class TestPostProcessStageMixin:
         for path in (warmup_inputs, run_inputs, keep_artifact, keep_outside):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text("test")
+        directory_inputs = log_dir / "artifacts" / "directory" / "inputs.json"
+        directory_inputs.mkdir(parents=True)
 
         mixin = PostProcessStageMixin()
         mixin.runtime = MagicMock(log_dir=log_dir)
@@ -240,6 +242,7 @@ class TestPostProcessStageMixin:
         with mixin._quarantine_excluded_artifacts():
             assert not warmup_inputs.exists()
             assert not run_inputs.exists()
+            assert directory_inputs.exists()
             assert keep_artifact.exists()
             assert keep_outside.exists()
             quarantine_roots = list(log_dir.parent.glob(".postprocess-quarantine-*"))
@@ -275,6 +278,18 @@ class TestPostProcessStageMixin:
                 assert not inputs.exists()
 
         assert inputs.read_text() == "test"
+
+    def test_artifact_exclusions_skip_unknown_benchmarks(self, tmp_path):
+        """Unknown benchmark types skip artifact exclusions."""
+        from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
+
+        mixin = PostProcessStageMixin()
+        mixin.runtime = MagicMock(log_dir=tmp_path / "logs")
+        mixin.config = MagicMock()
+        mixin.config.benchmark.type = "unknown-benchmark"
+
+        with mixin._quarantine_excluded_artifacts():
+            pass
 
     def test_artifact_exclusions_do_not_apply_to_other_benchmarks(self, tmp_path):
         """A matching filename is retained for benchmarks outside the policy."""
@@ -324,6 +339,28 @@ class TestPostProcessStageMixin:
 
         assert small.exists()
         assert threshold.read_text() == "12345"
+
+    def test_artifact_quarantine_logs_restore_and_cleanup_errors(self, tmp_path):
+        """Restore and quarantine cleanup errors are handled without raising."""
+        from srtctl.cli.mixins.postprocess_stage import (
+            PostProcessStageMixin,
+            _QuarantinedArtifact,
+        )
+
+        mixin = PostProcessStageMixin()
+        artifact = _QuarantinedArtifact(
+            original_path=tmp_path / "logs" / "artifacts" / "inputs.json",
+            quarantined_path=tmp_path / "quarantine" / "artifacts" / "inputs.json",
+        )
+
+        with patch("pathlib.Path.replace", side_effect=OSError("restore failed")):
+            mixin._restore_quarantined_artifacts(tmp_path / "quarantine", [artifact])
+
+        with patch(
+            "srtctl.cli.mixins.postprocess_stage.shutil.rmtree",
+            side_effect=OSError("cleanup failed"),
+        ):
+            mixin._restore_quarantined_artifacts(tmp_path / "quarantine", [])
 
     def test_artifact_quarantine_restores_after_postprocess_failure(self, tmp_path):
         """Excluded files are restored when work inside the quarantine fails."""

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -5,6 +5,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from srtctl.core.schema import (
     DEFAULT_AI_ANALYSIS_PROMPT,
     AIAnalysisConfig,
@@ -162,6 +164,9 @@ class TestPostProcessStageMixin:
         mixin.runtime.log_dir = log_dir
         mixin.config = MagicMock()
 
+        from contextlib import nullcontext
+
+        mixin._quarantine_excluded_artifacts = MagicMock(return_value=nullcontext())
         mixin._copy_config_to_logs = MagicMock()
         mixin._generate_rollup = MagicMock()
         mixin._extract_benchmark_results = MagicMock(return_value=None)
@@ -210,8 +215,159 @@ class TestPostProcessStageMixin:
 
         mixin._extract_benchmark_results.assert_called_once()
         mixin._run_postprocess_container.assert_called_once()
+        mixin._quarantine_excluded_artifacts.assert_called_once()
         # logs_url is stashed on self for do_sweep's final report_completed PUT
         assert mixin._last_logs_url is None  # no S3 configured in this mock
+
+    def test_applies_benchmark_artifact_exclusions(self, tmp_path):
+        """Postprocess policy removes matching AIPerf files only."""
+        from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
+
+        log_dir = tmp_path / "logs"
+        warmup_inputs = log_dir / "artifacts" / "warmup" / "inputs.json"
+        run_inputs = log_dir / "artifacts" / "run" / "nested" / "inputs.json"
+        keep_artifact = log_dir / "artifacts" / "run" / "profile_export.jsonl"
+        keep_outside = log_dir / "inputs.json"
+        for path in (warmup_inputs, run_inputs, keep_artifact, keep_outside):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("test")
+
+        mixin = PostProcessStageMixin()
+        mixin.runtime = MagicMock(log_dir=log_dir)
+        mixin.config = MagicMock()
+        mixin.config.benchmark.type = "trace-replay"
+
+        with mixin._quarantine_excluded_artifacts():
+            assert not warmup_inputs.exists()
+            assert not run_inputs.exists()
+            assert keep_artifact.exists()
+            assert keep_outside.exists()
+            quarantine_roots = list(log_dir.parent.glob(".postprocess-quarantine-*"))
+            assert len(quarantine_roots) == 1
+            assert quarantine_roots[0].parent == log_dir.parent
+            assert not quarantine_roots[0].is_relative_to(log_dir)
+
+        assert warmup_inputs.read_text() == "test"
+        assert run_inputs.read_text() == "test"
+        assert not list(tmp_path.glob(".postprocess-quarantine-*"))
+
+    def test_artifact_exclusions_apply_to_aiperf_runners(self, tmp_path):
+        """AIPerf inheritance, rather than a benchmark-name list, selects policy."""
+        from srtctl.benchmarks.base import AIPerfBenchmarkRunner
+        from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
+
+        log_dir = tmp_path / "logs"
+        inputs = log_dir / "artifacts" / "run" / "inputs.json"
+        inputs.parent.mkdir(parents=True)
+        inputs.write_text("test")
+
+        mixin = PostProcessStageMixin()
+        mixin.runtime = MagicMock(log_dir=log_dir)
+        mixin.config = MagicMock()
+        mixin.config.benchmark.type = "aiperf-benchmark"
+
+        runner = MagicMock(spec=AIPerfBenchmarkRunner)
+        with patch(
+            "srtctl.cli.mixins.postprocess_stage.get_runner",
+            return_value=runner,
+        ):
+            with mixin._quarantine_excluded_artifacts():
+                assert not inputs.exists()
+
+        assert inputs.read_text() == "test"
+
+    def test_artifact_exclusions_do_not_apply_to_other_benchmarks(self, tmp_path):
+        """A matching filename is retained for benchmarks outside the policy."""
+        from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
+
+        log_dir = tmp_path / "logs"
+        inputs = log_dir / "artifacts" / "run" / "inputs.json"
+        inputs.parent.mkdir(parents=True)
+        inputs.write_text("test")
+
+        mixin = PostProcessStageMixin()
+        mixin.runtime = MagicMock(log_dir=log_dir)
+        mixin.config = MagicMock()
+        mixin.config.benchmark.type = "sa-bench"
+
+        with mixin._quarantine_excluded_artifacts():
+            assert inputs.exists()
+
+        assert inputs.exists()
+
+    def test_artifact_exclusion_honors_minimum_size(self, tmp_path):
+        """Size-qualified exclusions retain smaller files and remove files at the boundary."""
+        from srtctl.cli.mixins.postprocess_stage import (
+            PostProcessStageMixin,
+            _ArtifactExclusion,
+        )
+
+        log_dir = tmp_path / "logs"
+        small = log_dir / "artifacts" / "small" / "inputs.json"
+        threshold = log_dir / "artifacts" / "threshold" / "inputs.json"
+        for path, contents in ((small, "1234"), (threshold, "12345")):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(contents)
+
+        mixin = PostProcessStageMixin()
+        mixin.runtime = MagicMock(log_dir=log_dir)
+
+        exclusions = (
+            _ArtifactExclusion(
+                pattern="artifacts/**/inputs.json",
+                min_size_bytes=5,
+            ),
+        )
+        with mixin._quarantine_artifacts(exclusions):
+            assert small.exists()
+            assert not threshold.exists()
+
+        assert small.exists()
+        assert threshold.read_text() == "12345"
+
+    def test_artifact_quarantine_restores_after_postprocess_failure(self, tmp_path):
+        """Excluded files are restored when work inside the quarantine fails."""
+        from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
+
+        log_dir = tmp_path / "logs"
+        inputs = log_dir / "artifacts" / "run" / "inputs.json"
+        inputs.parent.mkdir(parents=True)
+        inputs.write_text("original")
+
+        mixin = PostProcessStageMixin()
+        mixin.runtime = MagicMock(log_dir=log_dir)
+        mixin.config = MagicMock()
+        mixin.config.benchmark.type = "trace-replay"
+
+        with pytest.raises(RuntimeError, match="postprocess failed"):
+            with mixin._quarantine_excluded_artifacts():
+                assert not inputs.exists()
+                raise RuntimeError("postprocess failed")
+
+        assert inputs.read_text() == "original"
+        assert not list(tmp_path.glob(".postprocess-quarantine-*"))
+
+    def test_artifact_quarantine_does_not_overwrite_recreated_file(self, tmp_path):
+        """A recreated destination wins and the original stays quarantined."""
+        from srtctl.cli.mixins.postprocess_stage import PostProcessStageMixin
+
+        log_dir = tmp_path / "logs"
+        inputs = log_dir / "artifacts" / "run" / "inputs.json"
+        inputs.parent.mkdir(parents=True)
+        inputs.write_text("original")
+
+        mixin = PostProcessStageMixin()
+        mixin.runtime = MagicMock(log_dir=log_dir)
+        mixin.config = MagicMock()
+        mixin.config.benchmark.type = "trace-replay"
+
+        with mixin._quarantine_excluded_artifacts():
+            inputs.write_text("replacement")
+
+        quarantine_roots = list(tmp_path.glob(".postprocess-quarantine-*"))
+        assert inputs.read_text() == "replacement"
+        assert len(quarantine_roots) == 1
+        assert (quarantine_roots[0] / "artifacts" / "run" / "inputs.json").read_text() == "original"
 
     def test_run_postprocess_eagerly_pushes_logs_url_to_reporter(self):
         """When a reporter is passed and S3 sync produces a URL, push eagerly."""

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -227,8 +227,8 @@ class TestPostProcessStageMixin:
         warmup_inputs = log_dir / "artifacts" / "warmup" / "inputs.json"
         run_inputs = log_dir / "artifacts" / "run" / "nested" / "inputs.json"
         keep_artifact = log_dir / "artifacts" / "run" / "profile_export.jsonl"
-        keep_outside = log_dir / "inputs.json"
-        for path in (warmup_inputs, run_inputs, keep_artifact, keep_outside):
+        root_inputs = log_dir / "inputs.json"
+        for path in (warmup_inputs, run_inputs, keep_artifact, root_inputs):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text("test")
         directory_inputs = log_dir / "artifacts" / "directory" / "inputs.json"
@@ -242,9 +242,9 @@ class TestPostProcessStageMixin:
         with mixin._quarantine_excluded_artifacts():
             assert not warmup_inputs.exists()
             assert not run_inputs.exists()
+            assert not root_inputs.exists()
             assert directory_inputs.exists()
             assert keep_artifact.exists()
-            assert keep_outside.exists()
             quarantine_roots = list(log_dir.parent.glob(".postprocess-quarantine-*"))
             assert len(quarantine_roots) == 1
             assert quarantine_roots[0].parent == log_dir.parent
@@ -252,6 +252,7 @@ class TestPostProcessStageMixin:
 
         assert warmup_inputs.read_text() == "test"
         assert run_inputs.read_text() == "test"
+        assert root_inputs.read_text() == "test"
         assert not list(tmp_path.glob(".postprocess-quarantine-*"))
 
     def test_artifact_exclusions_apply_to_aiperf_runners(self, tmp_path):


### PR DESCRIPTION
Feature Summary:

Exclude AIPerf-generated inputs.json files from saved artifacts. During postprocessing, srt-slurm temporarily moves these files outside the log directory so artifact rollup and upload ignore them, then restores them afterward. This applies to all benchmarks using `AIPerfBenchmarkRunner`.

Reasoning:

AIPerf now generates inputs.json, which can be large and is not useful as a persisted benchmark artifact. Keeping it increases archive size and upload/storage costs unnecessarily. Temporarily quarantining it avoids publishing the file while preserving the local output and leaving benchmark runners independent of artifact-handling concerns.