### PR TITLE
Add dynamo.source and pin source revs to commits at submit

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1020,21 +1020,34 @@ Dynamo installation configuration.
 
 ```yaml
 dynamo:
-  version: "0.8.0"            # Install from PyPI
-  # OR
-  hash: "abc123"              # Install from git commit
-  # OR
-  top_of_tree: true           # Install from main branch
-  sidecar: false               # Use native engines with Dynamo sidecars
+  source:                     # 2.0: one block for where Dynamo comes from
+    git: https://github.com/ai-dynamo/dynamo
+    rev: refs/pull/14000/head # a commit, a tag, or a PR head; never a branch name
+    # sha: <filled in by srtctl apply>
+  sidecar: false              # Use native engines with Dynamo sidecars
+```
+
+```yaml
+dynamo:
+  source:
+    pypi: "1.4.2"             # a release from PyPI
+```
+
+```yaml
+dynamo:
+  source:
+    wheel: "1.5.0.dev20260901" # a staged nightly wheel
 ```
 
 | Field                    | Type         | Default | Description                                            |
 | ------------------------ | ------------ | ------- | ------------------------------------------------------ |
 | `install`                | bool         | true    | Whether to install dynamo (set false if pre-installed) |
-| `version`                | string       | "0.8.0" | PyPI version                                           |
-| `hash`                   | string       | null    | Git commit hash (source install)                       |
-| `top_of_tree`            | bool         | false   | Install from main branch                               |
-| `wheel`                  | string       | null    | Exact `ai-dynamo` nightly version                      |
+| `source`                 | object       | null    | Exactly one of `git` + `rev` (optionally `patches`, `sha`), `pypi`, or `wheel`; see below |
+| `version`                | string       | "0.8.0" | Legacy: PyPI version (same as `source.pypi`)           |
+| `hash`                   | string       | null    | Legacy: git commit hash (same as `source.git` + `rev`) |
+| `top_of_tree`            | bool         | false   | Legacy: install from main branch                       |
+| `wheel`                  | string       | null    | Legacy: exact `ai-dynamo` nightly version (same as `source.wheel`) |
+| `cargo_patches`          | list[string] | null    | Legacy: Cargo dependency replacements (same as `source.patches`) |
 | `sidecar`                | bool         | false   | Replace legacy Python workers with native engines and Dynamo sidecars |
 | `sidecar_port`           | int          | 50051   | Base loopback gRPC port; co-located workers receive deterministic offsets |
 | `sidecar_binary`         | string/null  | null    | Optional standalone executable; null uses `python3 -m dynamo.<framework>.sidecar` |
@@ -1045,10 +1058,12 @@ dynamo:
 **Notes**:
 
 - Set `install: false` if your container already has dynamo pre-installed.
-- Only one of `version`, `hash`, or `top_of_tree` should be specified.
-- `hash` and `top_of_tree` are mutually exclusive.
-- When `hash` or `top_of_tree` is set, `version` is automatically cleared.
-- Source installs (`hash` or `top_of_tree`) clone the repo and build with maturin.
+- `source` is the same shape `services[].source` uses. `git` defaults to the upstream repository when only `rev` is given, so a fork is `git: https://github.com/<you>/dynamo`.
+- `rev` must be immutable: a commit SHA, a tag such as `v1.4.2`, or `refs/pull/<n>/head` for an unmerged PR. `main`, `master`, and `HEAD` are rejected; use `top_of_tree: true` if you really want a moving target.
+- `srtctl apply` resolves a non-commit `rev` with `git ls-remote`, writes the commit as `source.sha` into the submitted `config.yaml` (comments preserved, the recipe on disk is untouched), and echoes it as `pinned_sources` in `--json` output. The job builds that commit and the `/configs/dynamo-wheels` cache is keyed by it, so two runs of one recipe cannot silently build different code because the PR moved. If the login node cannot reach the remote, the submit continues with a warning and the compute node fetches the ref by name.
+- `source` cannot be combined with `hash`, `top_of_tree`, `wheel`, or `cargo_patches`. The legacy fields keep working unchanged; `source` maps onto them at load, so nothing downstream changes.
+- Source installs (`source.git`, `hash`, or `top_of_tree`) clone the repo and build with maturin; `patches` / `cargo_patches` replace Cargo dependency declarations tree-wide before the build.
+- `srtctl dry-run` prints the resolved Dynamo source.
 
 ### Native sidecar mode
 

--- a/docs/schema-reference.md
+++ b/docs/schema-reference.md
@@ -114,6 +114,7 @@ Dynamo installation configuration.
 | `hash` | str \| None | `None` |  |
 | `top_of_tree` | bool | `False` |  |
 | `wheel` | str \| None | `None` |  |
+| `source` | [DynamoSourceConfig](#dynamosourceconfig) \| None | `None` | The 2.0 way to say which Dynamo: one of git+rev, pypi, or wheel. Mapped onto the legacy fields above in __post_init__, so every consumer keeps reading hash / version / wheel / cargo_patches unchanged. |
 | `request_plane` | str | `'tcp'` |  |
 | `event_plane` | str \| None | `None` |  |
 | `sidecar` | bool | `False` |  |
@@ -274,7 +275,7 @@ One entry of the top-level ``services:`` list.
 | `args` | list[str] | `[]` | Extra argv appended to ``command``. |
 | `container` | str \| None | `None` | Container image or ``srtslurm.yaml`` alias. Defaults to the kind's fallback (Mooncake's ``mooncake_kv_store.container``), then the job container. |
 | `env` | dict[str, str] | `{}` | Environment for the service process, on top of what the kind injects. |
-| `source` | [ServiceSourceConfig](#servicesourceconfig) \| None | `None` | Optional git source to clone before ``build_command`` and ``command`` run. Single-node placements only. |
+| `source` | [SourceConfig](#sourceconfig) \| None | `None` | Optional git source to clone before ``build_command`` and ``command`` run. Single-node placements only. |
 | `build_command` | list[str] \| None | `None` | Argv run once inside the service container, from the clone, before ``command`` starts. Only meaningful with ``source``. |
 | `placement` | [ServicePlacementConfig](#serviceplacementconfig) | `ServicePlacementConfig()` | Where the service runs. Default ``head``. |
 | `start` | str \| None | `None` | ``after_frontend`` (default for ``generic``) or ``before_workers`` (default for ``mooncake-store``). |
@@ -306,6 +307,19 @@ Reporting configuration for status updates, AI analysis, and log exports.
 | `status` | [ReportingStatusConfig](#reportingstatusconfig) \| None | `None` |  |
 | `ai_analysis` | [AIAnalysisConfig](#aianalysisconfig) \| None | `None` |  |
 | `s3` | [S3Config](#s3config) \| None | `None` |  |
+
+### DynamoSourceConfig
+
+Where Dynamo comes from. Exactly one of ``git``, ``pypi``, or ``wheel``.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `git` | str \| None | `None` | Repository URL to build from (default upstream when ``rev`` is set without it). Builds ``ai-dynamo-runtime`` with maturin and installs ``ai-dynamo`` from the checkout; cached on ``/configs`` by commit. |
+| `rev` | str \| None | `None` | Immutable ref in ``git``: commit SHA, tag, or ``refs/pull/<n>/head``. |
+| `sha` | str \| None | `None` | The commit ``rev`` resolved to; filled in by ``srtctl apply``. |
+| `patches` | list[str] \| None | `None` | Cargo dependency replacements applied tree-wide before the build (the legacy ``cargo_patches``). |
+| `pypi` | str \| None | `None` | Release version from PyPI (the legacy ``version``). |
+| `wheel` | str \| None | `None` | Staged nightly ``ai-dynamo`` version (the legacy ``wheel``). |
 
 ### SweepConfig
 
@@ -352,15 +366,16 @@ Configuration for a metrics exporter deployed on worker nodes.
 | `port` | int | required |  |
 | `command` | str \| None | `None` |  |
 
-### ServiceSourceConfig
+### SourceConfig
 
-Git source to build a service from before launching it.
+A git repository at an immutable ref.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `git` | str | required | Repository URL to clone. |
-| `rev` | str | required | Immutable ref to check out: a commit SHA, a tag, or ``refs/pull/<n>/head`` for an unmerged PR. Branch names are rejected because they move out from under a build. |
-| `path` | str \| None | `None` | Optional subdirectory of the clone that ``build_command`` and ``command`` run from. Defaults to the repository root. |
+| `rev` | str | required | Immutable ref: a commit SHA, a tag, or ``refs/pull/<n>/head`` for an unmerged PR. Branch names are rejected because they move. |
+| `path` | str \| None | `None` | Optional subdirectory of the clone to build and run from. |
+| `sha` | str \| None | `None` | The commit ``rev`` resolved to. Filled in by ``srtctl apply`` at submit time; write it yourself only to pin an exact commit while keeping the human-readable ``rev`` beside it. |
 
 ### ServicePlacementConfig
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -152,6 +152,12 @@ the service node (git and network access are host concerns, and the job containe
 PR. `main`, `master`, and `HEAD` are rejected at load time. Because the build installs into one
 container instance, `source` is only allowed with single-node placements (`head`, `infra`).
 
+`source` is the same shape `dynamo.source` uses. At submit time `srtctl apply` resolves a non-commit
+`rev` with `git ls-remote` and records the commit as `source.sha` in the submitted `config.yaml`
+(the recipe on disk is untouched), so the job checks out exactly the commit the lockfile names even
+if the PR is pushed to again while the job waits in the queue. `--json` output lists what was pinned
+under `pinned_sources`. `srtctl dry-run` never touches the network.
+
 ## Service Types
 
 `type` selects a registered `ServiceKind` (`src/srtctl/services/`). A kind supplies defaults and the

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ Aggregated examples run two TP1 workers; disaggregated examples run one TP1 pref
 | `features/override.yaml` | `base` plus `override_*` and `zip_override_*` variants in one file |
 | `features/profiling.yaml` | `profiling:` torch capture on an aggregated worker |
 | `features/services.yaml` | `services:` sidecar (an HTTP log browser on the head node) with a `readiness:` port gate |
+| `features/dynamo-source.yaml` | `dynamo.source:` building Dynamo from a git tag (or a PR head via `--set dynamo.source.rev=refs/pull/<n>/head`), pinned to a commit at submit |
 
 ## Cluster aliases
 

--- a/examples/features/dynamo-source.yaml
+++ b/examples/features/dynamo-source.yaml
@@ -1,0 +1,61 @@
+# Dynamo built from a git ref instead of installed from PyPI.
+#
+# `dynamo.source` is one block for where Dynamo comes from: `git` + `rev`
+# (a commit, a tag, or `refs/pull/<n>/head` for an unmerged PR), or `pypi`, or
+# `wheel`. `srtctl apply` resolves a non-commit `rev` to a commit with
+# `git ls-remote` and records it as `sha` in the submitted config.yaml, so the
+# job builds exactly what the lockfile names and the /configs build cache is
+# keyed by commit. The build (rustup if needed, maturin, pip install) runs once
+# per commit per cluster and is reused by later jobs.
+#
+# To test a Dynamo PR: --set dynamo.source.rev=refs/pull/<n>/head
+#
+# Aliases (`qwen3-0.6b`, `sglang`) resolve through srtslurm.yaml; see examples/README.md.
+
+schema: 2
+name: "qwen3-0.6b-dynamo-source"
+
+slurm:
+  time_limit: "01:00:00"    # a cold build takes longer than a PyPI install
+
+model:
+  path: "qwen3-0.6b"
+  container: "sglang"
+  precision: "bf16"
+
+resources:
+  gpu_type: "h100"
+  gpus_per_node: 8
+
+dynamo:
+  source:
+    git: https://github.com/ai-dynamo/dynamo
+    rev: v1.4.2               # same release the PyPI examples install
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "kv"
+
+backend:
+  type: sglang
+roles:
+  agg:
+    nodes: 1
+    workers: 2
+    gpus: 1
+    env:
+      PYTHONUNBUFFERED: "1"
+    args:
+      served-model-name: "Qwen/Qwen3-0.6B"
+      tensor-parallel-size: 1
+      mem-fraction-static: 0.5
+      context-length: 4096
+      disable-piecewise-cuda-graph: true
+
+benchmark:
+  type: "sa-bench"
+  isl: 128
+  osl: 128
+  concurrencies: "4x8"

--- a/src/srtctl/cli/mixins/service_stage.py
+++ b/src/srtctl/cli/mixins/service_stage.py
@@ -150,11 +150,11 @@ class ServiceStageMixin:
             f"set -e; mkdir -p {shlex.quote(str(checkout_root.parent))}; "
             f"if [ ! -d {root} ]; then "
             f"{git} clone --filter=blob:none {shlex.quote(source.git)} {root} && "
-            f"{git} -C {root} fetch origin {shlex.quote(source.rev)} && "
+            f"{git} -C {root} fetch origin {shlex.quote(source.checkout)} && "
             f"{git} -C {root} checkout FETCH_HEAD; "
             "fi"
         )
-        logger.info("Cloning service %s source %s@%s on %s", service.name, source.git, source.rev, node)
+        logger.info("Cloning service %s source %s@%s on %s", service.name, source.git, source.checkout, node)
         popen = start_srun_process(
             command=["bash", "-c", clone_script],
             nodelist=[node],

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -71,11 +71,16 @@ _submissions: list[dict] = []
 # Rendered --set/--unset overrides for the current invocation; echoed into every
 # submission record so a caller can see exactly what was applied.
 _active_overrides: list[str] = []
+# "dynamo.source: refs/pull/14000/head -> <sha>" notes from pinning source revs at
+# submit time; echoed the same way so a caller can see exactly what will build.
+_pinned_sources: list[str] = []
 
 
 def _record_submission(data: dict) -> None:
     if _active_overrides:
         data["applied_overrides"] = list(_active_overrides)
+    if _pinned_sources:
+        data["pinned_sources"] = list(_pinned_sources)
     _submissions.append(data)
 
 
@@ -435,6 +440,17 @@ def show_config_details(config: SrtConfig) -> None:
         console.print(
             "[dim]srun --export (dynamo install):[/] ALL,ENROOT_REMAP_ROOT=yes [dim](workers + dynamo frontend)[/]"
         )
+        source = config.dynamo.source
+        if source is not None and source.git:
+            console.print(f"[dim]dynamo source:[/] {source.git} @ {source.rev}", crop=False)
+            if source.sha:
+                console.print(f"[dim]dynamo source sha:[/] {source.sha}", crop=False)
+            else:
+                console.print("[dim]dynamo source sha:[/] resolved from rev at submit (srtctl apply)")
+        elif source is not None and source.pypi:
+            console.print(f"[dim]dynamo source:[/] PyPI ai-dynamo=={source.pypi}")
+        elif source is not None and source.wheel:
+            console.print(f"[dim]dynamo source:[/] staged wheel ai-dynamo=={source.wheel}")
 
     show_extensions = (
         config.benchmark.type == "custom"
@@ -1298,36 +1314,56 @@ def is_override_config(config_path: Path) -> bool:
 
 
 @contextlib.contextmanager
-def materialize_config_path(config_path: Path, overrides: Sequence[Any] = ()):
-    """Stage stdin-backed or --set/--unset-modified configs to a temporary YAML file.
+def materialize_config_path(config_path: Path, overrides: Sequence[Any] = (), *, pin_sources: bool = False):
+    """Stage stdin-backed, --set/--unset-modified, or source-pinned configs to a temporary YAML file.
 
     Overrides are applied to the raw document (comments preserved) before any
     reader sees it, so they take effect identically for plain, sweep, and
     override-format files and end up in the config.yaml copied into the job
-    output directory. The source file is never modified.
+    output directory. With ``pin_sources`` (submit only), every ``source.rev``
+    that is not already a commit is resolved with ``git ls-remote`` and recorded
+    as ``source.sha`` in that same document, so the job builds exactly the
+    commit the lockfile names. The source file is never modified.
     """
     from_stdin = str(config_path) in {"-", "/dev/stdin"}
-    if not from_stdin and not overrides:
+    if not from_stdin and not overrides and not pin_sources:
         yield config_path
         return
     if not from_stdin and (not config_path.exists() or config_path.is_dir()):
-        if config_path.is_dir():
+        if config_path.is_dir() and overrides:
             raise ValueError("--set/--unset apply to a single config file, not a directory")
-        yield config_path  # let the caller report the missing file
+        yield config_path  # let the caller report the missing file, or handle the directory
         return
 
     payload = sys.stdin.read() if from_stdin else config_path.read_text()
     if not payload.strip():
         raise ValueError("No YAML received on stdin" if from_stdin else f"{config_path} is empty")
 
-    if overrides:
-        from srtctl.core.overrides import apply_overrides_to_recipe
+    changed = from_stdin
+    if overrides or pin_sources:
         from srtctl.core.yaml_utils import dump_yaml_with_comments, load_yaml_text_with_comments
 
         document = load_yaml_text_with_comments(payload)
-        for entry in apply_overrides_to_recipe(document, overrides):
-            logger.info("Applied override: %s", entry)
-        payload = dump_yaml_with_comments(document) or ""
+        if overrides:
+            from srtctl.core.overrides import apply_overrides_to_recipe
+
+            for entry in apply_overrides_to_recipe(document, overrides):
+                logger.info("Applied override: %s", entry)
+            changed = True
+        if pin_sources and "source" in payload:
+            from srtctl.core.source import pin_source_revs
+
+            pinned = pin_source_revs(document)
+            for entry in pinned:
+                logger.info("Pinned source: %s", entry)
+            _pinned_sources.extend(pinned)
+            changed = changed or bool(pinned)
+        if changed:
+            payload = dump_yaml_with_comments(document) or ""
+
+    if not changed:
+        yield config_path
+        return
 
     fd, temp_path = tempfile.mkstemp(
         suffix=".yaml",
@@ -1845,7 +1881,9 @@ def main():
     tags = [t.strip() for t in (getattr(args, "tags", "") or "").split(",") if t.strip()] or None
 
     try:
-        with materialize_config_path(config_path, overrides) as effective_config_path:
+        with materialize_config_path(
+            config_path, overrides, pin_sources=args.command == "apply"
+        ) as effective_config_path:
             if not effective_config_path.exists():
                 console.print(f"[bold red]Config not found:[/] {config_path}")
                 sys.exit(1)

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -47,6 +47,7 @@ from srtctl.core.formatting import (
 
 # Leaf module (stdlib-only imports), so this cannot cycle back into schema.
 from srtctl.core.power.contract import CONTAINER_LOG_DIR
+from srtctl.core.source import DynamoSourceConfig, is_commit_sha
 from srtctl.services.config import ServiceConfig
 
 logger = logging.getLogger(__name__)
@@ -1331,13 +1332,19 @@ _DYNAMO_CACHE_ROOT = "/configs/dynamo-wheels"
 
 
 def dynamo_source_cache_key(dynamo_hash: str, cargo_patches: list[str] | None = None) -> str:
-    """Return the cache key shared by Slurm and direct source builds."""
+    """Return the cache key shared by Slurm and direct source builds.
+
+    A ref that is not a commit (``refs/pull/14000/head`` when ``srtctl apply``
+    could not pin it) is sanitized into a directory name; such a key can go
+    stale as the ref moves, which is why apply pins refs to SHAs up front.
+    """
+    key = dynamo_hash.strip().replace("/", "-")
     if not cargo_patches:
-        return dynamo_hash
+        return key
     # Version the build recipe so a patching change invalidates old artifacts
     # even when the dependency declarations themselves do not change.
     digest = hashlib.sha1(("dep-override-v3\n" + "\n".join(cargo_patches)).encode()).hexdigest()[:8]
-    return f"{dynamo_hash}-patch-{digest}"
+    return f"{key}-patch-{digest}"
 
 
 def dynamo_cargo_patch_commands(cargo_patches: list[str] | None = None) -> tuple[str, ...]:
@@ -1363,8 +1370,17 @@ def _git_clone_cmd() -> str:
     return shlex.join(git_clone_command_prefix())
 
 
-def _hash_cached_source_install(dynamo_hash: str, cargo_patches: list[str] | None = None) -> str:
+def _hash_cached_source_install(
+    dynamo_hash: str,
+    cargo_patches: list[str] | None = None,
+    repo_url: str = DynamoSourceConfig.DEFAULT_GIT,
+) -> str:
     """Bash for hash-pinned source install with a /configs/dynamo-wheels cache.
+
+    ``dynamo_hash`` is normally a commit SHA (``srtctl apply`` pins
+    ``dynamo.source.rev`` before submit). A bare ref such as
+    ``refs/pull/14000/head`` still works: it is fetched by name and checked out
+    as ``FETCH_HEAD``, since a plain clone does not carry PR refs.
 
     Cache layout: ``{root}/<key>/`` contains the maturin wheel
     (``ai_dynamo_runtime-*.whl``), a tarball of the dynamo source tree
@@ -1391,6 +1407,11 @@ def _hash_cached_source_install(dynamo_hash: str, cargo_patches: list[str] | Non
         override_cmd += " && "
     cache = f"{_DYNAMO_CACHE_ROOT}/{cache_key}"
     lock = f"{_DYNAMO_CACHE_ROOT}/.{cache_key}.lock"
+    checkout_cmd = (
+        f"git checkout {dynamo_hash}"
+        if is_commit_sha(dynamo_hash)
+        else f"git fetch origin {shlex.quote(dynamo_hash)} && git checkout FETCH_HEAD"
+    )
     return (
         f"echo 'Installing dynamo from source ({dynamo_hash}, /configs cache)...' && "
         f"mkdir -p {_DYNAMO_CACHE_ROOT} && "
@@ -1410,8 +1431,8 @@ def _hash_cached_source_install(dynamo_hash: str, cargo_patches: list[str] | Non
         f"pip install --break-system-packages --force-reinstall --quiet maturin && "
         # Clone + build the runtime wheel.
         f"DYN_BUILD_DIR=$(mktemp -d) && cd $DYN_BUILD_DIR && "
-        f"{_git_clone_cmd()} clone https://github.com/ai-dynamo/dynamo.git && "
-        f"cd dynamo && git checkout {dynamo_hash} && "
+        f"{_git_clone_cmd()} clone {shlex.quote(repo_url)} dynamo && "
+        f"cd dynamo && {checkout_cmd} && "
         f"{override_cmd}"
         f"cd lib/bindings/python/ && "
         f'export RUSTFLAGS="${{RUSTFLAGS:-}} -C target-cpu=native --cfg tokio_unstable" && '
@@ -1545,6 +1566,9 @@ class DynamoConfig:
         top_of_tree: Clone repo at HEAD (latest)
         wheel: ai-dynamo package version to install via staged wheels. The
                matching ai-dynamo-runtime wheel is installed automatically.
+        source: One block for all of the above: ``git`` + ``rev`` (commit, tag,
+               or ``refs/pull/<n>/head``; ``srtctl apply`` pins it to ``sha``),
+               ``pypi``, or ``wheel``. Cannot be combined with the legacy fields.
         request_plane: Request plane to use (default: "tcp"). Valid values: "nats", "tcp", "http"
         event_plane: Event plane override, sets DYN_EVENT_PLANE (default: None — follow
                      the Dynamo image's own default). Valid values: "nats", "zmq"
@@ -1561,6 +1585,10 @@ class DynamoConfig:
     hash: str | None = None
     top_of_tree: bool = False
     wheel: str | None = None
+    # The 2.0 way to say which Dynamo: one of git+rev, pypi, or wheel. Mapped onto
+    # the legacy fields above in __post_init__, so every consumer keeps reading
+    # hash / version / wheel / cargo_patches unchanged.
+    source: DynamoSourceConfig | None = None
     request_plane: str = "tcp"
     event_plane: str | None = None
     sidecar: bool = False
@@ -1577,6 +1605,27 @@ class DynamoConfig:
     cargo_patches: list[str] | None = None
 
     def __post_init__(self) -> None:
+        if self.source is not None:
+            legacy = [
+                name
+                for name, on in (
+                    ("hash", self.hash is not None),
+                    ("top_of_tree", self.top_of_tree),
+                    ("wheel", self.wheel is not None),
+                    ("cargo_patches", bool(self.cargo_patches)),
+                )
+                if on
+            ]
+            if legacy:
+                raise ValueError("dynamo.source cannot be combined with dynamo." + ", dynamo.".join(legacy))
+            if self.source.pypi is not None:
+                object.__setattr__(self, "version", self.source.pypi)
+            elif self.source.wheel is not None:
+                object.__setattr__(self, "wheel", self.source.wheel)
+            else:
+                object.__setattr__(self, "hash", self.source.checkout)
+                object.__setattr__(self, "cargo_patches", list(self.source.patches) if self.source.patches else None)
+
         install_sources = [
             ("hash", self.hash is not None),
             ("top_of_tree", self.top_of_tree),
@@ -1692,7 +1741,10 @@ class DynamoConfig:
         # to ~10 sec lustre access for repeat hashes. top_of_tree skips the
         # cache (no stable key) and always live-builds.
         if self.hash is not None:
-            return _hash_cached_source_install(self.hash, self.cargo_patches)
+            repo_url = (
+                self.source.git if self.source is not None and self.source.git else DynamoSourceConfig.DEFAULT_GIT
+            )
+            return _hash_cached_source_install(self.hash, self.cargo_patches, repo_url=repo_url)
 
         return _live_source_install_for_top_of_tree()
 

--- a/src/srtctl/core/source.py
+++ b/src/srtctl/core/source.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One way to say "this code, from git": the ``source:`` shape.
+
+Used by ``services[].source`` (build a sidecar before launching it) and
+``dynamo.source`` (which Dynamo to install). A source names a repository and an
+immutable ref. Because a ref like ``refs/pull/14000/head`` moves, ``srtctl apply``
+resolves every non-SHA ``rev`` to a commit with ``git ls-remote`` and records it
+as ``sha`` in the submitted ``config.yaml`` (see :func:`pin_source_revs`), so the
+job builds exactly what the lockfile says and build caches key on the commit.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from typing import Any, ClassVar
+
+from marshmallow import Schema, ValidationError
+from marshmallow_dataclass import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Branch names that move out from under a build. Tags, SHAs, and PR head refs are fine.
+MOVING_REFS: frozenset[str] = frozenset({"main", "master", "HEAD"})
+
+# 4 is git's minimum abbreviation; legacy recipes pin short hashes like "abc123".
+_SHA_RE = re.compile(r"^[0-9a-f]{4,40}$")
+
+
+def is_commit_sha(rev: str) -> bool:
+    """Whether ``rev`` already names a commit (4 to 40 hex chars, an abbreviated or full SHA)."""
+    return bool(_SHA_RE.match(rev.strip()))
+
+
+def validate_ref(rev: str, *, where: str) -> None:
+    """Reject empty or moving refs; ``where`` labels the recipe path in the error."""
+    if not rev.strip():
+        raise ValidationError(f"{where}.rev must be a non-empty ref (commit SHA, tag, or refs/pull/<n>/head)")
+    if rev.strip() in MOVING_REFS:
+        raise ValidationError(
+            f"{where}.rev must be an immutable ref (commit SHA, tag, or refs/pull/<n>/head), "
+            f"not a moving branch name: {rev!r}"
+        )
+
+
+def resolve_rev(git: str, rev: str, *, timeout: float = 60.0) -> str:
+    """Resolve ``rev`` in ``git`` to a commit SHA with ``git ls-remote``.
+
+    A SHA is returned as-is. For a tag the peeled commit (``<ref>^{}``) is
+    preferred over the tag object so annotated and lightweight tags resolve
+    the same way. Raises ``RuntimeError`` when the ref does not exist or the
+    remote cannot be reached.
+    """
+    rev = rev.strip()
+    if is_commit_sha(rev):
+        return rev
+    patterns = [rev, f"refs/tags/{rev}", f"refs/heads/{rev}"] if not rev.startswith("refs/") else [rev]
+    cmd = ["git", "-c", "http.version=HTTP/1.1", "ls-remote", git, *patterns, *(f"{p}^{{}}" for p in patterns)]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env={"GIT_TERMINAL_PROMPT": "0", "PATH": "/usr/bin:/bin:/usr/local/bin"},
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"git ls-remote {git} {rev} failed: {exc}") from exc
+    if result.returncode != 0:
+        raise RuntimeError(f"git ls-remote {git} {rev} failed (exit {result.returncode}): {result.stderr.strip()}")
+    found: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        sha, _, ref = line.partition("\t")
+        if sha and ref:
+            found[ref] = sha
+    for pattern in patterns:
+        for candidate in (f"{pattern}^{{}}", pattern):
+            if candidate in found:
+                return found[candidate]
+    raise RuntimeError(f"ref {rev!r} not found in {git}")
+
+
+@dataclass(frozen=True)
+class SourceConfig:
+    """A git repository at an immutable ref.
+
+    Attributes:
+        git: Repository URL to clone.
+        rev: Immutable ref: a commit SHA, a tag, or ``refs/pull/<n>/head`` for
+            an unmerged PR. Branch names are rejected because they move.
+        path: Optional subdirectory of the clone to build and run from.
+        sha: The commit ``rev`` resolved to. Filled in by ``srtctl apply`` at
+            submit time; write it yourself only to pin an exact commit while
+            keeping the human-readable ``rev`` beside it.
+    """
+
+    git: str
+    rev: str
+    path: str | None = None
+    sha: str | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        if not self.git.strip():
+            raise ValidationError("source.git must be a non-empty repository URL")
+        validate_ref(self.rev, where="source")
+        if self.path is not None and not self.path.strip():
+            raise ValidationError("source.path must not be blank when set")
+        if self.sha is not None and not is_commit_sha(self.sha):
+            raise ValidationError(f"source.sha must be a commit SHA, got {self.sha!r}")
+
+    @property
+    def checkout(self) -> str:
+        """What to actually check out: the pinned commit when present, else the ref."""
+        return self.sha or self.rev.strip()
+
+
+@dataclass(frozen=True)
+class DynamoSourceConfig:
+    """Where Dynamo comes from. Exactly one of ``git``, ``pypi``, or ``wheel``.
+
+    Attributes:
+        git: Repository URL to build from (default upstream when ``rev`` is set
+            without it). Builds ``ai-dynamo-runtime`` with maturin and installs
+            ``ai-dynamo`` from the checkout; cached on ``/configs`` by commit.
+        rev: Immutable ref in ``git``: commit SHA, tag, or ``refs/pull/<n>/head``.
+        sha: The commit ``rev`` resolved to; filled in by ``srtctl apply``.
+        patches: Cargo dependency replacements applied tree-wide before the
+            build (the legacy ``cargo_patches``).
+        pypi: Release version from PyPI (the legacy ``version``).
+        wheel: Staged nightly ``ai-dynamo`` version (the legacy ``wheel``).
+    """
+
+    DEFAULT_GIT: ClassVar[str] = "https://github.com/ai-dynamo/dynamo.git"
+
+    git: str | None = None
+    rev: str | None = None
+    sha: str | None = None
+    patches: list[str] | None = None
+    pypi: str | None = None
+    wheel: str | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        if self.rev is not None and self.git is None:
+            object.__setattr__(self, "git", self.DEFAULT_GIT)
+        chosen = [name for name, on in (("git", self.git), ("pypi", self.pypi), ("wheel", self.wheel)) if on]
+        if len(chosen) != 1:
+            raise ValidationError(
+                f"dynamo.source needs exactly one of git (with rev), pypi, or wheel; got {', '.join(chosen) or 'none'}"
+            )
+        if self.git is not None:
+            if not self.git.strip():
+                raise ValidationError("dynamo.source.git must be a non-empty repository URL")
+            if self.rev is None:
+                raise ValidationError("dynamo.source.git requires rev (commit SHA, tag, or refs/pull/<n>/head)")
+            validate_ref(self.rev, where="dynamo.source")
+        elif self.rev is not None or self.sha is not None or self.patches:
+            raise ValidationError("dynamo.source.rev, sha, and patches only apply to a git source")
+        if self.sha is not None and not is_commit_sha(self.sha):
+            raise ValidationError(f"dynamo.source.sha must be a commit SHA, got {self.sha!r}")
+        for name in ("pypi", "wheel"):
+            value = getattr(self, name)
+            if value is not None and not value.strip():
+                raise ValidationError(f"dynamo.source.{name} must be a non-empty version")
+
+    @property
+    def checkout(self) -> str | None:
+        """Commit or ref to check out for a git source; None otherwise."""
+        if self.git is None or self.rev is None:
+            return None
+        return self.sha or self.rev.strip()
+
+
+def pin_source_revs(document: Any, *, resolve=None) -> list[str]:
+    """Resolve every unpinned ``source.rev`` in a raw recipe document to a ``sha``, in place.
+
+    Walks the whole document (plain, sweep, and override-format files alike),
+    so it works on the comment-preserving ``ruamel`` tree before any reader
+    sees it. A ``source`` mapping is any dict under the key ``source`` with
+    ``git`` and ``rev`` and no ``sha``. A resolution failure is logged and left
+    unpinned rather than blocking the submit; the install path then fetches
+    the ref by name on the compute node.
+
+    Returns one human-readable note per pinned source.
+    """
+    resolve = resolve or resolve_rev
+    notes: list[str] = []
+
+    def walk(node: Any, path: tuple[Any, ...]) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "source" and isinstance(value, dict) and value.get("git") and value.get("rev"):
+                    if not value.get("sha"):
+                        git, rev = str(value["git"]), str(value["rev"])
+                        dotted = ".".join(str(p) for p in (*path, key))
+                        if is_commit_sha(rev):
+                            continue
+                        try:
+                            sha = resolve(git, rev)
+                        except RuntimeError as exc:
+                            logger.warning(
+                                "%s: could not pin rev %r (%s); the job will fetch the ref by name and "
+                                "any build cache keys on the ref, not the commit",
+                                dotted,
+                                rev,
+                                exc,
+                            )
+                            continue
+                        value["sha"] = sha
+                        notes.append(f"{dotted}: {rev} -> {sha}")
+                    continue
+                if isinstance(value, dict | list):
+                    walk(value, (*path, key))
+        elif isinstance(node, list):
+            for index, item in enumerate(node):
+                walk(item, (*path, index))
+
+    walk(document, ())
+    return notes
+
+
+__all__ = [
+    "MOVING_REFS",
+    "DynamoSourceConfig",
+    "SourceConfig",
+    "is_commit_sha",
+    "pin_source_revs",
+    "resolve_rev",
+    "validate_ref",
+]

--- a/src/srtctl/services/config.py
+++ b/src/srtctl/services/config.py
@@ -19,6 +19,8 @@ from typing import ClassVar
 from marshmallow import Schema, ValidationError
 from marshmallow_dataclass import dataclass
 
+from srtctl.core.source import SourceConfig
+
 logger = logging.getLogger(__name__)
 
 # Where a service runs. head / infra are one node; prefill / decode / agg are the
@@ -29,41 +31,8 @@ SINGLE_NODE_PLACEMENTS: frozenset[str] = frozenset({"head", "infra"})
 # When a service starts relative to the rest of the job.
 SERVICE_STARTS: tuple[str, ...] = ("before_workers", "after_frontend")
 
-# Immutable-ref guard for services[].source.rev.
-_MOVING_REFS: frozenset[str] = frozenset({"main", "master", "HEAD"})
-
-
-@dataclass(frozen=True)
-class ServiceSourceConfig:
-    """Git source to build a service from before launching it.
-
-    Attributes:
-        git: Repository URL to clone.
-        rev: Immutable ref to check out: a commit SHA, a tag, or
-            ``refs/pull/<n>/head`` for an unmerged PR. Branch names are
-            rejected because they move out from under a build.
-        path: Optional subdirectory of the clone that ``build_command`` and
-            ``command`` run from. Defaults to the repository root.
-    """
-
-    git: str
-    rev: str
-    path: str | None = None
-
-    Schema: ClassVar[type[Schema]] = Schema
-
-    def __post_init__(self) -> None:
-        if not self.git.strip():
-            raise ValidationError("services[].source.git must be a non-empty repository URL")
-        if not self.rev.strip():
-            raise ValidationError("services[].source.rev must be a non-empty immutable ref")
-        if self.rev.strip() in _MOVING_REFS:
-            raise ValidationError(
-                "services[].source.rev must be an immutable ref (commit SHA, tag, or refs/pull/<n>/head), "
-                f"not a moving branch name: {self.rev!r}"
-            )
-        if self.path is not None and not self.path.strip():
-            raise ValidationError("services[].source.path must not be blank when set")
+# services[].source is the shared git-at-an-immutable-ref shape.
+ServiceSourceConfig = SourceConfig
 
 
 @dataclass(frozen=True)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -492,6 +492,28 @@ class TestDryRunServices:
         assert "Services:" not in capsys.readouterr().out
 
 
+class TestDryRunDynamoSource:
+    """dynamo.source: the repo, ref, and whether it is pinned must be visible before submitting."""
+
+    def test_git_source_shown_unpinned_and_pinned(self, capsys):
+        base = {"frontend": {"type": "dynamo"}}
+        config = _make_config({**base, "dynamo": {"source": {"rev": "refs/pull/14000/head"}}})
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "https://github.com/ai-dynamo/dynamo.git @ refs/pull/14000/head" in output
+        assert "resolved from rev at submit" in output
+
+        sha = "2ecbdfdf192c69c02c6d21e931d20d3b4a0bb64a"
+        config = _make_config({**base, "dynamo": {"source": {"rev": "v1.4.2", "sha": sha}}})
+        show_config_details(config)
+        assert f"dynamo source sha: {sha}" in capsys.readouterr().out
+
+    def test_pypi_source_shown(self, capsys):
+        config = _make_config({"frontend": {"type": "dynamo"}, "dynamo": {"source": {"pypi": "1.4.2"}}})
+        show_config_details(config)
+        assert "PyPI ai-dynamo==1.4.2" in capsys.readouterr().out
+
+
 class TestDryRunHetJobs:
     """Het structure panel appears only when het is enabled."""
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared ``source:`` shape: validation, ref pinning, and the Dynamo mapping."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from marshmallow import ValidationError
+
+from srtctl.core.schema import DynamoConfig, SrtConfig
+from srtctl.core.source import DynamoSourceConfig, SourceConfig, is_commit_sha, pin_source_revs, resolve_rev
+from srtctl.core.yaml_utils import dump_yaml_with_comments, load_yaml_text_with_comments
+
+SHA = "2ecbdfdf192c69c02c6d21e931d20d3b4a0bb64a"
+UPSTREAM = "https://github.com/ai-dynamo/dynamo.git"
+
+
+# --- SourceConfig -------------------------------------------------------------------
+
+
+def test_is_commit_sha() -> None:
+    assert is_commit_sha(SHA)
+    assert is_commit_sha("abc1234")
+    assert is_commit_sha("abc123")  # legacy recipes use short hashes
+    assert not is_commit_sha("v1.4.2")
+    assert not is_commit_sha("refs/pull/14000/head")
+    assert not is_commit_sha("main")
+
+
+def test_source_config_rules() -> None:
+    src = SourceConfig(git="https://example.com/r", rev="refs/pull/1/head")
+    assert src.checkout == "refs/pull/1/head"
+    assert SourceConfig(git="https://example.com/r", rev="v1", sha=SHA).checkout == SHA
+    for rev in ("main", "master", "HEAD", " "):
+        with pytest.raises(ValidationError, match="rev must be"):
+            SourceConfig(git="https://example.com/r", rev=rev)
+    with pytest.raises(ValidationError, match="sha must be a commit SHA"):
+        SourceConfig(git="https://example.com/r", rev="v1", sha="not-a-sha")
+    with pytest.raises(ValidationError, match="git must be"):
+        SourceConfig(git="", rev="v1")
+
+
+# --- resolve_rev ---------------------------------------------------------------------
+
+
+def _ls_remote(stdout: str, returncode: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = "" if returncode == 0 else "fatal: repository not found"
+    return result
+
+
+def test_resolve_rev_returns_sha_unchanged_without_network() -> None:
+    with patch("srtctl.core.source.subprocess.run") as run:
+        assert resolve_rev(UPSTREAM, SHA) == SHA
+    run.assert_not_called()
+
+
+def test_resolve_rev_prefers_peeled_tag_and_handles_pr_refs() -> None:
+    tag_obj, commit = "1" * 40, "2" * 40
+    with patch(
+        "srtctl.core.source.subprocess.run",
+        return_value=_ls_remote(f"{tag_obj}\trefs/tags/v1.4.2\n{commit}\trefs/tags/v1.4.2^{{}}\n"),
+    ) as run:
+        assert resolve_rev(UPSTREAM, "v1.4.2") == commit
+    cmd = run.call_args.args[0]
+    assert cmd[:4] == ["git", "-c", "http.version=HTTP/1.1", "ls-remote"]
+    assert "refs/tags/v1.4.2" in cmd
+    assert run.call_args.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+    with patch("srtctl.core.source.subprocess.run", return_value=_ls_remote(f"{commit}\trefs/pull/14000/head\n")):
+        assert resolve_rev(UPSTREAM, "refs/pull/14000/head") == commit
+
+
+def test_resolve_rev_failures_raise() -> None:
+    with (
+        patch("srtctl.core.source.subprocess.run", return_value=_ls_remote("", returncode=128)),
+        pytest.raises(RuntimeError, match="repository not found"),
+    ):
+        resolve_rev(UPSTREAM, "v1")
+    with (
+        patch("srtctl.core.source.subprocess.run", return_value=_ls_remote("")),
+        pytest.raises(RuntimeError, match="not found in"),
+    ):
+        resolve_rev(UPSTREAM, "refs/pull/99/head")
+    with (
+        patch("srtctl.core.source.subprocess.run", side_effect=subprocess.TimeoutExpired("git", 60)),
+        pytest.raises(RuntimeError, match="failed"),
+    ):
+        resolve_rev(UPSTREAM, "v1")
+
+
+# --- pin_source_revs ------------------------------------------------------------------
+
+RECIPE = """\
+name: pin-test
+dynamo:
+  source:
+    rev: refs/pull/14000/head   # the PR under test
+services:
+  - name: router
+    command: [python3, -m, router]
+    source:
+      git: https://example.com/r
+      rev: v2.0.0
+  - name: pinned
+    command: [/bin/true]
+    source:
+      git: https://example.com/r
+      rev: v1
+      sha: 2ecbdfdf192c69c02c6d21e931d20d3b4a0bb64a
+"""
+
+
+def test_pin_source_revs_pins_every_unpinned_source_and_keeps_comments() -> None:
+    document = load_yaml_text_with_comments(RECIPE)
+    document["dynamo"]["source"]["git"] = UPSTREAM  # what DynamoSourceConfig defaults to
+    seen: list[tuple[str, str]] = []
+
+    def fake_resolve(git: str, rev: str) -> str:
+        seen.append((git, rev))
+        return SHA
+
+    notes = pin_source_revs(document, resolve=fake_resolve)
+
+    assert seen == [(UPSTREAM, "refs/pull/14000/head"), ("https://example.com/r", "v2.0.0")]
+    assert notes == [
+        f"dynamo.source: refs/pull/14000/head -> {SHA}",
+        f"services.0.source: v2.0.0 -> {SHA}",
+    ]
+    assert document["dynamo"]["source"]["sha"] == SHA
+    assert document["dynamo"]["source"]["rev"] == "refs/pull/14000/head"
+    text = dump_yaml_with_comments(document)
+    assert "# the PR under test" in text  # ruamel round-trip keeps the recipe's comments
+
+
+def test_pin_source_revs_walks_override_format_and_leaves_failures_unpinned(caplog) -> None:
+    document = load_yaml_text_with_comments(
+        "base:\n  dynamo:\n    source:\n      git: https://example.com/d\n      rev: refs/pull/1/head\n"
+        "override_x:\n  dynamo:\n    source:\n      git: https://example.com/d\n      rev: refs/pull/2/head\n"
+    )
+
+    def flaky(git: str, rev: str) -> str:
+        if rev.endswith("2/head"):
+            raise RuntimeError("boom")
+        return SHA
+
+    notes = pin_source_revs(document, resolve=flaky)
+    assert notes == [f"base.dynamo.source: refs/pull/1/head -> {SHA}"]
+    assert document["override_x"]["dynamo"]["source"].get("sha") is None
+    assert "could not pin rev 'refs/pull/2/head'" in caplog.text
+
+
+# --- dynamo.source -----------------------------------------------------------------------
+
+
+def test_dynamo_source_git_maps_to_hash_and_defaults_upstream_repo() -> None:
+    config = DynamoConfig(source=DynamoSourceConfig(rev="refs/pull/14000/head"))
+    assert config.source is not None and config.source.git == UPSTREAM
+    assert config.hash == "refs/pull/14000/head"
+    assert config.version is None
+    assert config.needs_source_install
+    cmd = config.get_install_commands()
+    # An unpinned ref is fetched by name; a plain clone has no PR refs.
+    assert "git fetch origin refs/pull/14000/head && git checkout FETCH_HEAD" in cmd
+    assert "/configs/dynamo-wheels/refs-pull-14000-head" in cmd
+    assert f"clone {UPSTREAM} dynamo" in cmd
+
+
+def test_dynamo_source_pinned_sha_and_fork_and_patches() -> None:
+    patch_line = 'dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates", branch = "feat" }'
+    config = DynamoConfig(
+        source=DynamoSourceConfig(
+            git="https://github.com/me/dynamo-fork", rev="refs/pull/3/head", sha=SHA, patches=[patch_line]
+        )
+    )
+    assert config.hash == SHA
+    assert config.cargo_patches == [patch_line]
+    cmd = config.get_install_commands()
+    assert "clone https://github.com/me/dynamo-fork dynamo" in cmd
+    assert f"git checkout {SHA}" in cmd
+    assert f"/configs/dynamo-wheels/{SHA}-patch-" in cmd
+    assert patch_line in cmd
+
+
+def test_dynamo_source_pypi_and_wheel() -> None:
+    assert DynamoConfig(source=DynamoSourceConfig(pypi="1.4.2")).version == "1.4.2"
+    assert "ai-dynamo==1.4.2" in DynamoConfig(source=DynamoSourceConfig(pypi="1.4.2")).get_install_commands()
+    wheel = DynamoConfig(source=DynamoSourceConfig(wheel="1.5.0.dev20260901"))
+    assert wheel.wheel == "1.5.0.dev20260901"
+    assert wheel.version is None
+    assert not wheel.needs_source_install
+
+
+def test_dynamo_source_validation() -> None:
+    with pytest.raises(ValidationError, match="exactly one of"):
+        DynamoSourceConfig()
+    with pytest.raises(ValidationError, match="exactly one of"):
+        DynamoSourceConfig(pypi="1.0", wheel="1.0")
+    with pytest.raises(ValidationError, match="requires rev"):
+        DynamoSourceConfig(git="https://example.com/d")
+    with pytest.raises(ValidationError, match="immutable ref"):
+        DynamoSourceConfig(rev="main")
+    with pytest.raises(ValidationError, match="only apply to a git source"):
+        DynamoSourceConfig(pypi="1.0", patches=["x = 1"])
+    with pytest.raises(ValueError, match="cannot be combined with dynamo.hash"):
+        DynamoConfig(hash="abc1234", source=DynamoSourceConfig(pypi="1.0"))
+    with pytest.raises(ValueError, match="cannot be combined with dynamo.top_of_tree, dynamo.cargo_patches"):
+        DynamoConfig(top_of_tree=True, cargo_patches=["x = 1"], source=DynamoSourceConfig(rev="v1"))
+
+
+def test_dynamo_source_loads_from_recipe_yaml() -> None:
+    raw = yaml.safe_load(
+        """
+name: t
+model:
+  path: /m
+  container: /c.sqsh
+  precision: bf16
+resources:
+  gpu_type: h100
+  gpus_per_node: 8
+  agg_nodes: 1
+  agg_workers: 2
+  gpus_per_agg: 1
+frontend:
+  type: dynamo
+dynamo:
+  source:
+    git: https://github.com/ai-dynamo/dynamo
+    rev: v1.4.2
+    sha: 2ecbdfdf192c69c02c6d21e931d20d3b4a0bb64a
+backend:
+  type: sglang
+benchmark:
+  type: manual
+"""
+    )
+    config = SrtConfig.Schema().load(raw)
+    assert config.dynamo.hash == SHA
+    assert config.dynamo.version is None
+    assert config.dynamo.source is not None and config.dynamo.source.rev == "v1.4.2"
+
+
+# --- submit-time pinning through materialize_config_path -----------------------------------
+
+
+def test_materialize_pins_sources_only_on_apply(tmp_path) -> None:
+    from srtctl.cli.submit import materialize_config_path
+
+    recipe = tmp_path / "r.yaml"
+    recipe.write_text("name: t\ndynamo:\n  source:\n    git: https://example.com/d\n    rev: refs/pull/7/head\n")
+
+    with patch("srtctl.core.source.resolve_rev", return_value=SHA) as resolve:
+        with materialize_config_path(recipe, pin_sources=False) as path:
+            assert path == recipe  # dry-run / preflight never touch the network
+        resolve.assert_not_called()
+
+        with materialize_config_path(recipe, pin_sources=True) as path:
+            assert path != recipe
+            staged = yaml.safe_load(path.read_text())
+        resolve.assert_called_once_with("https://example.com/d", "refs/pull/7/head")
+
+    assert staged["dynamo"]["source"]["sha"] == SHA
+    assert staged["dynamo"]["source"]["rev"] == "refs/pull/7/head"
+    assert recipe.read_text().count("sha") == 0  # the source file is never modified
+
+
+def test_materialize_without_sources_is_a_passthrough(tmp_path) -> None:
+    from srtctl.cli.submit import materialize_config_path
+
+    recipe = tmp_path / "r.yaml"
+    recipe.write_text("name: t\ndynamo:\n  version: '1.4.2'\n")
+    with patch("srtctl.core.source.resolve_rev") as resolve, materialize_config_path(recipe, pin_sources=True) as path:
+        assert path == recipe
+    resolve.assert_not_called()


### PR DESCRIPTION
Stacked on #399 (Track 2 of https://github.com/NVIDIA/srt-slurm/issues/385). Draft until the stack below it merges.

## What

One shape for "this code, from git", shared by `services[].source` (#399) and the new `dynamo.source`:

```yaml
dynamo:
  source:
    git: https://github.com/ai-dynamo/dynamo   # default when only rev is given, so forks are one line
    rev: refs/pull/14000/head                  # a commit, a tag such as v1.4.2, or a PR head
```

`dynamo.source` takes exactly one of `git` + `rev` (with optional `patches`, the old `cargo_patches`), `pypi` (the old `version`), or `wheel`. It maps onto the legacy `DynamoConfig` fields at load, so the install code and every downstream consumer keep reading `hash` / `version` / `wheel` unchanged and v1 recipes still load. Combining `source` with a legacy field is rejected.

Testing an unmerged Dynamo PR was not possible before: `hash` needed a commit SHA, and a plain clone does not carry PR refs. The cached source install now clones the configured repository and fetches a non-commit ref by name before checkout.

## Pinning at submit

A ref like `refs/pull/14000/head` moves. `srtctl apply` resolves every unpinned `source.rev` (Dynamo and services alike) with `git ls-remote`, preferring the peeled commit for tags, and records it as `source.sha` in the submitted `config.yaml`. Comments are preserved and the recipe on disk is untouched. The job builds exactly the commit the lockfile names, and the `/configs/dynamo-wheels` cache is keyed by that commit, so two runs of one recipe cannot silently build different code because the PR was pushed to while the job sat in the queue.

- `dry-run`, `preflight`, and `resolve-override` never touch the network.
- A resolution failure warns and leaves the ref unpinned rather than blocking the submit; the compute node then fetches the ref by name and the cache keys on the sanitized ref.
- `--json` output lists what was pinned under `pinned_sources`; `dry-run` prints the Dynamo source and whether it is pinned.

## Also

- `examples/features/dynamo-source.yaml`: Dynamo built from the `v1.4.2` tag (the same release the PyPI examples install). `--set dynamo.source.rev=refs/pull/<n>/head` turns it into a PR test.
- Docs: `## dynamo` in `docs/config-reference.md`, the pinning note in `docs/services.md`, regenerated `docs/schema-reference.md`.
- Tests: `tests/test_source.py` (shape validation, `git ls-remote` resolution incl. peeled tags and failures, pinning across plain and override-format documents with comments kept, the Dynamo mapping and install script for unpinned refs, pinned SHAs, forks, and patches, and the submit-path `materialize_config_path` behaviour) plus dry-run cases.

## Validation

- Full suite green (1827 passed); lint, schema-docs drift check, every example validates.
- Live `git ls-remote` resolution of `v1.4.2` and `refs/pull/14000/head` against ai-dynamo/dynamo from this branch.
- sa-b200, job 12007: `srtctl apply` pinned `v1.4.2` to `2ecbdfdf` and wrote the `sha` into the submitted `config.yaml` (`--json` listed it under `pinned_sources`); the workers did a cold source build at that commit inside the SGLang container (rustup, cargo, maturin), populated `/configs/dynamo-wheels/2ecbdfdf...`, and the aggregated Dynamo benchmark completed. Whole job, build included: 7m45s.
- sa-b200, job 12009: the same recipe resubmitted. The install reused the cached wheel for the pinned commit (no cargo or maturin output in the worker logs, straight to `Dynamo installed from source (2ecbdfdf...)`) and the benchmark completed. Whole job: 3m06s.


