### PR TITLE
[2.0] Add the roles: authoring surface for recipe topology

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -197,6 +197,35 @@ model:
 
 ---
 
+## roles
+
+`roles:` is the 2.0 way to describe a worker role. It groups everything about a role in one place instead of spreading it across `resources`, `backend.*_environment`, and `backend.<engine>_config.*`:
+
+```yaml
+roles:
+  prefill:
+    nodes: 2          # -> resources.prefill_nodes
+    workers: 6        # -> resources.prefill_workers
+    gpus: 2           # -> resources.gpus_per_prefill
+    env:              # -> backend.prefill_environment
+      PYTHONUNBUFFERED: "1"
+    args:             # -> backend.<engine>_config.prefill (engine from backend.type)
+      tensor-parallel-size: 2
+      disaggregation-mode: prefill
+  decode:
+    nodes: 0          # 0 shares the prefill node's spare GPUs
+    workers: 2
+    gpus: 2
+    env: { PYTHONUNBUFFERED: "1" }
+    args: { tensor-parallel-size: 2, disaggregation-mode: decode }
+```
+
+Role names are `prefill`, `decode`, and `agg`. The aggregated role is `agg` (matching `resources.agg_*`); its `env` and `args` map to `backend.aggregated_environment` and `backend.<engine>_config.aggregated`. Per-role `extra_args` maps to `backend.<mode>_extra_args` (TRT-LLM). `roles:` is normalized into those fields before validation, so it is exactly equivalent to writing them directly; you cannot set both for the same role.
+
+The legacy fields (`resources.prefill_workers`, `backend.prefill_environment`, `backend.sglang_config.prefill`, ...) still load unchanged, so v1 recipes keep working. `srtctl migrate` stamps `schema: 2` but does not yet rewrite the legacy layout into `roles:`; both forms are valid v2. The `examples/` are written with `roles:` (except `features/override.yaml`, kept legacy to show that the v1 layout still loads).
+
+---
+
 ## resources
 
 GPU allocation and worker topology.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -216,9 +216,14 @@ roles:
     nodes: 0          # 0 shares the prefill node's spare GPUs
     workers: 2
     gpus: 2
-    env: { PYTHONUNBUFFERED: "1" }
-    args: { tensor-parallel-size: 2, disaggregation-mode: decode }
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
+      tensor-parallel-size: 2
+      disaggregation-mode: decode
 ```
+
+`env` and `args` are ordinary YAML mappings, written exactly as `backend.prefill_environment` and `backend.sglang_config.prefill` were. Nothing needs JSON or inline `{}` syntax.
 
 Role names are `prefill`, `decode`, and `agg`. The aggregated role is `agg` (matching `resources.agg_*`); its `env` and `args` map to `backend.aggregated_environment` and `backend.<engine>_config.aggregated`. Per-role `extra_args` maps to `backend.<mode>_extra_args` (TRT-LLM). `roles:` is normalized into those fields before validation, so it is exactly equivalent to writing them directly; you cannot set both for the same role.
 

--- a/examples/features/profiling.yaml
+++ b/examples/features/profiling.yaml
@@ -21,10 +21,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 1
-  gpus_per_agg: 1
-
 profiling:
   type: "torch"
   aggregated:
@@ -37,10 +33,14 @@ frontend:
 
 backend:
   type: sglang
-  aggregated_environment:
-    PYTHONUNBUFFERED: "1"
-  sglang_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       mem-fraction-static: 0.5

--- a/examples/features/sweep.yaml
+++ b/examples/features/sweep.yaml
@@ -28,10 +28,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 2
-  gpus_per_agg: 1
-
 frontend:
   type: sglang
   enable_multiple_frontends: false
@@ -40,10 +36,14 @@ frontend:
 
 backend:
   type: sglang
-  aggregated_environment:
-    PYTHONUNBUFFERED: "1"
-  sglang_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 2
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       mem-fraction-static: 0.5

--- a/examples/mocker/dynamo-agg.yaml
+++ b/examples/mocker/dynamo-agg.yaml
@@ -21,9 +21,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 1
-
 dynamo:
   version: "1.4.2"
 
@@ -36,6 +33,10 @@ backend:
   engine_type: vllm
   speedup_ratio: 100
 
+roles:
+  agg:
+    nodes: 1
+    workers: 1
 benchmark:
   type: "sa-bench"
   isl: 128

--- a/examples/sglang/dynamo-agg.yaml
+++ b/examples/sglang/dynamo-agg.yaml
@@ -21,10 +21,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 2
-  gpus_per_agg: 1
-
 dynamo:
   version: "1.4.2"
 
@@ -36,10 +32,14 @@ frontend:
 
 backend:
   type: sglang
-  aggregated_environment:
-    PYTHONUNBUFFERED: "1"
-  sglang_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 2
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       mem-fraction-static: 0.5

--- a/examples/sglang/dynamo-disagg.yaml
+++ b/examples/sglang/dynamo-disagg.yaml
@@ -21,13 +21,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 1
-  decode_nodes: 0
-  decode_workers: 1
-  gpus_per_decode: 1
-
 dynamo:
   version: "1.4.2"
 
@@ -39,18 +32,26 @@ frontend:
 
 backend:
   type: sglang
-  prefill_environment:
-    PYTHONUNBUFFERED: "1"
-  decode_environment:
-    PYTHONUNBUFFERED: "1"
-  sglang_config:
-    prefill:
+roles:
+  prefill:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       mem-fraction-static: 0.5
       context-length: 4096
       disable-piecewise-cuda-graph: true
-    decode:
+  decode:
+    nodes: 0
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       mem-fraction-static: 0.5

--- a/examples/sglang/sglang-router-agg.yaml
+++ b/examples/sglang/sglang-router-agg.yaml
@@ -20,10 +20,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 2
-  gpus_per_agg: 1
-
 frontend:
   type: sglang
   enable_multiple_frontends: false
@@ -32,10 +28,14 @@ frontend:
 
 backend:
   type: sglang
-  aggregated_environment:
-    PYTHONUNBUFFERED: "1"
-  sglang_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 2
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       mem-fraction-static: 0.5

--- a/examples/sglang/sglang-router-disagg.yaml
+++ b/examples/sglang/sglang-router-disagg.yaml
@@ -22,13 +22,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 1
-  decode_nodes: 0
-  decode_workers: 1
-  gpus_per_decode: 1
-
 frontend:
   type: sglang
   enable_multiple_frontends: false
@@ -37,18 +30,26 @@ frontend:
 
 backend:
   type: sglang
-  prefill_environment:
-    PYTHONUNBUFFERED: "1"
-  decode_environment:
-    PYTHONUNBUFFERED: "1"
-  sglang_config:
-    prefill:
+roles:
+  prefill:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       mem-fraction-static: 0.5
       context-length: 4096
       disable-piecewise-cuda-graph: true
-    decode:
+  decode:
+    nodes: 0
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       mem-fraction-static: 0.5

--- a/examples/trtllm/dynamo-agg.yaml
+++ b/examples/trtllm/dynamo-agg.yaml
@@ -20,10 +20,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 2
-  gpus_per_agg: 1
-
 dynamo:
   install: false
 
@@ -36,11 +32,15 @@ frontend:
 backend:
   type: trtllm
   served_model_name: "Qwen/Qwen3-0.6B"
-  aggregated_environment:
-    PYTHONUNBUFFERED: "1"
-    TLLM_LOG_LEVEL: "INFO"
-  trtllm_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 2
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+      TLLM_LOG_LEVEL: "INFO"
+    args:
       backend: "pytorch"
       tensor_parallel_size: 1
       max_batch_size: 64

--- a/examples/trtllm/dynamo-disagg.yaml
+++ b/examples/trtllm/dynamo-disagg.yaml
@@ -21,13 +21,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 1
-  decode_nodes: 0
-  decode_workers: 1
-  gpus_per_decode: 1
-
 dynamo:
   install: false
 
@@ -40,14 +33,15 @@ frontend:
 backend:
   type: trtllm
   served_model_name: "Qwen/Qwen3-0.6B"
-  prefill_environment:
-    PYTHONUNBUFFERED: "1"
-    TLLM_LOG_LEVEL: "INFO"
-  decode_environment:
-    PYTHONUNBUFFERED: "1"
-    TLLM_LOG_LEVEL: "INFO"
-  trtllm_config:
-    prefill:
+roles:
+  prefill:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+      TLLM_LOG_LEVEL: "INFO"
+    args:
       backend: "pytorch"
       tensor_parallel_size: 1
       max_batch_size: 8
@@ -59,7 +53,14 @@ backend:
         free_gpu_memory_fraction: 0.5
       cache_transceiver_config:
         backend: "UCX"
-    decode:
+  decode:
+    nodes: 0
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+      TLLM_LOG_LEVEL: "INFO"
+    args:
       backend: "pytorch"
       tensor_parallel_size: 1
       max_batch_size: 64

--- a/examples/trtllm/trtllm-serve-agg.yaml
+++ b/examples/trtllm/trtllm-serve-agg.yaml
@@ -20,10 +20,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 1
-  gpus_per_agg: 1
-
 frontend:
   type: trtllm_serve
   enable_multiple_frontends: false
@@ -31,11 +27,15 @@ frontend:
 backend:
   type: trtllm
   served_model_name: "Qwen/Qwen3-0.6B"
-  aggregated_environment:
-    PYTHONUNBUFFERED: "1"
-    TLLM_LOG_LEVEL: "INFO"
-  trtllm_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+      TLLM_LOG_LEVEL: "INFO"
+    args:
       backend: "pytorch"
       tensor_parallel_size: 1
       max_batch_size: 64

--- a/examples/trtllm/trtllm-serve-disagg.yaml
+++ b/examples/trtllm/trtllm-serve-disagg.yaml
@@ -22,13 +22,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 1
-  decode_nodes: 0
-  decode_workers: 1
-  gpus_per_decode: 1
-
 frontend:
   type: trtllm_serve
   enable_multiple_frontends: false
@@ -36,14 +29,15 @@ frontend:
 backend:
   type: trtllm
   served_model_name: "Qwen/Qwen3-0.6B"
-  prefill_environment:
-    PYTHONUNBUFFERED: "1"
-    TLLM_LOG_LEVEL: "INFO"
-  decode_environment:
-    PYTHONUNBUFFERED: "1"
-    TLLM_LOG_LEVEL: "INFO"
-  trtllm_config:
-    prefill:
+roles:
+  prefill:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+      TLLM_LOG_LEVEL: "INFO"
+    args:
       backend: "pytorch"
       tensor_parallel_size: 1
       max_batch_size: 8
@@ -55,7 +49,14 @@ backend:
         free_gpu_memory_fraction: 0.5
       cache_transceiver_config:
         backend: "UCX"
-    decode:
+  decode:
+    nodes: 0
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+      TLLM_LOG_LEVEL: "INFO"
+    args:
       backend: "pytorch"
       tensor_parallel_size: 1
       max_batch_size: 64

--- a/examples/vllm/dynamo-agg.yaml
+++ b/examples/vllm/dynamo-agg.yaml
@@ -21,10 +21,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 2
-  gpus_per_agg: 1
-
 dynamo:
   version: "1.4.2"
 
@@ -36,11 +32,15 @@ frontend:
 
 backend:
   type: vllm
-  aggregated_environment:
-    DYN_HEALTH_CHECK_ENABLED: "false"
-    PYTHONUNBUFFERED: "1"
-  vllm_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 2
+    gpus: 1
+    env:
+      DYN_HEALTH_CHECK_ENABLED: "false"
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       gpu-memory-utilization: 0.5

--- a/examples/vllm/dynamo-disagg.yaml
+++ b/examples/vllm/dynamo-disagg.yaml
@@ -20,13 +20,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 1
-  decode_nodes: 0
-  decode_workers: 1
-  gpus_per_decode: 1
-
 dynamo:
   version: "1.4.2"
 
@@ -39,19 +32,27 @@ frontend:
 backend:
   type: vllm
   connector: nixl
-  prefill_environment:
-    DYN_HEALTH_CHECK_ENABLED: "false"
-    PYTHONUNBUFFERED: "1"
-  decode_environment:
-    DYN_HEALTH_CHECK_ENABLED: "false"
-    PYTHONUNBUFFERED: "1"
-  vllm_config:
-    prefill:
+roles:
+  prefill:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      DYN_HEALTH_CHECK_ENABLED: "false"
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       gpu-memory-utilization: 0.5
       max-model-len: 4096
-    decode:
+  decode:
+    nodes: 0
+    workers: 1
+    gpus: 1
+    env:
+      DYN_HEALTH_CHECK_ENABLED: "false"
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       gpu-memory-utilization: 0.5

--- a/examples/vllm/vllm-direct-agg.yaml
+++ b/examples/vllm/vllm-direct-agg.yaml
@@ -20,20 +20,20 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 1
-  gpus_per_agg: 1
-
 frontend:
   type: vllm
   enable_multiple_frontends: false
 
 backend:
   type: vllm
-  aggregated_environment:
-    PYTHONUNBUFFERED: "1"
-  vllm_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       gpu-memory-utilization: 0.5

--- a/examples/vllm/vllm-router-agg.yaml
+++ b/examples/vllm/vllm-router-agg.yaml
@@ -20,10 +20,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  agg_nodes: 1
-  agg_workers: 2
-  gpus_per_agg: 1
-
 frontend:
   type: vllm-router
   enable_multiple_frontends: false
@@ -32,10 +28,14 @@ frontend:
 
 backend:
   type: vllm
-  aggregated_environment:
-    PYTHONUNBUFFERED: "1"
-  vllm_config:
-    aggregated:
+roles:
+  agg:
+    nodes: 1
+    workers: 2
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       gpu-memory-utilization: 0.5

--- a/examples/vllm/vllm-router-disagg.yaml
+++ b/examples/vllm/vllm-router-disagg.yaml
@@ -21,13 +21,6 @@ model:
 resources:
   gpu_type: "h100"
   gpus_per_node: 8
-  prefill_nodes: 1
-  prefill_workers: 1
-  gpus_per_prefill: 1
-  decode_nodes: 0
-  decode_workers: 1
-  gpus_per_decode: 1
-
 frontend:
   type: vllm-router
   enable_multiple_frontends: false
@@ -37,17 +30,25 @@ frontend:
 backend:
   type: vllm
   connector: nixl
-  prefill_environment:
-    PYTHONUNBUFFERED: "1"
-  decode_environment:
-    PYTHONUNBUFFERED: "1"
-  vllm_config:
-    prefill:
+roles:
+  prefill:
+    nodes: 1
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       gpu-memory-utilization: 0.5
       max-model-len: 4096
-    decode:
+  decode:
+    nodes: 0
+    workers: 1
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
       served-model-name: "Qwen/Qwen3-0.6B"
       tensor-parallel-size: 1
       gpu-memory-utilization: 0.5

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -163,6 +163,14 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
     """
     # Deep copy to avoid mutating original
     config = copy.deepcopy(user_config)
+
+    # Normalize the 2.0 ``roles:`` authoring block into the existing internal
+    # fields (resources.*_workers, backend.*_environment, backend.<engine>_config.*)
+    # before anything else reads them. No-op for legacy recipes.
+    from srtctl.core.roles import expand_roles
+
+    expand_roles(config)
+
     if cluster_config is None:
         return config
 

--- a/src/srtctl/core/roles.py
+++ b/src/srtctl/core/roles.py
@@ -6,8 +6,20 @@
 A recipe can group everything about a worker role under one block::
 
     roles:
-      prefill: {nodes: 2, workers: 6, gpus: 2, env: {...}, args: {...}}
-      decode:  {nodes: 0, workers: 2, gpus: 2, env: {...}, args: {...}}
+      prefill:
+        nodes: 2
+        workers: 6
+        gpus: 2
+        env:
+          PYTHONUNBUFFERED: "1"
+        args:
+          tensor-parallel-size: 2
+      decode:
+        nodes: 0
+        workers: 2
+        gpus: 2
+        args:
+          tensor-parallel-size: 2
 
 instead of spreading it across ``resources.prefill_workers`` /
 ``resources.gpus_per_prefill``, ``backend.prefill_environment``, and

--- a/src/srtctl/core/roles.py
+++ b/src/srtctl/core/roles.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The 2.0 ``roles:`` authoring surface for recipe topology.
+
+A recipe can group everything about a worker role under one block::
+
+    roles:
+      prefill: {nodes: 2, workers: 6, gpus: 2, env: {...}, args: {...}}
+      decode:  {nodes: 0, workers: 2, gpus: 2, env: {...}, args: {...}}
+
+instead of spreading it across ``resources.prefill_workers`` /
+``resources.gpus_per_prefill``, ``backend.prefill_environment``, and
+``backend.<engine>_config.prefill``. :func:`expand_roles` normalizes a
+``roles:`` block back into those existing internal fields before schema load, so
+no downstream consumer changes; :func:`roles_from_legacy` is the inverse, used to
+migrate a v1 recipe and to prove the two forms are equivalent.
+
+Role names are ``prefill``, ``decode``, and ``agg``. The aggregated role is
+``agg`` here (matching ``resources.agg_*``); it maps to the ``aggregated`` key in
+``backend.aggregated_environment`` and ``backend.<engine>_config.aggregated``.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+# backend.type -> the engine's per-mode CLI config key.
+ENGINE_CONFIG_KEY: dict[str, str] = {
+    "sglang": "sglang_config",
+    "vllm": "vllm_config",
+    "trtllm": "trtllm_config",
+    "mocker": "mocker_config",
+}
+_ALL_ENGINE_CONFIG_KEYS = frozenset(ENGINE_CONFIG_KEY.values())
+
+# roles: role name -> the mode name used in backend env / engine-config keys.
+ROLE_TO_MODE: dict[str, str] = {"prefill": "prefill", "decode": "decode", "agg": "aggregated"}
+ROLE_NAMES: tuple[str, ...] = ("prefill", "decode", "agg")
+
+# Per-role spec keys.
+_ROLE_SPEC_KEYS = frozenset({"nodes", "workers", "gpus", "env", "args", "extra_args"})
+
+
+def _engine_key(config: dict[str, Any]) -> str:
+    backend = config.get("backend")
+    btype = backend.get("type", "sglang") if isinstance(backend, dict) else "sglang"
+    return ENGINE_CONFIG_KEY.get(btype, "sglang_config")
+
+
+def _legacy_targets_present(config: dict[str, Any]) -> list[str]:
+    """Internal v1 fields that would collide with a ``roles:`` block."""
+    present: list[str] = []
+    resources = config.get("resources")
+    if isinstance(resources, dict):
+        for role in ROLE_NAMES:
+            for key in (f"{role}_nodes", f"{role}_workers", f"gpus_per_{role}"):
+                if key in resources:
+                    present.append(f"resources.{key}")
+    backend = config.get("backend")
+    if isinstance(backend, dict):
+        for mode in ("prefill", "decode", "aggregated"):
+            for key in (f"{mode}_environment", f"{mode}_extra_args"):
+                if key in backend:
+                    present.append(f"backend.{key}")
+        for engine_key in _ALL_ENGINE_CONFIG_KEYS:
+            if backend.get(engine_key):
+                present.append(f"backend.{engine_key}")
+    return present
+
+
+def expand_roles(config: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a ``roles:`` block into the existing internal fields, in place.
+
+    A no-op when there is no ``roles:`` key. Rejects mixing ``roles:`` with the
+    v1 ``prefill_*`` / ``<engine>_config`` fields it expands into.
+    """
+    roles = config.get("roles")
+    if not isinstance(roles, dict):
+        return config
+
+    collisions = _legacy_targets_present(config)
+    if collisions:
+        raise ValueError(
+            "roles: cannot be combined with the fields it expands into: "
+            + ", ".join(sorted(collisions))
+            + ". Use roles: or the legacy fields, not both."
+        )
+
+    engine_key = _engine_key(config)
+    resources = config.setdefault("resources", {})
+    backend = config.setdefault("backend", {})
+
+    for role_name, spec in roles.items():
+        if role_name not in ROLE_TO_MODE:
+            raise ValueError(f"unknown role {role_name!r}; valid roles are {', '.join(ROLE_NAMES)}")
+        if not isinstance(spec, dict):
+            raise TypeError(f"roles.{role_name} must be a mapping")
+        unknown = set(spec) - _ROLE_SPEC_KEYS
+        if unknown:
+            raise ValueError(f"roles.{role_name} has unknown keys: {', '.join(sorted(unknown))}")
+
+        mode = ROLE_TO_MODE[role_name]
+        if "nodes" in spec:
+            resources[f"{role_name}_nodes"] = spec["nodes"]
+        if "workers" in spec:
+            resources[f"{role_name}_workers"] = spec["workers"]
+        if "gpus" in spec:
+            resources[f"gpus_per_{role_name}"] = spec["gpus"]
+        if "env" in spec:
+            backend[f"{mode}_environment"] = spec["env"]
+        if "args" in spec:
+            engine_cfg = backend.setdefault(engine_key, {})
+            engine_cfg[mode] = {**(engine_cfg.get(mode) or {}), **spec["args"]}
+        if "extra_args" in spec:
+            backend[f"{mode}_extra_args"] = spec["extra_args"]
+
+    config.pop("roles", None)
+    return config
+
+
+def roles_from_legacy(config: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``config`` with legacy role fields folded into a ``roles:`` block.
+
+    The inverse of :func:`expand_roles`, used by ``srtctl migrate`` and by tests
+    that assert the two forms are equivalent. Only non-empty roles appear.
+    """
+    result = copy.deepcopy(config)
+    resources = result.get("resources") if isinstance(result.get("resources"), dict) else {}
+    backend = result.get("backend") if isinstance(result.get("backend"), dict) else {}
+    engine_key = _engine_key(result)
+    engine_cfg = backend.get(engine_key) if isinstance(backend.get(engine_key), dict) else {}
+
+    roles: dict[str, dict[str, Any]] = {}
+    for role_name in ROLE_NAMES:
+        mode = ROLE_TO_MODE[role_name]
+        spec: dict[str, Any] = {}
+        if f"{role_name}_nodes" in resources:
+            spec["nodes"] = resources[f"{role_name}_nodes"]
+        if f"{role_name}_workers" in resources:
+            spec["workers"] = resources[f"{role_name}_workers"]
+        if f"gpus_per_{role_name}" in resources:
+            spec["gpus"] = resources[f"gpus_per_{role_name}"]
+        if backend.get(f"{mode}_environment"):
+            spec["env"] = backend[f"{mode}_environment"]
+        if engine_cfg.get(mode):
+            spec["args"] = engine_cfg[mode]
+        if backend.get(f"{mode}_extra_args"):
+            spec["extra_args"] = backend[f"{mode}_extra_args"]
+        if spec:
+            roles[role_name] = spec
+
+    if not roles:
+        return result
+
+    # Strip the folded fields from resources/backend.
+    for role_name in ROLE_NAMES:
+        mode = ROLE_TO_MODE[role_name]
+        for key in (f"{role_name}_nodes", f"{role_name}_workers", f"gpus_per_{role_name}"):
+            resources.pop(key, None)
+        backend.pop(f"{mode}_environment", None)
+        backend.pop(f"{mode}_extra_args", None)
+        if isinstance(engine_cfg, dict):
+            engine_cfg.pop(mode, None)
+    if isinstance(engine_cfg, dict) and not engine_cfg:
+        backend.pop(engine_key, None)
+    if isinstance(resources, dict) and not resources:
+        result.pop("resources", None)
+
+    result["roles"] = roles
+    return result

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -2417,9 +2417,11 @@ class SrtConfig:
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":
         from srtctl.core.config import expand_observability
+        from srtctl.core.roles import expand_roles
 
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
+        expand_roles(data)
         expand_observability(data)
         schema = cls.Schema()
         return schema.load(data)

--- a/src/srtctl/core/validation.py
+++ b/src/srtctl/core/validation.py
@@ -493,7 +493,9 @@ def preflight_config_variants(
         resolved = resolve_config_with_defaults(variant, active_cluster_config)
         model, model_issues = _preflight_model(variant, resolved, active_cluster_config)
         container, container_issues = _preflight_container(variant, resolved, active_cluster_config)
-        topology_issues = validate_topology(variant.get("resources"))
+        # Validate the resolved resources (post roles: expansion), not the raw
+        # variant: a roles: recipe has its topology under roles, not resources.
+        topology_issues = validate_topology(resolved.get("resources"))
         telemetry_issues = _preflight_telemetry(variant, resolved, active_cluster_config)
         issues = [*model_issues, *container_issues, *topology_issues, *telemetry_issues]
         results.append(

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from srtctl.core.roles import expand_roles, roles_from_legacy
+from srtctl.core.schema import SrtConfig
+
+
+def _legacy_sglang_disagg() -> dict:
+    return {
+        "schema": 2,
+        "name": "roles-test",
+        "model": {"path": "/m", "container": "/c.sqsh", "precision": "fp8"},
+        "resources": {
+            "gpu_type": "h100",
+            "gpus_per_node": 8,
+            "prefill_nodes": 2,
+            "prefill_workers": 6,
+            "gpus_per_prefill": 2,
+            "decode_nodes": 0,
+            "decode_workers": 2,
+            "gpus_per_decode": 2,
+        },
+        "backend": {
+            "type": "sglang",
+            "prefill_environment": {"PYTHONUNBUFFERED": "1"},
+            "decode_environment": {"PYTHONUNBUFFERED": "1"},
+            "sglang_config": {
+                "prefill": {"tensor-parallel-size": 2, "disaggregation-mode": "prefill"},
+                "decode": {"tensor-parallel-size": 2, "disaggregation-mode": "decode"},
+            },
+        },
+        "frontend": {"type": "sglang", "enable_multiple_frontends": False},
+        "benchmark": {"type": "sa-bench", "isl": 128, "osl": 128, "concurrencies": "4"},
+    }
+
+
+def _roles_sglang_disagg() -> dict:
+    return {
+        "schema": 2,
+        "name": "roles-test",
+        "model": {"path": "/m", "container": "/c.sqsh", "precision": "fp8"},
+        "resources": {"gpu_type": "h100", "gpus_per_node": 8},
+        "backend": {"type": "sglang"},
+        "roles": {
+            "prefill": {
+                "nodes": 2,
+                "workers": 6,
+                "gpus": 2,
+                "env": {"PYTHONUNBUFFERED": "1"},
+                "args": {"tensor-parallel-size": 2, "disaggregation-mode": "prefill"},
+            },
+            "decode": {
+                "nodes": 0,
+                "workers": 2,
+                "gpus": 2,
+                "env": {"PYTHONUNBUFFERED": "1"},
+                "args": {"tensor-parallel-size": 2, "disaggregation-mode": "decode"},
+            },
+        },
+        "frontend": {"type": "sglang", "enable_multiple_frontends": False},
+        "benchmark": {"type": "sa-bench", "isl": 128, "osl": 128, "concurrencies": "4"},
+    }
+
+
+def test_expand_roles_produces_the_legacy_layout() -> None:
+    expanded = expand_roles(_roles_sglang_disagg())
+    assert "roles" not in expanded
+    assert expanded["resources"] == _legacy_sglang_disagg()["resources"]
+    assert expanded["backend"] == _legacy_sglang_disagg()["backend"]
+
+
+def test_roles_and_legacy_load_to_identical_configs() -> None:
+    from_roles = SrtConfig.Schema().load(expand_roles(_roles_sglang_disagg()))
+    from_legacy = SrtConfig.Schema().load(_legacy_sglang_disagg())
+    schema = SrtConfig.Schema()
+    assert schema.dump(from_roles) == schema.dump(from_legacy)
+
+
+def test_roles_round_trips_through_roles_from_legacy() -> None:
+    legacy = _legacy_sglang_disagg()
+    as_roles = roles_from_legacy(legacy)
+    assert as_roles["roles"] == _roles_sglang_disagg()["roles"]
+    assert "prefill_workers" not in as_roles.get("resources", {})
+    assert "prefill_environment" not in as_roles["backend"]
+    assert "sglang_config" not in as_roles["backend"]
+    # And expanding it back reproduces the original internal layout.
+    assert expand_roles(copy.deepcopy(as_roles))["resources"] == legacy["resources"]
+    assert expand_roles(copy.deepcopy(as_roles))["backend"] == legacy["backend"]
+
+
+def test_agg_role_maps_to_aggregated_env_and_config() -> None:
+    config = {
+        "backend": {"type": "vllm"},
+        "roles": {"agg": {"workers": 2, "gpus": 1, "env": {"X": "1"}, "args": {"tensor-parallel-size": 1}}},
+    }
+    expand_roles(config)
+    assert config["resources"] == {"agg_workers": 2, "gpus_per_agg": 1}
+    assert config["backend"]["aggregated_environment"] == {"X": "1"}
+    assert config["backend"]["vllm_config"]["aggregated"] == {"tensor-parallel-size": 1}
+
+
+def test_engine_config_key_follows_backend_type() -> None:
+    for btype, key in (("sglang", "sglang_config"), ("vllm", "vllm_config"), ("trtllm", "trtllm_config")):
+        config = {"backend": {"type": btype}, "roles": {"agg": {"args": {"a": 1}}}}
+        expand_roles(config)
+        assert config["backend"][key]["aggregated"] == {"a": 1}
+
+
+def test_trtllm_extra_args_route_to_mode_extra_args() -> None:
+    config = {"backend": {"type": "trtllm"}, "roles": {"prefill": {"extra_args": ["--x"]}}}
+    expand_roles(config)
+    assert config["backend"]["prefill_extra_args"] == ["--x"]
+
+
+def test_mixing_roles_with_legacy_fields_is_rejected() -> None:
+    config = _roles_sglang_disagg()
+    config["resources"]["prefill_workers"] = 1
+    with pytest.raises(ValueError, match="cannot be combined"):
+        expand_roles(config)
+
+
+def test_unknown_role_and_unknown_spec_key_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown role"):
+        expand_roles({"backend": {"type": "sglang"}, "roles": {"warmup": {"workers": 1}}})
+    with pytest.raises(ValueError, match="unknown keys"):
+        expand_roles({"backend": {"type": "sglang"}, "roles": {"prefill": {"gpu": 1}}})
+
+
+def test_no_roles_block_is_a_no_op() -> None:
+    legacy = _legacy_sglang_disagg()
+    assert expand_roles(copy.deepcopy(legacy)) == legacy
+
+
+def test_decode_nodes_zero_shared_node_survives() -> None:
+    config = {"backend": {"type": "sglang"}, "roles": {"decode": {"nodes": 0, "workers": 2}}}
+    expand_roles(config)
+    assert config["resources"]["decode_nodes"] == 0
+    assert config["resources"]["decode_workers"] == 2
+
+
+def test_preflight_topology_reads_expanded_roles(tmp_path) -> None:
+    """A roles: recipe passes topology preflight; the check runs post-expansion."""
+    import yaml
+
+    from srtctl.core.validation import preflight_config_variants
+
+    recipe = {
+        "schema": 2,
+        "name": "roles-preflight",
+        "model": {"path": "/m", "container": "/c.sqsh", "precision": "fp8"},
+        "resources": {"gpu_type": "h100", "gpus_per_node": 8},
+        "backend": {"type": "sglang"},
+        "roles": {"agg": {"nodes": 1, "workers": 2, "gpus": 1}},
+        "benchmark": {"type": "sa-bench", "isl": 128, "osl": 128, "concurrencies": "4"},
+    }
+    results = preflight_config_variants(yaml.safe_load(yaml.safe_dump(recipe)), cluster_config=None)
+    topo_errors = [issue for result in results for issue in result.errors if issue.field == "resources"]
+    assert topo_errors == [], topo_errors


### PR DESCRIPTION
## Summary

Ninth PR of the 2.0 stack (plan: #385, Track 2 step 5, authoring surface). Stacked on #393.

A recipe can now describe a worker role in one block instead of spreading it across `resources`, `backend.*_environment`, and `backend.<engine>_config.*`:

```yaml
roles:
  prefill:
    nodes: 2
    workers: 6
    gpus: 2
    env:
      PYTHONUNBUFFERED: "1"
    args:
      tensor-parallel-size: 2
      disaggregation-mode: prefill
  decode:
    nodes: 0
    workers: 2
    gpus: 2
    args:
      tensor-parallel-size: 2
      disaggregation-mode: decode
```

- `src/srtctl/core/roles.py::expand_roles` normalizes `roles:` into the existing internal fields (`resources.prefill_workers` / `gpus_per_prefill`, `backend.prefill_environment`, `backend.<engine>_config.prefill`) **before** schema load, wired into `resolve_config_with_defaults` and `SrtConfig.from_yaml` so every load path is covered and no downstream consumer changes.
- Role names are `prefill` / `decode` / `agg`; `agg` maps to the `aggregated` env/config keys; `args` route to the engine's config by `backend.type`; `extra_args` to `<mode>_extra_args` (TRT-LLM).
- `roles_from_legacy` is the inverse, proving the two forms load identically and providing the transform the future migrator will use.
- Mixing `roles:` with the fields it expands into is rejected.

**v1 stays valid.** The legacy layout still loads unchanged, so v1 recipes keep working. `srtctl migrate` still only stamps `schema: 2`; the comment-preserving legacy-to-`roles:` rewrite over the 481-recipe downstream corpus is deferred to the golden-CI migration release, because that structural surgery is where the risk concentrates. Both forms are valid v2.

The 16 topology examples are converted to `roles:`; `features/override.yaml` stays legacy to demonstrate v1 still loads.

## Validation

- `ruff` clean; full suite: 1776 passed
- `tests/test_roles.py` (10): expand produces the legacy layout, roles and legacy load to identical `SrtConfig`, round-trip through `roles_from_legacy`, `agg`→`aggregated`, engine-config key by backend type, TRT-LLM `extra_args`, mixing rejected, unknown role/spec key rejected, no-op without `roles:`, `decode_nodes: 0` survives
- All 17 examples pass `validate_config_file`; the e2e disagg tests pass against the converted examples
- Cluster: PASSED. Job 11936 ran the converted examples/sglang/sglang-router-agg.yaml (roles: agg block). It required fixing preflight to validate the resolved resources (post roles expansion) rather than the raw variant; with that, the recipe submitted and the two aggregated workers launched. The preflight fix has its own test.

## Stack

9 of the stack; see #386-#393 for the earlier PRs.

`env` and `args` are ordinary block-style YAML mappings, written exactly like the legacy `backend.prefill_environment` / `backend.sglang_config.prefill` blocks they normalize into. No inline `{}` or JSON needed; the earlier flow-style snippet here was only shorthand.
