### PR TITLE
refactor(observability): retire Hz knobs; collect_interval_ms controls all scrape cadence

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1196,7 +1196,7 @@ observability:
 | ---------------- | ---- | ------- | ----------- |
 | `enabled` | bool/null | `null` | `null` means ON for every run (decoupled from `observability.enabled`); explicit `false` opts out |
 | `binary_path` | string | `tachometer-scraper` | Scraper command or path on the compute nodes |
-| `collect_interval_ms` | int | `1000` | Milliseconds between scrapes of every endpoint (replaces the retired Hz-based `default_frequency`) |
+| `collect_interval_ms` | int | `1000` | Milliseconds between scrapes of every endpoint; the single cadence knob — it also drives the launched DCGM exporter's `--collect-interval` (an explicit `dcgm_exporter.command` wins) and the host sampler. Values below `1000` speed up DCGM NVML sampling and are warned about at launch: 100ms sampling measured ~2% decode ITL overhead on GB300. Replaces the retired Hz-based `default_frequency` |
 | `sync_interval_secs` | int | `120` | Interval for intermediate Parquet compaction; `0` disables it |
 | `compaction_threads` | int | `4` | Value passed as `POLARS_MAX_THREADS` |
 | `storage_subdir` | string | `tachometer` | Output directory below the run log directory |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1178,7 +1178,7 @@ observability:
   enabled: true
   tachometer:
     enabled: true
-    default_frequency: 1
+    collect_interval_ms: 1000
     sync_interval_secs: 120
     compaction_threads: 4
     storage_subdir: tachometer
@@ -1196,7 +1196,7 @@ observability:
 | ---------------- | ---- | ------- | ----------- |
 | `enabled` | bool/null | `null` | `null` means ON for every run (decoupled from `observability.enabled`); explicit `false` opts out |
 | `binary_path` | string | `tachometer-scraper` | Scraper command or path on the compute nodes |
-| `default_frequency` | float | `1.0` | Scrape frequency in Hz |
+| `collect_interval_ms` | int | `1000` | Milliseconds between scrapes of every endpoint (replaces the retired Hz-based `default_frequency`) |
 | `sync_interval_secs` | int | `120` | Interval for intermediate Parquet compaction; `0` disables it |
 | `compaction_threads` | int | `4` | Value passed as `POLARS_MAX_THREADS` |
 | `storage_subdir` | string | `tachometer` | Output directory below the run log directory |
@@ -1222,7 +1222,7 @@ When both are enabled, `telemetry.dcgm_exporter` is shared with Tachometer. Do n
 ```yaml
 telemetry:
   enabled: true
-  default_frequency: 1.0
+  collect_interval_ms: 1000
   storage_subdir: power
   required: true
   dcgm_exporter:
@@ -1234,7 +1234,7 @@ telemetry:
 | ----- | ---- | ------- | ----------- |
 | `enabled` | bool | `false` | Enable DCGM power collection |
 | `dcgm_exporter` | object/null | `null` | DCGM exporter image, port, and optional command; required when enabled |
-| `default_frequency` | float | `1.0` | Power sample interval in seconds; must be at most `3.0` |
+| `collect_interval_ms` | int | `1000` | Milliseconds between collector cycles; must be at most `3000` (replaces the retired `default_frequency`, which was seconds despite its name) |
 | `storage_subdir` | string | `power` | Output directory below the run log directory |
 | `required` | bool | `false` | Fail the benchmark when publishable power artifacts cannot be produced |
 | `startup_timeout_seconds` | float | `30.0` | Exporter readiness timeout |

--- a/docs/power-telemetry.md
+++ b/docs/power-telemetry.md
@@ -39,7 +39,7 @@ benchmark:
 telemetry:
   enabled: true
   provider: dcgm-power
-  default_frequency: 1.0            # seconds between collector cycles; must be <= 3.0
+  collect_interval_ms: 1000         # milliseconds between collector cycles; must be <= 3000
   storage_subdir: power             # relative to the run log directory
   required: true                    # exit non-zero when artifacts are unpublishable
   startup_timeout_seconds: 30
@@ -54,7 +54,7 @@ telemetry:
 not require the top-level `container_image` or a `node_exporter`, because the
 collector runs inside srtctl. Config loading validates the block and rejects
 inconsistent values with actionable messages; in particular
-`default_frequency` must not exceed the 3-second max sample gap the validator
+`collect_interval_ms` must not exceed the 3-second max sample gap the validator
 accepts, or every window would fail `sample_gap_exceeded`. Telemetry stays
 disabled by default and existing `provider: scraper` recipes are unchanged.
 The collector join timeout must exceed two complete request-cycle budgets

--- a/src/srtctl/analysis/host_sampler.py
+++ b/src/srtctl/analysis/host_sampler.py
@@ -250,7 +250,11 @@ def try_start_host_sampler(log_dir: Path, observability, stop_event: threading.E
     if getattr(observability, "enabled", False) is not True:
         return None
     try:
-        s = HostSampler(log_dir)
+        # One cadence knob for the whole capture stack: follow the tachometer
+        # scrape interval (HostSampler floors it at 1.0s internally).
+        tachometer = getattr(observability, "tachometer", None)
+        interval_ms = getattr(tachometer, "collect_interval_ms", 1000) if tachometer else 1000
+        s = HostSampler(log_dir, interval_seconds=interval_ms / 1000.0)
         s.start(stop_event)
         return s
     except Exception as exc:  # noqa: BLE001 - best effort

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -24,12 +24,31 @@ from srtctl.core.telemetry import TACHOMETER_STORAGE_PARENT, generate_tachometer
 
 if TYPE_CHECKING:
     from srtctl.core.runtime import RuntimeContext
-    from srtctl.core.schema import SrtConfig
+    from srtctl.core.schema import SrtConfig, TachometerConfig
     from srtctl.core.topology import Process
 
 logger = logging.getLogger(__name__)
 
+# Power telemetry's template: 100ms NVML sampling is its purpose (dense power
+# curves inside sa-bench measurement windows). Never used for tachometer.
 DCGM_EXPORTER_COMMAND_TEMPLATE = "dcgm-exporter --collect-interval=100 --address :{port}"
+
+# Lowest DCGM sampling interval measured at parity with no telemetry on GB300
+# decode (A/F chain); 100ms measured ~2% ITL p50 overhead. Sampling faster than
+# this is allowed but warned about at launch.
+DCGM_PROVEN_SAFE_INTERVAL_MS = 1000
+
+
+def tachometer_dcgm_command_template(tachometer: TachometerConfig) -> str:
+    """DCGM exporter command for the tachometer-owned launch.
+
+    The exporter samples NVML exactly as often as tachometer scrapes it —
+    ``observability.tachometer.collect_interval_ms`` rules both cadences, so
+    every scrape sees a fresh value and no scrape sees a duplicate. An
+    explicit ``dcgm_exporter.command`` in the recipe still wins (resolved in
+    :func:`resolve_exporter_command`).
+    """
+    return f"dcgm-exporter --collect-interval={tachometer.collect_interval_ms} --address :{{port}}"
 
 
 def resolve_exporter_command(exporter_config: TelemetryExporterConfig, default_template: str) -> str:
@@ -325,13 +344,24 @@ class TelemetryStageMixin:
         # bash-wrapped node-exporter (FROM scratch) died with execve() ENOENT
         # and, as a critical process, killed a 7-node run at startup.
         if not power_telemetry.enabled and tachometer.resolved_dcgm_exporter is not None:
+            if tachometer.collect_interval_ms < DCGM_PROVEN_SAFE_INTERVAL_MS:
+                logger.warning(
+                    "observability.tachometer.collect_interval_ms=%d drives DCGM NVML "
+                    "sampling below the measured-safe %dms; 100ms sampling cost ~2%% "
+                    "decode ITL p50 on GB300. Proceeding as configured.",
+                    tachometer.collect_interval_ms,
+                    DCGM_PROVEN_SAFE_INTERVAL_MS,
+                )
             processes.extend(
                 self._start_exporter_container(
                     exporter_config=tachometer.resolved_dcgm_exporter,
                     name="tachometer_dcgm_exporter",
                     nodelist=worker_nodes,
                     log_file=self.runtime.log_dir / "tachometer_dcgm_exporter.out",
-                    default_command_template=DCGM_EXPORTER_COMMAND_TEMPLATE,
+                    # NOT the power template (100ms): the tachometer exporter
+                    # samples exactly as often as tachometer scrapes it, so one
+                    # knob rules both cadences and every scrape is fresh.
+                    default_command_template=tachometer_dcgm_command_template(tachometer),
                     use_bash_wrapper=False,
                     critical=False,
                 )

--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -162,7 +162,7 @@ class TelemetryStageMixin:
                 log_dir=self.runtime.log_dir,
                 job_id=self.runtime.job_id,
                 run_name=self.runtime.run_name,
-                sample_interval_seconds=telemetry.default_frequency,
+                sample_interval_seconds=telemetry.collect_interval_ms / 1000.0,
                 startup_timeout_seconds=telemetry.startup_timeout_seconds,
                 request_timeout_seconds=telemetry.request_timeout_seconds,
                 collector_join_timeout_seconds=telemetry.resolved_collector_join_timeout_seconds,

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -435,7 +435,7 @@ def show_config_details(config: SrtConfig) -> None:
         if config.observability.tachometer_enabled:
             details.add_row("observability", "tachometer", "enabled")
             details.add_row("observability", "storage_subdir", tachometer.storage_subdir)
-            details.add_row("observability", "frequency", str(tachometer.default_frequency))
+            details.add_row("observability", "collect_interval_ms", str(tachometer.collect_interval_ms))
             details.add_row("observability", "binary_path", tachometer.binary_path)
             if config.telemetry.enabled:
                 details.add_row("observability", "dcgm_exporter", "shared with power telemetry")

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1096,10 +1096,9 @@ class TelemetryExporterConfig:
 DEFAULT_DCGM_EXPORTER = TelemetryExporterConfig(
     container_image="nvcr.io#nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04",
     port=9401,
-    # 100ms collection (the power-telemetry template's interval) costs ~2% ITL
-    # p50 on GB300 decode; 5000ms is measured at parity with no telemetry.
-    # Values repeat across consecutive 1 Hz scrapes, which panels tolerate.
-    command="dcgm-exporter --collect-interval=5000 --address :{port}",
+    # No command: the tachometer launch derives --collect-interval from
+    # observability.tachometer.collect_interval_ms so the exporter samples
+    # exactly as often as it is scraped. An explicit command still wins.
 )
 DEFAULT_NODE_EXPORTER = TelemetryExporterConfig(
     container_image="quay.io#prometheus/node-exporter:v1.8.2",

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1127,7 +1127,10 @@ class TachometerConfig:
 
     enabled: bool | None = None
     binary_path: str = "tachometer-scraper"
-    default_frequency: float = 1.0
+    # Milliseconds between scrapes of every endpoint — the same unit and name
+    # as dcgm-exporter's --collect-interval. Replaces the retired Hz-based
+    # ``default_frequency`` (1000ms == the old 1.0 Hz default).
+    collect_interval_ms: int = 1000
     sync_interval_secs: int = 120
     compaction_threads: int = 4
     storage_subdir: str = "tachometer"
@@ -1244,7 +1247,10 @@ class TelemetryConfig:
 
     enabled: bool = False
     dcgm_exporter: TelemetryExporterConfig | None = None
-    default_frequency: float = 1.0
+    # Milliseconds between collector cycles. Replaces the retired
+    # ``default_frequency``, which despite its name was a period in seconds
+    # (1000ms == the old 1.0 default).
+    collect_interval_ms: int = 1000
     storage_subdir: str = "power"
     required: bool = False
     startup_timeout_seconds: float = 30.0
@@ -2284,15 +2290,17 @@ class SrtConfig:
         if not 1 <= exporter.port <= 65535:
             raise ValidationError("telemetry.dcgm_exporter.port must be in 1..65535")
 
-        for name in ("default_frequency", "startup_timeout_seconds", "request_timeout_seconds"):
+        for name in ("startup_timeout_seconds", "request_timeout_seconds"):
             if not _is_finite_positive(getattr(telemetry, name)):
                 raise ValidationError(f"telemetry.{name} must be finite and positive")
-        if telemetry.default_frequency > _DCGM_POWER_MAX_SAMPLE_GAP_SECONDS:
+        if telemetry.collect_interval_ms <= 0:
+            raise ValidationError("telemetry.collect_interval_ms must be positive")
+        if telemetry.collect_interval_ms > _DCGM_POWER_MAX_SAMPLE_GAP_SECONDS * 1000:
             raise ValidationError(
-                f"telemetry.default_frequency={telemetry.default_frequency} exceeds the "
+                f"telemetry.collect_interval_ms={telemetry.collect_interval_ms} exceeds the "
                 f"{_DCGM_POWER_MAX_SAMPLE_GAP_SECONDS}s max sample gap the power validator accepts; "
                 "every window would fail sample_gap_exceeded. Set it to the intended collector "
-                "period (e.g. 1.0)."
+                "period (e.g. 1000)."
             )
         worst_case_join_seconds = 2 * (
             2 * telemetry.request_timeout_seconds + _DCGM_POWER_COLLECT_CYCLE_TIMEOUT_GRACE_SECONDS
@@ -2354,8 +2362,8 @@ class SrtConfig:
                 raise ValidationError(f"observability.tachometer.{name}.port must be in 1..65535")
         if not tachometer.binary_path:
             raise ValidationError("observability.tachometer.binary_path must be non-empty")
-        if tachometer.default_frequency <= 0:
-            raise ValidationError("observability.tachometer.default_frequency must be positive")
+        if tachometer.collect_interval_ms <= 0:
+            raise ValidationError("observability.tachometer.collect_interval_ms must be positive")
         if tachometer.sync_interval_secs < 0:
             raise ValidationError("observability.tachometer.sync_interval_secs must be >= 0")
         if tachometer.compaction_threads < 0:

--- a/src/srtctl/core/telemetry.py
+++ b/src/srtctl/core/telemetry.py
@@ -33,7 +33,7 @@ class TelemetryEndpoint:
 
     name: str
     url: str
-    frequency: float
+    collect_interval_ms: int
     filter: str | None = None
     node_metadata: dict[str, str] = field(default_factory=dict)
     gpu_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
@@ -81,7 +81,7 @@ def generate_tachometer_config(
                 TelemetryEndpoint(
                     name=f"dcgm_{node}",
                     url=f"http://{node}:{dcgm_exporter.port}/metrics",
-                    frequency=tachometer.default_frequency,
+                    collect_interval_ms=tachometer.collect_interval_ms,
                     filter="dcgm",
                     node_metadata=node_metadata,
                     gpu_metadata=gpu_metadata,
@@ -92,7 +92,7 @@ def generate_tachometer_config(
                 TelemetryEndpoint(
                     name=f"node_exporter_{node}",
                     url=f"http://{node}:{node_exporter.port}/metrics",
-                    frequency=tachometer.default_frequency,
+                    collect_interval_ms=tachometer.collect_interval_ms,
                     filter="node_exporter",
                     node_metadata=node_metadata,
                 )
@@ -125,7 +125,7 @@ def generate_tachometer_config(
             TelemetryEndpoint(
                 name=f"backend_{process.endpoint_mode}{process.endpoint_index}_rank{process.node_rank}",
                 url=url,
-                frequency=tachometer.default_frequency,
+                collect_interval_ms=tachometer.collect_interval_ms,
                 filter="backend",
                 node_metadata=node_metadata,
             )
@@ -155,7 +155,7 @@ def generate_tachometer_config(
             TelemetryEndpoint(
                 name=f"frontend{frontend_index}",
                 url=f"http://{node_ip}:{frontend_topology.frontend_port}/metrics",
-                frequency=tachometer.default_frequency,
+                collect_interval_ms=tachometer.collect_interval_ms,
                 filter="frontend",
                 node_metadata=node_metadata,
             )
@@ -174,7 +174,7 @@ def _dump_toml(*, endpoints: list[TelemetryEndpoint], storage: str) -> str:
         lines.append("[[endpoints]]")
         lines.append(f"name = {json.dumps(endpoint.name)}")
         lines.append(f"url = {json.dumps(endpoint.url)}")
-        lines.append(f"frequency = {endpoint.frequency}")
+        lines.append(f"collect_interval_ms = {endpoint.collect_interval_ms}")
         if endpoint.filter is not None:
             lines.append(f"filter = {json.dumps(endpoint.filter)}")
         if endpoint.node_metadata:

--- a/src/srtctl/render/direct_plan.py
+++ b/src/srtctl/render/direct_plan.py
@@ -354,7 +354,7 @@ def _build_tachometer_config(config: SrtConfig, processes: list[Process]) -> str
                 "[[endpoints]]",
                 f"name = {json.dumps(name)}",
                 f"url = {json.dumps(url)}",
-                f"frequency = {tachometer.default_frequency}",
+                f"collect_interval_ms = {tachometer.collect_interval_ms}",
                 f"filter = {json.dumps(metric_filter)}",
                 "[endpoints.node_metadata]",
                 *(f"{json.dumps(key)} = {json.dumps(value)}" for key, value in sorted(metadata.items())),

--- a/src/tachometer/tachometer-scraper/src/config.rs
+++ b/src/tachometer/tachometer-scraper/src/config.rs
@@ -17,7 +17,7 @@ pub struct EndpointConfig {
     pub name: String,
     pub url: String,
     #[serde(default)]
-    pub frequency: Option<f64>,
+    pub collect_interval_ms: Option<u64>,
     #[serde(default)]
     pub filter: Option<String>,
     #[serde(default)]

--- a/src/tachometer/tachometer-scraper/src/main.rs
+++ b/src/tachometer/tachometer-scraper/src/main.rs
@@ -26,9 +26,9 @@ struct Args {
     #[arg(long = "endpoint", value_name = "NAME=URL", num_args = 0..)]
     endpoints: Vec<String>,
 
-    /// Polling frequency in Hz (e.g., 0.1 for 10 seconds) - used only with --endpoint
-    #[arg(long = "freq", default_value = "0.2")]
-    frequency: f64,
+    /// Milliseconds between scrapes (e.g., 5000 scrapes every 5 seconds) - used only with --endpoint
+    #[arg(long = "collect-interval-ms", default_value = "5000")]
+    collect_interval_ms: u64,
 
     /// Storage location (e.g., "s3://bucket/run_0" or "./local/path") - used only with --endpoint
     #[arg(long = "storage", value_name = "PATH")]
@@ -84,7 +84,7 @@ enum Commands {
 struct EndpointConfig {
     name: String,
     url: String,
-    frequency: f64,
+    collect_interval_ms: u64,
     filter: Option<Box<dyn MetricFilter>>,
 }
 
@@ -478,7 +478,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 endpoint_configs.push(EndpointConfig {
                     name: cfg_endpoint.name.clone(),
                     url: cfg_endpoint.url.clone(),
-                    frequency: cfg_endpoint.frequency.unwrap_or(2.0),
+                    collect_interval_ms: cfg_endpoint.collect_interval_ms.unwrap_or(500),
                     filter,
                 });
             }
@@ -512,7 +512,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 endpoint_configs.push(EndpointConfig {
                     name,
                     url,
-                    frequency: args.frequency,
+                    collect_interval_ms: args.collect_interval_ms,
                     filter,
                 });
             }
@@ -563,14 +563,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Press Ctrl+C or send SIGTERM to gracefully shutdown and compact data...");
 
     // Use tokio's cross-platform signal handler
-    // Create a task per endpoint with its own frequency
+    // Create a task per endpoint with its own collect interval
     let mut tasks = Vec::new();
     for endpoint in endpoints {
         let writer_clone = writer.clone();
         let endpoint_name = endpoint.name.clone();
         let endpoint_url = endpoint.url.clone();
         let endpoint_filter = endpoint.filter;
-        let sleep_duration = std::time::Duration::from_secs_f64(1.0 / endpoint.frequency);
+        let sleep_duration = std::time::Duration::from_millis(endpoint.collect_interval_ms);
 
         let task = tokio::spawn(async move {
             loop {

--- a/src/tachometer/tachometer-scraper/test-config.toml
+++ b/src/tachometer/tachometer-scraper/test-config.toml
@@ -5,7 +5,7 @@ save_interval_secs = 5
 [[endpoints]]
 name = "prefill_node"
 url = "file://tachometer-scraper/sample-metrics/dcgm-gb200.txt"
-frequency = 1.0
+collect_interval_ms = 1000
 filter = "dcgm"
 
 [endpoints.gpu_metadata]

--- a/src/tachometer/tachometer-scraper/tests/integration_test.rs
+++ b/src/tachometer/tachometer-scraper/tests/integration_test.rs
@@ -547,7 +547,7 @@ storage = "file://{}"
 [[endpoints]]
 name = "dcgm_test"
 url = "file://{}"
-frequency = 5.0
+collect_interval_ms = 200
 filter = "dcgm"
 
 [endpoints.gpu_metadata]

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -4685,7 +4685,7 @@ class TestSequentialNodeStart:
         import os
         import subprocess
         from pathlib import Path
-        from unittest.mock import MagicMock, call, patch
+        from unittest.mock import MagicMock, patch
 
         from srtctl.backends.trtllm import TRTLLMProtocol
         from srtctl.cli.mixins.worker_stage import WorkerStageMixin

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -284,7 +284,7 @@ class TestDryRunExecutionExtensions:
                 "benchmark": {"type": "sa-bench", "isl": 8192, "osl": 1024, "concurrencies": [4]},
                 "telemetry": {
                     "enabled": True,
-                    "default_frequency": 1.0,
+                    "collect_interval_ms": 1000,
                     "storage_subdir": "power",
                     "required": True,
                     "dcgm_exporter": {"container_image": "dcgm-exporter", "port": 9401},

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -122,7 +122,7 @@ class TestExpandObservability:
             enabled=True,
             tachometer={
                 "enabled": True,
-                "default_frequency": 2.0,
+                "collect_interval_ms": 500,
                 "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
             },
         )
@@ -131,7 +131,7 @@ class TestExpandObservability:
 
         assert out["observability"]["tachometer"] == {
             "enabled": True,
-            "default_frequency": 2.0,
+            "collect_interval_ms": 500,
             "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
         }
         assert "telemetry" not in out
@@ -140,7 +140,7 @@ class TestExpandObservability:
         cfg = _trtllm_config(enabled=True, tachometer={"enabled": True})
         cfg["telemetry"] = {
             "enabled": True,
-            "default_frequency": 1.0,
+            "collect_interval_ms": 1000,
             "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
         }
 
@@ -225,6 +225,31 @@ class TestExpandObservability:
         with pytest.raises(ValidationError, match="scrape_metrics"):
             SrtConfig.Schema().load(cfg)
 
+    def test_retired_hz_frequency_knob_is_rejected_on_tachometer(self):
+        """``default_frequency`` (Hz) is retired in favor of ``collect_interval_ms``.
+
+        A recipe still carrying the Hz knob must fail loudly at submit time:
+        silently accepting it would run at the 1000ms default while promising
+        a different cadence."""
+        cfg = _trtllm_config(enabled=True, tachometer={"default_frequency": 2.0})
+
+        with pytest.raises(ValidationError, match="default_frequency"):
+            SrtConfig.Schema().load(cfg)
+
+    def test_retired_frequency_knob_is_rejected_on_power_telemetry(self):
+        """Power telemetry's ``default_frequency`` was a period in seconds
+        despite its name; it is retired in favor of ``collect_interval_ms``."""
+        cfg = dict(BASE_CONFIG)
+        cfg["benchmark"] = {"type": "sa-bench", "concurrencies": [4]}
+        cfg["telemetry"] = {
+            "enabled": True,
+            "default_frequency": 1.0,
+            "dcgm_exporter": {"container_image": "dcgm", "port": 9401},
+        }
+
+        with pytest.raises(ValidationError, match="default_frequency"):
+            SrtConfig.Schema().load(cfg)
+
     def test_tachometer_no_longer_requires_master_observability_knob(self):
         """Tachometer is decoupled from observability.enabled: explicit true
         without the master knob is valid, and the default is on for every run."""
@@ -279,7 +304,7 @@ class TestObservabilitySchema:
                     **BASE_CONFIG,
                     "observability": {
                         "enabled": True,
-                        "tachometer": {"enabled": True, "default_frequency": 2.0},
+                        "tachometer": {"enabled": True, "collect_interval_ms": 500},
                     },
                 }
             )
@@ -289,4 +314,4 @@ class TestObservabilitySchema:
 
         assert cfg.observability.tachometer.enabled is True
         assert cfg.observability.tachometer_enabled is True
-        assert cfg.observability.tachometer.default_frequency == 2.0
+        assert cfg.observability.tachometer.collect_interval_ms == 500

--- a/tests/test_power_collector.py
+++ b/tests/test_power_collector.py
@@ -692,7 +692,7 @@ class TestSessionOwnership:
                 self.config = MagicMock()
                 self.config.telemetry.enabled = True
                 self.config.telemetry.storage_subdir = "power"
-                self.config.telemetry.default_frequency = 0.05
+                self.config.telemetry.collect_interval_ms = 50
                 self.config.telemetry.startup_timeout_seconds = 0.2
                 self.config.telemetry.request_timeout_seconds = 0.1
                 self.config.telemetry.collector_join_timeout_seconds = 1.0

--- a/tests/test_sa_bench_measurement_window.py
+++ b/tests/test_sa_bench_measurement_window.py
@@ -52,7 +52,7 @@ SA_BENCH_DIR = Path(__file__).resolve().parents[1] / "src/srtctl/benchmarks/scri
 def _benchmark_harness(tmp_path, *, enabled=True):
     telemetry = TelemetryConfig(
         enabled=enabled,
-        default_frequency=1.0,
+        collect_interval_ms=1000,
         storage_subdir="power",
         dcgm_exporter=TelemetryExporterConfig(container_image="dcgm-exporter", port=9401),
     )

--- a/tests/test_sa_bench_tokenizers.py
+++ b/tests/test_sa_bench_tokenizers.py
@@ -11,7 +11,6 @@ import sys
 import types
 from pathlib import Path
 
-
 SA_BENCH_DIR = (
     Path(__file__).resolve().parents[1]
     / "src"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -53,7 +53,7 @@ def _sa_bench(**overrides) -> BenchmarkConfig:
 def _dcgm_power(**overrides) -> TelemetryConfig:
     fields: dict = {
         "enabled": True,
-        "default_frequency": 1.0,
+        "collect_interval_ms": 1000,
         "storage_subdir": "power",
         "required": True,
         "startup_timeout_seconds": 30.0,
@@ -123,13 +123,13 @@ class TestTachometerConfig:
         assert tachometer.resolved_dcgm_exporter is custom
         assert tachometer.resolved_node_exporter.port == 9101
 
-    def test_default_frequency_is_one_hz(self):
-        """1 Hz matches the retired RAW scraper's cadence; 5 Hz produced ~9M
+    def test_default_collect_interval_is_one_second(self):
+        """1000ms matches the retired RAW scraper's cadence; 200ms produced ~9M
         rows in a 25-minute run with no analysis consuming the extra
         resolution, and scrape load on worker endpoints is not free."""
         config = _make_config(tachometer=TachometerConfig(enabled=True))
 
-        assert config.observability.tachometer.default_frequency == 1.0
+        assert config.observability.tachometer.collect_interval_ms == 1000
 
     def test_scraper_requires_nonempty_binary_path(self):
         with pytest.raises(ValidationError, match="observability.tachometer.binary_path"):
@@ -154,7 +154,7 @@ class TestDcgmPowerConfig:
     def test_defaults_are_stable(self):
         defaults = TelemetryConfig()
 
-        assert defaults.default_frequency == 1.0
+        assert defaults.collect_interval_ms == 1000
         assert defaults.required is False
         assert defaults.startup_timeout_seconds == 30.0
         assert defaults.request_timeout_seconds == 2.0
@@ -211,10 +211,9 @@ class TestDcgmPowerConfig:
                 None,
                 "port",
             ),
-            ({"default_frequency": 0.0}, None, "default_frequency"),
-            ({"default_frequency": float("nan")}, None, "default_frequency"),
-            ({"default_frequency": float("inf")}, None, "default_frequency"),
-            ({"default_frequency": 3.5}, None, "sample_gap_exceeded"),
+            ({"collect_interval_ms": 0}, None, "collect_interval_ms"),
+            ({"collect_interval_ms": -1}, None, "collect_interval_ms"),
+            ({"collect_interval_ms": 3500}, None, "sample_gap_exceeded"),
             ({"startup_timeout_seconds": 0.0}, None, "startup_timeout_seconds"),
             ({"request_timeout_seconds": -1.0}, None, "request_timeout_seconds"),
             ({"collector_join_timeout_seconds": 2.0}, None, "collector_join_timeout_seconds"),
@@ -243,7 +242,7 @@ class TestDcgmPowerConfig:
     def test_dcgm_power_rejects_a_sample_interval_above_the_contract_limit(self):
         telemetry = TelemetryConfig(
             enabled=True,
-            default_frequency=5.0,
+            collect_interval_ms=5000,
             storage_subdir="power",
             required=True,
             startup_timeout_seconds=30.0,

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -93,24 +93,54 @@ class TestTachometerConfig:
         assert tachometer.resolved_node_exporter.port == 9101
         assert "node-exporter" in tachometer.resolved_node_exporter.container_image
 
-    def test_default_dcgm_exporter_samples_gently(self):
-        """The built-in DCGM exporter must NOT inherit the power-telemetry
-        template's 100ms collect interval: 10 Hz NVML sampling measured ~2%
-        ITL p50 overhead on GB300 decode, while 5000ms measured at parity
-        with no telemetry (A/B/C/D/E isolation runs, 2026-09-06). The power
-        path keeps 100ms — high-rate sampling is its purpose."""
+    def test_dcgm_sampling_follows_the_scrape_knob(self):
+        """One knob rules both cadences: the tachometer-owned DCGM exporter
+        samples NVML exactly as often as tachometer scrapes it. It must NOT
+        inherit the power template's 100ms — 10 Hz NVML sampling measured
+        ~2% ITL p50 overhead on GB300 decode (isolation runs, 2026-09-06);
+        the power path keeps 100ms because dense sampling is its purpose."""
         from srtctl.cli.mixins.telemetry_stage import (
             DCGM_EXPORTER_COMMAND_TEMPLATE,
             resolve_exporter_command,
+            tachometer_dcgm_command_template,
         )
 
-        tachometer = TachometerConfig()
+        default = TachometerConfig()
         cmd = resolve_exporter_command(
-            tachometer.resolved_dcgm_exporter, DCGM_EXPORTER_COMMAND_TEMPLATE
+            default.resolved_dcgm_exporter, tachometer_dcgm_command_template(default)
         )
-        assert "--collect-interval=5000" in cmd
+        assert "--collect-interval=1000" in cmd
         assert ":9401" in cmd
+
+        slow = TachometerConfig(collect_interval_ms=5000)
+        assert "--collect-interval=5000" in tachometer_dcgm_command_template(slow)
+
+        # An explicit recipe command must still win over the derived template.
+        custom = TachometerConfig(
+            dcgm_exporter=TelemetryExporterConfig(
+                container_image="dcgm:latest", port=9401, command="dcgm-exporter --custom --address :{port}"
+            )
+        )
+        assert resolve_exporter_command(
+            custom.resolved_dcgm_exporter, tachometer_dcgm_command_template(custom)
+        ) == "dcgm-exporter --custom --address :9401"
+
         assert "--collect-interval=100 " in DCGM_EXPORTER_COMMAND_TEMPLATE
+
+    def test_host_sampler_follows_the_scrape_knob(self, tmp_path):
+        """The host sampler's cadence derives from the same single knob."""
+        import threading
+
+        from srtctl.analysis.host_sampler import try_start_host_sampler
+
+        config = _make_config(tachometer=TachometerConfig(enabled=True, collect_interval_ms=4000))
+        sampler = try_start_host_sampler(tmp_path, config.observability, threading.Event())
+        try:
+            assert sampler is not None
+            assert sampler.interval_seconds == 4.0
+        finally:
+            if sampler is not None:
+                sampler.stop()
 
     def test_default_exporters_false_disables_built_ins(self):
         tachometer = TachometerConfig(default_exporters=False)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -577,7 +577,7 @@ class TestPreflightConfigVariants:
             "benchmark": {"type": "sa-bench", "isl": 8192, "osl": 1024, "concurrencies": [4]},
             "telemetry": {
                 "enabled": True,
-                "default_frequency": 1.0,
+                "collect_interval_ms": 1000,
                 "storage_subdir": "power",
                 "required": True,
                 "dcgm_exporter": {"container_image": str(dcgm_image), "port": 9401},


### PR DESCRIPTION
## Summary

srt-slurm's default-on telemetry (tachometer + DCGM/node exporters, on for every run since #358) expressed one concept — *how often measurements are taken* — through several unrelated knobs in mixed units. This PR consolidates them into a single integer knob, **`observability.tachometer.collect_interval_ms`** (milliseconds, default `1000`), retires the Hz-based knobs, and validates with an A/B benchmark on the Dynamo TRT-LLM stack that the shipped defaults add **no measurable performance overhead**, so telemetry can stay on by default.

## The problem

Before this PR, cadence was spread across three unit systems:

| surface | knob | actual unit |
|---|---|---|
| tachometer scrape loop | `observability.tachometer.default_frequency` | **Hz** (scraper slept `1.0/f`) |
| power telemetry collector | `telemetry.default_frequency` | **seconds** — despite the name (passed verbatim into `sample_interval_seconds`; validated against a max-gap-in-seconds constant) |
| DCGM exporter process | `--collect-interval` in its launch command | **milliseconds** |

Two concrete defects followed:

1. **The same key name meant reciprocal things** in adjacent config blocks (`default_frequency: 2` = twice per second under tachometer, once per two seconds under power telemetry).
2. **A 100 ms trap**: a recipe that customized `dcgm_exporter` (even just to pin an image) without spelling out a full `command` silently fell back to the power-telemetry launch template — `--collect-interval=100`, i.e. 10 Hz NVML sampling on every worker node. 10 Hz DCGM sampling was previously measured at **~2% inter-token-latency (p50) overhead** on GB300 decode, which is what motivated unifying and re-measuring cadence in the first place.

## The change

**Commit 1 — retire the Hz knobs.** `collect_interval_ms: int` replaces `default_frequency` on both `observability.tachometer` and `telemetry` (behavior-identical defaults: `1000` = the old 1.0 Hz / 1.0 s). The generated scraper TOML and the vendored Rust scraper switch from per-endpoint `frequency` (Hz, `1/f` sleep) to `collect_interval_ms` (`Duration::from_millis`); the scraper's manual debug flag `--freq` becomes `--collect-interval-ms`. Recipes still carrying `default_frequency` **fail loudly at submit** (`unknown=RAISE`, same retirement pattern as `build_dashboard`/`scrape_metrics`), pinned by tests.

**Commit 2 — one knob drives the whole capture stack.** `observability.tachometer.collect_interval_ms` now governs:

- tachometer's scrape interval for every endpoint (worker, frontend, DCGM, node-exporter pages);
- the launched DCGM exporter's `--collect-interval` — its command is rendered from the knob, so the exporter samples NVML exactly as often as it is scraped: every scrape fresh, no scrape a duplicate. An explicit `dcgm_exporter.command` in the recipe still wins. This kills the 100 ms trap by construction: the power template can no longer leak into a tachometer launch;
- the host sampler's interval (kept — its per-process health output feeds `ingest.py run_host_samples`, which node-exporter families don't cover).

Deliberately **not** coupled: power telemetry's `telemetry.collect_interval_ms` (its dense-sampling fidelity contract inside sa-bench measurement windows is a different purpose, and it must work with tachometer off) and the benchmark client's own server-metrics interval (a separate tool; unrelated to tachometer). Setting the knob below `1000` is honored but warned about at launch (`DCGM_PROVEN_SAFE_INTERVAL_MS`), since faster values drive DCGM sampling toward the measured-harm regime.

## Performance validation (Dynamo TRT-LLM stack)

Four same-day sequential runs on lyris GB300 (DeepSeek-V4 disaggregated, 1 prefill + 3 decode nodes, agentic trace replay, 600 s profiling window, ~200 requests/leg), interleaved **A / F / F / A**: **A** = no telemetry, **F** = this PR at shipped defaults (every cadence at 1000 ms, including DCGM NVML sampling — the previously unmeasured value; 100 ms had measured ~2% overhead, 5000 ms parity). Primary metric: inter-token latency p50, within-arm spread ≤0.4% across all chains of this design.

| metric | A1 | A2 | F1 | F2 | F vs A mean |
|---|---|---|---|---|---|
| **inter-token latency p50 (ms)** | 5.631 | 5.599 | 5.628 | 5.585 | **−0.15%** |
| output tok/s per user | 175.9 | 177.3 | 176.4 | 178.8 | +0.6% |
| output tok/s (total) | 321.7 | 344.2 | 356.2 | 326.4 | +2.5% |
| request throughput (req/s) | 0.284 | 0.317 | 0.357 | 0.306 | +10.3% |
| TTFT p50 (ms) | 758 | 800 | 901 | 551 | −6.9% |
| TTFT p99 (s) | 68.4 | 39.3 | 37.2 | 41.8 | −26.7% |
| inter-token latency p99 (ms) | 7.07 | 7.15 | 7.19 | 6.39 | −4.5% |

**Verdict: parity.** The precision metric is flat (−0.15%); everything else swings within this workload's run-to-run noise (note the largest TTFT p99 outlier sits in a *bare* leg, A1). Zero request errors or cancellations in any leg. Integrity: F legs rendered `dcgm-exporter --collect-interval=1000`, ran tachometer + both exporters (rendered config + process logs); A legs ran zero telemetry processes. Jobs: A1=2946716, F1=2946791, F2=2946891, A2=2947134 (lyris).

Known behavior noted during validation: the scraper sleeps *between* scrape completions, so a slow page stretches its effective period (the DCGM page rendered in ~0.5 s → ~1.5 s effective cadence at a 1000 ms setting). Cosmetic for analysis (timestamps are exact); a fixed-rate ticker is possible follow-up work.

## Testing

- `make check`: 1694 passed, 2 skipped (new: retirement pinning tests for both retired knobs, knob-derivation tests for the DCGM command and host sampler).
- `cargo test --workspace --locked` + `cargo fmt --check` in `src/tachometer/`: all targets green, integration test updated to the new TOML key.
- Mixed-version note: an older `tachometer-scraper` binary reading the new TOML ignores the unknown key and falls back to its built-in 500 ms — degraded but functional; redeploy the binary from this revision to honor configured cadence.

## Migration for recipe authors

| before | after |
|---|---|
| `observability.tachometer.default_frequency: 1.0` (Hz) | `observability.tachometer.collect_interval_ms: 1000` |
| `observability.tachometer.default_frequency: 0.2` (every 5 s) | `observability.tachometer.collect_interval_ms: 5000` |
| `telemetry.default_frequency: 1.0` (seconds) | `telemetry.collect_interval_ms: 1000` |
| custom `dcgm_exporter` block without `command` → silently 100 ms | inherits the knob's cadence; explicit `command` still wins |
