### PR TITLE
[2.0] Add the placement: vocabulary for frontend, benchmark, and infra

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -231,6 +231,28 @@ The legacy fields (`resources.prefill_workers`, `backend.prefill_environment`, `
 
 ---
 
+## placement
+
+`placement:` is one vocabulary for where the frontend, benchmark client, and infra services run, replacing the per-block placement knobs:
+
+```yaml
+frontend:  { placement: { node: head | first_decode | dedicated } }
+benchmark: { placement: { node: head | last_decode | dedicated } }
+infra:     { placement: { node: head | dedicated } }
+```
+
+`node: dedicated` reserves a node for that component (and implies the head location, which the legacy validation already required). Any other value is a location string.
+
+| Block | `node: dedicated` sets | `node: <location>` sets |
+| --- | --- | --- |
+| `frontend` | `frontend.dedicated_node: true` + `orchestrator_placement: head` | `frontend.orchestrator_placement: <location>` |
+| `benchmark` | `benchmark.client_dedicated_node: true` + `client_placement: head` | `benchmark.client_placement: <location>` |
+| `infra` | `infra.etcd_nats_dedicated_node: true` | `head` only |
+
+Like `roles:`, this is normalized into the existing fields before validation, so it is exactly equivalent to writing them, cannot be combined with them for the same block, and the legacy fields still load.
+
+---
+
 ## resources
 
 GPU allocation and worker topology.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -236,9 +236,15 @@ The legacy fields (`resources.prefill_workers`, `backend.prefill_environment`, `
 `placement:` is one vocabulary for where the frontend, benchmark client, and infra services run, replacing the per-block placement knobs:
 
 ```yaml
-frontend:  { placement: { node: head | first_decode | dedicated } }
-benchmark: { placement: { node: head | last_decode | dedicated } }
-infra:     { placement: { node: head | dedicated } }
+frontend:
+  placement:
+    node: head          # head | first_decode | dedicated
+benchmark:
+  placement:
+    node: last_decode   # head | last_decode | dedicated
+infra:
+  placement:
+    node: dedicated     # head | dedicated
 ```
 
 `node: dedicated` reserves a node for that component (and implies the head location, which the legacy validation already required). Any other value is a location string.

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -167,9 +167,11 @@ def resolve_config_with_defaults(user_config: dict[str, Any], cluster_config: di
     # Normalize the 2.0 ``roles:`` authoring block into the existing internal
     # fields (resources.*_workers, backend.*_environment, backend.<engine>_config.*)
     # before anything else reads them. No-op for legacy recipes.
+    from srtctl.core.placement import expand_placement
     from srtctl.core.roles import expand_roles
 
     expand_roles(config)
+    expand_placement(config)
 
     if cluster_config is None:
         return config

--- a/src/srtctl/core/placement.py
+++ b/src/srtctl/core/placement.py
@@ -5,9 +5,15 @@
 
 One vocabulary replaces the per-block placement knobs::
 
-    frontend:  {placement: {node: head | first_decode | dedicated}}
-    benchmark: {placement: {node: head | last_decode | dedicated}}
-    infra:     {placement: {node: head | dedicated}}
+    frontend:
+      placement:
+        node: head          # head | first_decode | dedicated
+    benchmark:
+      placement:
+        node: last_decode   # head | last_decode | dedicated
+    infra:
+      placement:
+        node: dedicated     # head | dedicated
 
 ``node: dedicated`` reserves a node for that component (and implies the head
 location, which the legacy validation already required). Any other value is a

--- a/src/srtctl/core/placement.py
+++ b/src/srtctl/core/placement.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The 2.0 ``placement:`` authoring surface for where the frontend, benchmark client, and infra run.
+
+One vocabulary replaces the per-block placement knobs::
+
+    frontend:  {placement: {node: head | first_decode | dedicated}}
+    benchmark: {placement: {node: head | last_decode | dedicated}}
+    infra:     {placement: {node: head | dedicated}}
+
+``node: dedicated`` reserves a node for that component (and implies the head
+location, which the legacy validation already required). Any other value is a
+location string passed through. :func:`expand_placement` normalizes these blocks
+into the existing internal fields before schema load, so no consumer changes and
+the legacy fields still load.
+
+| Block       | node: dedicated sets                          | node: <other> sets                    |
+|-------------|-----------------------------------------------|---------------------------------------|
+| frontend    | dedicated_node=True, orchestrator_placement=head | orchestrator_placement=<other>     |
+| benchmark   | client_dedicated_node=True, client_placement=head | client_placement=<other>          |
+| infra       | etcd_nats_dedicated_node=True                 | (only ``head`` is valid; = False)     |
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEDICATED = "dedicated"
+
+# block name -> (placement-str field, dedicated-bool field or None, legacy fields it fills)
+_FRONTEND = ("orchestrator_placement", "dedicated_node")
+_BENCHMARK = ("client_placement", "client_dedicated_node")
+
+
+def _expand_block(section: dict[str, Any], *, place_field: str, dedicated_field: str, block: str) -> None:
+    placement = section.get("placement")
+    if not isinstance(placement, dict):
+        return
+    collisions = [f for f in (place_field, dedicated_field) if f in section]
+    if collisions:
+        raise ValueError(f"{block}.placement cannot be combined with {block}." + f", {block}.".join(collisions))
+    node = placement.get("node")
+    if node is None:
+        raise ValueError(f"{block}.placement requires a 'node' value")
+    unknown = set(placement) - {"node"}
+    if unknown:
+        raise ValueError(f"{block}.placement has unknown keys: {', '.join(sorted(unknown))}")
+    if node == DEDICATED:
+        section[dedicated_field] = True
+        section[place_field] = "head"
+    else:
+        section[place_field] = node
+    section.pop("placement", None)
+
+
+def expand_placement(config: dict[str, Any]) -> dict[str, Any]:
+    """Normalize ``placement:`` blocks on frontend / benchmark / infra into the internal fields, in place."""
+    frontend = config.get("frontend")
+    if isinstance(frontend, dict):
+        _expand_block(frontend, place_field=_FRONTEND[0], dedicated_field=_FRONTEND[1], block="frontend")
+
+    benchmark = config.get("benchmark")
+    if isinstance(benchmark, dict):
+        _expand_block(benchmark, place_field=_BENCHMARK[0], dedicated_field=_BENCHMARK[1], block="benchmark")
+
+    infra = config.get("infra")
+    if isinstance(infra, dict) and isinstance(infra.get("placement"), dict):
+        if "etcd_nats_dedicated_node" in infra:
+            raise ValueError("infra.placement cannot be combined with infra.etcd_nats_dedicated_node")
+        placement = infra["placement"]
+        node = placement.get("node")
+        unknown = set(placement) - {"node"}
+        if unknown:
+            raise ValueError(f"infra.placement has unknown keys: {', '.join(sorted(unknown))}")
+        if node == DEDICATED:
+            infra["etcd_nats_dedicated_node"] = True
+        elif node == "head":
+            infra["etcd_nats_dedicated_node"] = False
+        else:
+            raise ValueError(f"infra.placement.node must be 'head' or 'dedicated', got {node!r}")
+        infra.pop("placement", None)
+
+    return config

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -2417,11 +2417,13 @@ class SrtConfig:
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":
         from srtctl.core.config import expand_observability
+        from srtctl.core.placement import expand_placement
         from srtctl.core.roles import expand_roles
 
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         expand_roles(data)
+        expand_placement(data)
         expand_observability(data)
         schema = cls.Schema()
         return schema.load(data)

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from srtctl.core.placement import expand_placement
+from srtctl.core.schema import SrtConfig
+
+
+def test_frontend_placement_location_and_dedicated() -> None:
+    cfg = {"frontend": {"type": "dynamo", "placement": {"node": "first_decode"}}}
+    expand_placement(cfg)
+    assert cfg["frontend"]["orchestrator_placement"] == "first_decode"
+    assert "placement" not in cfg["frontend"]
+
+    cfg = {"frontend": {"type": "dynamo", "placement": {"node": "dedicated"}}}
+    expand_placement(cfg)
+    assert cfg["frontend"]["dedicated_node"] is True
+    assert cfg["frontend"]["orchestrator_placement"] == "head"
+
+
+def test_benchmark_placement_location_and_dedicated() -> None:
+    cfg = {"benchmark": {"type": "sa-bench", "placement": {"node": "last_decode"}}}
+    expand_placement(cfg)
+    assert cfg["benchmark"]["client_placement"] == "last_decode"
+
+    cfg = {"benchmark": {"type": "sa-bench", "placement": {"node": "dedicated"}}}
+    expand_placement(cfg)
+    assert cfg["benchmark"]["client_dedicated_node"] is True
+    assert cfg["benchmark"]["client_placement"] == "head"
+
+
+def test_infra_placement() -> None:
+    cfg = {"infra": {"placement": {"node": "dedicated"}}}
+    expand_placement(cfg)
+    assert cfg["infra"]["etcd_nats_dedicated_node"] is True
+    assert "placement" not in cfg["infra"]
+
+    cfg = {"infra": {"placement": {"node": "head"}}}
+    expand_placement(cfg)
+    assert cfg["infra"]["etcd_nats_dedicated_node"] is False
+
+
+def test_placement_and_legacy_load_identically() -> None:
+    base = {
+        "name": "placement",
+        "model": {"path": "/m", "container": "/c.sqsh", "precision": "fp8"},
+        "resources": {
+            "gpu_type": "h100",
+            "gpus_per_node": 8,
+            "prefill_nodes": 1,
+            "prefill_workers": 1,
+            "decode_nodes": 1,
+            "decode_workers": 1,
+        },
+        "backend": {"type": "sglang"},
+        "benchmark": {"type": "sa-bench", "isl": 128, "osl": 128, "concurrencies": "4"},
+    }
+    legacy = {
+        **base,
+        "frontend": {"type": "dynamo", "orchestrator_placement": "first_decode"},
+        "infra": {"etcd_nats_dedicated_node": True},
+    }
+    placed = {
+        **base,
+        "frontend": {"type": "dynamo", "placement": {"node": "first_decode"}},
+        "infra": {"placement": {"node": "dedicated"}},
+    }
+
+    schema = SrtConfig.Schema()
+    a = schema.dump(schema.load(expand_placement(dict(placed))))
+    b = schema.dump(schema.load(legacy))
+    assert a == b
+
+
+def test_mixing_placement_with_legacy_fields_rejected() -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        expand_placement({"frontend": {"placement": {"node": "head"}, "orchestrator_placement": "head"}})
+    with pytest.raises(ValueError, match="cannot be combined"):
+        expand_placement({"infra": {"placement": {"node": "head"}, "etcd_nats_dedicated_node": False}})
+
+
+def test_invalid_placement_values_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown keys"):
+        expand_placement({"frontend": {"placement": {"node": "head", "extra": 1}}})
+    with pytest.raises(ValueError, match="requires a 'node'"):
+        expand_placement({"frontend": {"placement": {}}})
+    with pytest.raises(ValueError, match="must be 'head' or 'dedicated'"):
+        expand_placement({"infra": {"placement": {"node": "first_decode"}}})
+
+
+def test_no_placement_is_a_no_op() -> None:
+    cfg = {"frontend": {"type": "dynamo", "orchestrator_placement": "head"}}
+    assert expand_placement(dict(cfg)) == cfg


### PR DESCRIPTION
## Summary

Tenth PR of the 2.0 stack (plan: #385, Track 2 step 6). Stacked on #394.

One `placement:` vocabulary replaces the per-block placement knobs:

```yaml
frontend:
  placement:
    node: head          # head | first_decode | dedicated
benchmark:
  placement:
    node: last_decode   # head | last_decode | dedicated
infra:
  placement:
    node: dedicated     # head | dedicated
```

`node: dedicated` reserves a node for that component and implies the head location (which the legacy validation already required for a dedicated node); any other value is a location string. `src/srtctl/core/placement.py::expand_placement` normalizes these into the existing internal fields (`frontend.orchestrator_placement` / `dedicated_node`, `benchmark.client_placement` / `client_dedicated_node`, `infra.etcd_nats_dedicated_node`) before schema load, wired in next to `expand_roles`. No consumer changes; the legacy fields still load; mixing `placement:` with the fields it fills is rejected.

## Validation

- `ruff` clean; full suite: 1784 passed
- `tests/test_placement.py`: frontend/benchmark location + `dedicated`, infra head/dedicated, placement and legacy load to identical `SrtConfig`, mixing rejected, invalid values rejected, no-op without `placement:`

- Cluster: dry-run on sa-b200 with `--set frontend.placement.node=head --set infra.placement.node=head` resolved cleanly (placement expands through the CLI path). Dedicated-node placement needs multi-node to exercise and was not run.\n\n## Stack

10 of the stack; see #386-#394 for the earlier PRs.
