### PR TITLE
[2.0] Add --set KEY=VALUE and --unset KEY recipe overrides

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -254,13 +254,22 @@ srtctl apply -f <config.yaml> [options]
 | `--setup-script` | Custom setup script from `configs/` |
 | `--tags` | Comma-separated tags for the run |
 | `--serve-only` | Deploy the endpoint without running a benchmark; serve until cancellation |
+| `--set KEY=VALUE` | Override one recipe value by dotted path before validation (repeatable). Also on `dry-run`, `preflight`, `resolve-override` |
+| `--unset KEY` | Remove one recipe key by dotted path before validation (repeatable) |
 | `-y, --yes` | Skip confirmation prompts |
+
+`--set` and `--unset` are the supported way to tweak a recipe from a script instead of editing the YAML. Paths are dotted, `[N]` indexes a list, and quotes protect a segment that contains dots (`container_mounts."/a/b.c"`). Values parse as YAML: `720` is an int, `"720"` a string, `[4, 8]` a list; a mapping such as `{"rope_type": "yarn"}` stays a literal string because that is how engine flags take JSON. Overrides are applied to the raw document before cluster defaults, sweep expansion, and validation, so an explicit `--set` always wins and `{placeholder}` values still expand. On an override file the value is written into `base` and every `override_*` / `zip_override_*` variant, so no variant can shadow it. The applied overrides are listed in each `--json` record as `applied_overrides`, and the `config.yaml` copied into the job directory reflects them. The source file is never modified.
 
 **Examples:**
 
 ```bash
 # Submit single job
 srtctl apply -f examples/sglang/sglang-router-disagg.yaml
+
+# Tweak a recipe from a script without editing it
+srtctl apply -f config.yaml --set health_check.max_attempts=720 --unset sbatch_directives.exclude
+srtctl apply -f config.yaml --set 'backend.sglang_config.decode.speculative-config={"method": "eagle"}'
+srtctl dry-run -f config.yaml --set benchmark.concurrencies=[4,8]
 
 # Serve the same recipe without running its configured benchmark
 srtctl apply -f examples/sglang/sglang-router-disagg.yaml --serve-only

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -24,6 +24,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -67,8 +68,14 @@ logger = logging.getLogger(__name__)
 # main() when --json is set so callers get one JSON line per submitted job.
 _submissions: list[dict] = []
 
+# Rendered --set/--unset overrides for the current invocation; echoed into every
+# submission record so a caller can see exactly what was applied.
+_active_overrides: list[str] = []
+
 
 def _record_submission(data: dict) -> None:
+    if _active_overrides:
+        data["applied_overrides"] = list(_active_overrides)
     _submissions.append(data)
 
 
@@ -1263,19 +1270,40 @@ def is_override_config(config_path: Path) -> bool:
 
 
 @contextlib.contextmanager
-def materialize_config_path(config_path: Path):
-    """Stage stdin-backed configs to a temporary YAML file for repeated reads."""
-    if str(config_path) not in {"-", "/dev/stdin"}:
+def materialize_config_path(config_path: Path, overrides: Sequence[Any] = ()):
+    """Stage stdin-backed or --set/--unset-modified configs to a temporary YAML file.
+
+    Overrides are applied to the raw document (comments preserved) before any
+    reader sees it, so they take effect identically for plain, sweep, and
+    override-format files and end up in the config.yaml copied into the job
+    output directory. The source file is never modified.
+    """
+    from_stdin = str(config_path) in {"-", "/dev/stdin"}
+    if not from_stdin and not overrides:
         yield config_path
         return
+    if not from_stdin and (not config_path.exists() or config_path.is_dir()):
+        if config_path.is_dir():
+            raise ValueError("--set/--unset apply to a single config file, not a directory")
+        yield config_path  # let the caller report the missing file
+        return
 
-    payload = sys.stdin.read()
+    payload = sys.stdin.read() if from_stdin else config_path.read_text()
     if not payload.strip():
-        raise ValueError("No YAML received on stdin")
+        raise ValueError("No YAML received on stdin" if from_stdin else f"{config_path} is empty")
+
+    if overrides:
+        from srtctl.core.overrides import apply_overrides_to_recipe
+        from srtctl.core.yaml_utils import dump_yaml_with_comments, load_yaml_text_with_comments
+
+        document = load_yaml_text_with_comments(payload)
+        for entry in apply_overrides_to_recipe(document, overrides):
+            logger.info("Applied override: %s", entry)
+        payload = dump_yaml_with_comments(document) or ""
 
     fd, temp_path = tempfile.mkstemp(
         suffix=".yaml",
-        prefix="srtctl_stdin_",
+        prefix="srtctl_stdin_" if from_stdin else "srtctl_override_",
         text=True,
     )
     try:
@@ -1462,6 +1490,29 @@ def main():
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    def add_override_args(p):
+        p.add_argument(
+            "--set",
+            action="append",
+            default=[],
+            metavar="KEY=VALUE",
+            dest="set_overrides",
+            help=(
+                "Override a recipe value by dotted path before validation (repeatable), e.g. "
+                "--set health_check.max_attempts=720 or --set 'backend.sglang_config.prefill.dist-timeout=1800'. "
+                "Values parse as YAML scalars or lists; mappings stay literal strings. "
+                "On override files the value is written into base and every variant."
+            ),
+        )
+        p.add_argument(
+            "--unset",
+            action="append",
+            default=[],
+            metavar="KEY",
+            dest="unset_overrides",
+            help="Remove a recipe key by dotted path before validation (repeatable), e.g. --unset health_check",
+        )
+
     def add_common_args(p):
         p.add_argument(
             "-f",
@@ -1474,6 +1525,7 @@ def main():
         p.add_argument("-o", "--output", type=Path, dest="output_dir", help="Custom output directory for job logs")
         p.add_argument("--sweep", action="store_true", help="Force sweep mode")
         p.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts")
+        add_override_args(p)
 
     apply_parser = subparsers.add_parser("apply", help="Submit job(s) to SLURM")
     add_common_args(apply_parser)
@@ -1535,6 +1587,7 @@ def main():
         dest="config",
         help="YAML config file, or file:selector for overrides",
     )
+    add_override_args(preflight_parser)
 
     monitor_parser = subparsers.add_parser("monitor", help="Live dashboard for srt-slurm jobs", add_help=False)
     monitor_parser.add_argument("args", nargs=argparse.REMAINDER)
@@ -1563,6 +1616,7 @@ def main():
         action="store_true",
         help="Print resolved YAML to stdout instead of writing files",
     )
+    add_override_args(resolve_parser)
 
     # Fingerprint comparison: srtctl diff <path_a> <path_b>
     diff_parser = subparsers.add_parser("diff", help="Compare fingerprints from two runs")
@@ -1637,6 +1691,15 @@ def main():
 
     if json_mode:
         _submissions.clear()
+
+    from srtctl.core.overrides import parse_overrides
+
+    try:
+        overrides = parse_overrides(getattr(args, "set_overrides", None), getattr(args, "unset_overrides", None))
+    except ValueError as exc:
+        parser.error(str(exc))
+    global _active_overrides
+    _active_overrides = [override.render() for override in overrides]
 
     _mock_patch_teardowns: list = []
     if mock_mode:
@@ -1754,7 +1817,7 @@ def main():
     tags = [t.strip() for t in (getattr(args, "tags", "") or "").split(",") if t.strip()] or None
 
     try:
-        with materialize_config_path(config_path) as effective_config_path:
+        with materialize_config_path(config_path, overrides) as effective_config_path:
             if not effective_config_path.exists():
                 console.print(f"[bold red]Config not found:[/] {config_path}")
                 sys.exit(1)

--- a/src/srtctl/core/overrides.py
+++ b/src/srtctl/core/overrides.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Command-line recipe overrides: ``--set KEY=VALUE`` and ``--unset KEY``.
+
+Paths are dotted, with ``[N]`` for list indexes and quotes for segments that
+contain dots (``container_mounts."/a/b.c"``). Values are parsed as YAML scalars
+or sequences: ``720`` is an int, ``"720"`` a string, ``true`` a bool,
+``[4, 8]`` a list. A value that parses as a mapping (``{"a": 1}``) is kept as
+the literal string, because that is how engine flags take JSON.
+
+Overrides are applied to the raw recipe document before cluster defaults,
+observability expansion, sweep expansion, and schema validation, so an explicit
+``--set`` always wins and ``{placeholder}`` values still expand. On override
+files (``base`` plus ``override_*`` / ``zip_override_*``) a ``--set`` is written
+into ``base`` and into every variant so no variant can shadow it; a ``--unset``
+removes the key from all of them.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, MutableMapping, MutableSequence, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+from ruamel.yaml.comments import CommentedMap
+
+Segment = str | int
+
+
+@dataclass(frozen=True)
+class Override:
+    """One ``--set`` or ``--unset``."""
+
+    path: tuple[Segment, ...]
+    value: Any = None
+    unset: bool = False
+
+    def render(self) -> str:
+        key = format_path(self.path)
+        if self.unset:
+            return f"--unset {key}"
+        return f"--set {key}={_render_value(self.value)}"
+
+
+def _render_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, int | float):
+        return str(value)
+    return json.dumps(value)
+
+
+def format_path(path: Sequence[Segment]) -> str:
+    out = ""
+    for segment in path:
+        if isinstance(segment, int):
+            out += f"[{segment}]"
+        else:
+            text = segment if "." not in segment and "[" not in segment and "]" not in segment else f'"{segment}"'
+            out += text if not out else f".{text}"
+    return out
+
+
+def parse_path(text: str) -> tuple[Segment, ...]:
+    """Parse ``a.b[2]."c.d".e`` into ``("a", "b", 2, "c.d", "e")``."""
+    text = text.strip()
+    if not text:
+        raise ValueError("override path must not be empty")
+    segments: list[Segment] = []
+    i = 0
+    n = len(text)
+    expect_segment = True
+    while i < n:
+        ch = text[i]
+        if ch == ".":
+            if expect_segment:
+                raise ValueError(f"empty segment in override path {text!r}")
+            expect_segment = True
+            i += 1
+            continue
+        if ch == "[":
+            if expect_segment and not segments:
+                raise ValueError(f"override path {text!r} must start with a key, not an index")
+            end = text.find("]", i)
+            if end == -1 or not text[i + 1 : end].isdigit():
+                raise ValueError(f"bad list index in override path {text!r}")
+            segments.append(int(text[i + 1 : end]))
+            i = end + 1
+            expect_segment = False
+            continue
+        if not expect_segment:
+            raise ValueError(f"expected '.' or '[' at position {i} in override path {text!r}")
+        if ch in ('"', "'"):
+            end = text.find(ch, i + 1)
+            if end == -1:
+                raise ValueError(f"unterminated quote in override path {text!r}")
+            segments.append(text[i + 1 : end])
+            i = end + 1
+        else:
+            j = i
+            while j < n and text[j] not in ".[":
+                j += 1
+            segments.append(text[i:j])
+            i = j
+        expect_segment = False
+    if expect_segment:
+        raise ValueError(f"override path {text!r} ends with a separator")
+    return tuple(segments)
+
+
+def parse_value(raw: str) -> Any:
+    """YAML-scalar parsing with mappings kept as literal strings."""
+    if raw == "":
+        return ""
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return raw
+    if isinstance(parsed, dict):
+        return raw
+    return parsed
+
+
+def parse_set(arg: str) -> Override:
+    key, sep, raw = arg.partition("=")
+    if not sep:
+        raise ValueError(f"--set expects KEY=VALUE, got {arg!r}")
+    return Override(path=parse_path(key), value=parse_value(raw))
+
+
+def parse_unset(arg: str) -> Override:
+    return Override(path=parse_path(arg), unset=True)
+
+
+def parse_overrides(sets: Iterable[str] | None, unsets: Iterable[str] | None) -> list[Override]:
+    overrides = [parse_set(item) for item in (sets or [])]
+    overrides.extend(parse_unset(item) for item in (unsets or []))
+    return overrides
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def _new_mapping(like: Any) -> MutableMapping[str, Any]:
+    return CommentedMap() if isinstance(like, CommentedMap) else {}
+
+
+def _step(container: Any, segment: Segment, *, create: bool, path: Sequence[Segment]) -> Any:
+    if isinstance(segment, int):
+        if not isinstance(container, MutableSequence):
+            raise TypeError(f"{format_path(path)}: cannot index a non-list with [{segment}]")
+        if segment >= len(container):
+            raise ValueError(f"{format_path(path)}: index [{segment}] is out of range (length {len(container)})")
+        return container[segment]
+    if not isinstance(container, MutableMapping):
+        raise TypeError(f"{format_path(path)}: cannot descend into a non-mapping at {segment!r}")
+    if segment not in container:
+        if not create:
+            return None
+        container[segment] = _new_mapping(container)
+    return container[segment]
+
+
+def apply_override(doc: MutableMapping[str, Any], override: Override) -> bool:
+    """Apply one override to a mapping. Returns True when the document changed."""
+    *parents, last = override.path
+    container: Any = doc
+    for depth, segment in enumerate(parents):
+        container = _step(container, segment, create=not override.unset, path=override.path[: depth + 1])
+        if container is None:
+            return False  # --unset on a missing path is a no-op
+    if override.unset:
+        if isinstance(last, int):
+            if isinstance(container, MutableSequence) and last < len(container):
+                del container[last]
+                return True
+            return False
+        if isinstance(container, MutableMapping) and last in container:
+            del container[last]
+            return True
+        return False
+    if isinstance(last, int):
+        if not isinstance(container, MutableSequence) or last >= len(container):
+            raise ValueError(f"{format_path(override.path)}: index out of range")
+        container[last] = override.value
+        return True
+    if not isinstance(container, MutableMapping):
+        raise TypeError(f"{format_path(override.path)}: cannot set a key on a non-mapping")
+    container[last] = override.value
+    return True
+
+
+def apply_overrides_to_recipe(doc: MutableMapping[str, Any], overrides: Sequence[Override]) -> list[str]:
+    """Apply overrides to a plain, sweep, or override-format recipe document.
+
+    Returns the rendered overrides that changed something (for logging).
+    """
+    if not overrides:
+        return []
+    applied: list[str] = []
+    is_override_file = "base" in doc
+    for override in overrides:
+        changed = False
+        if not is_override_file:
+            changed = apply_override(doc, override)
+        else:
+            changed = apply_override(doc["base"], override)
+            for key, section in doc.items():
+                if not isinstance(key, str) or not isinstance(section, MutableMapping):
+                    continue
+                if key.startswith("zip_override_"):
+                    # A one-element list broadcasts to every zipped variant, whatever the value.
+                    zipped = override if override.unset else Override(path=override.path, value=[override.value])
+                    changed = apply_override(section, zipped) or changed
+                elif key.startswith("override_"):
+                    changed = apply_override(section, override) or changed
+        if changed:
+            applied.append(override.render())
+    return applied

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from srtctl.cli import submit as submit_cli
+from srtctl.core.overrides import (
+    Override,
+    apply_override,
+    apply_overrides_to_recipe,
+    format_path,
+    parse_overrides,
+    parse_path,
+    parse_set,
+    parse_value,
+)
+from srtctl.core.yaml_utils import dump_yaml_with_comments, load_yaml_text_with_comments
+
+PLAIN = {
+    "schema": 2,
+    "name": "override-test",
+    "model": {"path": "hf:fake/mock-model", "container": "nvcr.io/fake:latest", "precision": "fp8"},
+    "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1, "agg_workers": 1},
+    "backend": {"type": "sglang", "sglang_config": {"aggregated": {"tp-size": 1}}},
+    "frontend": {"type": "sglang", "enable_multiple_frontends": False},
+    "health_check": {"max_attempts": 180, "interval_seconds": 10},
+    "benchmark": {"type": "custom", "command": "echo hi"},
+}
+
+
+def _write(tmp_path: Path, data: dict, name: str = "config.yaml") -> Path:
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("name", ("name",)),
+        ("health_check.max_attempts", ("health_check", "max_attempts")),
+        ("backend.sglang_config.prefill.dist-timeout", ("backend", "sglang_config", "prefill", "dist-timeout")),
+        ('container_mounts."/a/b.c"', ("container_mounts", "/a/b.c")),
+        ("host_setup.commands[1]", ("host_setup", "commands", 1)),
+        ("a[0].b[2].c", ("a", 0, "b", 2, "c")),
+    ],
+)
+def test_parse_path(text: str, expected: tuple) -> None:
+    assert parse_path(text) == expected
+    assert parse_path(format_path(expected)) == expected
+
+
+@pytest.mark.parametrize("bad", ["", "a..b", ".a", "a.", "[0]", "a[x]", 'a."unterminated'])
+def test_parse_path_rejects_malformed(bad: str) -> None:
+    with pytest.raises(ValueError):
+        parse_path(bad)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("720", 720),
+        ('"720"', "720"),
+        ("true", True),
+        ("0.85", 0.85),
+        ("[4, 8]", [4, 8]),
+        ("1x2x4", "1x2x4"),
+        ("", ""),
+        ('{"rope_type": "yarn"}', '{"rope_type": "yarn"}'),
+        ("{concurrency}", "{concurrency}"),
+    ],
+)
+def test_parse_value(raw: str, expected: object) -> None:
+    assert parse_value(raw) == expected
+
+
+def test_parse_set_requires_equals() -> None:
+    with pytest.raises(ValueError, match="KEY=VALUE"):
+        parse_set("health_check.max_attempts")
+    assert parse_set("a.b=x=y").value == "x=y"
+
+
+def test_parse_overrides_orders_sets_before_unsets() -> None:
+    overrides = parse_overrides(["a=1"], ["b"])
+    assert [o.unset for o in overrides] == [False, True]
+    assert overrides[0].render() == "--set a=1"
+    assert overrides[1].render() == "--unset b"
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def test_set_creates_intermediate_mappings() -> None:
+    doc: dict = {}
+    assert apply_override(doc, parse_set("backend.sglang_config.prefill.dist-timeout=1800"))
+    assert doc == {"backend": {"sglang_config": {"prefill": {"dist-timeout": 1800}}}}
+
+
+def test_set_replaces_existing_values_and_list_items() -> None:
+    doc = {"host_setup": {"commands": ["a", "b"]}}
+    apply_override(doc, parse_set("host_setup.commands[1]=c"))
+    assert doc["host_setup"]["commands"] == ["a", "c"]
+    with pytest.raises(ValueError, match="out of range"):
+        apply_override(doc, parse_set("host_setup.commands[5]=z"))
+
+
+def test_unset_is_lenient_on_missing_paths() -> None:
+    doc = {"health_check": {"max_attempts": 1}}
+    assert apply_override(doc, Override(path=("health_check",), unset=True))
+    assert "health_check" not in doc
+    assert not apply_override(doc, Override(path=("health_check", "interval_seconds"), unset=True))
+    assert not apply_override(doc, Override(path=("nope", "deeper"), unset=True))
+
+
+def test_set_on_non_mapping_fails_loudly() -> None:
+    with pytest.raises(TypeError, match="non-mapping"):
+        apply_override({"name": "x"}, parse_set("name.child=1"))
+
+
+def test_override_file_semantics_write_to_base_and_every_variant() -> None:
+    doc = {
+        "base": {"name": "b", "resources": {"agg_workers": 2}, "health_check": {"max_attempts": 10}},
+        "override_small": {"resources": {"agg_workers": 1}},
+        "zip_override_ctx": {"name": ["x", "y"], "resources": {"agg_workers": [3, 4]}},
+    }
+    applied = apply_overrides_to_recipe(doc, parse_overrides(["resources.agg_workers=8"], ["health_check"]))
+    assert applied == ["--set resources.agg_workers=8", "--unset health_check"]
+    assert doc["base"]["resources"]["agg_workers"] == 8
+    assert doc["override_small"]["resources"]["agg_workers"] == 8, "a variant must not shadow --set"
+    assert doc["zip_override_ctx"]["resources"]["agg_workers"] == [8], "zip groups get a broadcast list"
+    assert "health_check" not in doc["base"]
+
+
+def test_overrides_preserve_comments_on_round_trip_documents() -> None:
+    text = "# recipe\nname: x  # job\nhealth_check:\n  max_attempts: 10\n"
+    doc = load_yaml_text_with_comments(text)
+    apply_overrides_to_recipe(doc, parse_overrides(["health_check.max_attempts=720", "resources.gpu_type=h100"], []))
+    out = dump_yaml_with_comments(doc) or ""
+    assert out.startswith("# recipe\nname: x  # job\n")
+    assert "max_attempts: 720" in out
+    assert "gpu_type: h100" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_applies_set_and_unset(tmp_path: Path, monkeypatch, capsys) -> None:
+    path = _write(tmp_path, PLAIN)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["srtctl", "dry-run", "-f", str(path), "--set", "name=renamed-by-set", "--unset", "health_check"],
+    )
+    submit_cli.main()
+    out = capsys.readouterr().out
+    assert "renamed-by-set" in out
+    assert yaml.safe_load(path.read_text())["name"] == "override-test", "the source file is never modified"
+
+
+def test_set_value_wins_over_a_cluster_default_block() -> None:
+    from srtctl.core.config import resolve_config_with_defaults
+
+    recipe = {k: v for k, v in PLAIN.items() if k != "health_check"}
+    apply_overrides_to_recipe(recipe, parse_overrides(["health_check.max_attempts=720"], []))
+    resolved = resolve_config_with_defaults(
+        recipe, {"default_health_check": {"max_attempts": 5, "interval_seconds": 10}}
+    )
+    assert resolved["health_check"] == {"max_attempts": 720}, "an explicit --set beats default_health_check"
+
+
+def test_apply_mock_json_records_applied_overrides(tmp_path: Path, monkeypatch, capsys) -> None:
+    path = _write(tmp_path, PLAIN)
+    outputs = tmp_path / "outputs"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "srtctl",
+            "apply",
+            "-f",
+            str(path),
+            "-o",
+            str(outputs),
+            "--mock",
+            "--mock-tick-s",
+            "0.05",
+            "--json",
+            "--set",
+            "benchmark.command=echo overridden",
+            "--unset",
+            "health_check",
+        ],
+    )
+    submit_cli.main()
+    record = json.loads(capsys.readouterr().out.strip().splitlines()[0])
+    assert record["status"] == "submitted"
+    assert record["applied_overrides"] == ["--set benchmark.command=echo overridden", "--unset health_check"]
+    written = yaml.safe_load((Path(record["output_dir"]) / "config.yaml").read_text())
+    assert written["benchmark"]["command"] == "echo overridden"
+    assert "health_check" not in written
+
+
+def test_resolve_override_stdout_applies_overrides(tmp_path: Path, monkeypatch, capsys) -> None:
+    path = _write(
+        tmp_path,
+        {"schema": 2, "base": dict(PLAIN), "override_small": {"resources": {"agg_workers": 4}}},
+        "override.yaml",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["srtctl", "resolve-override", "-f", f"{path}:override_small", "--stdout", "--set", "resources.agg_workers=2"],
+    )
+    submit_cli.main()
+    out = capsys.readouterr().out
+    assert "agg_workers: 2" in out
+    assert "agg_workers: 4" not in out


### PR DESCRIPTION
## Summary

Fifth PR of the 2.0 stack (plan: #385, Track 2 step 2). Stacked on #389; the diff against that branch is what to review.

Downstream runners edit recipes with `sed` anchored on v1 indentation and field names, which breaks silently under any re-nesting. This adds a supported, path-based override so scripts can tweak a recipe without editing the YAML, before the structural 2.0 changes land.

```bash
srtctl apply -f recipe.yaml --set health_check.max_attempts=720 --unset sbatch_directives.exclude
srtctl apply -f recipe.yaml --set 'backend.sglang_config.decode.speculative-config={"method": "eagle"}'
srtctl dry-run -f recipe.yaml --set benchmark.concurrencies=[4,8]
```

- Paths are dotted, `[N]` indexes a list, quotes protect segments with dots. Values parse as YAML scalars or lists; mappings stay literal strings because engine flags take JSON.
- Applied in `materialize_config_path` to the raw document (ruamel round trip, comments kept) before cluster defaults, observability expansion, sweep expansion, and validation, so an explicit `--set` always wins and `{placeholder}` values still expand.
- On override files the value is written into `base` and every `override_*` / `zip_override_*` variant (one-element-list broadcast for zip groups), so no variant can shadow it. `--unset` removes from all of them and is a no-op on missing paths.
- The overridden document is what becomes `config.yaml` in the job directory; the source file is never modified. Every `--json` record lists `applied_overrides`.
- Available on `apply`, `dry-run`, `preflight`, and `resolve-override`.

## Validation

- `ruff` clean; full suite green
- `tests/test_overrides.py` (24 tests): path grammar and rejections, value typing incl. JSON-as-string and placeholders, nested creation, list indexes, lenient unset, override-file semantics, comment preservation, dry-run, `--set` beating `default_health_check`, `--json` record and written `config.yaml` under `--mock`, `resolve-override --stdout`
- Cluster: PASSED on sa-b200. Job 11866 ran examples/sglang/sglang-router-agg.yaml with --set name=..., --set benchmark.concurrencies=[2], --set backend.sglang_config.aggregated.max-running-requests=32, --unset slurm.time_limit. The written outputs/11866/config.yaml showed name renamed, concurrencies=[2], max-running-requests=32; the sbatch script fell back to the cluster default --time=4:00:00 after the unset; the --json record listed all four applied_overrides.

## Stack

1. #386 remove `--bash`
2. #387 examples matrix
3. #388 schema-generated reference
4. #389 schema version key and migrate
5. **this PR** `--set` / `--unset`