### PR TITLE
Add the readiness probe vocabulary for services: tcp, http, log

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1808,7 +1808,7 @@ services:
 | `env` | dict | `{}` | Service environment; placeholders like `{node_ip}` are substituted |
 | `placement.node` | string | `head` | One instance for `head`/`infra`; one per node for `prefill`/`decode`/`agg`/`workers` |
 | `start` | string | type default | `after_frontend` (generic) or `before_workers` (mooncake-store) |
-| `readiness` | object | none | `port` + `timeout_seconds`; the job waits for it on every service node |
+| `readiness` | object | none | One probe (`port`/`tcp`, `http`, or `log`) plus `timeout_seconds` and `interval_seconds`; the job waits for it on every service node |
 | `inherit_discovery_env` | bool | `true` | Inject the Dynamo discovery env |
 | `critical` | bool | type default | A crash fails the run when true |
 | `source`, `build_command` | object, list[string] | none | Clone an immutable git rev and build once before launch; single-node placements only |

--- a/docs/schema-reference.md
+++ b/docs/schema-reference.md
@@ -387,12 +387,16 @@ Where a service runs.
 
 ### ServiceReadinessConfig
 
-TCP readiness gate: the launch blocks until ``port`` accepts connections on every service node.
+Readiness gate: the launch blocks until the probe passes on every service node.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `port` | int | required | TCP port the service listens on. |
+| `port` | int \| None | `None` | Shorthand for ``tcp: {port: <port>}``. |
+| `tcp` | [TcpProbe](#tcpprobe) \| None | `None` | TCP connect probe. |
+| `http` | [HttpProbe](#httpprobe) \| None | `None` | HTTP GET probe. |
+| `log` | [LogProbe](#logprobe) \| None | `None` | Log-pattern probe against ``service_<name>.out``. |
 | `timeout_seconds` | int | `120` | How long to wait per node before failing the job. |
+| `interval_seconds` | int | `2` | Seconds between probe attempts. |
 
 ### IdentityModelConfig
 
@@ -445,6 +449,32 @@ S3 upload configuration for log artifacts.
 | `endpoint_url` | str \| None | `None` | Custom S3-compatible endpoint URL (optional) |
 | `access_key_id` | str \| None | `None` | AWS access key ID (falls back to AWS_ACCESS_KEY_ID env var) |
 | `secret_access_key` | str \| None | `None` | AWS secret access key (falls back to AWS_SECRET_ACCESS_KEY env var) |
+
+### TcpProbe
+
+Ready when ``port`` accepts a TCP connection on the service node.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `port` | int | required |  |
+
+### HttpProbe
+
+Ready when ``GET http://<node>:<port><path>`` returns ``status``.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `port` | int | required |  |
+| `path` | str | `'/health'` |  |
+| `status` | int | `200` |  |
+
+### LogProbe
+
+Ready when the service's log file contains a line matching the regular expression ``pattern``.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `pattern` | str | required |  |
 
 ## Backend types
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -58,9 +58,10 @@ services:
     placement:
       node: head                 # head | infra | prefill | decode | agg | workers
     start: after_frontend        # after_frontend | before_workers
-    readiness:                   # optional TCP gate, checked on every service node
-      port: 9000
+    readiness:                   # optional probe, checked on every service node
+      port: 9000                 # or tcp: {port} / http: {port, path, status} / log: {pattern}
       timeout_seconds: 120
+      interval_seconds: 2
     inherit_discovery_env: true  # inject ETCD_ENDPOINTS / NATS_SERVER
     critical: false              # a crash fails the run when true
     preamble: |                  # shell run before command, inside the container
@@ -89,7 +90,7 @@ services:
 | `env` | `{}` | Merged over the type's defaults; see [Environment](#environment). |
 | `placement.node` | `head` | See [Placement](#placement). |
 | `start` | type default | `generic`: `after_frontend`. `mooncake-store`: `before_workers`. |
-| `readiness` | none | TCP port gate per node. Timing out terminates what this stage started and fails the job. |
+| `readiness` | none | One probe per node: `port` / `tcp`, `http`, or `log`, plus `timeout_seconds` and `interval_seconds`. See [Start Order and Readiness](#start-order-and-readiness). Timing out terminates what this stage started and fails the job. |
 | `inherit_discovery_env` | `true` | Inject the same `ETCD_ENDPOINTS` / `NATS_SERVER` the Dynamo frontend gets. |
 | `critical` | type default | `generic`: `false`. `mooncake-store`: `true`. |
 | `preamble` | none | Shell run after the environment is exported and before `command`. |
@@ -122,8 +123,40 @@ Services launch in declaration order within a start phase:
 - `after_frontend`: once workers and the frontend are healthy, before telemetry. For sidecars that
   register into a running job.
 
-Within a phase, a service with `readiness` blocks until its port answers on each of its nodes; a
-service without one is considered started when its `srun` is launched. Ongoing health is the shared
+Within a phase, a service with `readiness` blocks until its probe passes on each of its nodes; a
+service without one is considered started when its `srun` is launched. Three probes are available,
+and a `readiness` block names exactly one:
+
+```yaml
+readiness:
+  port: 9000                 # shorthand for tcp
+  timeout_seconds: 120       # per node; the job fails when it runs out
+  interval_seconds: 2        # between attempts
+```
+
+```yaml
+readiness:
+  tcp:
+    port: 9000               # a TCP connection is accepted
+```
+
+```yaml
+readiness:
+  http:
+    port: 8000
+    path: /ready             # GET http://<node>:8000/ready
+    status: 200              # returns this status
+```
+
+```yaml
+readiness:
+  log:
+    pattern: 'Uvicorn running on .*:\d+'   # a regex matched against service_<name>.out
+```
+
+The probe is re-run every `interval_seconds` until it passes. Between attempts the stage checks that
+the process is still alive, so a service that crashes fails the job at once with its exit code rather
+than after the full timeout. Ongoing health is the shared
 `ProcessRegistry` monitor, the same as every other process in the job. It tears the run down only for
 `critical: true` services. Anything other components register under or route through should be
 critical: a router that dies mid-run otherwise leaves the frontend silently talking to the raw

--- a/examples/features/services.yaml
+++ b/examples/features/services.yaml
@@ -61,7 +61,9 @@ services:
       node: head          # head | infra | prefill | decode | agg | workers
     # start: after_frontend (default). Use before_workers for something workers need.
     readiness:
-      port: 9911          # the job waits until this port answers on the service node
+      http:               # or `port: 9911` (tcp), or `log: {pattern: ...}` against the service log
+        port: 9911
+        path: /           # the directory listing; the job waits until it returns 200
       timeout_seconds: 60
     inherit_discovery_env: false   # no etcd/NATS here; the SGLang router runs without them
     # critical: false (default). A dead sidecar costs its own log, not the run.

--- a/src/srtctl/cli/mixins/service_stage.py
+++ b/src/srtctl/cli/mixins/service_stage.py
@@ -6,7 +6,7 @@
 Every service kind launches the same way: resolve the nodes its ``placement``
 selects, optionally clone and build a ``source`` once, then one ``srun`` per
 node with the kind's environment merged around the recipe's ``env``, an
-optional TCP readiness gate, and a ``ManagedProcess`` for the shared
+optional readiness probe (tcp, http, or log), and a ``ManagedProcess`` for the shared
 ``ProcessRegistry`` (which provides crash detection and teardown). The kind
 (``srtctl.services.registry.ServiceKind``) never launches anything itself.
 
@@ -30,8 +30,8 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from srtctl.core.health import wait_for_port
 from srtctl.core.processes import ManagedProcess, ProcessRegistry, terminate_and_reap
+from srtctl.core.readiness import ProcessDied, wait_until_ready
 from srtctl.core.slurm import get_hostname_ip, start_srun_process
 from srtctl.ports import ETCD_CLIENT_PORT, NATS_PORT
 from srtctl.services.registry import ServiceLaunchContext, get_service_kind
@@ -46,9 +46,6 @@ logger = logging.getLogger(__name__)
 
 # The clone script runs three git commands, each under its own `timeout 600s`.
 CLONE_TIMEOUT_SECONDS = 3 * 600 + 60
-# Readiness polling slice: how long one wait_for_port call may block before we
-# re-check that the service process is still alive.
-_READINESS_SLICE_SECONDS = 5
 
 
 def render_placeholders(value: str, replacements: dict[str, str]) -> str:
@@ -94,15 +91,16 @@ class ServiceStageMixin:
         """Two services that both listen on the same readiness port cannot share a node."""
         owners: dict[tuple[str, int], str] = {}
         for service in services:
-            if service.readiness is None:
+            port = service.readiness.probe_port if service.readiness is not None else None
+            if port is None:
                 continue
             for node in self.service_nodes(service):
-                key = (node, service.readiness.port)
+                key = (node, port)
                 other = owners.setdefault(key, service.name)
                 if other != service.name:
                     raise ValueError(
                         f"services[{service.name}] and services[{other}] both listen on port "
-                        f"{service.readiness.port} on node {node}; give them disjoint placements or ports"
+                        f"{port} on node {node}; give them disjoint placements or ports"
                     )
 
     # -- one-shot steps (clone, build) ----------------------------------------------
@@ -253,30 +251,28 @@ class ServiceStageMixin:
 
     @staticmethod
     def _wait_ready(proc: ManagedProcess, service: ServiceConfig, readiness: ServiceReadinessConfig) -> None:
-        """Block until the service's port answers, failing fast if the process dies first."""
+        """Block until the service's readiness probe passes, failing fast if the process dies first."""
         assert proc.node is not None
-        logger.info(
-            "Waiting for service %s on %s (port %d, timeout %ds)",
-            service.name,
-            proc.node,
-            readiness.port,
-            readiness.timeout_seconds,
-        )
-        waited = 0
-        while waited < readiness.timeout_seconds:
-            step = min(_READINESS_SLICE_SECONDS, readiness.timeout_seconds - waited)
-            if wait_for_port(proc.node, readiness.port, timeout=step):
-                return
-            waited += step
-            if not proc.is_running:
-                raise RuntimeError(
-                    f"services[{service.name}] exited with code {proc.exit_code} on {proc.node} before opening "
-                    f"port {readiness.port}; see {proc.log_file}"
-                )
-        raise RuntimeError(
-            f"services[{service.name}] did not open port {readiness.port} on {proc.node} within "
-            f"{readiness.timeout_seconds}s; see {proc.log_file}"
-        )
+        logger.info("Waiting for service %s on %s (%s)", service.name, proc.node, readiness.describe())
+        try:
+            ready = wait_until_ready(
+                readiness.probe,
+                host=proc.node,
+                log_file=proc.log_file,
+                timeout=readiness.timeout_seconds,
+                interval=readiness.interval_seconds,
+                is_alive=lambda: proc.is_running,
+            )
+        except ProcessDied:
+            raise RuntimeError(
+                f"services[{service.name}] exited with code {proc.exit_code} on {proc.node} before its readiness "
+                f"probe passed ({readiness.describe()}); see {proc.log_file}"
+            ) from None
+        if not ready:
+            raise RuntimeError(
+                f"services[{service.name}] on {proc.node} was not ready within {readiness.timeout_seconds}s "
+                f"({readiness.describe()}); see {proc.log_file}"
+            )
 
     def start_services(self, start: str, registry: ProcessRegistry | None = None) -> list[ManagedProcess]:
         """Launch every service whose (effective) ``start`` matches, in declaration order.

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -420,9 +420,7 @@ def show_config_details(config: SrtConfig) -> None:
             if service.build_command:
                 console.print(f"    [yellow]build_command:[/] {shlex.join(service.build_command)}", crop=False)
             if service.readiness is not None:
-                console.print(
-                    f"    [yellow]readiness:[/] tcp/{service.readiness.port}, timeout={service.readiness.timeout_seconds}s"
-                )
+                console.print(f"    [yellow]readiness:[/] {service.readiness.describe()}")
             if service.preamble:
                 console.print(f"    [yellow]preamble:[/] {service.preamble.strip()}", crop=False)
             console.print(f"    [yellow]inherit_discovery_env:[/] {str(service.inherit_discovery_env).lower()}")

--- a/src/srtctl/core/readiness.py
+++ b/src/srtctl/core/readiness.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic readiness probes: is this process ready, by its own definition?
+
+The worker and frontend health checks in :mod:`srtctl.core.health` know what a
+Dynamo or SGLang endpoint looks like. A user-declared service does not have that
+luxury, so ``services[].readiness`` picks one of three generic probes:
+
+- ``tcp``: a port accepts a connection,
+- ``http``: a URL returns an expected status,
+- ``log``: the process log matches a regular expression.
+
+:func:`wait_until_ready` runs one probe until it passes, the deadline expires,
+or the process dies, checking liveness between attempts so a crashed service
+fails at once instead of after the full timeout.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import socket
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import requests
+
+if TYPE_CHECKING:
+    from srtctl.services.config import HttpProbe, LogProbe, TcpProbe
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessDied(RuntimeError):
+    """The probed process exited before its probe passed."""
+
+
+def probe_tcp(host: str, port: int, *, connect_timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=connect_timeout):
+            return True
+    except (TimeoutError, ConnectionRefusedError, OSError):
+        return False
+
+
+def probe_http(host: str, port: int, path: str, status: int, *, request_timeout: float = 5.0) -> bool:
+    try:
+        return requests.get(f"http://{host}:{port}{path}", timeout=request_timeout).status_code == status
+    except requests.exceptions.RequestException:
+        return False
+
+
+def probe_log(log_file: Path | None, pattern: str) -> bool:
+    if log_file is None or not log_file.exists():
+        return False
+    try:
+        text = log_file.read_text(errors="replace")
+    except OSError:
+        return False
+    return re.search(pattern, text, flags=re.MULTILINE) is not None
+
+
+def run_probe(probe: TcpProbe | HttpProbe | LogProbe, *, host: str, log_file: Path | None) -> bool:
+    """Run one probe attempt against ``host`` (and ``log_file`` for log probes)."""
+    from srtctl.services.config import HttpProbe, LogProbe, TcpProbe
+
+    if isinstance(probe, TcpProbe):
+        return probe_tcp(host, probe.port)
+    if isinstance(probe, HttpProbe):
+        return probe_http(host, probe.port, probe.path, probe.status)
+    if isinstance(probe, LogProbe):
+        return probe_log(log_file, probe.pattern)
+    raise TypeError(f"unknown probe type {type(probe).__name__}")
+
+
+def wait_until_ready(
+    probe: TcpProbe | HttpProbe | LogProbe,
+    *,
+    host: str,
+    log_file: Path | None,
+    timeout: float,
+    interval: float,
+    is_alive: Callable[[], bool],
+    sleep: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Probe until it passes (True), the deadline passes (False), or the process dies (:class:`ProcessDied`).
+
+    Liveness is checked after every failed attempt, so a process that exits
+    never waits out the full ``timeout``.
+    """
+    deadline = clock() + timeout
+    while True:
+        if run_probe(probe, host=host, log_file=log_file):
+            return True
+        if not is_alive():
+            raise ProcessDied("process exited before its readiness probe passed")
+        remaining = deadline - clock()
+        if remaining <= 0:
+            return False
+        sleep(min(interval, remaining))

--- a/src/srtctl/services/__init__.py
+++ b/src/srtctl/services/__init__.py
@@ -8,10 +8,13 @@ from srtctl.services import generic, mooncake_store
 from srtctl.services.config import (
     SERVICE_PLACEMENTS,
     SERVICE_STARTS,
+    HttpProbe,
+    LogProbe,
     ServiceConfig,
     ServicePlacementConfig,
     ServiceReadinessConfig,
     ServiceSourceConfig,
+    TcpProbe,
 )
 from srtctl.services.registry import (
     ServiceKind,
@@ -24,12 +27,15 @@ from srtctl.services.registry import (
 __all__ = [
     "SERVICE_PLACEMENTS",
     "SERVICE_STARTS",
+    "HttpProbe",
+    "LogProbe",
     "ServiceConfig",
     "ServiceKind",
     "ServiceLaunchContext",
     "ServicePlacementConfig",
     "ServiceReadinessConfig",
     "ServiceSourceConfig",
+    "TcpProbe",
     "generic",
     "get_service_kind",
     "list_service_types",

--- a/src/srtctl/services/config.py
+++ b/src/srtctl/services/config.py
@@ -57,24 +57,118 @@ class ServicePlacementConfig:
 
 
 @dataclass(frozen=True)
-class ServiceReadinessConfig:
-    """TCP readiness gate: the launch blocks until ``port`` accepts connections on every service node.
-
-    Attributes:
-        port: TCP port the service listens on.
-        timeout_seconds: How long to wait per node before failing the job.
-    """
+class TcpProbe:
+    """Ready when ``port`` accepts a TCP connection on the service node."""
 
     port: int
-    timeout_seconds: int = 120
 
     Schema: ClassVar[type[Schema]] = Schema
 
     def __post_init__(self) -> None:
         if not 1 <= self.port <= 65535:
-            raise ValidationError("services[].readiness.port must be between 1 and 65535")
+            raise ValidationError("readiness.tcp.port must be between 1 and 65535")
+
+
+@dataclass(frozen=True)
+class HttpProbe:
+    """Ready when ``GET http://<node>:<port><path>`` returns ``status``."""
+
+    port: int
+    path: str = "/health"
+    status: int = 200
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.port <= 65535:
+            raise ValidationError("readiness.http.port must be between 1 and 65535")
+        if not self.path.startswith("/"):
+            raise ValidationError("readiness.http.path must start with '/'")
+        if not 100 <= self.status <= 599:
+            raise ValidationError("readiness.http.status must be an HTTP status code")
+
+
+@dataclass(frozen=True)
+class LogProbe:
+    """Ready when the service's log file contains a line matching the regular expression ``pattern``."""
+
+    pattern: str
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        import re
+
+        try:
+            re.compile(self.pattern)
+        except re.error as exc:
+            raise ValidationError(f"readiness.log.pattern is not a valid regular expression: {exc}") from None
+
+
+@dataclass(frozen=True)
+class ServiceReadinessConfig:
+    """Readiness gate: the launch blocks until the probe passes on every service node.
+
+    Exactly one probe: ``tcp`` (a port accepts connections), ``http`` (a URL
+    returns a status), or ``log`` (the service log matches a pattern). ``port``
+    alone is shorthand for ``tcp``.
+
+    Attributes:
+        port: Shorthand for ``tcp: {port: <port>}``.
+        tcp: TCP connect probe.
+        http: HTTP GET probe.
+        log: Log-pattern probe against ``service_<name>.out``.
+        timeout_seconds: How long to wait per node before failing the job.
+        interval_seconds: Seconds between probe attempts.
+    """
+
+    port: int | None = None
+    tcp: TcpProbe | None = None
+    http: HttpProbe | None = None
+    log: LogProbe | None = None
+    timeout_seconds: int = 120
+    interval_seconds: int = 2
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        if self.port is not None:
+            if self.tcp is not None:
+                raise ValidationError("services[].readiness: give either port (shorthand) or tcp, not both")
+            object.__setattr__(self, "tcp", TcpProbe(port=self.port))
+        probes = [name for name in ("tcp", "http", "log") if getattr(self, name) is not None]
+        if len(probes) != 1:
+            raise ValidationError(
+                f"services[].readiness needs exactly one probe: port, tcp, http, or log; got {', '.join(probes) or 'none'}"
+            )
         if self.timeout_seconds <= 0:
             raise ValidationError("services[].readiness.timeout_seconds must be positive")
+        if self.interval_seconds <= 0:
+            raise ValidationError("services[].readiness.interval_seconds must be positive")
+
+    @property
+    def probe(self) -> TcpProbe | HttpProbe | LogProbe:
+        for name in ("tcp", "http", "log"):
+            value = getattr(self, name)
+            if value is not None:
+                return value
+        raise AssertionError("unreachable: __post_init__ guarantees one probe")
+
+    @property
+    def probe_port(self) -> int | None:
+        """The port the service is expected to own, when the probe implies one."""
+        probe = self.probe
+        return probe.port if isinstance(probe, TcpProbe | HttpProbe) else None
+
+    def describe(self) -> str:
+        probe = self.probe
+        if isinstance(probe, TcpProbe):
+            what = f"tcp/{probe.port}"
+        elif isinstance(probe, HttpProbe):
+            what = f"http://<node>:{probe.port}{probe.path} -> {probe.status}"
+        else:
+            what = f"log matches /{probe.pattern}/"
+        return f"{what}, timeout={self.timeout_seconds}s"
 
 
 @dataclass(frozen=True)

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the readiness probe vocabulary and the generic wait loop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from marshmallow import ValidationError
+
+from srtctl.core.readiness import ProcessDied, probe_log, run_probe, wait_until_ready
+from srtctl.services import HttpProbe, LogProbe, ServiceReadinessConfig, TcpProbe
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+    def __call__(self) -> float:
+        return self.now
+
+
+# --- schema ---------------------------------------------------------------------
+
+
+def test_port_is_shorthand_for_tcp() -> None:
+    ready = ServiceReadinessConfig.Schema().load({"port": 9911})
+    assert isinstance(ready.probe, TcpProbe) and ready.probe.port == 9911
+    assert ready.probe_port == 9911
+    assert ready.describe() == "tcp/9911, timeout=120s"
+
+
+def test_http_and_log_probes() -> None:
+    http = ServiceReadinessConfig.Schema().load(
+        {"http": {"port": 8000, "path": "/ready", "status": 204}, "timeout_seconds": 30}
+    )
+    assert isinstance(http.probe, HttpProbe)
+    assert http.probe_port == 8000
+    assert http.describe() == "http://<node>:8000/ready -> 204, timeout=30s"
+
+    log = ServiceReadinessConfig.Schema().load({"log": {"pattern": r"Uvicorn running on .*:\d+"}})
+    assert isinstance(log.probe, LogProbe)
+    assert log.probe_port is None
+    assert log.describe().startswith("log matches /Uvicorn")
+
+
+def test_exactly_one_probe() -> None:
+    with pytest.raises(ValidationError, match="exactly one probe"):
+        ServiceReadinessConfig.Schema().load({})
+    with pytest.raises(ValidationError, match="exactly one probe"):
+        ServiceReadinessConfig.Schema().load({"tcp": {"port": 1}, "log": {"pattern": "x"}})
+    with pytest.raises(ValidationError, match="either port .* or tcp"):
+        ServiceReadinessConfig.Schema().load({"port": 1, "tcp": {"port": 2}})
+    with pytest.raises(ValidationError, match="valid regular expression"):
+        ServiceReadinessConfig.Schema().load({"log": {"pattern": "("}})
+    with pytest.raises(ValidationError, match="path must start with"):
+        ServiceReadinessConfig.Schema().load({"http": {"port": 80, "path": "health"}})
+    with pytest.raises(ValidationError, match="interval_seconds must be positive"):
+        ServiceReadinessConfig.Schema().load({"port": 80, "interval_seconds": 0})
+
+
+# --- probes ------------------------------------------------------------------------
+
+
+def test_log_probe_reads_the_file(tmp_path: Path) -> None:
+    log = tmp_path / "service_x.out"
+    assert not probe_log(log, "ready")
+    log.write_text("starting\nserver ready on 9000\n")
+    assert probe_log(log, r"ready on \d+")
+    assert not probe_log(None, "ready")
+
+
+def test_http_probe_checks_status() -> None:
+    response = MagicMock(status_code=200)
+    with patch("srtctl.core.readiness.requests.get", return_value=response) as get:
+        assert run_probe(HttpProbe(port=8000, path="/ready"), host="node1", log_file=None)
+        assert not run_probe(HttpProbe(port=8000, path="/ready", status=204), host="node1", log_file=None)
+    assert get.call_args.args[0] == "http://node1:8000/ready"
+
+
+# --- wait loop ----------------------------------------------------------------------
+
+
+def test_wait_until_ready_passes_after_retries() -> None:
+    clock = FakeClock()
+    with patch("srtctl.core.readiness.probe_tcp", side_effect=[False, False, True]):
+        assert wait_until_ready(
+            TcpProbe(port=1),
+            host="n",
+            log_file=None,
+            timeout=60,
+            interval=5,
+            is_alive=lambda: True,
+            sleep=clock.sleep,
+            clock=clock,
+        )
+    assert clock.slept == [5, 5]
+
+
+def test_wait_until_ready_fails_fast_when_process_dies() -> None:
+    clock = FakeClock()
+    with patch("srtctl.core.readiness.probe_tcp", return_value=False), pytest.raises(ProcessDied):
+        wait_until_ready(
+            TcpProbe(port=1),
+            host="n",
+            log_file=None,
+            timeout=600,
+            interval=5,
+            is_alive=lambda: False,
+            sleep=clock.sleep,
+            clock=clock,
+        )
+    assert clock.slept == []  # no waiting out the 600s budget
+
+
+def test_wait_until_ready_times_out() -> None:
+    clock = FakeClock()
+    with patch("srtctl.core.readiness.probe_tcp", return_value=False):
+        assert not wait_until_ready(
+            TcpProbe(port=1),
+            host="n",
+            log_file=None,
+            timeout=7,
+            interval=3,
+            is_alive=lambda: True,
+            sleep=clock.sleep,
+            clock=clock,
+        )
+    assert clock.slept == [3, 3, 1]  # the last sleep is clipped to the remaining budget

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -14,6 +14,7 @@ import yaml
 from marshmallow import ValidationError
 
 from srtctl.cli.do_sweep import SweepOrchestrator
+from srtctl.core.readiness import ProcessDied
 from srtctl.core.runtime import Nodes, RuntimeContext
 from srtctl.core.schema import SrtConfig
 from srtctl.core.topology import Endpoint
@@ -21,7 +22,7 @@ from srtctl.ports import MOONCAKE_HTTP_METADATA_PORT, MOONCAKE_MASTER_PORT
 from srtctl.services import ServiceConfig, ServiceSourceConfig, list_service_types
 
 SRUN = "srtctl.cli.mixins.service_stage.start_srun_process"
-WAIT = "srtctl.cli.mixins.service_stage.wait_for_port"
+WAIT = "srtctl.cli.mixins.service_stage.wait_until_ready"
 HOST_IP = "srtctl.cli.mixins.service_stage.get_hostname_ip"
 
 DISAGG_HEAD = """
@@ -245,7 +246,11 @@ def test_readiness_gate_blocks_and_failure_terminates_started(tmp_path: Path) ->
         patch(WAIT, return_value=True) as wait,
     ):
         orchestrator.start_services("after_frontend")
-    wait.assert_called_once_with("node0", 9000, timeout=5)
+    wait.assert_called_once()
+    assert wait.call_args.kwargs["host"] == "node0"
+    assert wait.call_args.kwargs["timeout"] == 5
+    assert wait.call_args.kwargs["log_file"] == tmp_path / "service_a.out"
+    assert wait.call_args.args[0].port == 9000
 
     popen = _proc()
     registry = MagicMock()
@@ -253,7 +258,7 @@ def test_readiness_gate_blocks_and_failure_terminates_started(tmp_path: Path) ->
         patch(SRUN, return_value=popen),
         patch(HOST_IP, return_value="10.0.0.10"),
         patch(WAIT, return_value=False),
-        pytest.raises(RuntimeError, match="did not open port 9000"),
+        pytest.raises(RuntimeError, match="was not ready within 5s"),
     ):
         orchestrator.start_services("after_frontend", registry)
     popen.terminate.assert_called_once()
@@ -271,12 +276,10 @@ def test_readiness_fails_fast_when_the_process_dies(tmp_path: Path) -> None:
     with (
         patch(SRUN, return_value=dead),
         patch(HOST_IP, return_value="10.0.0.10"),
-        patch(WAIT, return_value=False) as wait,
-        pytest.raises(RuntimeError, match="exited with code 127 .* before opening port 9000"),
+        patch(WAIT, side_effect=ProcessDied("gone")),
+        pytest.raises(RuntimeError, match="exited with code 127 .* before its readiness probe passed"),
     ):
         _orchestrator(config, tmp_path).start_services("after_frontend")
-    # One 5s slice, not the full 600s budget.
-    wait.assert_called_once_with("node0", 9000, timeout=5)
 
 
 def test_signal_during_readiness_wait_terminates_started(tmp_path: Path) -> None:


### PR DESCRIPTION
Stacked on #400 (Track 2 step 8 of https://github.com/NVIDIA/srt-slurm/issues/385). Draft until the stack below it merges.

## What

`services[].readiness` gains the probe vocabulary from the schema design: exactly one of

```yaml
readiness:
  port: 9000                 # shorthand for tcp
```

```yaml
readiness:
  tcp:
    port: 9000               # a TCP connection is accepted
```

```yaml
readiness:
  http:
    port: 8000
    path: /ready             # GET http://<node>:8000/ready
    status: 200              # returns this status
```

```yaml
readiness:
  log:
    pattern: 'Uvicorn running on .*:\d+'   # regex against service_<name>.out
```

plus `timeout_seconds` (default 120) and `interval_seconds` (default 2). The generic wait loop in `core/readiness.py` re-runs the probe until it passes, the deadline expires, or the process dies, so a crashed service fails the job at once with its exit code instead of after the full timeout. The port-collision check now keys on the port a `tcp` or `http` probe implies.

Per the design, the global `health_check` block and the worker and frontend health checks are untouched: this fixes the silent-dead-sidecar class (NVIDIA/InferenceMAX#271) without touching the downstream recipes that set `health_check`.

## Also

- `examples/features/services.yaml` now gates on an `http` probe against the log browser's directory listing.
- `tests/test_readiness.py` covers the schema (shorthand, exactly-one, invalid regex/path/interval), each probe, and the wait loop with a fake clock (retries, fail-fast on death, clipped final sleep). `tests/test_services.py` updated for the probe API.
- Docs: probe section in `docs/services.md`, config-reference row, regenerated schema reference.

## Validation

- Full suite green (1835 passed); lint, schema-docs drift check, every example validates.
- sa-b200, job 12295: the services example gated on `http://<node>:9911/ -> 200` came ready after 40s, the benchmark completed, and the job finished clean (3m25s).

