### PR TITLE
feat(trtllm-serve): default return_perf_metrics on so worker Prometheus metrics exist

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -328,6 +328,17 @@ supported). A recipe can be switched between the two TRT-LLM serving stacks by
 changing only `frontend.type` between `dynamo` and `trtllm_serve`. See the sample
 recipe `recipes/trtllm/b200-fp8/1k1k/stp/ctx1_gen3_tp8_batch1024_eplb0_mtp0_4_trtllm_serve.yaml`.
 
+**Worker metrics default.** srtctl sets `return_perf_metrics: true` in the
+`trtllm_config` section of every mode a `trtllm_serve` recipe uses (prefill and
+decode, or `aggregated`), creating the section when the recipe has none. This is
+a setdefault: an explicit `return_perf_metrics: false` in the recipe wins and is
+warned about. trtllm-serve mounts a worker's `/prometheus/metrics` route only
+when the engine runs with that flag, and TensorRT-LLM's own default is `false`,
+so without it Tachometer's `backend_*` endpoints answer HTTP 404 and the capture
+has no worker-level data. The route carries the per-request series (request
+latency, TTFT, TPOT, queue/prefill/decode time, token counters); it applies
+independently of `observability.enabled`, which keeps its own expansion.
+
 ### vllm frontend
 
 `type: vllm` runs aggregate vLLM jobs **without Dynamo**. The OpenAI-compatible
@@ -703,9 +714,12 @@ their URLs are appended to `AIPERF_SERVER_METRICS_URLS` after the logical worker
 
 Two caveats for `AIPERF_SERVER_METRICS_URLS`:
 
-- **TRT-LLM worker URLs are omitted when the workers publish no metrics.** A TRT-LLM worker
+- **TRT-LLM worker URLs are omitted when the workers publish no metrics.** A Dynamo TRT-LLM worker
   launched without `--publish-events-and-metrics` (the default; `observability.enabled` turns it
-  on) serves nothing on its sys-port `/metrics`, so those URLs are not advertised. KVBM URLs are
+  on) serves nothing on its sys-port `/metrics`, so those URLs are not advertised. With
+  `frontend.type: trtllm_serve` the gate is the worker's own engine config instead: its
+  `/prometheus/metrics` URL is advertised when that mode's `return_perf_metrics` is true (the
+  srtctl default for trtllm_serve recipes; an explicit `false` drops the URL). KVBM URLs are
   unaffected — KVBM serves its own endpoint regardless of the flag.
 - **An explicit `AIPERF_SERVER_METRICS_URLS` in the recipe `environment:` wins.** Injection is
   skipped when the variable is already set, so a curated endpoint list is never clobbered.

--- a/src/srtctl/cli/mixins/benchmark_stage.py
+++ b/src/srtctl/cli/mixins/benchmark_stage.py
@@ -640,15 +640,21 @@ class BenchmarkStageMixin:
             # trtllm-serve workers bind only their OpenAI http_port (leaders) —
             # the DYN_SYSTEM_PORT sys-port endpoints are never created in this
             # mode, so advertising them would point the client at dead ports.
-            # The Prometheus mount exists when return_perf_metrics is set,
-            # which observability.enabled injects alongside
-            # publish_events_and_metrics.
+            # trtllm-serve mounts the Prometheus route only when the engine
+            # runs with return_perf_metrics (expand_trtllm_serve_defaults sets
+            # it on every trtllm_serve recipe; an explicit false opts out), so
+            # gate each worker on its own effective engine config --
+            # publish_events_and_metrics is a dynamo.trtllm flag that never
+            # reaches a trtllm-serve worker.
             if self.config.frontend.type == "trtllm_serve":
-                if getattr(self.config.backend, "publish_events_and_metrics", False):
-                    for process in self.backend_processes:
-                        if process.endpoint_mode != "agg" and process.http_port > 0:
-                            host = get_hostname_ip(process.node, self.runtime.network_interface)
-                            urls.append(f"http://{host}:{process.http_port}{metrics_path}")
+                for process in self.backend_processes:
+                    if process.endpoint_mode == "agg" or process.http_port <= 0:
+                        continue
+                    engine_config = self.config.backend.get_config_for_mode(process.endpoint_mode)
+                    if not engine_config.get("return_perf_metrics"):
+                        continue
+                    host = get_hostname_ip(process.node, self.runtime.network_interface)
+                    urls.append(f"http://{host}:{process.http_port}{metrics_path}")
             # TRT-LLM workers only publish engine metrics when launched with
             # --publish-events-and-metrics (pre-v1.3.0 Dynamo gates the whole
             # worker /metrics surface on it; observability.enabled sets it at

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -695,6 +695,67 @@ def expand_observability(cfg: dict) -> dict:
     return cfg
 
 
+def expand_trtllm_serve_defaults(cfg: dict) -> dict:
+    """Bake the trtllm-serve worker-metrics default into the TRT-LLM engine configs.
+
+    trtllm-serve registers a worker's Prometheus route (``/prometheus/metrics``)
+    only when the engine runs with ``return_perf_metrics: true`` (TensorRT-LLM
+    ``serve/openai_server.py``, ``register_routes``); TensorRT-LLM's own default
+    is ``false``. Tachometer scrapes that route on every run, so without this
+    default every trtllm-serve worker endpoint answers HTTP 404 and the capture
+    silently has no worker-level data.
+
+    Applies to every ``frontend.type: trtllm_serve`` recipe with a TRT-LLM
+    backend, independent of ``observability.enabled``. The engine sections for
+    the modes the recipe uses (prefill + decode for a disaggregated
+    ``resources`` block, ``aggregated`` otherwise) are created when absent, so a
+    recipe with no ``trtllm_config`` gets the default too. Every write is a
+    ``setdefault``: an explicit ``return_perf_metrics: false`` in the recipe
+    wins, but is reported loudly. Mutates ``cfg`` in place and returns it.
+    """
+    from srtctl.core.schema import TRTLLM_SERVE_ENGINE_DEFAULTS
+
+    frontend = cfg.get("frontend")
+    if not isinstance(frontend, dict) or frontend.get("type") != "trtllm_serve":
+        return cfg
+    backend = cfg.get("backend")
+    if not isinstance(backend, dict) or backend.get("type", "sglang") != "trtllm":
+        return cfg
+    trtllm_config = backend.get("trtllm_config")
+    if not isinstance(trtllm_config, dict):
+        trtllm_config = {}
+        backend["trtllm_config"] = trtllm_config
+
+    # Modes the layout uses: mirror ResourceConfig.is_disaggregated -- a
+    # prefill_nodes/decode_nodes pair means prefill + decode, otherwise agg.
+    resources = cfg.get("resources") if isinstance(cfg.get("resources"), dict) else {}
+    disaggregated = resources.get("prefill_nodes") is not None or resources.get("decode_nodes") is not None
+    modes_in_use = ("prefill", "decode") if disaggregated else ("aggregated",)
+
+    opted_out: list[str] = []
+    for mode in ("prefill", "decode", "aggregated"):
+        section = trtllm_config.get(mode)
+        if not isinstance(section, dict):
+            if mode not in modes_in_use:
+                continue
+            section = {}
+            trtllm_config[mode] = section
+        if section.get("return_perf_metrics") is False:
+            opted_out.append(mode)
+        for key, value in TRTLLM_SERVE_ENGINE_DEFAULTS.items():
+            section.setdefault(key, value)
+
+    if opted_out:
+        logger.warning(
+            "frontend.type: trtllm_serve with return_perf_metrics: false on %s — those "
+            "trtllm-serve workers will NOT mount /prometheus/metrics (HTTP 404), so the "
+            "Tachometer backend_* endpoints and the per-request Prometheus histograms "
+            "will be empty for them. Remove the line to keep the default.",
+            ", ".join(opted_out),
+        )
+    return cfg
+
+
 def load_config(path: Path | str) -> SrtConfig:
     """
     Load and validate YAML config, applying cluster defaults.
@@ -744,6 +805,9 @@ def load_config(path: Path | str) -> SrtConfig:
     # downstream consumer -- worker command builder, engine YAML writer,
     # frontend env -- sees the expanded values with no extra plumbing.
     expand_observability(resolved_config)
+    # trtllm-serve needs return_perf_metrics for its Prometheus route to exist
+    # at all; bake that default in for every trtllm_serve recipe (setdefault).
+    expand_trtllm_serve_defaults(resolved_config)
 
     # Parse with marshmallow schema to get typed SrtConfig
     try:

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1327,6 +1327,17 @@ ANALYTICS_ENGINE_CONFIG: dict[str, bool] = {
     "return_perf_metrics": True,
 }
 
+# Engine-config default baked in for every ``frontend.type: trtllm_serve`` run,
+# independent of ``observability.enabled``. trtllm-serve registers a worker's
+# Prometheus route (``/prometheus/metrics``) only when the engine runs with
+# ``return_perf_metrics: true`` (TensorRT-LLM ``serve/openai_server.py``,
+# ``register_routes``); TensorRT-LLM's own default is ``false``. Tachometer
+# scrapes that route on every run, so without this default every trtllm-serve
+# worker endpoint answers HTTP 404 and the capture silently has no worker data.
+TRTLLM_SERVE_ENGINE_DEFAULTS: dict[str, bool] = {
+    "return_perf_metrics": True,
+}
+
 
 # /configs/dynamo-wheels is the lustre-mounted cache for hash-pinned dynamo
 # source builds. The bench/frontend container always mounts srtslurm's
@@ -2381,11 +2392,12 @@ class SrtConfig:
 
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> "SrtConfig":
-        from srtctl.core.config import expand_observability
+        from srtctl.core.config import expand_observability, expand_trtllm_serve_defaults
 
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         expand_observability(data)
+        expand_trtllm_serve_defaults(data)
         schema = cls.Schema()
         return schema.load(data)
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -239,6 +239,7 @@ class TestCustomBenchmarkRunner:
         aggregated_environment=None,
         environment=None,
         dynamo_sidecar=False,
+        trtllm_config=None,
     ):
         from types import SimpleNamespace
 
@@ -249,6 +250,13 @@ class TestCustomBenchmarkRunner:
             def backend_processes(self):
                 return processes
 
+        # Mirrors TRTLLMProtocol.get_config_for_mode: the engine yaml section for
+        # a worker mode ("agg" maps to the "aggregated" section).
+        engine_sections = trtllm_config or {}
+
+        def get_config_for_mode(mode):
+            return dict(engine_sections.get("aggregated" if mode == "agg" else mode, {}))
+
         stage = Stage()
         stage.config = SimpleNamespace(
             benchmark=SimpleNamespace(type=benchmark_type, aiperf_package=None),
@@ -257,6 +265,7 @@ class TestCustomBenchmarkRunner:
                 publish_events_and_metrics=publish_events_and_metrics,
                 prefill_environment=prefill_environment or {},
                 aggregated_environment=aggregated_environment or {},
+                get_config_for_mode=get_config_for_mode,
             ),
             backend_type=backend_type,
             dynamo=SimpleNamespace(sidecar=dynamo_sidecar),
@@ -421,8 +430,10 @@ class TestCustomBenchmarkRunner:
     def test_trtllm_serve_physical_endpoints_use_worker_http_ports(self):
         """Built-in AIPerf path: trtllm-serve never binds the DYN_SYSTEM_PORT
         sys-ports, so the physical-process URLs use leader http_ports at
-        /prometheus/metrics, gated on publish_events_and_metrics exactly like
-        the Dynamo sys-port path."""
+        /prometheus/metrics. The route exists only when the worker's engine
+        config carries return_perf_metrics (which expand_trtllm_serve_defaults
+        sets on every trtllm_serve recipe), so the gate is that key -- not
+        publish_events_and_metrics, a dynamo.trtllm flag trtllm-serve never sees."""
         from unittest.mock import patch
 
         from srtctl.core.topology import Process
@@ -432,9 +443,8 @@ class TestCustomBenchmarkRunner:
             Process("node-b", frozenset(range(4)), 7501, 0, "prefill", 0, node_rank=1),
             Process("node-c", frozenset(range(4)), 7502, 6100, "decode", 0, node_rank=0),
         ]
-        stage = self._benchmark_stage(
-            "trtllm_serve", processes, backend_type="trtllm", publish_events_and_metrics=True
-        )
+        engine = {"prefill": {"return_perf_metrics": True}, "decode": {"return_perf_metrics": True}}
+        stage = self._benchmark_stage("trtllm_serve", processes, backend_type="trtllm", trtllm_config=engine)
         with patch(
             "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
             side_effect=lambda node, interface: f"ip-{node}",
@@ -444,8 +454,24 @@ class TestCustomBenchmarkRunner:
             "http://ip-node-a:6100/prometheus/metrics,http://ip-node-c:6100/prometheus/metrics"
         )
 
-        # Without the metrics leg there is nothing to poll — no dead-port URLs.
-        stage_off = self._benchmark_stage("trtllm_serve", processes, backend_type="trtllm")
+        # A mode that opted out (return_perf_metrics: false) mounts no route:
+        # only the other mode's leader is advertised -- no dead URLs.
+        engine_partial = {"prefill": {"return_perf_metrics": True}, "decode": {"return_perf_metrics": False}}
+        stage_partial = self._benchmark_stage(
+            "trtllm_serve", processes, backend_type="trtllm", trtllm_config=engine_partial
+        )
+        with patch(
+            "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
+            side_effect=lambda node, interface: f"ip-{node}",
+        ):
+            env = stage_partial._get_aiperf_server_metrics_env()
+        assert env["AIPERF_SERVER_METRICS_URLS"] == "http://ip-node-a:6100/prometheus/metrics"
+
+        # No engine config at all (nothing set the default): nothing to poll, and
+        # publish_events_and_metrics must not be mistaken for the trtllm-serve gate.
+        stage_off = self._benchmark_stage(
+            "trtllm_serve", processes, backend_type="trtllm", publish_events_and_metrics=True
+        )
         with patch(
             "srtctl.cli.mixins.benchmark_stage.get_hostname_ip",
             side_effect=lambda node, interface: f"ip-{node}",

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -7,7 +7,7 @@ import pytest
 import yaml
 from marshmallow import ValidationError
 
-from srtctl.core.config import expand_observability
+from srtctl.core.config import expand_observability, expand_trtllm_serve_defaults
 from srtctl.core.schema import SrtConfig
 
 BASE_CONFIG = {
@@ -278,6 +278,123 @@ class TestExpandObservability:
 
         with pytest.raises(ValidationError, match="binary_path"):
             SrtConfig.Schema().load(cfg)
+
+
+def _trtllm_serve_config(**observability):
+    cfg = _trtllm_config(**observability)
+    cfg["frontend"] = {"type": "trtllm_serve", "enable_multiple_frontends": False}
+    return cfg
+
+
+class TestTrtllmServeDefaults:
+    """trtllm-serve mounts a worker's /prometheus/metrics route only when the engine
+    runs with return_perf_metrics: true, and TensorRT-LLM's own default is false.
+    srtctl bakes that default in for every trtllm_serve recipe so Tachometer's
+    backend_* endpoints are never a silent 404."""
+
+    def test_return_perf_metrics_defaults_on_without_observability(self):
+        out = expand_trtllm_serve_defaults(_trtllm_serve_config())
+        for mode in ("prefill", "decode"):
+            section = out["backend"]["trtllm_config"][mode]
+            assert section["return_perf_metrics"] is True
+            # Only this key is touched; the recipe's own values survive.
+            assert "enable_iter_perf_stats" not in section
+            assert section["max_batch_size"] in (256, 64)
+
+    def test_explicit_false_wins_and_warns(self, caplog):
+        cfg = _trtllm_serve_config()
+        cfg["backend"]["trtllm_config"]["decode"]["return_perf_metrics"] = False
+        with caplog.at_level("WARNING"):
+            out = expand_trtllm_serve_defaults(cfg)
+        assert out["backend"]["trtllm_config"]["decode"]["return_perf_metrics"] is False
+        assert out["backend"]["trtllm_config"]["prefill"]["return_perf_metrics"] is True
+        assert any("decode" in rec.message and "/prometheus/metrics" in rec.message for rec in caplog.records)
+
+    def test_dynamo_frontend_is_untouched(self):
+        cfg = _trtllm_config()
+        out = expand_trtllm_serve_defaults(cfg)
+        for mode in ("prefill", "decode"):
+            assert "return_perf_metrics" not in out["backend"]["trtllm_config"][mode]
+
+    def test_non_trtllm_backend_is_untouched(self):
+        cfg = dict(BASE_CONFIG)
+        cfg["frontend"] = {"type": "trtllm_serve"}
+        cfg["backend"] = {"type": "sglang", "sglang_config": {"prefill": {}}}
+        out = expand_trtllm_serve_defaults(cfg)
+        assert out["backend"] == {"type": "sglang", "sglang_config": {"prefill": {}}}
+
+    def test_missing_sections_are_created_for_the_modes_in_use(self):
+        """A disaggregated recipe with no engine yaml at all still gets the route:
+        prefill and decode sections are created; aggregated is not (unused)."""
+        cfg = _trtllm_serve_config()
+        del cfg["backend"]["trtllm_config"]
+        out = expand_trtllm_serve_defaults(cfg)
+        assert out["backend"]["trtllm_config"] == {
+            "prefill": {"return_perf_metrics": True},
+            "decode": {"return_perf_metrics": True},
+        }
+
+    def test_partial_sections_are_completed(self):
+        cfg = _trtllm_serve_config()
+        del cfg["backend"]["trtllm_config"]["decode"]
+        out = expand_trtllm_serve_defaults(cfg)
+        assert out["backend"]["trtllm_config"]["prefill"]["return_perf_metrics"] is True
+        assert out["backend"]["trtllm_config"]["decode"] == {"return_perf_metrics": True}
+        assert "aggregated" not in out["backend"]["trtllm_config"]
+
+    def test_aggregated_layout_gets_the_default_and_can_opt_out(self, caplog):
+        cfg = dict(BASE_CONFIG)
+        cfg["resources"] = {"gpu_type": "h100", "gpus_per_node": 8, "agg_nodes": 1, "agg_workers": 1}
+        cfg["frontend"] = {"type": "trtllm_serve", "enable_multiple_frontends": False}
+        cfg["backend"] = {"type": "trtllm", "trtllm_config": {"aggregated": {"max_batch_size": 8}}}
+        out = expand_trtllm_serve_defaults(cfg)
+        assert out["backend"]["trtllm_config"]["aggregated"]["return_perf_metrics"] is True
+        assert "prefill" not in out["backend"]["trtllm_config"]
+
+        cfg["backend"]["trtllm_config"]["aggregated"]["return_perf_metrics"] = False
+        with caplog.at_level("WARNING"):
+            expand_trtllm_serve_defaults(cfg)
+        assert any("aggregated" in rec.message for rec in caplog.records)
+
+    def test_from_yaml_applies_the_default(self, tmp_path):
+        cfg = _trtllm_serve_config()
+        cfg["benchmark"] = {"type": "sa-bench", "concurrencies": [4]}
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.safe_dump(cfg))
+
+        loaded = SrtConfig.from_yaml(config_path)
+
+        for mode in ("prefill", "decode"):
+            section = getattr(loaded.backend.trtllm_config, mode)
+            assert section["return_perf_metrics"] is True
+
+    def test_load_config_applies_the_default(self, tmp_path, monkeypatch):
+        """load_config is the path every real entry point uses (srtctl apply,
+        dry-run, the in-job orchestrator); from_yaml has no production callers."""
+        from srtctl.core.config import load_config
+
+        monkeypatch.delenv("SRTSLURM_CONFIG", raising=False)
+        monkeypatch.setattr("srtctl.core.config.load_cluster_config", lambda: None)
+        cfg = _trtllm_serve_config()
+        cfg["benchmark"] = {"type": "sa-bench", "concurrencies": [4]}
+        config_path = tmp_path / "recipe.yaml"
+        config_path.write_text(yaml.safe_dump(cfg))
+
+        loaded = load_config(config_path)
+
+        for mode in ("prefill", "decode"):
+            assert loaded.backend.get_config_for_mode(mode)["return_perf_metrics"] is True
+
+    def test_observability_expansion_is_unchanged_and_composes(self):
+        """observability.enabled still injects both engine keys; the trtllm-serve
+        default only fills return_perf_metrics where nothing else set it."""
+        cfg = _trtllm_serve_config(enabled=True)
+        expand_observability(cfg)
+        out = expand_trtllm_serve_defaults(cfg)
+        for mode in ("prefill", "decode"):
+            section = out["backend"]["trtllm_config"][mode]
+            assert section["return_perf_metrics"] is True
+            assert section["enable_iter_perf_stats"] is True
 
 
 class TestObservabilitySchema:


### PR DESCRIPTION
## What

`frontend.type: trtllm_serve` recipes now run their TRT-LLM workers with `return_perf_metrics: true` by default, so every trtllm-serve worker exposes `/prometheus/metrics` and Tachometer's `backend_*` endpoints carry data.

## Why

trtllm-serve registers a worker's Prometheus route only when the engine runs with `return_perf_metrics: true` (`tensorrt_llm/serve/openai_server.py`, `register_routes`), and TensorRT-LLM's default is `false`. Tachometer scrapes `/prometheus/metrics` on every trtllm-serve run (#397), so a recipe that did not set the flag got HTTP 404 on every worker endpoint and a capture with no worker-level metrics. The scraper logs only connection failures, so this was silent: the parquet simply had zero rows for the `backend_*` endpoints while dcgm, node_exporter and the orchestrator endpoint were complete (observed on a c24 2p3d job: all five worker URLs answered `404 {"detail":"Not Found"}`).

## How

- New `expand_trtllm_serve_defaults()` in `srtctl/core/config.py`, applied in `load_config()` and `SrtConfig.from_yaml()` right after the observability expansion. For `frontend.type: trtllm_serve` with a TRT-LLM backend it writes `return_perf_metrics: true` into the engine section of each mode the layout uses (prefill + decode, or `aggregated`), creating the section when the recipe has none. Setdefault semantics: an explicit `return_perf_metrics: false` is kept and logged as a warning that those workers will have no Prometheus route.
- `AIPERF_SERVER_METRICS_URLS` for trtllm-serve is now gated on each worker's effective `return_perf_metrics` instead of `publish_events_and_metrics`, which is a `dynamo.trtllm` flag that never reaches a trtllm-serve worker. Worker URLs are advertised by default and dropped for modes that opt out.
- `observability.enabled` is unchanged: it still expands to `enable_iter_perf_stats: true` and `return_perf_metrics: true` on every engine config.

## Behaviour change

trtllm-serve workers expose the per-request Prometheus series (`trtllm_request_success_total`, `trtllm_e2e_request_latency_seconds`, TTFT/TPOT, queue/prefill/decode time, token counters) on every run, and the aiperf client is pointed at them. Engine-side the flag turns on TensorRT-LLM's per-request perf-metrics bookkeeping. Recipes that must not have it write `return_perf_metrics: false`.

## Tests

- `tests/test_observability.py`: `TestTrtllmServeDefaults` — default applied without observability; explicit `false` wins and warns (naming the mode); dynamo frontends and non-TRT-LLM backends untouched; missing and partial sections created for the modes in use; aggregated layout; `SrtConfig.from_yaml` and the production `load_config()` path; composition with `observability.enabled` (both engine keys still injected).
- `tests/test_benchmarks.py`: trtllm-serve `AIPERF_SERVER_METRICS_URLS` gated per mode on `return_perf_metrics` (all on, one mode opted out, no engine config).
- `ruff check src/srtctl/` clean; full suite passes (e2e deselected).
