### PR TITLE
Migrate v1 recipes to the v2 layout and prove equality with srtctl migrate --verify

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -229,3 +229,34 @@ jobs:
               exit(1)
           print(f'\nAll {len(examples)} examples valid')
           "
+
+  # Golden equality: every v1 recipe we know of must resolve to the same config
+  # after `srtctl migrate` rewrites it to schema 2. Corpus: the curated examples
+  # plus the 555 historical recipes from the last commit that carried recipes/.
+  golden-equality:
+    runs-on: ubuntu-latest
+    env:
+      GOLDEN_RECIPES_COMMIT: e6e9d8b9
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.10
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Extract the historical recipe corpus
+        run: |
+          git fetch --depth=1 origin "$GOLDEN_RECIPES_COMMIT"
+          mkdir -p /tmp/golden
+          git archive "$GOLDEN_RECIPES_COMMIT" recipes | tar -x -C /tmp/golden
+          find /tmp/golden/recipes -name '*.yaml' | wc -l
+
+      - name: Migrate in memory and compare resolved configs
+        run: uv run srtctl migrate --verify -f examples -f /tmp/golden/recipes

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test test-cov ci check setup cleanup examples schema-docs schema-docs-check tachometer-scraper tachometer-scraper-download
+.PHONY: lint test test-cov ci check setup cleanup examples schema-docs schema-docs-check golden-check tachometer-scraper tachometer-scraper-download
 
 NATS_VERSION ?= v2.10.28
 ETCD_VERSION ?= v3.5.21
@@ -31,6 +31,15 @@ schema-docs-check:
 
 # Run lint + tests in one command
 check: lint schema-docs-check test
+
+# Golden equality: migrate every known v1 recipe in memory and prove the resolved
+# config is unchanged. Extracts the historical recipes from the last commit that
+# carried recipes/ (same corpus as the CI job).
+GOLDEN_RECIPES_COMMIT ?= e6e9d8b9
+golden-check:
+	@mrm -rf /tmp/srt-golden && mkdir -p /tmp/srt-golden
+	@git archive $(GOLDEN_RECIPES_COMMIT) recipes | tar -x -C /tmp/srt-golden
+	uv run srtctl migrate --verify -f examples -f /tmp/srt-golden/recipes
 	@echo "✓ All checks passed"
 
 tachometer-scraper:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -159,7 +159,7 @@ This is useful for portable recipes that you want to share across clusters or ha
 | -------- | ------- | -------- | --------------------------------------------------------------------------- |
 | `schema` | integer | No       | Recipe schema version. Absent means `1` (the pre-2.0 layout); `2` is current. |
 
-Every supported version loads. Put the key first in the file, beside `base:` in an override file. Upgrade a recipe with `srtctl migrate -f recipe.yaml --in-place`, which preserves comments and key order.
+Every supported version loads. Put the key first in the file, beside `base:` in an override file. Upgrade a recipe with `srtctl migrate -f recipe.yaml --in-place`, which preserves comments and key order and folds the legacy layout into `roles:`, `placement:`, and `dynamo.source` (a directory is walked recursively). `srtctl migrate --verify -f <path>` migrates in memory and checks that the v1 and v2 documents resolve to the same config; CI runs it over the examples and the historical recipe corpus (golden equality).
 
 ```yaml
 schema: 2
@@ -229,7 +229,7 @@ roles:
 
 Role names are `prefill`, `decode`, and `agg`. The aggregated role is `agg` (matching `resources.agg_*`); its `env` and `args` map to `backend.aggregated_environment` and `backend.<engine>_config.aggregated`. Per-role `extra_args` maps to `backend.<mode>_extra_args` (TRT-LLM). `roles:` is normalized into those fields before validation, so it is exactly equivalent to writing them directly; you cannot set both for the same role.
 
-The legacy fields (`resources.prefill_workers`, `backend.prefill_environment`, `backend.sglang_config.prefill`, ...) still load unchanged, so v1 recipes keep working. `srtctl migrate` stamps `schema: 2` but does not yet rewrite the legacy layout into `roles:`; both forms are valid v2. The `examples/` are written with `roles:` (except `features/override.yaml`, kept legacy to show that the v1 layout still loads).
+The legacy fields (`resources.prefill_workers`, `backend.prefill_environment`, `backend.sglang_config.prefill`, ...) still load unchanged, so v1 recipes keep working, and both forms are valid v2. `srtctl migrate -f recipe.yaml --in-place` rewrites the legacy layout into `roles:` (and `placement:` / `dynamo.source`), preserving comments and key order; `srtctl migrate --verify -f <dir>` proves that every recipe under a directory resolves to the same config before and after. The `examples/` are written with `roles:` (except `features/override.yaml`, kept legacy to show that the v1 layout still loads).
 
 ---
 

--- a/src/srtctl/cli/submit.py
+++ b/src/srtctl/cli/submit.py
@@ -1554,6 +1554,7 @@ def main():
   srtctl view /path/to/run-output                # Local ruter route-decision viewer
   srtctl schema-docs [--check]                   # Regenerate (or verify) docs/schema-reference.md
   srtctl migrate -f config.yaml --in-place       # Upgrade a recipe to the current schema version
+  srtctl migrate -f recipes/ --verify            # Prove v1 and migrated v2 recipes resolve identically
 """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1726,15 +1727,21 @@ def main():
         "--file",
         type=Path,
         required=True,
-        dest="migrate_file",
-        help="Recipe YAML to migrate",
+        action="append",
+        dest="migrate_files",
+        help="Recipe YAML to migrate; a directory is walked recursively (repeatable)",
     )
-    migrate_parser.add_argument("--in-place", action="store_true", help="Rewrite the file instead of printing")
+    migrate_parser.add_argument("--in-place", action="store_true", help="Rewrite the file(s) instead of printing")
     migrate_parser.add_argument(
         "--output",
         type=Path,
         default=None,
-        help="Write the migrated recipe to this path (default: print to stdout)",
+        help="Write the migrated recipe to this path (single file only; default: print to stdout)",
+    )
+    migrate_parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Do not write: migrate in memory and prove the v1 and v2 recipes resolve identically (golden equality)",
     )
 
     args = parser.parse_args()
@@ -1851,16 +1858,44 @@ def main():
         return
 
     if args.command == "migrate":
-        from srtctl.core.migrate import migrate_recipe_file
+        from srtctl.core.migrate import migrate_recipe_file, recipe_files, verify_migration_file
 
-        result = migrate_recipe_file(args.migrate_file, in_place=args.in_place, output=args.output)
-        if not args.in_place and args.output is None:
-            sys.stdout.write(result.text)
-            sys.stdout.flush()
-        else:
-            target = args.migrate_file if args.in_place else args.output
-            detail = ", ".join(result.notes) if result.notes else "already current"
-            console.print(f"[green]✓[/] {target}: schema {result.from_version} -> {result.to_version} ({detail})")
+        files = recipe_files(args.migrate_files)
+        if not files:
+            console.print("[bold red]No recipe files found[/]")
+            sys.exit(1)
+        if args.verify:
+            counts: dict[str, int] = {"ok": 0, "mismatch": 0, "skipped": 0, "error": 0}
+            for path in files:
+                outcome = verify_migration_file(path)
+                counts[outcome.status] += 1
+                if outcome.status == "ok":
+                    console.print(f"[green]✓[/] {path} ({outcome.variants} variant(s) resolve identically)")
+                elif outcome.status == "skipped":
+                    console.print(f"[yellow]-[/] {path}: skipped, {outcome.detail}")
+                else:
+                    console.print(f"[bold red]✗[/] {path}: {outcome.detail}")
+            console.print(
+                f"\n{counts['ok']} identical, {counts['mismatch']} mismatched, "
+                f"{counts['skipped']} skipped (v1 does not load), {counts['error']} unreadable"
+            )
+            restore_console()
+            sys.exit(1 if counts["mismatch"] or counts["error"] else 0)
+        if not args.in_place and args.output is None and len(files) > 1:
+            console.print("[bold red]Error:[/] printing to stdout needs a single file; use --in-place for many")
+            sys.exit(1)
+        if args.output is not None and len(files) > 1:
+            console.print("[bold red]Error:[/] --output takes a single file")
+            sys.exit(1)
+        for path in files:
+            result = migrate_recipe_file(path, in_place=args.in_place, output=args.output)
+            if not args.in_place and args.output is None:
+                sys.stdout.write(result.text)
+                sys.stdout.flush()
+            else:
+                target = path if args.in_place else args.output
+                detail = ", ".join(result.notes) if result.notes else "already current"
+                console.print(f"[green]✓[/] {target}: schema {result.from_version} -> {result.to_version} ({detail})")
         restore_console()
         return
 

--- a/src/srtctl/core/migrate.py
+++ b/src/srtctl/core/migrate.py
@@ -4,23 +4,44 @@
 """Upgrade recipe YAML to the current schema version, preserving comments.
 
 ``srtctl migrate -f recipe.yaml`` rewrites a plain recipe, an override file
-(``base`` plus ``override_*`` variants), or a lockfile so that it declares
-``schema: <current>`` and uses the current layout. The transformation is done on
-a ruamel round-trip document, so comments, key order, and quoting survive.
+(``base`` plus ``override_*`` / ``zip_override_*`` variants), a sweep file, or a
+lockfile so that it declares ``schema: <current>`` and uses the current layout.
+The transformation is done on a ruamel round-trip document, so comments, key
+order, and quoting survive; keys that move between blocks carry their comments.
 
-Each schema step registers its structural rewrite in :func:`_migrate_1_to_2`;
-this module starts with the version key alone.
+v1 -> v2 rewrites (each is a pure re-spelling; the resolved config is identical):
+
+- ``resources.<role>_nodes/_workers``, ``gpus_per_<role>``,
+  ``backend.<mode>_environment``, ``backend.<engine>_config.<mode>``, and
+  ``backend.<mode>_extra_args`` fold into ``roles.<role>``.
+- ``frontend.orchestrator_placement`` / ``dedicated_node``,
+  ``benchmark.client_placement`` / ``client_dedicated_node``, and
+  ``infra.etcd_nats_dedicated_node`` fold into ``placement.node``.
+- ``dynamo.hash`` / ``cargo_patches`` / ``wheel`` / ``version`` fold into
+  ``dynamo.source``. ``top_of_tree`` has no immutable equivalent and is left.
+- ``benchmark`` fields the recipe's benchmark type never reads are removed
+  (schema 2 rejects them; they were silent no-ops).
+
+``srtctl migrate --verify`` proves the equivalence: it migrates in memory,
+resolves both documents through the same loader, and compares the results.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import copy
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from ruamel.yaml.comments import CommentedMap
 
+from srtctl.core.roles import ENGINE_CONFIG_KEY, ROLE_NAMES, ROLE_TO_MODE
 from srtctl.core.schema import CURRENT_SCHEMA_VERSION, SUPPORTED_SCHEMA_VERSIONS
 from srtctl.core.yaml_utils import dump_yaml_with_comments, load_yaml_text_with_comments
+
+_VARIANT_PREFIXES = ("override_", "zip_override_")
+_ENGINE_KEYS = frozenset(ENGINE_CONFIG_KEY.values())
 
 
 @dataclass(frozen=True)
@@ -34,6 +55,56 @@ class MigrationResult:
     notes: tuple[str, ...]
 
 
+# --- ruamel helpers -------------------------------------------------------------------
+
+
+def _move(src: CommentedMap, key: str, dst: CommentedMap, new_key: str) -> None:
+    """Move ``src[key]`` to ``dst[new_key]``, carrying the key's comment tokens along."""
+    value = src.pop(key)
+    dst[new_key] = value
+    if key in src.ca.items:
+        dst.ca.items[new_key] = src.ca.items.pop(key)
+
+
+def _child_map(parent: CommentedMap, key: str, *, after: str | None = None) -> CommentedMap:
+    """``parent[key]`` as a mapping, created (after ``after`` when given) if missing."""
+    existing = parent.get(key)
+    if isinstance(existing, CommentedMap):
+        return existing
+    created = CommentedMap()
+    keys = list(parent.keys())
+    if after is not None and after in keys:
+        parent.insert(keys.index(after) + 1, key, created)
+    else:
+        parent[key] = created
+    return created
+
+
+def _drop_if_empty(parent: CommentedMap, key: str) -> None:
+    value = parent.get(key)
+    if isinstance(value, dict) and not value:
+        parent.pop(key)
+        parent.ca.items.pop(key, None)
+
+
+def _neutralize_if_empty(parent: CommentedMap, key: str) -> bool:
+    """Keep an emptied block as ``key: {}`` (comments cleared so ruamel emits valid flow style).
+
+    The key stays because override variants may refer to it: a zip list with a
+    ``null`` deletes a base key only when the block exists in the base.
+    """
+    value = parent.get(key)
+    if isinstance(value, CommentedMap) and not value:
+        value.ca.comment = None
+        value.ca.items.clear()
+        value.ca.end = None
+        return True
+    return False
+
+
+_ENGINE_FOR_KEY = {config_key: engine for engine, config_key in ENGINE_CONFIG_KEY.items()}
+
+
 def _declared_version(doc: CommentedMap) -> int:
     raw = doc.get("schema", 1)
     if isinstance(raw, bool) or not isinstance(raw, int):
@@ -43,19 +114,209 @@ def _declared_version(doc: CommentedMap) -> int:
     return raw
 
 
+def _variants(doc: CommentedMap) -> Iterator[tuple[str, CommentedMap]]:
+    """The recipe mappings a document holds: the document itself, or base plus every override variant."""
+    if "base" in doc:
+        for key, value in doc.items():
+            if (key == "base" or str(key).startswith(_VARIANT_PREFIXES)) and isinstance(value, CommentedMap):
+                yield str(key), value
+    else:
+        yield "", doc
+
+
+# --- v1 -> v2 transforms --------------------------------------------------------------
+
+
+def _engine_key_for(variant: CommentedMap, base: CommentedMap) -> str:
+    """The ``backend.<engine>_config`` key from the variant's or base's ``backend.type``, else from what is present."""
+    for source in (variant, base):
+        backend = source.get("backend")
+        if isinstance(backend, dict) and backend.get("type"):
+            return ENGINE_CONFIG_KEY.get(str(backend["type"]), "sglang_config")
+    backend = variant.get("backend")
+    if isinstance(backend, dict):
+        for key in _ENGINE_KEYS:
+            if key in backend:
+                return key
+    return "sglang_config"
+
+
+def _fold_roles(variant: CommentedMap, engine_key: str, label: str) -> list[str]:
+    notes: list[str] = []
+    resources = variant.get("resources")
+    backend = variant.get("backend")
+    resources = resources if isinstance(resources, CommentedMap) else None
+    backend = backend if isinstance(backend, CommentedMap) else None
+    engine_cfg = backend.get(engine_key) if backend is not None else None
+    engine_cfg = engine_cfg if isinstance(engine_cfg, CommentedMap) else None
+
+    roles: CommentedMap | None = None
+    for role in ROLE_NAMES:
+        mode = ROLE_TO_MODE[role]
+        moves: list[tuple[CommentedMap, str, str]] = []
+        if resources is not None:
+            for legacy, new in (
+                (f"{role}_nodes", "nodes"),
+                (f"{role}_workers", "workers"),
+                (f"gpus_per_{role}", "gpus"),
+            ):
+                if legacy in resources:
+                    moves.append((resources, legacy, new))
+        if backend is not None:
+            if f"{mode}_environment" in backend:
+                moves.append((backend, f"{mode}_environment", "env"))
+            if f"{mode}_extra_args" in backend:
+                moves.append((backend, f"{mode}_extra_args", "extra_args"))
+        if engine_cfg is not None and mode in engine_cfg:
+            moves.append((engine_cfg, mode, "args"))
+        if not moves:
+            continue
+        if roles is None:
+            anchor = "backend" if "backend" in variant else ("resources" if "resources" in variant else None)
+            roles = _child_map(variant, "roles", after=anchor)
+        spec = _child_map(roles, role)
+        for src, legacy, new in moves:
+            if new in spec:
+                notes.append(f"{label}roles.{role}.{new} already set; kept it and dropped legacy {legacy}")
+                src.pop(legacy)
+                src.ca.items.pop(legacy, None)
+                continue
+            _move(src, legacy, spec, new)
+        notes.append(f"{label}folded {role} fields into roles.{role}")
+
+    if backend is not None:
+        _drop_if_empty(backend, engine_key)
+    return notes
+
+
+def _fold_placement_block(section: CommentedMap, place_key: str, dedicated_key: str, label: str) -> list[str]:
+    if place_key not in section and dedicated_key not in section:
+        return []
+    dedicated = bool(section.pop(dedicated_key, False))
+    section.ca.items.pop(dedicated_key, None)
+    location = section.pop(place_key, "head")
+    section.ca.items.pop(place_key, None)
+    placement = _child_map(section, "placement")
+    placement["node"] = "dedicated" if dedicated else location
+    return [f"{label}placement.node: {placement['node']}"]
+
+
+def _fold_placement(variant: CommentedMap, label: str) -> list[str]:
+    notes: list[str] = []
+    frontend = variant.get("frontend")
+    if isinstance(frontend, CommentedMap):
+        notes += _fold_placement_block(frontend, "orchestrator_placement", "dedicated_node", f"{label}frontend.")
+    benchmark = variant.get("benchmark")
+    if isinstance(benchmark, CommentedMap):
+        notes += _fold_placement_block(benchmark, "client_placement", "client_dedicated_node", f"{label}benchmark.")
+    infra = variant.get("infra")
+    if isinstance(infra, CommentedMap) and "etcd_nats_dedicated_node" in infra:
+        dedicated = bool(infra.pop("etcd_nats_dedicated_node"))
+        infra.ca.items.pop("etcd_nats_dedicated_node", None)
+        _child_map(infra, "placement")["node"] = "dedicated" if dedicated else "head"
+        notes.append(f"{label}infra.placement.node: {'dedicated' if dedicated else 'head'}")
+    return notes
+
+
+def _fold_dynamo_source(variant: CommentedMap, label: str) -> list[str]:
+    dynamo = variant.get("dynamo")
+    if not isinstance(dynamo, CommentedMap) or "source" in dynamo:
+        return []
+    notes: list[str] = []
+    if dynamo.get("top_of_tree"):
+        notes.append(f"{label}dynamo.top_of_tree left as is (no immutable rev to pin; choose a commit for source.rev)")
+        return notes
+    has_git = dynamo.get("hash") is not None
+    has_wheel = dynamo.get("wheel") is not None
+    has_version = dynamo.get("version") is not None
+    if not (has_git or has_wheel or has_version):
+        return notes
+    source = _child_map(dynamo, "source", after="install" if "install" in dynamo else None)
+    if has_git:
+        _move(dynamo, "hash", source, "rev")
+        if "cargo_patches" in dynamo:
+            _move(dynamo, "cargo_patches", source, "patches")
+        if has_version:  # version is auto-cleared when hash is set; the legacy loader ignored it
+            dynamo.pop("version")
+            dynamo.ca.items.pop("version", None)
+            notes.append(f"{label}dropped dynamo.version (ignored alongside hash)")
+        notes.append(f"{label}dynamo.hash -> dynamo.source.rev")
+    elif has_wheel:
+        _move(dynamo, "wheel", source, "wheel")
+        if has_version:
+            dynamo.pop("version")
+            dynamo.ca.items.pop("version", None)
+        notes.append(f"{label}dynamo.wheel -> dynamo.source.wheel")
+    else:
+        _move(dynamo, "version", source, "pypi")
+        notes.append(f"{label}dynamo.version -> dynamo.source.pypi")
+    return notes
+
+
+def _strip_unused_benchmark_fields(variant: CommentedMap, base: CommentedMap, label: str) -> list[str]:
+    """Remove benchmark fields the recipe's type never reads (schema 2 rejects them)."""
+    benchmark = variant.get("benchmark")
+    if not isinstance(benchmark, CommentedMap):
+        return []
+    btype = benchmark.get("type")
+    if btype is None:
+        base_benchmark = base.get("benchmark")
+        btype = base_benchmark.get("type", "manual") if isinstance(base_benchmark, dict) else "manual"
+    try:
+        import srtctl.benchmarks  # noqa: F401 - registers runners
+        from srtctl.benchmarks.base import benchmark_config_fields, list_benchmarks
+    except Exception:  # noqa: BLE001
+        return []
+    if btype not in {*list_benchmarks(), "manual"}:
+        return []  # unknown type: the loader reports it; nothing to strip safely
+    accepted = benchmark_config_fields(str(btype)) | {"placement"}
+    notes: list[str] = []
+    for key in [k for k in benchmark if k not in accepted]:
+        benchmark.pop(key)
+        benchmark.ca.items.pop(key, None)
+        notes.append(f"{label}removed benchmark.{key} (unused by type {btype})")
+    return notes
+
+
 def _migrate_1_to_2(doc: CommentedMap) -> list[str]:
-    """Structural v1 -> v2 rewrites. Later schema steps add their transforms here."""
-    del doc
-    return []
+    """Structural v1 -> v2 rewrites, applied to every variant a document holds."""
+    notes: list[str] = []
+    base = doc.get("base") if isinstance(doc.get("base"), CommentedMap) else doc
+    for name, variant in _variants(doc):
+        label = f"{name}: " if name else ""
+        notes += _fold_roles(variant, _engine_key_for(variant, base), label)
+        notes += _fold_placement(variant, label)
+        notes += _fold_dynamo_source(variant, label)
+        notes += _strip_unused_benchmark_fields(variant, base, label)
+        # A `backend:` that only held per-mode env and engine config is empty now.
+        # Make the implicit engine explicit rather than dropping the block: an
+        # override variant may `null` its way back to the default type, which
+        # only works when the base still has the key.
+        backend = variant.get("backend")
+        if isinstance(backend, CommentedMap) and not backend:
+            engine = _ENGINE_FOR_KEY.get(_engine_key_for(variant, base), "sglang")
+            backend.ca.comment = None
+            backend.ca.items.clear()
+            backend.ca.end = None
+            backend["type"] = engine
+            notes.append(f"{label}backend.type: {engine} (was the implicit default)")
+        for key in ("resources", "dynamo", "infra", "frontend"):
+            _neutralize_if_empty(variant, key)
+    return notes
+
+
+# --- entry points -----------------------------------------------------------------------
 
 
 def migrate_recipe_text(text: str) -> MigrationResult:
-    """Migrate one YAML document (plain, override, or lock format) to the current schema."""
+    """Migrate one YAML document (plain, override, sweep, or lock format) to the current schema."""
     doc = load_yaml_text_with_comments(text)
     from_version = _declared_version(doc)
     notes: list[str] = []
 
-    if from_version < 2:
+    # The v2 layout folds are pure re-spellings, so they apply to a schema: 2
+    # document that still uses the legacy layout as well (a no-op once folded).
+    if from_version <= 2:
         notes.extend(_migrate_1_to_2(doc))
 
     if doc.get("schema") != CURRENT_SCHEMA_VERSION:
@@ -87,3 +348,151 @@ def migrate_recipe_file(path: Path, *, in_place: bool = False, output: Path | No
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(result.text, encoding="utf-8")
     return result
+
+
+def recipe_files(paths: Iterable[Path]) -> list[Path]:
+    """Expand files and directories (recursively, ``*.yaml`` / ``*.yml``) into a sorted list of recipe files."""
+    found: set[Path] = set()
+    for path in paths:
+        if path.is_dir():
+            found.update(p for p in path.rglob("*") if p.suffix in {".yaml", ".yml"} and p.is_file())
+        else:
+            found.add(path)
+    return sorted(found)
+
+
+# --- golden equality ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    """Golden-equality outcome for one recipe file."""
+
+    path: Path
+    status: str  # ok | mismatch | skipped | error
+    detail: str = ""
+    variants: int = 0
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {"ok", "skipped"}
+
+
+def _expand(raw: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """Every concrete recipe a raw document produces: plain, override variants, or sweep points."""
+    from srtctl.core.config import generate_override_configs
+
+    if "base" in raw:
+        return generate_override_configs(raw)
+    if "sweep" in raw:
+        from srtctl.core.sweep import generate_sweep_configs
+
+        return [(str(params), cfg) for cfg, params in generate_sweep_configs(copy.deepcopy(raw))]
+    return [("", raw)]
+
+
+def _resolved_dump(raw: dict[str, Any]) -> dict[str, Any]:
+    """Resolve and load a raw recipe exactly as the loader does, then dump it for comparison."""
+    from srtctl.core.config import resolve_config_with_defaults
+    from srtctl.core.schema import SrtConfig
+
+    schema = SrtConfig.Schema()
+    dumped = schema.dump(schema.load(resolve_config_with_defaults(raw, None)))
+    dumped.pop("schema", None)
+    return dumped
+
+
+def _mask_spelling_only_fields(dump: dict[str, Any]) -> None:
+    """Blank fields that only record how the recipe was spelled, not what it resolves to.
+
+    ``dynamo.source`` maps onto ``hash`` / ``version`` / ``wheel`` / ``cargo_patches``
+    in ``DynamoConfig.__post_init__``; those mapped fields are what gets compared.
+    """
+    dynamo = dump.get("dynamo")
+    if isinstance(dynamo, dict):
+        dynamo["source"] = None
+
+
+def _mask_unused_benchmark_fields(dump: dict[str, Any]) -> None:
+    """Blank benchmark fields the type never reads: the migrator removes them, and they never had an effect."""
+    try:
+        import srtctl.benchmarks  # noqa: F401
+        from srtctl.benchmarks.base import benchmark_config_fields
+    except Exception:  # noqa: BLE001
+        return
+    benchmark = dump.get("benchmark")
+    if not isinstance(benchmark, dict):
+        return
+    accepted = benchmark_config_fields(str(benchmark.get("type", "manual")))
+    for key in list(benchmark):
+        if key not in accepted:
+            benchmark[key] = None
+
+
+def _diff(a: Any, b: Any, path: str = "") -> list[str]:
+    if isinstance(a, dict) and isinstance(b, dict):
+        out: list[str] = []
+        for key in sorted(set(a) | set(b)):
+            out += _diff(a.get(key), b.get(key), f"{path}.{key}" if path else str(key))
+        return out
+    if isinstance(a, list) and isinstance(b, list) and len(a) == len(b):
+        out = []
+        for i, (x, y) in enumerate(zip(a, b, strict=True)):
+            out += _diff(x, y, f"{path}[{i}]")
+        return out
+    return [] if a == b else [f"{path}: v1={a!r} v2={b!r}"]
+
+
+def verify_migration_text(text: str, path: Path = Path("<text>")) -> VerifyResult:
+    """Migrate in memory and prove the v1 and v2 documents resolve to the same config."""
+    import yaml
+
+    try:
+        original = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return VerifyResult(path, "error", f"YAML parse error: {exc}")
+    if not isinstance(original, dict):
+        return VerifyResult(path, "error", "not a YAML mapping")
+
+    try:
+        result = migrate_recipe_text(text)
+        migrated = yaml.safe_load(result.text)
+    except Exception as exc:  # noqa: BLE001 - a migrator crash is a finding, not a skip
+        detail = next((line for line in str(exc).splitlines() if "duplicate key" in line), str(exc).splitlines()[0])
+        return VerifyResult(path, "error", f"migration failed: {detail} (fix the recipe, then re-run)")
+    if not isinstance(migrated, dict):
+        return VerifyResult(path, "error", "migrated document is not a YAML mapping", notes=result.notes)
+
+    try:
+        before = _expand(original)
+    except Exception as exc:  # noqa: BLE001
+        return VerifyResult(path, "skipped", f"v1 document does not expand: {exc}", notes=result.notes)
+    try:
+        after = _expand(migrated)
+    except Exception as exc:  # noqa: BLE001
+        return VerifyResult(path, "mismatch", f"migrated document does not expand: {exc}", notes=result.notes)
+    if len(before) != len(after):
+        return VerifyResult(path, "mismatch", f"{len(before)} variants before, {len(after)} after", notes=result.notes)
+
+    for (name_a, raw_a), (_name_b, raw_b) in zip(before, after, strict=True):
+        where = f" [{name_a}]" if name_a else ""
+        try:
+            dump_a = _resolved_dump(raw_a)
+        except Exception as exc:  # noqa: BLE001
+            return VerifyResult(path, "skipped", f"v1 does not load{where}: {exc}", notes=result.notes)
+        try:
+            dump_b = _resolved_dump(raw_b)
+        except Exception as exc:  # noqa: BLE001
+            return VerifyResult(path, "mismatch", f"migrated recipe does not load{where}: {exc}", notes=result.notes)
+        for dump in (dump_a, dump_b):
+            _mask_spelling_only_fields(dump)
+            _mask_unused_benchmark_fields(dump)
+        differences = _diff(dump_a, dump_b)
+        if differences:
+            return VerifyResult(path, "mismatch", f"resolved configs differ{where}: " + "; ".join(differences[:5]))
+    return VerifyResult(path, "ok", variants=len(before), notes=result.notes)
+
+
+def verify_migration_file(path: Path) -> VerifyResult:
+    return verify_migration_text(path.read_text(encoding="utf-8"), path)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the v1 -> v2 layout migrator and the golden-equality check."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from srtctl.cli import submit as submit_cli
+from srtctl.core.migrate import migrate_recipe_text, verify_migration_text
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+
+LEGACY = """\
+# A v1 recipe with everything the migrator folds.
+name: legacy
+model:
+  path: /m
+  container: /c.sqsh
+  precision: bf16
+resources:
+  gpu_type: h100         # keep me
+  gpus_per_node: 8
+  prefill_nodes: 1       # one prefill node
+  prefill_workers: 2
+  decode_nodes: 1
+  decode_workers: 1
+  gpus_per_decode: 4
+frontend:
+  type: dynamo
+  orchestrator_placement: first_decode
+dynamo:
+  install: true
+  hash: "abc1234"        # pinned build
+  cargo_patches:
+    - 'x = 1'
+backend:
+  type: sglang
+  prefill_environment:
+    PYTHONUNBUFFERED: "1"
+  decode_environment:
+    SGLANG_X: "2"
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 4   # tp
+    decode:
+      tensor-parallel-size: 4
+infra:
+  etcd_nats_dedicated_node: true
+benchmark:
+  type: gsm8k
+  num_examples: 100
+  isl: 1024              # never read by gsm8k
+  client_placement: last_decode
+"""
+
+
+def test_migrate_folds_roles_placement_source_and_strips_unused_benchmark_fields() -> None:
+    result = migrate_recipe_text(LEGACY)
+    doc = yaml.safe_load(result.text)
+
+    assert doc["schema"] == 2
+    assert doc["roles"] == {
+        "prefill": {
+            "nodes": 1,
+            "workers": 2,
+            "env": {"PYTHONUNBUFFERED": "1"},
+            "args": {"tensor-parallel-size": 4},
+        },
+        "decode": {"nodes": 1, "workers": 1, "gpus": 4, "env": {"SGLANG_X": "2"}, "args": {"tensor-parallel-size": 4}},
+    }
+    assert doc["resources"] == {"gpu_type": "h100", "gpus_per_node": 8}
+    assert doc["backend"] == {"type": "sglang"}
+    assert doc["frontend"] == {"type": "dynamo", "placement": {"node": "first_decode"}}
+    assert doc["infra"] == {"placement": {"node": "dedicated"}}
+    assert doc["dynamo"] == {"install": True, "source": {"rev": "abc1234", "patches": ["x = 1"]}}
+    assert doc["benchmark"] == {"type": "gsm8k", "num_examples": 100, "placement": {"node": "last_decode"}}
+    assert "removed benchmark.isl (unused by type gsm8k)" in result.notes
+
+    # Comments travel with their keys.
+    assert "# keep me" in result.text
+    assert "nodes: 1       # one prefill node" in result.text or "# one prefill node" in result.text
+    assert "# pinned build" in result.text
+    assert "# tp" in result.text
+    # roles sits right after backend.
+    keys = list(doc)
+    assert keys.index("roles") == keys.index("backend") + 1
+
+
+def test_migrate_is_idempotent_and_layout_folds_apply_to_schema_2_documents() -> None:
+    once = migrate_recipe_text(LEGACY)
+    twice = migrate_recipe_text(once.text)
+    assert not twice.changed
+    assert twice.notes == ()
+
+    legacy_v2 = "schema: 2\n" + LEGACY.split("\n", 1)[1]
+    folded = migrate_recipe_text(legacy_v2)
+    assert "roles" in yaml.safe_load(folded.text)
+
+
+def test_migrate_override_file_folds_every_variant() -> None:
+    text = """\
+base:
+  name: o
+  model:
+    path: /m
+    container: /c.sqsh
+    precision: bf16
+  resources:
+    gpu_type: h100
+    gpus_per_node: 8
+    agg_nodes: 1
+    agg_workers: 2
+    gpus_per_agg: 1
+  backend:
+    type: sglang
+    sglang_config:
+      aggregated:
+        tensor-parallel-size: 1
+  benchmark:
+    type: sa-bench
+    isl: 128
+    osl: 128
+    concurrencies: "4"
+override_tp2:
+  resources:
+    agg_workers: 1
+    gpus_per_agg: 2
+  backend:
+    sglang_config:
+      aggregated:
+        tensor-parallel-size: 2
+zip_override_ctx:
+  backend:
+    sglang_config:
+      aggregated:
+        context-length: [2048, 8192]
+"""
+    doc = yaml.safe_load(migrate_recipe_text(text).text)
+    assert doc["base"]["roles"]["agg"] == {"nodes": 1, "workers": 2, "gpus": 1, "args": {"tensor-parallel-size": 1}}
+    assert "backend" not in doc["override_tp2"] or "sglang_config" not in doc["override_tp2"]["backend"]
+    assert doc["override_tp2"]["roles"]["agg"] == {"workers": 1, "gpus": 2, "args": {"tensor-parallel-size": 2}}
+    assert doc["zip_override_ctx"]["roles"]["agg"] == {"args": {"context-length": [2048, 8192]}}
+    # And the variants still combine: a partially migrated file would collide on roles vs legacy fields.
+    verified = verify_migration_text(text)
+    assert verified.status == "ok", verified.detail
+    assert verified.variants == 3
+
+
+def test_dynamo_version_and_wheel_and_top_of_tree() -> None:
+    head = "name: d\nmodel:\n  path: /m\n  container: /c\n  precision: bf16\n"
+    assert yaml.safe_load(migrate_recipe_text(head + "dynamo:\n  version: '1.4.2'\n").text)["dynamo"] == {
+        "source": {"pypi": "1.4.2"}
+    }
+    assert yaml.safe_load(migrate_recipe_text(head + "dynamo:\n  wheel: '1.5.0.dev1'\n").text)["dynamo"] == {
+        "source": {"wheel": "1.5.0.dev1"}
+    }
+    result = migrate_recipe_text(head + "dynamo:\n  top_of_tree: true\n")
+    assert yaml.safe_load(result.text)["dynamo"] == {"top_of_tree": True}
+    assert any("top_of_tree left as is" in note for note in result.notes)
+
+
+def test_verify_reports_identical_and_mismatched() -> None:
+    ok = verify_migration_text(LEGACY)
+    assert ok.status == "ok", ok.detail
+    assert ok.variants == 1
+
+    # A recipe the v1 loader itself rejects is skipped, not counted against the migrator.
+    skipped = verify_migration_text(
+        "name: x\nmodel:\n  path: /m\n  container: /c\n  precision: bf16\nbenchmark:\n  type: nope\n"
+    )
+    assert skipped.status == "skipped"
+    assert "does not load" in skipped.detail
+
+
+def test_every_example_is_golden() -> None:
+    for path in sorted(EXAMPLES_DIR.rglob("*.yaml")):
+        outcome = verify_migration_text(path.read_text(), path)
+        assert outcome.status == "ok", f"{path}: {outcome.detail}"
+
+
+def test_cli_verify_directory(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / "a.yaml").write_text(LEGACY)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.yaml").write_text(LEGACY.replace("name: legacy", "name: other"))
+    monkeypatch.setattr(sys, "argv", ["srtctl", "migrate", "--verify", "-f", str(tmp_path)])
+    with pytest.raises(SystemExit) as exc:
+        submit_cli.main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "2 identical, 0 mismatched" in out
+    assert "a.yaml" in out and "b.yaml" in out
+
+
+def test_cli_in_place_directory(tmp_path: Path, monkeypatch) -> None:
+    for name in ("a.yaml", "b.yml"):
+        (tmp_path / name).write_text(LEGACY)
+    monkeypatch.setattr(sys, "argv", ["srtctl", "migrate", "--in-place", "-f", str(tmp_path)])
+    submit_cli.main()
+    for name in ("a.yaml", "b.yml"):
+        doc = yaml.safe_load((tmp_path / name).read_text())
+        assert doc["schema"] == 2 and "roles" in doc


### PR DESCRIPTION
Stacked on #405 (Track 2 step 11 and the deferred full migrator from https://github.com/NVIDIA/srt-slurm/issues/385).

## What

`srtctl migrate` now rewrites the legacy layout, not just the `schema:` key, on a ruamel round-trip document so comments, key order, and quoting survive and moved keys keep their comments:

| v1 | v2 |
| --- | --- |
| `resources.<role>_nodes/_workers`, `gpus_per_<role>`, `backend.<mode>_environment`, `backend.<engine>_config.<mode>`, `backend.<mode>_extra_args` | `roles.<role>.{nodes, workers, gpus, env, args, extra_args}` |
| `frontend.orchestrator_placement` / `dedicated_node`, `benchmark.client_placement` / `client_dedicated_node`, `infra.etcd_nats_dedicated_node` | `placement.node` |
| `dynamo.hash` / `cargo_patches` / `wheel` / `version` | `dynamo.source.{rev, patches, wheel, pypi}` (`top_of_tree` is left with a note; it has no immutable rev) |
| benchmark fields the type never reads | removed (schema 2 rejects them; they were silent no-ops) |

Every variant of an override file (`base`, `override_*`, `zip_override_*`) is rewritten, since a half-migrated file would collide `roles` with the legacy keys on merge. A `backend:` emptied by the folds keeps an explicit `type` instead of disappearing, because a zip variant may `null` its way back to the default and that only works while the base has the key. `-f` accepts directories and repeats; `--in-place` rewrites many files at once.

## Golden equality

`srtctl migrate --verify -f <paths>` migrates in memory, expands plain, override, and sweep files, resolves both documents through the loader, and compares the dumps (masking `dynamo.source`, which only records spelling, and benchmark fields the type never reads). Exit 1 on any mismatch. A new CI job `golden-equality` runs it over `examples/` and the 555 historical recipes extracted from the last commit that carried `recipes/` (`make golden-check` does the same locally).

| Corpus | Identical | Mismatched | Skipped (v1 itself does not load) | Unreadable |
| --- | --- | --- | --- | --- |
| `examples/` (19) | 19 | 0 | 0 | 0 |
| historical in-repo recipes (555) | 553 | 0 | 2 (`benchmark.type: gsm8k-bench`, unknown on main) | 0 |
| downstream InferenceMAX (481, run locally; private repo) | 370 | 0 | 105 (`telemetry.provider` / `benchmark.tokenizer_mode`, unknown on main) | 6 (duplicate YAML keys, reported by name) |

The skipped and unreadable rows are pre-existing recipe or schema gaps that fail on `main` today, independent of this stack; the report names each one so they can be fixed downstream.

## Also

- Docs: `## schema` and `## roles` in `docs/config-reference.md` describe the rewrite and `--verify`.
- Tests: `tests/test_migrate.py` covers each fold with comments preserved, idempotency, override and zip variants, `dynamo.source` cases, verify outcomes, every example being golden, and the directory forms of `--verify` and `--in-place`.
- Full suite green (1855 passed); lint, schema-docs drift check, every example validates.
