### PR TITLE
Make sure trtllm agg serving can attach numactl as well

### DIFF
--- a/src/srtctl/backends/trtllm.py
+++ b/src/srtctl/backends/trtllm.py
@@ -301,7 +301,7 @@ class TRTLLMProtocol:
         if self.numa_memory_bind is None:
             use_numactl = runtime.gpu_type in ("gb200", "gb300") and mode in ("prefill", "decode")
         else:
-            use_numactl = self.numa_memory_bind and mode in ("prefill", "decode")
+            use_numactl = self.numa_memory_bind
         numactl_prefix = ["numactl", "-m", "0,1"] if use_numactl else []
         base_prefix = list(nsys_prefix or []) + numactl_prefix + ["trtllm-llmapi-launch"]
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3825,6 +3825,27 @@ class TestHuggingFaceModelSupport:
 
         assert "numactl" not in cmd
 
+    def test_trtllm_numa_memory_bind_true_applies_to_agg_mode(self):
+        """numa_memory_bind=True also wraps aggregated-mode workers with numactl."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from srtctl.backends import TRTLLMProtocol
+
+        backend = TRTLLMProtocol(numa_memory_bind=True)
+        process = self._make_process(mode="agg")
+        runtime = self._make_runtime(is_hf=False)
+        runtime.log_dir = Path("/tmp/test-logs")
+        runtime.gpu_type = "h100"
+
+        with (
+            patch("pathlib.Path.write_text"),
+            patch("srtctl.core.slurm.get_hostname_ip", return_value="10.0.0.1"),
+        ):
+            cmd = backend.build_worker_command(process=process, endpoint_processes=[process], runtime=runtime)
+
+        assert cmd[:3] == ["numactl", "-m", "0,1"]
+
     def test_trtllm_numa_cpu_bind_wraps_decode_command_with_taskset(self):
         """numa_cpu_bind=True wraps decode commands with configs/numa_cpu_bind.sh."""
         from pathlib import Path


### PR DESCRIPTION
## Summary
- Apply `numactl -m 0,1` to aggregated-mode TRTLLM workers when `numa_memory_bind: true` is set, not just prefill/decode.
- Previously the explicit override only checked `mode in ("prefill", "decode")`, so agg-mode workers silently skipped NUMA memory binding even with the config set to `true`.