### PR TITLE
[2.0] Add the recipe schema version key and srtctl migrate

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -148,6 +148,21 @@ This is useful for portable recipes that you want to share across clusters or ha
 
 ---
 
+## schema
+
+| Field    | Type    | Required | Description                                                                 |
+| -------- | ------- | -------- | --------------------------------------------------------------------------- |
+| `schema` | integer | No       | Recipe schema version. Absent means `1` (the pre-2.0 layout); `2` is current. |
+
+Every supported version loads. Put the key first in the file, beside `base:` in an override file. Upgrade a recipe with `srtctl migrate -f recipe.yaml --in-place`, which preserves comments and key order.
+
+```yaml
+schema: 2
+name: "deepseek-r1-benchmark"
+```
+
+---
+
 ## name
 
 | Field  | Type   | Required | Description                                        |

--- a/docs/schema-reference.md
+++ b/docs/schema-reference.md
@@ -13,6 +13,7 @@ Top-level keys of a recipe YAML.
 | `name` | str | required |  |
 | `model` | [ModelConfig](#modelconfig) | required |  |
 | `resources` | [ResourceConfig](#resourceconfig) | required |  |
+| `schema` | int | `1` | Recipe schema version (YAML key `schema`). Absent means 1, the pre-2.0 layout. `schema: 2` selects the 2.0 layout; `srtctl migrate` upgrades a recipe in place. Both versions load on main. |
 | `slurm` | [SlurmConfig](#slurmconfig) | `SlurmConfig()` |  |
 | `backend` | [SGLangProtocol](#sglangprotocol) \| [TRTLLMProtocol](#trtllmprotocol) \| [VLLMProtocol](#vllmprotocol) \| [MockerProtocol](#mockerprotocol) | `SGLangProtocol()` |  |
 | `frontend` | [FrontendConfig](#frontendconfig) | `FrontendConfig()` |  |

--- a/examples/features/override.yaml
+++ b/examples/features/override.yaml
@@ -12,6 +12,7 @@
 #
 # Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 base:
   name: "qwen3-0.6b-override"
 
@@ -68,8 +69,8 @@ override_tp2:
 # A length-1 list broadcasts; a list of lists gives each variant a literal list.
 zip_override_context:
   name:
-    - "qwen3-0.6b-override-ctx2k"
-    - "qwen3-0.6b-override-ctx8k"
+  - "qwen3-0.6b-override-ctx2k"
+  - "qwen3-0.6b-override-ctx8k"
   backend:
     sglang_config:
       aggregated:

--- a/examples/features/profiling.yaml
+++ b/examples/features/profiling.yaml
@@ -7,6 +7,7 @@
 #
 # Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-profiling"
 
 slurm:

--- a/examples/features/sweep.yaml
+++ b/examples/features/sweep.yaml
@@ -10,6 +10,7 @@
 #
 # Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-sweep"
 
 sweep:

--- a/examples/mocker/dynamo-agg.yaml
+++ b/examples/mocker/dynamo-agg.yaml
@@ -7,6 +7,7 @@
 #
 # Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-mocker-dynamo-agg"
 
 slurm:

--- a/examples/sglang/dynamo-agg.yaml
+++ b/examples/sglang/dynamo-agg.yaml
@@ -7,6 +7,7 @@
 #
 # Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-sglang-dynamo-agg"
 
 slurm:

--- a/examples/sglang/dynamo-disagg.yaml
+++ b/examples/sglang/dynamo-disagg.yaml
@@ -7,6 +7,7 @@
 #
 # Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-sglang-dynamo-disagg"
 
 slurm:

--- a/examples/sglang/sglang-router-agg.yaml
+++ b/examples/sglang/sglang-router-agg.yaml
@@ -6,6 +6,7 @@
 #
 # Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-sglang-router-agg"
 
 slurm:

--- a/examples/sglang/sglang-router-disagg.yaml
+++ b/examples/sglang/sglang-router-disagg.yaml
@@ -8,6 +8,7 @@
 #
 # Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-sglang-router-disagg"
 
 slurm:

--- a/examples/trtllm/dynamo-agg.yaml
+++ b/examples/trtllm/dynamo-agg.yaml
@@ -6,6 +6,7 @@
 #
 # Aliases (`qwen3-0.6b`, `trtllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-trtllm-dynamo-agg"
 
 slurm:

--- a/examples/trtllm/dynamo-disagg.yaml
+++ b/examples/trtllm/dynamo-disagg.yaml
@@ -7,6 +7,7 @@
 #
 # Aliases (`qwen3-0.6b`, `trtllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-trtllm-dynamo-disagg"
 
 slurm:

--- a/examples/trtllm/trtllm-serve-agg.yaml
+++ b/examples/trtllm/trtllm-serve-agg.yaml
@@ -6,6 +6,7 @@
 #
 # Aliases (`qwen3-0.6b`, `trtllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-trtllm-serve-agg"
 
 slurm:

--- a/examples/trtllm/trtllm-serve-disagg.yaml
+++ b/examples/trtllm/trtllm-serve-disagg.yaml
@@ -8,6 +8,7 @@
 #
 # Aliases (`qwen3-0.6b`, `trtllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-trtllm-serve-disagg"
 
 slurm:

--- a/examples/vllm/dynamo-agg.yaml
+++ b/examples/vllm/dynamo-agg.yaml
@@ -7,6 +7,7 @@
 #
 # Aliases (`qwen3-0.6b`, `vllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-vllm-dynamo-agg"
 
 slurm:

--- a/examples/vllm/dynamo-disagg.yaml
+++ b/examples/vllm/dynamo-disagg.yaml
@@ -6,6 +6,7 @@
 #
 # Aliases (`qwen3-0.6b`, `vllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-vllm-dynamo-disagg"
 
 slurm:

--- a/examples/vllm/vllm-direct-agg.yaml
+++ b/examples/vllm/vllm-direct-agg.yaml
@@ -6,6 +6,7 @@
 #
 # Aliases (`qwen3-0.6b`, `vllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-vllm-direct-agg"
 
 slurm:

--- a/examples/vllm/vllm-router-agg.yaml
+++ b/examples/vllm/vllm-router-agg.yaml
@@ -6,6 +6,7 @@
 #
 # Aliases (`qwen3-0.6b`, `vllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-vllm-router-agg"
 
 slurm:

--- a/examples/vllm/vllm-router-disagg.yaml
+++ b/examples/vllm/vllm-router-disagg.yaml
@@ -7,6 +7,7 @@
 #
 # Aliases (`qwen3-0.6b`, `vllm`) resolve through srtslurm.yaml; see examples/README.md.
 
+schema: 2
 name: "qwen3-0.6b-vllm-router-disagg"
 
 slurm:

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -1455,6 +1455,7 @@ def main():
   srtctl monitor --outputs /path/to/outputs      # Dashboard with custom outputs dir
   srtctl view /path/to/run-output                # Local ruter route-decision viewer
   srtctl schema-docs [--check]                   # Regenerate (or verify) docs/schema-reference.md
+  srtctl migrate -f config.yaml --in-place       # Upgrade a recipe to the current schema version
 """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1591,6 +1592,27 @@ def main():
         help="Write to this path instead of docs/schema-reference.md",
     )
 
+    # Recipe migration: srtctl migrate -f recipe.yaml [--in-place | --output PATH]
+    migrate_parser = subparsers.add_parser(
+        "migrate",
+        help="Upgrade a recipe (plain, override, or lock file) to the current schema version",
+    )
+    migrate_parser.add_argument(
+        "-f",
+        "--file",
+        type=Path,
+        required=True,
+        dest="migrate_file",
+        help="Recipe YAML to migrate",
+    )
+    migrate_parser.add_argument("--in-place", action="store_true", help="Rewrite the file instead of printing")
+    migrate_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the migrated recipe to this path (default: print to stdout)",
+    )
+
     args = parser.parse_args()
 
     json_mode = bool(getattr(args, "json_output", False))
@@ -1692,6 +1714,20 @@ def main():
             sys.exit(1)
         written = write_schema_reference(output)
         console.print(f"[green]✓[/] Wrote {written}")
+        restore_console()
+        return
+
+    if args.command == "migrate":
+        from srtctl.core.migrate import migrate_recipe_file
+
+        result = migrate_recipe_file(args.migrate_file, in_place=args.in_place, output=args.output)
+        if not args.in_place and args.output is None:
+            sys.stdout.write(result.text)
+            sys.stdout.flush()
+        else:
+            target = args.migrate_file if args.in_place else args.output
+            detail = ", ".join(result.notes) if result.notes else "already current"
+            console.print(f"[green]✓[/] {target}: schema {result.from_version} -> {result.to_version} ({detail})")
         restore_console()
         return
 

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -373,6 +373,23 @@ def generate_override_configs(
     raw_config: dict[str, Any],
     selector: str | None = None,
 ) -> list[tuple[str, dict[str, Any]]]:
+    """Expand an override-format config into independent variants.
+
+    Wraps :func:`_expand_override_variants` and carries a top-level ``schema``
+    key (declared beside ``base``, not inside it) into every variant so each one
+    loads at the version the file declares.
+    """
+    variants = _expand_override_variants(raw_config, selector=selector)
+    if "schema" in raw_config:
+        for _suffix, config in variants:
+            config.setdefault("schema", raw_config["schema"])
+    return variants
+
+
+def _expand_override_variants(
+    raw_config: dict[str, Any],
+    selector: str | None = None,
+) -> list[tuple[str, dict[str, Any]]]:
     """Expand a raw config with base + override_* + zip_override_* keys into independent configs.
 
     Args:
@@ -502,22 +519,26 @@ def resolve_override_yaml(
     for suffix, merged_plain in plain_variants:
         if suffix == "base":
             # No override applied — return the base CommentedMap as-is.
-            results.append(("base", base_cm))
-            continue
-
-        override_key = f"override_{suffix}"
-        if override_key in raw_cm and isinstance(raw_cm[override_key], CommentedMap):
-            # Regular override: merge CommentedMaps so override comments are kept.
-            result_cm = comment_aware_merge(base_cm, raw_cm[override_key])
-            # Preserve auto-generated fields from the existing override expansion,
-            # such as the synthesized name when the override does not set one.
-            if "name" in merged_plain:
-                result_cm["name"] = merged_plain["name"]
+            result_cm = base_cm
         else:
-            # zip_override variant (values were lists → now scalars) or any
-            # other case: merge the plain resolved dict into the base CommentedMap
-            # so at least base field order and comments are preserved.
-            result_cm = comment_aware_merge(base_cm, merged_plain)
+            override_key = f"override_{suffix}"
+            if override_key in raw_cm and isinstance(raw_cm[override_key], CommentedMap):
+                # Regular override: merge CommentedMaps so override comments are kept.
+                result_cm = comment_aware_merge(base_cm, raw_cm[override_key])
+                # Preserve auto-generated fields from the existing override expansion,
+                # such as the synthesized name when the override does not set one.
+                if "name" in merged_plain:
+                    result_cm["name"] = merged_plain["name"]
+            else:
+                # zip_override variant (values were lists → now scalars) or any
+                # other case: merge the plain resolved dict into the base CommentedMap
+                # so at least base field order and comments are preserved.
+                result_cm = comment_aware_merge(base_cm, merged_plain)
+
+        # The file-level `schema` key lives beside `base`; each resolved variant
+        # is a standalone recipe, so it declares the version itself.
+        if "schema" in raw_plain and "schema" not in result_cm:
+            result_cm.insert(0, "schema", raw_plain["schema"])
 
         results.append((suffix, result_cm))
 

--- a/src/srtctl/core/migrate.py
+++ b/src/srtctl/core/migrate.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Upgrade recipe YAML to the current schema version, preserving comments.
+
+``srtctl migrate -f recipe.yaml`` rewrites a plain recipe, an override file
+(``base`` plus ``override_*`` variants), or a lockfile so that it declares
+``schema: <current>`` and uses the current layout. The transformation is done on
+a ruamel round-trip document, so comments, key order, and quoting survive.
+
+Each schema step registers its structural rewrite in :func:`_migrate_1_to_2`;
+this module starts with the version key alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ruamel.yaml.comments import CommentedMap
+
+from srtctl.core.schema import CURRENT_SCHEMA_VERSION, SUPPORTED_SCHEMA_VERSIONS
+from srtctl.core.yaml_utils import dump_yaml_with_comments, load_yaml_text_with_comments
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """Outcome of migrating one recipe document."""
+
+    text: str
+    changed: bool
+    from_version: int
+    to_version: int
+    notes: tuple[str, ...]
+
+
+def _declared_version(doc: CommentedMap) -> int:
+    raw = doc.get("schema", 1)
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise TypeError(f"schema must be an integer version, got {raw!r}")
+    if raw not in SUPPORTED_SCHEMA_VERSIONS:
+        raise ValueError(f"schema {raw} is not supported; known versions: {list(SUPPORTED_SCHEMA_VERSIONS)}")
+    return raw
+
+
+def _migrate_1_to_2(doc: CommentedMap) -> list[str]:
+    """Structural v1 -> v2 rewrites. Later schema steps add their transforms here."""
+    del doc
+    return []
+
+
+def migrate_recipe_text(text: str) -> MigrationResult:
+    """Migrate one YAML document (plain, override, or lock format) to the current schema."""
+    doc = load_yaml_text_with_comments(text)
+    from_version = _declared_version(doc)
+    notes: list[str] = []
+
+    if from_version < 2:
+        notes.extend(_migrate_1_to_2(doc))
+
+    if doc.get("schema") != CURRENT_SCHEMA_VERSION:
+        if "schema" in doc:
+            doc["schema"] = CURRENT_SCHEMA_VERSION
+        else:
+            doc.insert(0, "schema", CURRENT_SCHEMA_VERSION)
+        notes.append(f"set schema: {CURRENT_SCHEMA_VERSION}")
+
+    migrated = dump_yaml_with_comments(doc) or ""
+    return MigrationResult(
+        text=migrated,
+        changed=migrated != text,
+        from_version=from_version,
+        to_version=CURRENT_SCHEMA_VERSION,
+        notes=tuple(notes),
+    )
+
+
+def migrate_recipe_file(path: Path, *, in_place: bool = False, output: Path | None = None) -> MigrationResult:
+    """Migrate a recipe file. Writes back when ``in_place`` or to ``output`` when given."""
+    if in_place and output is not None:
+        raise ValueError("choose either --in-place or --output, not both")
+    result = migrate_recipe_text(path.read_text(encoding="utf-8"))
+    if in_place:
+        if result.changed:
+            path.write_text(result.text, encoding="utf-8")
+    elif output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(result.text, encoding="utf-8")
+    return result

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -30,7 +30,7 @@ from typing import (
 )
 
 import yaml
-from marshmallow import Schema, ValidationError, fields
+from marshmallow import Schema, ValidationError, fields, validate
 from marshmallow_dataclass import dataclass
 
 from srtctl.backends import (
@@ -1811,6 +1811,12 @@ class InfraConfig:
 # Main Configuration Dataclass
 # ============================================================================
 
+# Recipe schema versions. A recipe without a top-level `schema:` key is version 1
+# (the pre-2.0 layout); version 2 is the 2.0 layout. The loader accepts every
+# supported version; `srtctl migrate` rewrites a recipe to the current one.
+CURRENT_SCHEMA_VERSION = 2
+SUPPORTED_SCHEMA_VERSIONS: tuple[int, ...] = (1, 2)
+
 
 @dataclass(frozen=True)
 class SrtConfig:
@@ -1825,6 +1831,20 @@ class SrtConfig:
     name: str
     model: ModelConfig
     resources: ResourceConfig
+
+    # Recipe schema version (YAML key `schema`). Absent means 1, the pre-2.0
+    # layout. `schema: 2` selects the 2.0 layout; `srtctl migrate` upgrades a
+    # recipe in place. Both versions load on main.
+    schema_version: int = field(
+        default=1,
+        metadata={
+            "marshmallow_field": fields.Integer(
+                data_key="schema",
+                load_default=1,
+                validate=validate.OneOf(SUPPORTED_SCHEMA_VERSIONS),
+            )
+        },
+    )
 
     slurm: SlurmConfig = field(default_factory=SlurmConfig)
     backend: Annotated[BackendConfig, BackendConfigField()] = field(default_factory=SGLangProtocol)

--- a/src/srtctl/core/yaml_utils.py
+++ b/src/srtctl/core/yaml_utils.py
@@ -29,9 +29,14 @@ def _make_yaml() -> YAML:
 
 def load_yaml_with_comments(path: Path) -> CommentedMap:
     """Load a YAML file preserving comments and key insertion order."""
-    y = _make_yaml()
     with open(path) as f:
-        result = y.load(f)
+        return load_yaml_text_with_comments(f.read())
+
+
+def load_yaml_text_with_comments(text: str) -> CommentedMap:
+    """Load YAML text preserving comments and key insertion order."""
+    y = _make_yaml()
+    result = y.load(text)
     if not isinstance(result, CommentedMap):
         raise TypeError(f"Expected a YAML mapping at top level, got {type(result).__name__}")
     return result

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from srtctl.cli import submit as submit_cli
+from srtctl.core.config import generate_override_configs, load_config, validate_config_file
+from srtctl.core.migrate import migrate_recipe_text
+from srtctl.core.schema import CURRENT_SCHEMA_VERSION, SUPPORTED_SCHEMA_VERSIONS
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+
+PLAIN = {
+    "name": "schema-version-test",
+    "model": {"path": "hf:fake/mock-model", "container": "nvcr.io/fake:latest", "precision": "fp8"},
+    "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1, "agg_workers": 1},
+    "backend": {"type": "sglang"},
+    "frontend": {"type": "sglang", "enable_multiple_frontends": False},
+    "benchmark": {"type": "custom", "command": "echo hi"},
+}
+
+
+def _write(tmp_path: Path, data: dict, name: str = "config.yaml") -> Path:
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+def test_absent_schema_key_means_version_1(tmp_path: Path) -> None:
+    config = load_config(_write(tmp_path, PLAIN))
+    assert config.schema_version == 1
+
+
+def test_schema_2_is_accepted(tmp_path: Path) -> None:
+    config = load_config(_write(tmp_path, {"schema": 2, **PLAIN}))
+    assert config.schema_version == 2
+    assert CURRENT_SCHEMA_VERSION == 2
+    assert SUPPORTED_SCHEMA_VERSIONS == (1, 2)
+
+
+def test_unknown_schema_version_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="schema"):
+        load_config(_write(tmp_path, {"schema": 3, **PLAIN}))
+
+
+def test_schema_key_beside_base_propagates_to_every_override_variant() -> None:
+    raw = {
+        "schema": 2,
+        "base": dict(PLAIN),
+        "override_small": {"resources": {"agg_workers": 1}},
+        "zip_override_names": {"name": ["a", "b"], "benchmark": {"command": ["echo a", "echo b"]}},
+    }
+    variants = generate_override_configs(raw)
+    assert len(variants) == 3
+    assert all(cfg["schema"] == 2 for _, cfg in variants)
+    assert generate_override_configs(raw, selector="base")[0][1]["schema"] == 2
+
+
+def test_validate_config_file_accepts_schema_on_override_and_sweep_files(tmp_path: Path) -> None:
+    override = _write(
+        tmp_path,
+        {"schema": 2, "base": dict(PLAIN), "override_x": {"benchmark": {"command": "echo x"}}},
+        "override.yaml",
+    )
+    assert validate_config_file(override) == []
+
+    sweep_config = {"schema": 2, **PLAIN, "sweep": {"cmd": ["echo 1", "echo 2"]}}
+    sweep_config["benchmark"] = {"type": "custom", "command": "{cmd}"}
+    sweep = _write(tmp_path, sweep_config, "sweep.yaml")
+    assert validate_config_file(sweep) == []
+
+
+def test_migrate_inserts_schema_first_and_preserves_comments() -> None:
+    text = '# my recipe\nname: "x"  # keep quotes\nmodel:\n  path: m\n  container: c\n  precision: fp8\n'
+    result = migrate_recipe_text(text)
+    assert result.changed
+    assert result.from_version == 1
+    assert result.to_version == CURRENT_SCHEMA_VERSION
+    assert result.text.startswith('# my recipe\nschema: 2\nname: "x"  # keep quotes\n')
+    assert "set schema: 2" in result.notes
+
+
+def test_migrate_is_idempotent() -> None:
+    once = migrate_recipe_text("name: x\nmodel: {path: m, container: c, precision: fp8}\n")
+    twice = migrate_recipe_text(once.text)
+    assert not twice.changed
+    assert twice.notes == ()
+
+
+def test_migrate_upgrades_an_explicit_schema_1() -> None:
+    result = migrate_recipe_text("schema: 1\nname: x\n")
+    assert result.text.startswith("schema: 2\nname: x\n")
+
+
+def test_migrate_rejects_unknown_versions() -> None:
+    with pytest.raises(ValueError, match="not supported"):
+        migrate_recipe_text("schema: 9\nname: x\n")
+
+
+def test_migrate_keeps_override_and_lock_sections_top_level() -> None:
+    text = "base:\n  name: x\noverride_big:\n  name: y\nlock:\n  integrity: abc\n"
+    result = migrate_recipe_text(text)
+    loaded = yaml.safe_load(result.text)
+    assert list(loaded) == ["schema", "base", "override_big", "lock"]
+    assert "schema" not in loaded["base"]
+
+
+def test_cli_migrate_prints_to_stdout_by_default(tmp_path: Path, monkeypatch, capsys) -> None:
+    path = _write(tmp_path, PLAIN)
+    monkeypatch.setattr(sys, "argv", ["srtctl", "migrate", "-f", str(path)])
+    submit_cli.main()
+    out = capsys.readouterr().out
+    assert out.startswith("schema: 2\n")
+    assert yaml.safe_load(path.read_text()).get("schema") is None, "stdout mode must not touch the file"
+
+
+def test_cli_migrate_in_place_rewrites_the_file(tmp_path: Path, monkeypatch, capsys) -> None:
+    path = _write(tmp_path, PLAIN)
+    monkeypatch.setattr(sys, "argv", ["srtctl", "migrate", "-f", str(path), "--in-place"])
+    submit_cli.main()
+    assert yaml.safe_load(path.read_text())["schema"] == 2
+    assert "schema 1 -> 2" in capsys.readouterr().out
+    assert load_config(path).schema_version == 2
+
+
+def test_cli_migrate_output_writes_a_new_file(tmp_path: Path, monkeypatch) -> None:
+    path = _write(tmp_path, PLAIN)
+    output = tmp_path / "out" / "migrated.yaml"
+    monkeypatch.setattr(sys, "argv", ["srtctl", "migrate", "-f", str(path), "--output", str(output)])
+    submit_cli.main()
+    assert yaml.safe_load(output.read_text())["schema"] == 2
+
+
+def test_every_example_declares_the_current_schema() -> None:
+    for path in sorted(EXAMPLES_DIR.rglob("*.yaml")):
+        declared = yaml.safe_load(path.read_text()).get("schema")
+        assert declared == CURRENT_SCHEMA_VERSION, f"{path} declares schema {declared!r}"


### PR DESCRIPTION
## Summary

Fourth PR of the 2.0 stack (plan: #385, Track 2 step 1). Stacked on #388; the diff against that branch is what to review.

Recipes gain a top-level `schema:` key. Absent means `1` (the pre-2.0 layout); `schema: 2` is the 2.0 layout. Both versions load on `main`; unknown versions are rejected at load time. This is the dispatch point the structural 2.0 changes (`roles:`, `placement:`, `services:`) hang off, and it lets downstream recipes declare which layout they target instead of failing on unknown fields.

- `SrtConfig.schema_version` (YAML key `schema` via marshmallow `data_key`), plus `CURRENT_SCHEMA_VERSION` and `SUPPORTED_SCHEMA_VERSIONS`.
- Override files declare `schema:` beside `base:`; `generate_override_configs` and `resolve_override_yaml` carry it into every expanded variant. Sweep files carry it through expansion unchanged.
- `srtctl migrate -f recipe.yaml [--in-place | --output PATH]`: a ruamel round-trip migration that inserts or bumps `schema: 2` and preserves comments, key order, and quoting. Structural v1 to v2 rewrites plug into `_migrate_1_to_2` in later steps.
- All 17 examples were migrated with the new command (dogfooding), so `examples/` is the v2 reference corpus.
- Docs: `config-reference.md` gains a `## schema` section; `schema-reference.md` regenerated (the new field shows up automatically).

## Validation

- `ruff` clean; targeted suites 391 passed; full suite green
- `tests/test_schema_version.py` (14 tests): absent/2/unknown versions, propagation through override variants, validation of override and sweep files with the key, migration idempotence and comment preservation, override and lock files keep top-level sections, CLI stdout / in-place / output modes, every example declares the current version

## Stack

1. #386 remove `--bash`
2. #387 examples matrix
3. #388 schema-generated reference
4. **this PR** schema version key and migrate
