### PR TITLE
[2.0] Resolve every container alias with one recipe walker

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -118,13 +118,15 @@ The `srtslurm.yaml` file can contain the following fields:
 | `srtctl_root`                   | string | Root directory for srtctl                             |
 | `output_dir`                    | string | Custom output directory (overrides srtctl_root/outputs) |
 | `model_paths`                   | dict   | Model path aliases                                    |
-| `containers`                    | dict   | Container image aliases                               |
+| `containers`                    | dict   | Container image aliases, resolved for every image key in a recipe (see below) |
 | `default_mounts`                | dict   | Cluster-wide container mounts                         |
 | `default_bash_preamble`         | string | Shell snippet prepended to every container srun       |
 | `default_host_setup`            | object | Commands run on every node's bare host, outside the container |
 | `nginx_raise_ulimit`          | bool   | Optional default for `frontend.nginx_raise_ulimit`  |
 
 **output_dir**: When set, job logs are written to `output_dir/{job_id}/logs` instead of `srtctl_root/outputs/{job_id}/logs`. Useful for CI/CD and ephemeral environments.
+
+**containers**: A map from alias to image path or registry URI. One resolver walks the whole recipe and replaces any string under a `container`, `container_image`, `image`, or `nginx_container` key that matches an alias: `model.container`, `frontend.container_image`, `frontend.nginx_container`, `benchmark.container_image`, the Tachometer and power exporter images, `backend.mooncake_kv_store.container`, and any future block that names an image. Literal paths and registry URIs pass through untouched. Free-form maps (`environment`, `*_environment`, `env`, `args`, engine config blocks, `container_mounts`) and the `identity` block are never rewritten.
 
 **default_bash_preamble**: A shell snippet (e.g. `"ulimit -n 1048576 -s unlimited -u 1048576"`) prepended to every container srun launched by srtctl — workers, frontends, telemetry, benchmark, postprocess. Runs before per-call `bash_preamble` and the main command, so cluster-wide ulimits apply to everything downstream. Silently dropped for distroless containers (e.g. `prom/node-exporter`) that bypass the bash wrapper; a WARNING log is emitted in that case.
 

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -15,6 +15,7 @@ import fnmatch
 import logging
 import os
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -78,6 +79,71 @@ def load_cluster_config() -> dict[str, Any] | None:
         return None
 
 
+# Keys whose string values name a container image. Any such leaf anywhere in a
+# recipe resolves against the cluster `containers:` alias map.
+CONTAINER_ALIAS_KEYS: frozenset[str] = frozenset({"container", "container_image", "image", "nginx_container"})
+
+# Sub-trees the alias walker never enters: `identity` declares the pullable image a
+# run *should* be using (verification only, never an alias); the rest are free-form
+# maps (environment variables, engine flags, mounts) where a key happening to be
+# called `image` is user data, not a container reference.
+_CONTAINER_ALIAS_SKIP_KEYS: frozenset[str] = frozenset(
+    {
+        "identity",
+        "environment",
+        "prefill_environment",
+        "decode_environment",
+        "aggregated_environment",
+        "env",
+        "args",
+        "extra_args",
+        "prefill_extra_args",
+        "decode_extra_args",
+        "aggregated_extra_args",
+        "container_mounts",
+        "sbatch_directives",
+        "srun_options",
+        "sglang_config",
+        "vllm_config",
+        "trtllm_config",
+        "mocker_config",
+        "store_config",
+    }
+)
+
+
+def resolve_container_aliases(config: dict[str, Any], containers: Mapping[str, str]) -> list[str]:
+    """Replace every container-alias leaf in ``config`` with its ``containers:`` value, in place.
+
+    Walks the whole recipe once. A leaf is any string under a key in
+    :data:`CONTAINER_ALIAS_KEYS` whose value is a key of ``containers``; literal
+    paths and registry URIs are left alone. This is the single place container
+    aliases resolve (model, frontend, nginx, benchmark, exporters, Mooncake,
+    services), so a new block that names an image needs no resolver code.
+
+    Returns one human-readable note per resolved leaf.
+    """
+    notes: list[str] = []
+
+    def walk(node: Any, path: tuple[Any, ...]) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in _CONTAINER_ALIAS_SKIP_KEYS:
+                    continue
+                if key in CONTAINER_ALIAS_KEYS and isinstance(value, str) and value in containers:
+                    node[key] = containers[value]
+                    dotted = ".".join(str(part) for part in (*path, key))
+                    notes.append(f"Resolved container alias {dotted}: '{value}' -> '{containers[value]}'")
+                elif isinstance(value, dict | list):
+                    walk(value, (*path, key))
+        elif isinstance(node, list):
+            for index, item in enumerate(node):
+                walk(item, (*path, index))
+
+    walk(config, ())
+    return notes
+
+
 def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: dict[str, Any] | None) -> dict[str, Any]:
     """
     Resolve user config by applying cluster defaults and aliases.
@@ -85,7 +151,8 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
     This applies:
     1. Default SLURM settings (account, partition, time_limit)
     2. Model path alias resolution
-    3. Container alias resolution
+    3. Container alias resolution for every container-typed key (see
+       :func:`resolve_container_aliases`)
 
     Args:
         user_config: User's YAML config as dict
@@ -142,14 +209,13 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         model["path"] = resolved_path
         logger.debug(f"Resolved model alias '{model_path}' -> '{resolved_path}'")
 
-    # Resolve container alias
-    container = model.get("container", "")
-
+    # Resolve every container alias in one pass (model.container,
+    # frontend.container_image / nginx_container, benchmark.container_image,
+    # exporter images, mooncake_kv_store.container, services, ...).
     containers = cluster_config.get("containers")
-    if containers and container in containers:
-        resolved_container = containers[container]
-        model["container"] = resolved_container
-        logger.debug(f"Resolved container alias '{container}' -> '{resolved_container}'")
+    if containers:
+        for note in resolve_container_aliases(config, containers):
+            logger.debug(note)
 
     # Apply reporting defaults (if not specified in user config)
     if "reporting" not in config and cluster_config.get("reporting"):
@@ -168,70 +234,12 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
         config["host_setup"] = cluster_config["default_host_setup"]
         logger.debug("Applied default_host_setup: %s", config["host_setup"])
 
-    # Resolve frontend nginx_container alias
-    frontend = config.get("frontend", {})
-    nginx_container = frontend.get("nginx_container", "")
-
-    if containers and nginx_container in containers:
-        resolved_nginx = containers[nginx_container]
-        frontend["nginx_container"] = resolved_nginx
-        config["frontend"] = frontend
-        logger.debug(f"Resolved nginx_container alias '{nginx_container}' -> '{resolved_nginx}'")
-
-    router_container = frontend.get("container_image", "")
-    if containers and router_container in containers:
-        resolved_router = containers[router_container]
-        frontend["container_image"] = resolved_router
-        config["frontend"] = frontend
-        logger.debug(f"Resolved frontend.container_image alias '{router_container}' -> '{resolved_router}'")
-
     # Cluster-level default for nginx nofile ulimit (job yaml wins if present).
+    frontend = config.get("frontend", {})
     if "nginx_raise_ulimit" not in frontend and cluster_config.get("nginx_raise_ulimit") is not None:
         frontend["nginx_raise_ulimit"] = cluster_config["nginx_raise_ulimit"]
         config["frontend"] = frontend
         logger.debug(f"Applied cluster nginx_raise_ulimit: {frontend['nginx_raise_ulimit']}")
-
-    # Resolve benchmark.container_image alias for benches that ship their own
-    # eval container (e.g. NeMo Skills for accuracy benchmarks). Mirrors how
-    # model.container and frontend.nginx_container resolve against the same
-    # `containers:` map.
-    benchmark = config.get("benchmark", {})
-    benchmark_container = benchmark.get("container_image", "")
-
-    if containers and benchmark_container in containers:
-        resolved_bench = containers[benchmark_container]
-        benchmark["container_image"] = resolved_bench
-        config["benchmark"] = benchmark
-        logger.debug(f"Resolved benchmark.container_image alias '{benchmark_container}' -> '{resolved_bench}'")
-
-    # Resolve Tachometer exporter aliases from the observability block.
-    observability = config.get("observability")
-    tachometer = observability.get("tachometer") if isinstance(observability, dict) else None
-    if tachometer and containers:
-        for exporter_key in ("dcgm_exporter", "node_exporter"):
-            exporter = tachometer.get(exporter_key)
-            if not exporter:
-                continue
-            exporter_image = exporter.get("container_image")
-            if exporter_image and exporter_image in containers:
-                resolved_exporter = containers[exporter_image]
-                exporter["container_image"] = resolved_exporter
-                logger.debug(
-                    f"Resolved observability.tachometer.{exporter_key}.container_image alias "
-                    f"'{exporter_image}' -> '{resolved_exporter}'"
-                )
-
-    # Telemetry is reserved for the DCGM power collector.
-    telemetry = config.get("telemetry")
-    if telemetry and containers:
-        exporter = telemetry.get("dcgm_exporter")
-        exporter_image = exporter.get("container_image") if isinstance(exporter, dict) else None
-        if exporter_image and exporter_image in containers:
-            resolved_exporter = containers[exporter_image]
-            exporter["container_image"] = resolved_exporter
-            logger.debug(
-                f"Resolved telemetry.dcgm_exporter.container_image alias '{exporter_image}' -> '{resolved_exporter}'"
-            )
 
     return config
 

--- a/tests/test_container_aliases.py
+++ b/tests/test_container_aliases.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The single container-alias resolver behind resolve_config_with_defaults."""
+
+from __future__ import annotations
+
+from srtctl.core.config import CONTAINER_ALIAS_KEYS, resolve_config_with_defaults, resolve_container_aliases
+
+CONTAINERS = {
+    "sglang": "/sqsh/sglang.sqsh",
+    "nginx": "/sqsh/nginx.sqsh",
+    "router": "/sqsh/router.sqsh",
+    "evals": "/sqsh/evals.sqsh",
+    "dcgm-exporter": "/sqsh/dcgm.sqsh",
+    "node-exporter": "/sqsh/node.sqsh",
+    "mooncake": "/sqsh/mooncake.sqsh",
+    "sidecar": "/sqsh/sidecar.sqsh",
+}
+
+
+def _recipe() -> dict:
+    return {
+        "name": "aliases",
+        "model": {"path": "/models/m", "container": "sglang", "precision": "fp8"},
+        "resources": {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1},
+        "frontend": {"nginx_container": "nginx", "container_image": "router"},
+        "benchmark": {"type": "custom", "command": "echo", "container_image": "evals"},
+        "observability": {
+            "enabled": True,
+            "tachometer": {
+                "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},
+                "node_exporter": {"container_image": "node-exporter", "port": 9101},
+            },
+        },
+        "telemetry": {"enabled": True, "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401}},
+        "backend": {"type": "sglang", "mooncake_kv_store": {"container": "mooncake", "env": {"image": "sglang"}}},
+    }
+
+
+def test_every_known_container_key_resolves_in_one_pass() -> None:
+    resolved = resolve_config_with_defaults(_recipe(), {"containers": CONTAINERS})
+
+    assert resolved["model"]["container"] == "/sqsh/sglang.sqsh"
+    assert resolved["frontend"]["nginx_container"] == "/sqsh/nginx.sqsh"
+    assert resolved["frontend"]["container_image"] == "/sqsh/router.sqsh"
+    assert resolved["benchmark"]["container_image"] == "/sqsh/evals.sqsh"
+    assert resolved["observability"]["tachometer"]["dcgm_exporter"]["container_image"] == "/sqsh/dcgm.sqsh"
+    assert resolved["observability"]["tachometer"]["node_exporter"]["container_image"] == "/sqsh/node.sqsh"
+    assert resolved["telemetry"]["dcgm_exporter"]["container_image"] == "/sqsh/dcgm.sqsh"
+    # Newly covered: the Mooncake master container used to be the one image key no block resolved.
+    assert resolved["backend"]["mooncake_kv_store"]["container"] == "/sqsh/mooncake.sqsh"
+
+
+def test_free_form_maps_and_identity_are_never_touched() -> None:
+    recipe = _recipe()
+    recipe["identity"] = {"container": {"image": "sglang"}}
+    recipe["environment"] = {"image": "sglang", "container": "nginx"}
+    recipe["backend"]["aggregated_environment"] = {"container_image": "sglang"}
+    recipe["backend"]["sglang_config"] = {"aggregated": {"image": "sglang"}}
+
+    resolved = resolve_config_with_defaults(recipe, {"containers": CONTAINERS})
+
+    assert resolved["identity"] == {"container": {"image": "sglang"}}
+    assert resolved["environment"] == {"image": "sglang", "container": "nginx"}
+    assert resolved["backend"]["aggregated_environment"] == {"container_image": "sglang"}
+    assert resolved["backend"]["sglang_config"] == {"aggregated": {"image": "sglang"}}
+    assert resolved["backend"]["mooncake_kv_store"]["env"] == {"image": "sglang"}
+
+
+def test_literal_paths_registry_uris_and_unknown_aliases_pass_through() -> None:
+    recipe = _recipe()
+    recipe["model"]["container"] = "/direct/container.sqsh"
+    recipe["frontend"]["nginx_container"] = "nginx:1.27.4"
+    recipe["benchmark"]["container_image"] = "not-an-alias"
+
+    resolved = resolve_config_with_defaults(recipe, {"containers": CONTAINERS})
+
+    assert resolved["model"]["container"] == "/direct/container.sqsh"
+    assert resolved["frontend"]["nginx_container"] == "nginx:1.27.4"
+    assert resolved["benchmark"]["container_image"] == "not-an-alias"
+
+
+def test_new_blocks_with_image_or_container_image_keys_resolve_without_resolver_code() -> None:
+    """A future `services:` list (or anything else) that names an image just works."""
+    recipe = _recipe()
+    recipe["services"] = [
+        {"name": "a", "image": "sidecar", "command": ["x"]},
+        {"name": "b", "container_image": "router", "command": ["y"], "env": {"image": "sidecar"}},
+    ]
+
+    resolved = resolve_config_with_defaults(recipe, {"containers": CONTAINERS})
+
+    assert resolved["services"][0]["image"] == "/sqsh/sidecar.sqsh"
+    assert resolved["services"][1]["container_image"] == "/sqsh/router.sqsh"
+    assert resolved["services"][1]["env"] == {"image": "sidecar"}
+
+
+def test_walker_reports_each_resolution_and_mutates_in_place() -> None:
+    recipe = _recipe()
+    notes = resolve_container_aliases(recipe, CONTAINERS)
+
+    assert recipe["model"]["container"] == "/sqsh/sglang.sqsh"
+    assert "Resolved container alias model.container: 'sglang' -> '/sqsh/sglang.sqsh'" in notes
+    assert any(note.startswith("Resolved container alias frontend.nginx_container:") for note in notes)
+    assert len(notes) == 8
+    assert resolve_container_aliases(recipe, CONTAINERS) == [], "second pass finds nothing left to resolve"
+
+
+def test_no_cluster_containers_map_leaves_aliases_as_written() -> None:
+    resolved = resolve_config_with_defaults(_recipe(), {"default_account": "acct"})
+    assert resolved["model"]["container"] == "sglang"
+    assert resolve_config_with_defaults(_recipe(), None)["frontend"]["nginx_container"] == "nginx"
+
+
+def test_alias_key_set_is_the_documented_one() -> None:
+    assert set(CONTAINER_ALIAS_KEYS) == {"container", "container_image", "image", "nginx_container"}


### PR DESCRIPTION
## Summary

Sixth PR of the 2.0 stack (plan: #385, Track 2 step 3). Stacked on #390; the diff against that branch is what to review.

Container-alias resolution was seven copy-pasted blocks in `resolve_config_with_defaults`, one per image key (`model.container`, `frontend.container_image`, `frontend.nginx_container`, `benchmark.container_image`, the Tachometer and power exporter images), and `backend.mooncake_kv_store.container` had no block at all. This replaces them with one walk over the recipe.

- Any string under a `container`, `container_image`, `image`, or `nginx_container` key that names a `containers:` alias is resolved; literal paths and registry URIs pass through.
- Free-form maps (`environment`, `*_environment`, `env`, `args`, engine config blocks, `container_mounts`) and the `identity` block are skipped, so a key that happens to be named `image` in user data is never rewritten.
- A new recipe block that names an image (e.g. the future `services:` list) resolves with no resolver code. This is the seam Track 3 and step 7 need.

## Validation

- `ruff` clean; full suite: 1759 passed
- `tests/test_container_aliases.py`: every image key in one pass (incl. the newly-covered Mooncake container), the skip list, literal / registry-URI / unknown-alias pass-through, a synthetic `services:` block, in-place mutation with per-resolution notes, and no-`containers`-map behaviour. The existing nginx / benchmark / exporter alias tests in `test_configs.py` still pass unchanged.

## Stack

1. #386 remove `--bash`
2. #387 examples matrix
3. #388 schema-generated reference
4. #389 schema version key and migrate
5. #390 `--set` / `--unset`
6. **this PR** one container-alias resolver
