### PR TITLE
Add post_eval: passthrough_env and a command override for the eval dispatch

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -31,6 +31,7 @@ This page is the prose guide: what each block means, how the pieces interact, an
 - [srun_options](#srun_options)
 - [setup_script](#setup_script)
 - [host_setup](#host_setup)
+- [post_eval](#post_eval)
 - [services](#services)
 - [enable_config_dump](#enable_config_dump)
 - [Complete Examples](#complete-examples)
@@ -1767,6 +1768,32 @@ host_setup:
 - `teardown` runs from the job's cleanup path, so it fires on failure and cancellation too, and never changes the job's exit code.
 - Set cluster-wide via `default_host_setup` in `srtslurm.yaml` — that's the right home when *the cluster's machines* need this, rather than one recipe. See [Cluster Config Fields](#cluster-config-fields).
 - `srtctl dry-run -f config.yaml` renders the commands, their scope, and which file they came from.
+
+---
+
+## post_eval
+
+How the accuracy evaluation is dispatched when the job environment sets `RUN_EVAL=true` (run after the benchmark) or `EVAL_ONLY=true` (run instead of it). srtctl forwards a built-in list of workflow variables into the eval process (`RUN_EVAL`, `EVAL_ONLY`, `MODEL`, `ISL`, `OSL`, `PREFILL_TP`, ...); this block extends that list and can replace the command, so a runner sets config instead of patching srtctl's source.
+
+```yaml
+post_eval:
+  passthrough_env:          # forwarded into the eval process when set in the job environment
+    - EVAL_FRAMEWORK
+    - EVAL_CONC
+    - EVAL_LIMIT
+    - EVAL_SUITE
+  command:                  # optional; replaces the built-in lm-eval runner command
+    - bash
+    - /infmax-workspace/benchmarks/evals/run.sh
+    - "{endpoint}"
+```
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `passthrough_env` | list[string] | `[]` | Extra environment variable names copied from the orchestrator's environment into the eval process when set |
+| `command` | list[string] | none | Argv replacing the lm-eval runner. Placeholders: `{endpoint}` (frontend URL), `{infmax_workspace}`. Not shell-interpreted |
+
+`MODEL_NAME` (the served model name) and `EVAL_CONC` are always set by srtctl. `srtctl dry-run` prints the effective dispatch.
 
 ---
 

--- a/docs/schema-reference.md
+++ b/docs/schema-reference.md
@@ -34,6 +34,7 @@ Top-level keys of a recipe YAML.
 | `setup_script` | str \| None | `None` | Custom setup script (runs before dynamo install and worker startup) e.g. "custom-setup.sh" -> runs /configs/custom-setup.sh |
 | `host_setup` | [HostSetupConfig](#hostsetupconfig) | `HostSetupConfig()` | Commands run on each node's bare host, outside the container, before any worker starts. Cluster-wide default lives in srtslurm.yaml as default_host_setup; a recipe that sets this block replaces that default. |
 | `services` | list[[ServiceConfig](#serviceconfig)] | `[]` | Long-running processes launched next to the job: generic sidecars (an experimental router built from a PR) and typed ones (a standalone Mooncake store per worker node). See docs/services.md. |
+| `post_eval` | [PostEvalConfig](#postevalconfig) | `PostEvalConfig()` | Post-benchmark / eval-only evaluation dispatch: extra env forwarded into the eval process and an optional command override. Replaces the downstream source patch that used to extend the passthrough list in do_sweep.py. |
 | `identity` | [IdentityConfig](#identityconfig) | `IdentityConfig()` | Virtual identity — declares what *should* be running (verified against fingerprint) |
 | `reporting` | [ReportingConfig](#reportingconfig) \| None | `None` | Reporting configuration (status API, future: logs to S3, etc.) |
 
@@ -287,6 +288,15 @@ One entry of the top-level ``services:`` list.
 | `cpu_bind` | str \| None | `None` | Optional ``srun --cpu-bind``. |
 | `srun_options` | dict[str, str] | `{}` | Extra srun options for this service only. |
 | `build_timeout_seconds` | int | `1800` | Kill ``build_command`` after this many seconds. |
+
+### PostEvalConfig
+
+How the post-benchmark (or eval-only) accuracy evaluation is dispatched.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `passthrough_env` | list[str] | `[]` | Extra environment variable names forwarded from the orchestrator's environment into the eval process when set (on top of the built-in list: RUN_EVAL, EVAL_ONLY, MODEL, ISL, OSL, ...). |
+| `command` | list[str] \| None | `None` | Argv that replaces the built-in lm-eval runner command. May use the placeholders ``{endpoint}`` (the frontend URL) and ``{infmax_workspace}`` (the InferenceMAX workspace mount). Not shell-interpreted; wrap in ``bash -lc`` yourself if you need a shell. |
 
 ### IdentityConfig
 

--- a/src/srtctl/cli/do_sweep.py
+++ b/src/srtctl/cli/do_sweep.py
@@ -652,22 +652,34 @@ class SweepOrchestrator(
                 logger.error("Server health check failed before eval - skipping")
                 return 1
 
-        try:
-            runner = get_runner("lm-eval")
-        except ValueError as e:
-            logger.error("lm-eval runner not available: %s", e)
-            return 1
-
         eval_log = self.runtime.log_dir / "eval.out"
-        cmd = runner.build_command(self.config, self.runtime)
+        if self.config.post_eval.command is not None:
+            # Recipe-provided dispatch (post_eval.command), with the same placeholders
+            # the lm-eval runner fills in itself.
+            placeholders = {
+                "{endpoint}": f"http://localhost:{self.runtime.frontend_port}",
+                "{infmax_workspace}": "/infmax-workspace",
+            }
+            cmd = list(self.config.post_eval.command)
+            for token, value in placeholders.items():
+                cmd = [part.replace(token, value) for part in cmd]
+        else:
+            try:
+                runner = get_runner("lm-eval")
+            except ValueError as e:
+                logger.error("lm-eval runner not available: %s", e)
+                return 1
+            cmd = runner.build_command(self.config, self.runtime)
 
         logger.info("Eval command: %s", " ".join(cmd))
         logger.info("Eval log: %s", eval_log)
 
         # Pass through eval-related env vars. InferenceX writes multi-node
-        # metadata from these variables in append_lm_eval_summary().
+        # metadata from these variables in append_lm_eval_summary(). The recipe
+        # extends this list with post_eval.passthrough_env.
         env_to_set = {}
         for var in [
+            *self.config.post_eval.passthrough_env,
             "RUN_EVAL",
             "EVAL_ONLY",
             "IS_MULTINODE",

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -401,6 +401,14 @@ def show_config_details(config: SrtConfig) -> None:
                 "outlives this allocation and is inherited by the next job on these nodes."
             )
 
+    # --- post_eval (RUN_EVAL / EVAL_ONLY dispatch) ---
+    if config.post_eval.passthrough_env or config.post_eval.command:
+        console.print("[bold cyan]Post-eval dispatch:[/]")
+        if config.post_eval.command:
+            console.print(f"    [yellow]command:[/] {shlex.join(config.post_eval.command)}", crop=False)
+        if config.post_eval.passthrough_env:
+            console.print(f"    [yellow]passthrough_env:[/] {', '.join(config.post_eval.passthrough_env)}", crop=False)
+
     # --- services (see docs/services.md) ---
     # Plain lines, not a Table: repo URLs and long argv overflow a narrow console and a
     # Table would wrap or truncate them. crop=False keeps each value intact on one line.

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -198,6 +198,40 @@ class S3Config:
 
 
 @dataclass(frozen=True)
+class PostEvalConfig:
+    """How the post-benchmark (or eval-only) accuracy evaluation is dispatched.
+
+    The evaluation runs when the job environment sets ``RUN_EVAL=true`` (after
+    the benchmark) or ``EVAL_ONLY=true`` (instead of it). srtctl forwards a
+    built-in list of workflow variables into the eval process; downstream runners
+    used to patch that list in srtctl's source. This block makes it config.
+
+    Attributes:
+        passthrough_env: Extra environment variable names forwarded from the
+            orchestrator's environment into the eval process when set (on top
+            of the built-in list: RUN_EVAL, EVAL_ONLY, MODEL, ISL, OSL, ...).
+        command: Argv that replaces the built-in lm-eval runner command. May use
+            the placeholders ``{endpoint}`` (the frontend URL) and
+            ``{infmax_workspace}`` (the InferenceMAX workspace mount). Not
+            shell-interpreted; wrap in ``bash -lc`` yourself if you need a shell.
+    """
+
+    passthrough_env: list[str] = field(default_factory=list)
+    command: list[str] | None = None
+
+    Schema: ClassVar[type[Schema]] = Schema
+
+    def __post_init__(self) -> None:
+        for name in self.passthrough_env:
+            if not name.isidentifier():
+                raise ValidationError(
+                    f"post_eval.passthrough_env entries must be environment variable names, got {name!r}"
+                )
+        if self.command is not None and not self.command:
+            raise ValidationError("post_eval.command, if set, must be non-empty (omit it to use the lm-eval runner)")
+
+
+@dataclass(frozen=True)
 class HostSetupConfig:
     """Commands run on the bare host of each allocated node, outside the container.
 
@@ -1928,6 +1962,11 @@ class SrtConfig:
     # experimental router built from a PR) and typed ones (a standalone Mooncake
     # store per worker node). See docs/services.md.
     services: list[ServiceConfig] = field(default_factory=list)
+
+    # Post-benchmark / eval-only evaluation dispatch: extra env forwarded into the
+    # eval process and an optional command override. Replaces the downstream
+    # source patch that used to extend the passthrough list in do_sweep.py.
+    post_eval: PostEvalConfig = field(default_factory=PostEvalConfig)
 
     # Virtual identity — declares what *should* be running (verified against fingerprint)
     identity: IdentityConfig = field(default_factory=IdentityConfig)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -492,6 +492,22 @@ class TestDryRunServices:
         assert "Services:" not in capsys.readouterr().out
 
 
+class TestDryRunPostEval:
+    def test_post_eval_dispatch_shown(self, capsys):
+        config = _make_config(
+            {"post_eval": {"passthrough_env": ["EVAL_FRAMEWORK", "EVAL_SUITE"], "command": ["bash", "run.sh"]}}
+        )
+        show_config_details(config)
+        output = capsys.readouterr().out
+        assert "Post-eval dispatch:" in output
+        assert "bash run.sh" in output
+        assert "EVAL_FRAMEWORK, EVAL_SUITE" in output
+
+    def test_default_post_eval_is_silent(self, capsys):
+        show_config_details(_make_config())
+        assert "Post-eval dispatch" not in capsys.readouterr().out
+
+
 class TestDryRunDynamoSource:
     """dynamo.source: the repo, ref, and whether it is pinned must be visible before submitting."""
 

--- a/tests/test_post_eval.py
+++ b/tests/test_post_eval.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``post_eval:`` block: env passthrough and the command override for the eval dispatch."""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from marshmallow import ValidationError
+
+from srtctl.cli.do_sweep import SweepOrchestrator
+from srtctl.core.runtime import Nodes, RuntimeContext
+from srtctl.core.schema import PostEvalConfig, SrtConfig
+
+RECIPE = """
+name: post-eval-test
+model:
+  path: /model
+  container: /job.sqsh
+  precision: bf16
+resources:
+  gpu_type: h100
+  gpus_per_node: 8
+  agg_nodes: 1
+  agg_workers: 2
+  gpus_per_agg: 1
+frontend:
+  type: dynamo
+backend:
+  type: sglang
+  sglang_config:
+    aggregated:
+      served-model-name: Qwen/Qwen3-0.6B
+benchmark:
+  type: sa-bench
+  isl: 128
+  osl: 128
+  concurrencies: "4x8"
+"""
+
+
+def _load(extra: str = "") -> SrtConfig:
+    return SrtConfig.Schema().load(yaml.safe_load(RECIPE + extra))
+
+
+def _runtime(tmp_path: Path) -> RuntimeContext:
+    return RuntimeContext(
+        job_id="1",
+        run_name="r",
+        nodes=Nodes(head="node0", bench="node0", infra="node0", worker=("node0",)),
+        head_node_ip="10.0.0.10",
+        infra_node_ip="10.0.0.10",
+        log_dir=tmp_path,
+        model_path=Path("/model"),
+        container_image=Path("/job.sqsh"),
+        gpus_per_node=8,
+        network_interface=None,
+        container_mounts={},
+        environment={},
+    )
+
+
+def _run_eval(config: SrtConfig, tmp_path: Path, env: dict[str, str]) -> dict:
+    orchestrator = SweepOrchestrator(config=config, runtime=_runtime(tmp_path))
+    proc = MagicMock()
+    proc.poll.return_value = 0
+    proc.returncode = 0
+    with (
+        patch.dict(os.environ, env, clear=False),
+        patch("srtctl.cli.do_sweep.wait_for_port", return_value=True),
+        patch("srtctl.cli.do_sweep.start_srun_process", return_value=proc) as srun,
+    ):
+        assert orchestrator._run_post_eval(threading.Event()) == 0
+    return srun.call_args.kwargs
+
+
+def test_defaults_are_empty() -> None:
+    config = _load()
+    assert config.post_eval == PostEvalConfig()
+    assert config.post_eval.passthrough_env == []
+    assert config.post_eval.command is None
+
+
+def test_passthrough_env_extends_the_builtin_list(tmp_path: Path, monkeypatch) -> None:
+    for var in ("EVAL_FRAMEWORK", "EVAL_SUITE", "UNRELATED"):
+        monkeypatch.delenv(var, raising=False)
+    config = _load("post_eval:\n  passthrough_env:\n    - EVAL_FRAMEWORK\n    - EVAL_SUITE\n")
+    kwargs = _run_eval(
+        config, tmp_path, {"RUN_EVAL": "true", "EVAL_FRAMEWORK": "lm-eval", "EVAL_SUITE": "gsm8k", "UNRELATED": "x"}
+    )
+    env = kwargs["env_to_set"]
+    assert env["RUN_EVAL"] == "true"  # built-in list still applies
+    assert env["EVAL_FRAMEWORK"] == "lm-eval"
+    assert env["EVAL_SUITE"] == "gsm8k"
+    assert "UNRELATED" not in env
+    assert env["MODEL_NAME"] == "Qwen/Qwen3-0.6B"
+    assert kwargs["command"][:2] == ["bash", "/srtctl-benchmarks/lm-eval/bench.sh"]
+
+
+def test_command_override_replaces_the_lm_eval_runner(tmp_path: Path) -> None:
+    config = _load('post_eval:\n  command:\n    - bash\n    - /infmax-workspace/evals/run.sh\n    - "{endpoint}"\n')
+    kwargs = _run_eval(config, tmp_path, {"RUN_EVAL": "true"})
+    assert kwargs["command"] == ["bash", "/infmax-workspace/evals/run.sh", "http://localhost:8000"]
+    assert kwargs["env_to_set"]["MODEL_NAME"] == "Qwen/Qwen3-0.6B"
+
+
+def test_validation() -> None:
+    with pytest.raises(ValidationError, match="passthrough_env entries must be environment variable names"):
+        _load("post_eval:\n  passthrough_env:\n    - 'not a name'\n")
+    with pytest.raises(ValidationError, match="command, if set, must be non-empty"):
+        _load("post_eval:\n  command: []\n")


### PR DESCRIPTION
Stacked on #403 (Track 2 step 10 of https://github.com/NVIDIA/srt-slurm/issues/385). Draft until the stack below it merges.

## What

The `RUN_EVAL` / `EVAL_ONLY` evaluation forwards a built-in list of workflow variables into the eval process. Downstream runners extended that list by patching srtctl's source text (`patch_srt_eval_dispatch.py`, anchored on exact lines in `do_sweep.py`), the only runner patch that edits srtctl source. This makes it config:

```yaml
post_eval:
  passthrough_env:          # forwarded into the eval process when set in the job environment
    - EVAL_FRAMEWORK
    - EVAL_CONC
    - EVAL_LIMIT
    - EVAL_SUITE
  command:                  # optional; replaces the built-in lm-eval runner command
    - bash
    - /infmax-workspace/benchmarks/evals/run.sh
    - "{endpoint}"
```

- `passthrough_env` extends the built-in list (`RUN_EVAL`, `EVAL_ONLY`, `MODEL`, `ISL`, `OSL`, `PREFILL_TP`, ...). Names are validated as identifiers.
- `command` replaces the lm-eval runner argv, with `{endpoint}` and `{infmax_workspace}` placeholders, so a runner that rewrites `bench.sh` points at its own script instead of patching. `MODEL_NAME` and `EVAL_CONC` are still set by srtctl.
- `srtctl dry-run` prints the effective dispatch when the block is set.

## Validation

- Full suite green (1841 passed); lint, schema-docs drift check, every example validates.
- `tests/test_post_eval.py` drives `_run_post_eval` with a mocked srun and asserts the forwarded env and the substituted command.
