### PR TITLE
Split benchmark fields per type: schema 2 rejects fields the type does not use

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -701,6 +701,24 @@ backend:
 
 Benchmark configuration. The `type` field determines which benchmark runner is used and what additional fields are available.
 
+**Per-type fields (schema 2).** Every type accepts the shared fields (`client_placement`, `client_dedicated_node`, `colocate_with_frontend`, `sweep`, `aiperf_package`, `aiperf_args`, `export_node_metrics`) plus the fields its runner reads:
+
+| `type` | Fields |
+| --- | --- |
+| `sa-bench` | `isl`, `osl`, `concurrencies`, `req_rate`, `random_range_ratio`, `num_prompts_mult`, `num_warmup_mult`, `dataset_name`, `dataset_path`, `custom_tokenizer`, `use_chat_template`, `reuse_http_connections`, `slow_down_sleep_time`, `slow_down_wait_time` |
+| `sglang-bench` | `isl`, `osl`, `concurrencies`, `req_rate` |
+| `gsm8k` | `num_examples`, `max_tokens`, `repeat`, `num_threads`, `num_shots`, `temperature`, `top_p`, `top_k` |
+| `mmlu`, `gpqa` | `num_examples`, `max_tokens`, `repeat`, `num_threads` |
+| `longbenchv2` | `num_examples`, `max_tokens`, `num_threads`, `max_context_length`, `categories` |
+| `router` | `isl`, `osl`, `num_requests`, `concurrency`, `prefix_ratios` |
+| `mooncake-router` | `mooncake_workload`, `ttft_threshold_ms`, `itl_threshold_ms` |
+| `trace-replay` | `concurrencies`, `ttft_threshold_ms`, `itl_threshold_ms`, `trace_file` |
+| `agentperf` | `isl`, `concurrencies`, `concurrency`, `agentperf_client_dir`, `agentperf_config`, `container_image`, `env` |
+| `custom` | `command`, `container_image`, `env` |
+| `lm-eval`, `manual` | shared fields only |
+
+A `schema: 2` recipe that sets a field its type does not use is rejected at load with the list of accepted fields. A schema 1 recipe gets a warning and keeps loading. Before this, such a field was a silent no-op (`isl` on `gsm8k`, `num_shots` on `sa-bench`). Each runner declares its fields as `config_fields`; adding a field to a runner means adding it there.
+
 ### Post-process: node metrics CSV
 
 When `export_node_metrics` is `true`, after the benchmark finishes srtctl prepends

--- a/src/srtctl/benchmarks/__init__.py
+++ b/src/srtctl/benchmarks/__init__.py
@@ -19,18 +19,24 @@ from srtctl.benchmarks import (
     trace_replay,
 )
 from srtctl.benchmarks.base import (
+    SHARED_BENCHMARK_FIELDS,
     BenchmarkRunner,
+    benchmark_config_fields,
     get_runner,
+    get_runner_class,
     list_benchmarks,
     register_benchmark,
 )
 
 __all__ = [
+    "SHARED_BENCHMARK_FIELDS",
     "BenchmarkRunner",
     # Runners
     "agentperf",
+    "benchmark_config_fields",
     "custom",
     "get_runner",
+    "get_runner_class",
     "gpqa",
     "gsm8k",
     "list_benchmarks",

--- a/src/srtctl/benchmarks/agentperf.py
+++ b/src/srtctl/benchmarks/agentperf.py
@@ -22,7 +22,7 @@ concurrency so one workload file serves every topology.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -59,6 +59,11 @@ class AgentPerfRunner(BenchmarkRunner):
           AGENTPERF_EXTRA_ARGS="--seed 100 --no-eval" appended verbatim to the
           run.py invocation)
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset(
+        {"isl", "concurrencies", "concurrency", "agentperf_client_dir", "agentperf_config", "container_image", "env"}
+    )
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/base.py
+++ b/src/srtctl/benchmarks/base.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     from srtctl.core.runtime import RuntimeContext
@@ -18,8 +18,29 @@ if TYPE_CHECKING:
 SCRIPTS_DIR = Path(__file__).parent / "scripts"
 
 
+# BenchmarkConfig fields every type may set: where the client runs, sweeps, aiperf
+# plumbing, and post-processing. Everything else belongs to specific runners.
+SHARED_BENCHMARK_FIELDS: frozenset[str] = frozenset(
+    {
+        "type",
+        "client_placement",
+        "client_dedicated_node",
+        "colocate_with_frontend",
+        "sweep",
+        "aiperf_package",
+        "aiperf_args",
+        "export_node_metrics",
+    }
+)
+
+
 class BenchmarkRunner(ABC):
     """Abstract base class that all benchmark runners must inherit."""
+
+    # BenchmarkConfig fields this runner reads, beyond SHARED_BENCHMARK_FIELDS. A
+    # recipe that sets a field outside shared + these for its type is rejected
+    # (schema 2) or warned about (schema 1) at load, see SrtConfig._validate_benchmark_type.
+    config_fields: ClassVar[frozenset[str]] = frozenset()
 
     @property
     @abstractmethod
@@ -107,6 +128,17 @@ def register_benchmark(name: str):
         return cls
 
     return decorator
+
+
+def get_runner_class(benchmark_type: str) -> type[BenchmarkRunner] | None:
+    """The registered runner class for ``benchmark_type``, or None (``manual`` has no runner)."""
+    return _BENCHMARK_RUNNERS.get(benchmark_type)
+
+
+def benchmark_config_fields(benchmark_type: str) -> frozenset[str]:
+    """Every BenchmarkConfig field a recipe of this type may set: shared plus the runner's own."""
+    runner = _BENCHMARK_RUNNERS.get(benchmark_type)
+    return SHARED_BENCHMARK_FIELDS | (runner.config_fields if runner is not None else frozenset())
 
 
 def get_runner(benchmark_type: str) -> BenchmarkRunner:

--- a/src/srtctl/benchmarks/custom.py
+++ b/src/srtctl/benchmarks/custom.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import ClassVar
 
 from srtctl.benchmarks.base import BenchmarkRunner, register_benchmark
 from srtctl.core.runtime import RuntimeContext
@@ -42,6 +43,9 @@ class CustomBenchmarkRunner(BenchmarkRunner):
       intentionally excluded; see ``docs/config-reference.md`` for the full
       contract.
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset({"command", "container_image", "env"})
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/gpqa.py
+++ b/src/srtctl/benchmarks/gpqa.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -26,6 +26,9 @@ class GPQARunner(BenchmarkRunner):
         - benchmark.repeat: Number of repeats (default: 8)
         - benchmark.num_threads: Concurrent threads (default: 128)
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset({"num_examples", "max_tokens", "repeat", "num_threads"})
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/gsm8k.py
+++ b/src/srtctl/benchmarks/gsm8k.py
@@ -15,7 +15,7 @@ A single ``gsm8k`` type that adapts the eval harness to the backend:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -50,6 +50,11 @@ class GSM8KRunner(BenchmarkRunner):
         - benchmark.num_threads: Concurrent threads (sglang harness only, default: 512)
         - benchmark.repeat: Repeat the eval N times (vLLM path only, default: 1)
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset(
+        {"num_examples", "max_tokens", "repeat", "num_threads", "num_shots", "temperature", "top_p", "top_k"}
+    )
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/lm_eval.py
+++ b/src/srtctl/benchmarks/lm_eval.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -22,6 +22,9 @@ class LMEvalRunner(BenchmarkRunner):
     Runs lm-eval via the InferenceX benchmark_lib.sh harness,
     which handles task selection, result collection, and summary generation.
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset()
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/longbenchv2.py
+++ b/src/srtctl/benchmarks/longbenchv2.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -27,6 +27,11 @@ class LongBenchV2Runner(BenchmarkRunner):
         - benchmark.num_examples: Number of examples (default: all)
         - benchmark.categories: Task categories to run (default: all)
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset(
+        {"num_examples", "max_tokens", "num_threads", "max_context_length", "categories"}
+    )
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/mmlu.py
+++ b/src/srtctl/benchmarks/mmlu.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -26,6 +26,9 @@ class MMLURunner(BenchmarkRunner):
         - benchmark.repeat: Number of repeats (default: 8)
         - benchmark.num_threads: Concurrent threads (default: 512)
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset({"num_examples", "max_tokens", "repeat", "num_threads"})
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/mooncake_router.py
+++ b/src/srtctl/benchmarks/mooncake_router.py
@@ -16,7 +16,7 @@ https://github.com/ai-dynamo/dynamo/tree/main/recipes/qwen3-32b
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, AIPerfBenchmarkRunner, register_benchmark
 
@@ -47,6 +47,9 @@ class MooncakeRouterRunner(AIPerfBenchmarkRunner):
         - benchmark.ttft_threshold_ms: Goodput TTFT threshold (default: 2000)
         - benchmark.itl_threshold_ms: Goodput ITL threshold (default: 25)
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset({"mooncake_workload", "ttft_threshold_ms", "itl_threshold_ms"})
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/router.py
+++ b/src/srtctl/benchmarks/router.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -27,6 +27,9 @@ class RouterRunner(BenchmarkRunner):
         - benchmark.concurrency: Concurrency level (default: 20)
         - benchmark.prefix_ratios: Prefix ratios to test (default: "0.1 0.3 0.5 0.7 0.9")
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset({"isl", "osl", "num_requests", "concurrency", "prefix_ratios"})
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/sa_bench.py
+++ b/src/srtctl/benchmarks/sa_bench.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -34,6 +34,26 @@ class SABenchRunner(BenchmarkRunner):
           frontend is sglang, SA-Bench POSTs /slow_down on each decode worker leader (framework-derived
           URLs). Omit either field to disable slow_down.
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset(
+        {
+            "isl",
+            "osl",
+            "concurrencies",
+            "req_rate",
+            "random_range_ratio",
+            "num_prompts_mult",
+            "num_warmup_mult",
+            "dataset_name",
+            "dataset_path",
+            "custom_tokenizer",
+            "use_chat_template",
+            "reuse_http_connections",
+            "slow_down_sleep_time",
+            "slow_down_wait_time",
+        }
+    )
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/sglang_bench.py
+++ b/src/srtctl/benchmarks/sglang_bench.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, BenchmarkRunner, register_benchmark
 
@@ -29,6 +29,9 @@ class SGLangBenchRunner(BenchmarkRunner):
     Optional:
         - benchmark.req_rate: Request rate (default: "inf")
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset({"isl", "osl", "concurrencies", "req_rate"})
 
     @property
     def name(self) -> str:

--- a/src/srtctl/benchmarks/trace_replay.py
+++ b/src/srtctl/benchmarks/trace_replay.py
@@ -13,7 +13,7 @@ trace-replay takes a user-provided file and sweeps concurrency levels.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from srtctl.benchmarks.base import SCRIPTS_DIR, AIPerfBenchmarkRunner, register_benchmark
 
@@ -37,6 +37,11 @@ class TraceReplayRunner(AIPerfBenchmarkRunner):
         - benchmark.ttft_threshold_ms: Goodput TTFT threshold (default: 2000)
         - benchmark.itl_threshold_ms: Goodput ITL threshold (default: 25)
     """
+
+    # BenchmarkConfig fields this runner reads (beyond the shared ones); see benchmark_config_fields().
+    config_fields: ClassVar[frozenset[str]] = frozenset(
+        {"concurrencies", "ttft_threshold_ms", "itl_threshold_ms", "trace_file"}
+    )
 
     @property
     def name(self) -> str:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -12,6 +12,7 @@ Backend configs are defined in srtctl.backends.configs/ for modularity.
 """
 
 import builtins
+import dataclasses
 import hashlib
 import itertools
 import logging
@@ -51,6 +52,16 @@ from srtctl.core.source import DynamoSourceConfig, is_commit_sha
 from srtctl.services.config import ServiceConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _dataclass_default(item: dataclasses.Field) -> Any:
+    """The default a dataclass field would take when unset (None when it has none)."""
+    if item.default is not dataclasses.MISSING:
+        return item.default
+    if item.default_factory is not dataclasses.MISSING:
+        return item.default_factory()
+    return None
+
 
 # Local copies of srtctl.core.power.contract values so that loading a config
 # never imports the power package; equality is pinned by tests.
@@ -2021,13 +2032,32 @@ class SrtConfig:
         btype = self.benchmark.type
         try:
             import srtctl.benchmarks  # noqa: F401 - importing the package registers every runner
-            from srtctl.benchmarks.base import list_benchmarks
+            from srtctl.benchmarks.base import benchmark_config_fields, list_benchmarks
 
             allowed = set(list_benchmarks()) | {"manual"}
         except Exception:  # noqa: BLE001 - never block a config load on the registry import
             return
         if btype not in allowed:
             raise ValueError(f"Unknown benchmark.type {btype!r}. Available: {', '.join(sorted(allowed))}")
+
+        # Per-type field split: a field set for a type whose runner never reads it
+        # is a silent no-op today (isl on gsm8k, num_shots on sa-bench). Schema 2
+        # rejects it; schema 1 recipes get a warning so the corpus keeps loading.
+        accepted = benchmark_config_fields(btype)
+        stray = sorted(
+            item.name
+            for item in dataclasses.fields(BenchmarkConfig)
+            if item.name not in accepted and getattr(self.benchmark, item.name) != _dataclass_default(item)
+        )
+        if not stray:
+            return
+        message = (
+            f"benchmark.type {btype!r} does not use {', '.join(stray)}; fields it accepts: "
+            f"{', '.join(sorted(accepted))}"
+        )
+        if self.schema_version >= 2:
+            raise ValueError(message)
+        logger.warning("%s (a schema: 2 recipe would be rejected)", message)
 
     def _validate_host_setup(self) -> None:
         """Reject host_setup blocks that would fail or hang mid-job.

--- a/tests/test_benchmark_fields.py
+++ b/tests/test_benchmark_fields.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the per-type benchmark field split: schema 2 rejects stray fields, schema 1 warns."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+
+import pytest
+import yaml
+
+from srtctl import benchmarks
+from srtctl.benchmarks.base import SHARED_BENCHMARK_FIELDS, benchmark_config_fields
+from srtctl.core.schema import BenchmarkConfig, SrtConfig
+
+HEAD = """
+name: fields-test
+model:
+  path: /m
+  container: /c.sqsh
+  precision: bf16
+resources:
+  gpu_type: h100
+  gpus_per_node: 8
+  agg_nodes: 1
+  agg_workers: 1
+backend:
+  type: sglang
+"""
+
+
+def _load(benchmark: str, schema: int | None = 2) -> SrtConfig:
+    text = HEAD + benchmark
+    if schema is not None:
+        text = f"schema: {schema}\n" + text
+    return SrtConfig.Schema().load(yaml.safe_load(text))
+
+
+def test_every_declared_field_exists_on_benchmark_config() -> None:
+    names = {f.name for f in dataclasses.fields(BenchmarkConfig)}
+    assert names >= SHARED_BENCHMARK_FIELDS
+    for btype in benchmarks.list_benchmarks():
+        assert benchmark_config_fields(btype) <= names, btype
+    # manual has no runner: shared fields only
+    assert benchmark_config_fields("manual") == SHARED_BENCHMARK_FIELDS
+
+
+def test_each_type_accepts_the_fields_its_recipes_use() -> None:
+    # Field sets seen across the historical recipe corpus, per type.
+    _load(
+        "benchmark:\n  type: sa-bench\n  isl: 1024\n  osl: 1024\n  concurrencies: '4x8'\n  req_rate: inf\n"
+        "  random_range_ratio: 0.8\n  num_prompts_mult: 10\n  num_warmup_mult: 2\n  custom_tokenizer: a.B\n"
+        "  use_chat_template: false\n  slow_down_sleep_time: 0.1\n  slow_down_wait_time: 5\n"
+    )
+    _load(
+        "benchmark:\n  type: gsm8k\n  num_examples: 100\n  max_tokens: 256\n  num_threads: 8\n  num_shots: 5\n"
+        "  temperature: 0.0\n  top_p: 1.0\n  top_k: 1\n"
+    )
+    _load("benchmark:\n  type: gpqa\n  num_examples: 10\n  max_tokens: 64\n  repeat: 2\n  num_threads: 4\n")
+    _load(
+        "benchmark:\n  type: mooncake-router\n  mooncake_workload: conversation\n  ttft_threshold_ms: 2000\n"
+        "  itl_threshold_ms: 25\n"
+    )
+    _load(
+        "benchmark:\n  type: trace-replay\n  trace_file: /t.jsonl\n  concurrencies: '4'\n  ttft_threshold_ms: 1\n"
+        "  itl_threshold_ms: 1\n  aiperf_package: aiperf>=0.7\n"
+    )
+    _load("benchmark:\n  type: custom\n  command: echo hi\n  env:\n    A: b\n")
+    _load(
+        "benchmark:\n  type: agentperf\n  concurrencies: '4'\n  agentperf_client_dir: /c\n  agentperf_config: /c.yaml\n"
+    )
+
+
+def test_shared_fields_are_accepted_for_every_type() -> None:
+    config = _load(
+        "benchmark:\n  type: gsm8k\n  num_examples: 5\n  client_placement: last_decode\n  export_node_metrics: true\n"
+        "  aiperf_args:\n    workers-max: 8\n"
+    )
+    assert config.benchmark.client_placement == "last_decode"
+
+
+def test_schema_2_rejects_a_field_the_type_does_not_use() -> None:
+    with pytest.raises(ValueError, match="benchmark.type 'gsm8k' does not use isl, osl") as exc:
+        _load("benchmark:\n  type: gsm8k\n  num_examples: 5\n  isl: 1024\n  osl: 128\n")
+    assert "fields it accepts" in str(exc.value)
+    with pytest.raises(ValueError, match="'sa-bench' does not use num_shots"):
+        _load("benchmark:\n  type: sa-bench\n  isl: 1\n  osl: 1\n  concurrencies: '1'\n  num_shots: 5\n")
+    with pytest.raises(ValueError, match="'manual' does not use concurrencies, isl, osl"):
+        _load("benchmark:\n  type: manual\n  isl: 1\n  osl: 1\n  concurrencies: '1'\n")
+
+
+def test_schema_1_only_warns(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="srtctl.core.schema"):
+        config = _load("benchmark:\n  type: gsm8k\n  num_examples: 5\n  isl: 1024\n", schema=None)
+    assert config.benchmark.isl == 1024
+    assert "benchmark.type 'gsm8k' does not use isl" in caplog.text
+    assert "schema: 2 recipe would be rejected" in caplog.text
+
+
+def test_defaults_never_count_as_set() -> None:
+    # req_rate defaults to "inf" and use_chat_template to True; leaving them alone is not "setting" them.
+    config = _load("benchmark:\n  type: gsm8k\n  num_examples: 5\n")
+    assert config.benchmark.req_rate == "inf"
+    assert config.benchmark.use_chat_template is True


### PR DESCRIPTION
Stacked on #404 (Track 2, the deferred benchmark union from https://github.com/NVIDIA/srt-slurm/issues/385). Draft until the stack below it merges.

## What

`BenchmarkConfig` is one flat dataclass with every type's fields on it, so a field the runner never reads (`isl` on `gsm8k`, `num_shots` on `sa-bench`) loads fine and silently does nothing. Each runner now declares the fields it reads as `config_fields`, next to a shared set every type may set (`client_placement`, `client_dedicated_node`, `colocate_with_frontend`, `sweep`, `aiperf_package`, `aiperf_args`, `export_node_metrics`).

- A `schema: 2` recipe that sets a field outside shared + its type's fields is rejected at load, naming the stray fields and the accepted ones.
- A schema 1 recipe gets a warning and keeps loading, so nothing downstream breaks before it opts in.
- Adding a field to a runner means adding it to that runner's `config_fields`; a test asserts every declared field exists on `BenchmarkConfig`.

## Checked against the whole corpus

The rule was run over the 555 historical in-repo recipes and the 481 downstream InferenceMAX recipes, 1179 variants after override expansion, each forced to `schema: 2`. It rejects exactly one: a `manual`-type recipe carrying `isl`/`osl`/`concurrencies`. Every other field set per type is accepted. (The same pass surfaced two pre-existing, unrelated load failures in the downstream corpus: 98 recipes set `telemetry.provider` / `default_frequency`, which the current `TelemetryConfig` does not have, and 6 set `benchmark.tokenizer_mode`. Those fail on `main` today and are not touched here.)

## Validation

- Full suite green (1847 passed); lint, schema-docs drift check, every example validates.
- `tests/test_benchmark_fields.py`: declared fields exist, each type accepts the field sets its recipes use, shared fields work for every type, schema 2 rejects with the expected message, schema 1 warns, defaults never count as set.
