### PR TITLE
feat(observability): scrape trtllm-serve disagg over its Prometheus endpoints

### DIFF
--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -617,10 +617,14 @@ class BenchmarkStageMixin:
         ranks are not advertised as separate engines.
         """
         urls: list[str] = []
+        # trtllm-serve serves Prometheus at /prometheus/metrics on the worker
+        # OpenAI port (GET /metrics there is JSON iteration stats, not
+        # exposition text); every other frontend serves it at /metrics.
+        metrics_path = "/prometheus/metrics" if self.config.frontend.type == "trtllm_serve" else "/metrics"
         if logical_workers_only:
             if logical_endpoints is None:
                 logical_endpoints = self._logical_worker_endpoints()
-            urls = [f"http://{host}:{port}/metrics" for _, host, port in logical_endpoints]
+            urls = [f"http://{host}:{port}{metrics_path}" for _, host, port in logical_endpoints]
         else:
             if self.config.frontend.type in {"vllm", "vllm-router"}:
                 for process in self.backend_processes:
@@ -633,13 +637,25 @@ class BenchmarkStageMixin:
                 if urls:
                     return {"AIPERF_SERVER_METRICS_URLS": ",".join(sorted(set(urls)))}
 
+            # trtllm-serve workers bind only their OpenAI http_port (leaders) —
+            # the DYN_SYSTEM_PORT sys-port endpoints are never created in this
+            # mode, so advertising them would point the client at dead ports.
+            # The Prometheus mount exists when return_perf_metrics is set,
+            # which observability.enabled injects alongside
+            # publish_events_and_metrics.
+            if self.config.frontend.type == "trtllm_serve":
+                if getattr(self.config.backend, "publish_events_and_metrics", False):
+                    for process in self.backend_processes:
+                        if process.endpoint_mode != "agg" and process.http_port > 0:
+                            host = get_hostname_ip(process.node, self.runtime.network_interface)
+                            urls.append(f"http://{host}:{process.http_port}{metrics_path}")
             # TRT-LLM workers only publish engine metrics when launched with
             # --publish-events-and-metrics (pre-v1.3.0 Dynamo gates the whole
             # worker /metrics surface on it; observability.enabled sets it at
             # config load). Without the flag the sys-port endpoints serve
             # nothing, so advertising them would only create the impression
             # that worker metrics are being captured.
-            if self.config.backend_type != "trtllm" or getattr(
+            elif self.config.backend_type != "trtllm" or getattr(
                 self.config.backend, "publish_events_and_metrics", False
             ):
                 for process in self.backend_processes:

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -54,7 +54,20 @@ def generate_tachometer_config(
     URL (``AIPERF_SERVER_METRICS_URLS``): double-polling has been validated
     as harmless, and unconditional coverage keeps Tachometer the one
     whole-window, per-replica capture regardless of what the client does.
+
+    ``frontend_type: trtllm_serve`` targets a different surface than Dynamo:
+    workers bind only their OpenAI ``http_port`` (leaders; the DYN_SYSTEM_PORT
+    sys-ports are never created in this mode) and both the workers and the
+    disaggregated orchestrator serve Prometheus at ``/prometheus/metrics`` —
+    the worker's ``/metrics`` route is JSON iteration stats and the
+    orchestrator registers no ``/metrics`` route at all. Endpoint names keep
+    the Dynamo pattern (``backend_{mode}{index}_rank{rank}``, ``frontend{i}``)
+    so downstream grouping is identical across the two frontends. Aggregate
+    trtllm-serve is out of scope (disagg-only coverage).
     """
+    # trtllm-serve (worker and disagg orchestrator alike) exposes Prometheus
+    # text at /prometheus/metrics; every other frontend/backend uses /metrics.
+    metrics_path = "/prometheus/metrics" if frontend_type == "trtllm_serve" else "/metrics"
     dcgm_exporter = dcgm_exporter or tachometer.resolved_dcgm_exporter
     node_exporter = tachometer.resolved_node_exporter
     endpoints: list[TelemetryEndpoint] = []
@@ -106,14 +119,20 @@ def generate_tachometer_config(
             continue
         if frontend_type == "vllm-router" and process.http_port <= 0:
             continue
+        if frontend_type == "trtllm_serve" and (process.endpoint_mode == "agg" or process.http_port <= 0):
+            # trtllm-serve workers bind only the leader's OpenAI http_port;
+            # follower ranks serve nothing. Aggregate mode is out of scope
+            # (the one agg worker binds the public frontend port instead of
+            # process.http_port).
+            continue
         node_ip = get_hostname_ip(process.node, runtime.network_interface)
         if frontend_type == "vllm" and process.endpoint_mode == "agg":
             port = FRONTEND_PUBLIC_PORT
-        elif frontend_type == "vllm-router":
+        elif frontend_type in ("vllm-router", "trtllm_serve"):
             port = process.http_port
         else:
             port = process.sys_port
-        url = f"http://{node_ip}:{port}/metrics"
+        url = f"http://{node_ip}:{port}{metrics_path}"
         node_metadata = {
             "hostname": process.node,
             "worker_index": str(process.endpoint_index),
@@ -154,7 +173,7 @@ def generate_tachometer_config(
         endpoints.append(
             TelemetryEndpoint(
                 name=f"frontend{frontend_index}",
-                url=f"http://{node_ip}:{frontend_topology.frontend_port}/metrics",
+                url=f"http://{node_ip}:{frontend_topology.frontend_port}{metrics_path}",
                 collect_interval_ms=tachometer.collect_interval_ms,
                 filter="frontend",
                 node_metadata=node_metadata,

--- a/src/srtctl/frontends/trtllm_serve.py
+++ b/src/srtctl/frontends/trtllm_serve.py
@@ -187,7 +187,10 @@ class TRTLLMServeFrontend:
         if config.frontend.env:
             env_to_set.update(config.frontend.env)
 
-        orch_log = runtime.log_dir / f"{frontend_node}_trtllm_serve_orchestrator.out"
+        # Keep the Dynamo frontend's log naming pattern ({node}_frontend_{i}.out)
+        # so downstream tooling that globs *_frontend_*.out (perf dashboard,
+        # log collection) treats both frontends identically.
+        orch_log = runtime.log_dir / f"{frontend_node}_frontend_0.out"
         proc = start_srun_process(
             command=cmd,
             nodelist=[frontend_node],

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -392,6 +392,66 @@ class TestCustomBenchmarkRunner:
         assert "SRT_DECODE_ENDPOINTS" not in env
         assert env["AIPERF_SERVER_METRICS_URLS"] == "http://ip-node-a:6100/metrics"
 
+    def test_trtllm_serve_custom_endpoints_use_prometheus_path(self):
+        """Custom benchmarks against trtllm-serve advertise worker leaders'
+        OpenAI ports at /prometheus/metrics — the plain /metrics route there
+        is JSON iteration stats, not Prometheus exposition text."""
+        from unittest.mock import patch
+
+        from srtctl.benchmarks.custom import CustomBenchmarkRunner
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "prefill", 0, node_rank=1),
+            Process("node-c", frozenset(range(4)), 7502, 6100, "decode", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage("trtllm_serve", processes, backend_type="trtllm")
+
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_benchmark_env(CustomBenchmarkRunner())
+
+        assert env["AIPERF_SERVER_METRICS_URLS"] == (
+            "http://ip-node-a:6100/prometheus/metrics,http://ip-node-c:6100/prometheus/metrics"
+        )
+
+    def test_trtllm_serve_physical_endpoints_use_worker_http_ports(self):
+        """Built-in AIPerf path: trtllm-serve never binds the DYN_SYSTEM_PORT
+        sys-ports, so the physical-process URLs use leader http_ports at
+        /prometheus/metrics, gated on publish_events_and_metrics exactly like
+        the Dynamo sys-port path."""
+        from unittest.mock import patch
+
+        from srtctl.core.topology import Process
+
+        processes = [
+            Process("node-a", frozenset(range(4)), 7500, 6100, "prefill", 0, node_rank=0),
+            Process("node-b", frozenset(range(4)), 7501, 0, "prefill", 0, node_rank=1),
+            Process("node-c", frozenset(range(4)), 7502, 6100, "decode", 0, node_rank=0),
+        ]
+        stage = self._benchmark_stage(
+            "trtllm_serve", processes, backend_type="trtllm", publish_events_and_metrics=True
+        )
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage._get_aiperf_server_metrics_env()
+        assert env["AIPERF_SERVER_METRICS_URLS"] == (
+            "http://ip-node-a:6100/prometheus/metrics,http://ip-node-c:6100/prometheus/metrics"
+        )
+
+        # Without the metrics leg there is nothing to poll — no dead-port URLs.
+        stage_off = self._benchmark_stage("trtllm_serve", processes, backend_type="trtllm")
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            assert stage_off._get_aiperf_server_metrics_env() == {}
+
     def test_observability_does_not_reach_the_benchmark_client(self):
         """``observability`` configures what the servers emit, not the client.
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -527,6 +527,71 @@ class TestTachometerConfigGeneration:
         assert 'name = "backend_prefill0_rank0"' in config_text
         assert 'name = "backend_prefill0_rank1"' in config_text
 
+    @patch("srtctl.core.telemetry.get_hostname_ip", side_effect=lambda node, interface: f"ip-{node}")
+    def test_trtllm_serve_targets_worker_prometheus_endpoints(self, _mock_get_hostname_ip):
+        """frontend_type=trtllm_serve scrapes worker leaders on their OpenAI
+        http_port and the disagg orchestrator on the frontend port, both at
+        /prometheus/metrics (the worker /metrics route is JSON iteration
+        stats; the orchestrator registers no /metrics route). sys-ports are
+        never bound in this mode and follower ranks serve nothing, so neither
+        is targeted. Endpoint names keep the Dynamo pattern."""
+        tachometer = TachometerConfig(enabled=True)
+        runtime = MagicMock(job_id="12345", run_name="test_12345", network_interface="eth0")
+        runtime.log_dir = Path("/runs/12345/logs")
+        processes = [
+            Process(
+                node="node-a",
+                gpu_indices=frozenset({0}),
+                sys_port=7500,
+                http_port=6100,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=0,
+            ),
+            Process(
+                node="node-b",
+                gpu_indices=frozenset({0}),
+                sys_port=7501,
+                http_port=0,
+                endpoint_mode="prefill",
+                endpoint_index=0,
+                node_rank=1,
+            ),
+            Process(
+                node="node-c",
+                gpu_indices=frozenset({0}),
+                sys_port=7502,
+                http_port=6100,
+                endpoint_mode="decode",
+                endpoint_index=0,
+                node_rank=0,
+            ),
+        ]
+        topology = FrontendTopology(nginx_node=None, frontend_nodes=["head"], frontend_port=8000, public_port=8000)
+
+        config_text = generate_tachometer_config(
+            processes=processes,
+            frontend_topology=topology,
+            runtime=runtime,
+            tachometer=tachometer,
+            frontend_type="trtllm_serve",
+        )
+
+        # Worker leaders: OpenAI http_port at the Prometheus mount.
+        assert 'url = "http://ip-node-a:6100/prometheus/metrics"' in config_text
+        assert 'url = "http://ip-node-c:6100/prometheus/metrics"' in config_text
+        # Disagg orchestrator: frontend port at the Prometheus mount.
+        assert 'url = "http://ip-head:8000/prometheus/metrics"' in config_text
+        # Dead sys-ports and follower ranks are not targeted.
+        assert ":7500" not in config_text
+        assert ":7501" not in config_text
+        assert ":7502" not in config_text
+        assert "ip-node-b" not in config_text
+        # Naming stays aligned with the Dynamo frontend for downstream grouping.
+        assert 'name = "backend_prefill0_rank0"' in config_text
+        assert 'name = "backend_decode0_rank0"' in config_text
+        assert 'name = "frontend0"' in config_text
+
     @patch("srtctl.core.telemetry.get_hostname_ip", return_value="10.0.0.1")
     def test_generate_config_without_exporters_targets_servers_only(self, _mock_get_hostname_ip):
         tachometer = TachometerConfig(enabled=True, default_exporters=False)


### PR DESCRIPTION
## Summary

`frontend.type: trtllm_serve` runs collected **zero** engine or frontend metrics: telemetry scraped Dynamo-shaped targets (worker `DYN_SYSTEM_PORT` sys-ports, a frontend `/metrics` route) that this mode never binds, while the real metrics sat one port away. This PR points the tachometer scraper and the benchmark client at the Prometheus surfaces trtllm-serve disagg actually serves — and validates with an A/B benchmark that collecting them at the default cadence adds **no measurable performance overhead**, so default-on telemetry holds for this frontend too.

## What changes

- **Worker leaders** → scraped at `http://<ip>:<http_port>/prometheus/metrics`: the `prometheus_client` mount carrying the `trtllm_*` engine families (`tensorrt_llm/serve/openai_server.py` mounts it when `return_perf_metrics` is set, which `observability.enabled` already injects into the engine config). The plain `/metrics` route there is deliberately **not** scraped: it returns a JSON iteration-stats array, not Prometheus text, and reading it is destructive.
- **Disagg orchestrator** → scraped at `http://<ip>:<frontend_port>/prometheus/metrics` (mounted unconditionally by `openai_disagg_server.py`; it registers no `/metrics` route at all).
- **Follower ranks** (`http_port == 0`) are skipped — trtllm-serve workers bind only the leader's OpenAI port; followers serve nothing.
- **`AIPERF_SERVER_METRICS_URLS`** gets the same correction in both the custom (logical-leader) and built-in (physical-process) paths: it previously advertised sys-port URLs nothing binds in this mode (`trtllm-serve` binds only `--port <http_port>`; nothing in the TRT-LLM tree reads `DYN_SYSTEM*`).
- **Endpoint naming** keeps the Dynamo pattern (`backend_{mode}{i}_rank{r}`, `frontend{i}`) so parquet grouping is identical across frontends, enabling side-by-side dynamo-vs-trtllm-serve comparison; the orchestrator log is renamed `{node}_frontend_0.out` to match the Dynamo frontend's glob shape.

**Out of scope (deliberate):** aggregate trtllm-serve mode (disagg is the comparison of interest), the direct-host `--bash` lifecycle generator, and semantic mapping of the orchestrator's unprefixed family names onto `dynamo_frontend_*` (a post-processing concern).

## Collection validation

Four same-day runs on lyris GB300 (DeepSeek-V4 disagg via trtllm-serve: 1×4-GPU prefill + 3×8-GPU decode workers on 7 nodes, agentic trace replay, 600 s profiling, `observability.enabled: true`, all telemetry at the default 1000 ms cadence), interleaved **A / B / B / A**: **A** = `main` (b83dc4a8), **B** = this PR (the only delta).

| leg | parquet families | `trtllm_*` engine families | worker endpoints with data | frontend endpoints with data |
|---|---|---|---|---|
| A1 / A2 (main) | 144 | **0** | **0** | **0** |
| B1 / B2 (this PR) | **250** | **58** (all 4 worker leaders) | 4 | 1 (54 orchestrator `ctx_*`/`gen_*` families) |

On `main`, only DCGM and node-exporter data survives; every engine/frontend series is missing. With this PR the full engine surface (`trtllm_e2e_request_latency_seconds`, `trtllm_generation_tokens_total`, iteration latency, KV-cache families, …) and the orchestrator's disagg metrics are captured.

## Performance validation

Same four runs; primary metric is inter-token latency p50 (within-arm spread ≤0.4% across all chains of this A/B/B/A design on this cluster, so ~2% effects are unambiguous).

| metric | A1 | A2 | B1 | B2 | B vs A mean |
|---|---|---|---|---|---|
| **inter-token latency p50 (ms)** | 5.622 | 5.586 | 5.632 | 5.600 | **+0.22%** |
| output tok/s per user | 179.6 | 182.5 | 178.2 | 180.5 | −0.9% |
| output tok/s (total) | 248.1 | 282.5 | 268.1 | 265.2 | +0.5% |
| request throughput (req/s) | 0.208 | 0.230 | 0.225 | 0.232 | +4.3% |
| TTFT p50 (ms) | 1379 | 1345 | 1318 | 1319 | −3.2% |
| TTFT p99 (s) | 89.7 | 57.7 | 70.6 | 60.3 | −11.2% |
| inter-token latency p99 (ms) | 6.48 | 6.64 | 7.58 | 6.38 | +6.4% (single-leg B1; B2 below both A) |

**Verdict: parity.** The precision metric is flat (+0.22%); the remaining deltas sit inside this workload's run-to-run noise (the largest TTFT p99 outlier is in a *bare* leg, A1). Zero request errors or cancellations in any leg. Jobs: A1=2947452, B1=2947523, B2=2947580, A2=2947649 (lyris).

## Testing

`make check`: 1697 passed, 2 skipped. New tests: `test_trtllm_serve_targets_worker_prometheus_endpoints`, `test_trtllm_serve_custom_endpoints_use_prometheus_path`, `test_trtllm_serve_physical_endpoints_use_worker_http_ports`.
