### PR TITLE
fix(ingest): discover Dynamo's rotated request-trace shards and read them as one stream

### DIFF
--- a/docs/component-dashboard.md
+++ b/docs/component-dashboard.md
@@ -171,7 +171,7 @@ and loses Overview.
 | Leg | Recipe requirement | Artifact | Bundle output | Feeds |
 | --- | ------------------ | -------- | ------------- | ----- |
 | **Metrics** | `observability.enabled` (Tachometer), else the client's own export | `<log_dir>/tachometer/raw/scrape/*.parquet`, else historical `<log_dir>/raw_prometheus.jsonl`, else `<log_dir>/agentic/*/…/server_metrics_export.json(l)` | `server_metrics_export.jsonl` | every time-series panel |
-| **Request trace** | `observability.enabled` | `<log_dir>/dynamo-request-trace` | `request_trace.jsonl` | per-request card, per-session view, the waterfall's KV-transfer band |
+| **Request trace** | `observability.enabled` | `<log_dir>/dynamo-request-trace.NNNNNN.jsonl.gz` (Dynamo's rotated gzip shards; a bare `dynamo-request-trace` is also accepted) | `request_trace.jsonl` | per-request card, per-session view, the waterfall's KV-transfer band |
 | **Per-iteration** | `print_iter_log: true` in the engine config | `SPAN`-free lines in `<log_dir>/*_w*.out` | `iter_bins.json` | batch composition, host/device step time |
 | **Traces** | `observability.enabled` **and** an AIPerf benchmark | `SPAN_CLOSED` lines in `<log_dir>/*.out` | `tempo_traces/<xid>.json` | Overview, routing outcome on the card |
 | **Client** | an AIPerf benchmark at export level `records` (default) | `<log_dir>/agentic/*/aiperf_artifacts/` or `artifacts/*/` | `profile_export.jsonl` | Overview, warmup filtering |
@@ -270,7 +270,7 @@ Produces:
 | `--traces` | `spanlog` | `none` to skip |
 | `--span-logs` | `*.out` | srt-slurm's worker/frontend log naming |
 | `--metrics` | `prometheus` | parses `raw_prometheus.jsonl` |
-| `--request-trace` | `dynamo` | parses `dynamo-request-trace`; the only source of KV-transfer cost and `session_id` |
+| `--request-trace` | `dynamo` | parses every `dynamo-request-trace.*.jsonl[.gz]` shard (and a bare `dynamo-request-trace`) as one stream; the only source of KV-transfer cost and `session_id` |
 | `--iter-log` | `trtllm` | parses `print_iter_log` lines from the worker logs; local->UTC offset is derived per run, not hardcoded |
 | *(automatic)* | — | `trtllm_config_*.yaml` are copied from the run dir into the bundle, giving the Engine tab its real in-flight-batch ceilings instead of the `--max-batch-*` defaults |
 | *(automatic)* | — | `profile_export_aiperf.json` — AIPerf's run summary. Carries `theoretical_prefix_cache_hit` (the ceiling the *workload* offered), `error_summary` / `was_cancelled` / `branch_stats` (run validity), and `effective_concurrency`. Its **absence** is a signal too: AIPerf writes it when a concurrency finishes, so a run killed by its wall clock has none |

--- a/src/ingest/ingest.py
+++ b/src/ingest/ingest.py
@@ -576,6 +576,22 @@ def run_metrics(args, run_dir: Path, bundle: Path) -> bool:
     return out.exists()
 
 
+# Dynamo's request-trace sink is a rotating gzip JSONL appender. With
+# DYN_REQUEST_TRACE_FILE_PATH=<log_dir>/dynamo-request-trace it writes
+# dynamo-request-trace.000000.jsonl.gz, .000001.jsonl.gz, ... and never a bare
+# `dynamo-request-trace` file; the bare name is kept first for older captures and
+# hand-made inputs. `.jsonl*` also admits an uncompressed shard.
+REQUEST_TRACE_DEFAULT_PATTERNS = ("dynamo-request-trace", "dynamo-request-trace.*.jsonl*")
+
+
+def discover_request_trace(run_dir: Path) -> list[str]:
+    """Every request-trace input under ``run_dir`` (plain file and rotated shards), sorted."""
+    found: set[str] = set()
+    for pattern in REQUEST_TRACE_DEFAULT_PATTERNS:
+        found.update(resolve_inputs(pattern, run_dir))
+    return sorted(found)
+
+
 def run_request_trace(args, run_dir: Path, bundle: Path) -> bool:
     """L2 request-trace axis -> request_trace.jsonl. Returns whether produced.
 
@@ -584,22 +600,29 @@ def run_request_trace(args, run_dir: Path, bundle: Path) -> bool:
     the only one carrying ``session_id``, so both the per-request waterfall and the
     per-session view depend on it.
 
-    Dynamo writes it to the path in ``DYN_REQUEST_TRACE_FILE_PATH``, which srt-slurm
-    sets to ``<log_dir>/dynamo-request-trace`` (no extension, despite being JSON lines).
+    Dynamo writes it under the path in ``DYN_REQUEST_TRACE_FILE_PATH``, which srt-slurm
+    sets to ``<log_dir>/dynamo-request-trace``, as rotated ``.NNNNNN.jsonl.gz`` shards
+    (see ``REQUEST_TRACE_DEFAULT_PATTERNS``). All shards are handed to the processor as
+    one stream; a run of one hour on 8 VR200 nodes produced 12 shards of ~128 MB.
     """
     if args.request_trace == "none":
         _log("L2 req-trace", "skipped (--request-trace none)")
         return False
-    pattern = args.request_trace_input or "dynamo-request-trace"
-    srcs = resolve_inputs(pattern, run_dir)
+    if args.request_trace_input:
+        pattern: str | tuple[str, ...] = args.request_trace_input
+        srcs = resolve_inputs(args.request_trace_input, run_dir)
+    else:
+        pattern = REQUEST_TRACE_DEFAULT_PATTERNS
+        srcs = discover_request_trace(run_dir)
     if not srcs:
         _log("L2 req-trace", f"WARN no request trace matched {pattern!r} under {run_dir}; skipping")
         return False
     out = bundle / "request_trace.jsonl"
-    _log("L1", f"request trace raw: {srcs[0]}")
+    span = srcs[0] if len(srcs) == 1 else f"{srcs[0]} .. {os.path.basename(srcs[-1])}"
+    _log("L1", f"request trace raw: {len(srcs)} file(s): {span}")
     proc = get_processor("request_trace", "dynamo")
-    n = proc(srcs[0], str(out))
-    _log("L2 req-trace", f"dynamo -> {out.name}: {n} requests")
+    n = proc(srcs, str(out))
+    _log("L2 req-trace", f"dynamo -> {out.name}: {n} requests from {len(srcs)} file(s)")
     return n > 0
 
 
@@ -1207,7 +1230,8 @@ def build_parser() -> argparse.ArgumentParser:
     # request-trace axis
     p.add_argument("--request-trace", choices=["dynamo", "none"], default="dynamo")
     p.add_argument("--request-trace-input", default=None,
-                   help="dynamo-request-trace path/glob (default: dynamo-request-trace)")
+                   help="dynamo-request-trace path/glob (default: dynamo-request-trace plus the rotated "
+                        "dynamo-request-trace.NNNNNN.jsonl[.gz] shards Dynamo actually writes)")
 
     # per-iteration axis
     p.add_argument("--iter-log", choices=["trtllm", "none"], default="trtllm")

--- a/src/ingest/request_trace.py
+++ b/src/ingest/request_trace.py
@@ -52,17 +52,29 @@ the expensive input out of the bundle while keeping the signal.
 another, and it is the renderer's job to drop a flat series -- not this layer's job to
 decide the run had no queueing.
 
+INPUT FILES
+-----------
+Dynamo's file sink is a *rotating gzip JSONL* appender: with ``DYN_REQUEST_TRACE_FILE_PATH``
+set to ``<log_dir>/dynamo-request-trace`` it writes ``dynamo-request-trace.000000.jsonl.gz``,
+``dynamo-request-trace.000001.jsonl.gz``, ... (about 128 MB / ~11k requests per shard on
+the AgentX runs), never a bare ``dynamo-request-trace`` file. ``process`` therefore takes
+one path or a list of shard paths, reads ``.gz`` transparently, and treats the shards as
+one stream -- rows are sorted by ``received_ms`` afterwards, so shard order does not
+matter. A plain uncompressed file is still accepted.
+
 Stdlib only (runs under a bare cluster python3).
 
 Usage:
-    python3 -m src.ingest.request_trace IN_PATH OUT_PATH
+    python3 -m src.ingest.request_trace IN_PATH [IN_PATH ...] OUT_PATH
 """
 from __future__ import annotations
 
 import argparse
+import gzip
 import json
 import logging
 import sys
+from collections.abc import Iterator, Sequence
 from typing import Any
 
 logger = logging.getLogger("request_trace")
@@ -197,37 +209,51 @@ def _add_prefix_reuse(rows: list[dict], hashes: dict[str, list]) -> int:
     return annotated
 
 
-def process(in_path: str, out_path: str) -> int:
-    """``dynamo-request-trace`` -> ``request_trace.jsonl``. Returns rows written.
+def _iter_lines(paths: Sequence[str]) -> Iterator[str]:
+    """Yield the lines of every shard in order, decompressing ``.gz`` on the fly.
 
-    Two passes conceptually, one pass over the file: rows are flattened while the
+    ``errors="replace"`` on both openers: a torn last line in the shard that was
+    being written when the frontend was killed must not abort the whole ingest.
+    """
+    for path in paths:
+        opener = gzip.open if path.endswith(".gz") else open
+        with opener(path, "rt", errors="replace") as f:
+            yield from f
+
+
+def process(in_path: str | Sequence[str], out_path: str) -> int:
+    """``dynamo-request-trace`` shard(s) -> ``request_trace.jsonl``. Returns rows written.
+
+    ``in_path`` is one file or the list of rotated shards (see INPUT FILES above).
+
+    Two passes conceptually, one pass over the input: rows are flattened while the
     hash arrays are held aside, then the session-derived columns are filled and the
     hashes dropped. Peak memory is the hash arrays (~1.9M ints on the reference hour),
     which is the reason they never reach the bundle.
     """
+    paths = [in_path] if isinstance(in_path, str) else list(in_path)
     rows: list[dict] = []
     hashes: dict[str, list] = {}
     skipped = malformed = 0
 
-    with open(in_path, errors="replace") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                malformed += 1
-                continue
-            row = flatten(record)
-            if row is None:
-                skipped += 1
-                continue
-            seq = ((record.get("event") or {}).get("request") or {}).get("replay") or {}
-            seq_hashes = seq.get("input_sequence_hashes")
-            if seq_hashes:
-                hashes[row["x_request_id"]] = seq_hashes
-            rows.append(row)
+    for line in _iter_lines(paths):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            malformed += 1
+            continue
+        row = flatten(record)
+        if row is None:
+            skipped += 1
+            continue
+        seq = ((record.get("event") or {}).get("request") or {}).get("replay") or {}
+        seq_hashes = seq.get("input_sequence_hashes")
+        if seq_hashes:
+            hashes[row["x_request_id"]] = seq_hashes
+        rows.append(row)
 
     annotated = _add_prefix_reuse(rows, hashes)
     hashes.clear()
@@ -239,9 +265,9 @@ def process(in_path: str, out_path: str) -> int:
 
     sessions = len({r["session_id"] for r in rows if r.get("session_id")})
     logger.info(
-        "request_trace -> %s: %d rows, %d sessions, %d turns with prefix reuse"
+        "request_trace -> %s: %d rows from %d file(s), %d sessions, %d turns with prefix reuse"
         "%s%s",
-        out_path, len(rows), sessions, annotated,
+        out_path, len(rows), len(paths), sessions, annotated,
         f", {skipped} non-request_end skipped" if skipped else "",
         f", {malformed} malformed lines" if malformed else "",
     )
@@ -251,7 +277,7 @@ def process(in_path: str, out_path: str) -> int:
 def main(argv=None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S")
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("in_path", help="dynamo-request-trace (JSON lines)")
+    p.add_argument("in_path", nargs="+", help="dynamo-request-trace shard(s): JSON lines, plain or .gz")
     p.add_argument("out_path", help="output request_trace.jsonl")
     args = p.parse_args(argv)
     process(args.in_path, args.out_path)

--- a/tests/test_request_trace.py
+++ b/tests/test_request_trace.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the request-trace L2 processor and its discovery in the ingest pipeline.
+
+Dynamo's request-trace sink rotates: ``dynamo-request-trace.000000.jsonl.gz``,
+``.000001.jsonl.gz``, ... A real capture (hecate 565811, 2026-09-09) produced 12 such
+shards and no bare ``dynamo-request-trace`` file, and the ingest logged
+``WARN no request trace matched 'dynamo-request-trace'`` -- the axis was silently
+empty. These tests pin the shard discovery, the gzip reading and the merge.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _record(xid: str, received_ms: int, session: str = "s1", **request_fields) -> str:
+    request = {
+        "request_id": f"rid-{xid}",
+        "x_request_id": xid,
+        "model": "m",
+        "input_tokens": 10,
+        "output_tokens": 4,
+        "request_received_ms": received_ms,
+        "prefill_wait_time_ms": 1.0,
+        "prefill_time_ms": 20.0,
+        "ttft_ms": 21.0,
+        "total_time_ms": 100.0,
+        "avg_itl_ms": 26.0,
+        "kv_transfer_estimated_latency_ms": 5.0,
+    }
+    request.update(request_fields)
+    return json.dumps(
+        {
+            "timestamp": received_ms,
+            "event": {
+                "schema": "dynamo.request.trace.v1",
+                "event_type": "request_end",
+                "event_time_unix_ms": received_ms + 100,
+                "event_source": "dynamo",
+                "agent_context": {"session_id": session, "input_trigger": "user_message"},
+                "request": request,
+            },
+        }
+    )
+
+
+def _write_gz(path: Path, lines: list[str]) -> Path:
+    with gzip.open(path, "wt") as f:
+        f.write("\n".join(lines) + "\n")
+    return path
+
+
+def _rows(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class TestProcess:
+    def test_reads_rotated_gzip_shards_as_one_stream(self, tmp_path):
+        from src.ingest.request_trace import process
+
+        # Shard order and arrival order disagree on purpose: the output must be
+        # sorted by received_ms across shards, not concatenated.
+        shard0 = _write_gz(tmp_path / "dynamo-request-trace.000000.jsonl.gz", [_record("a", 1000), _record("c", 3000)])
+        shard1 = _write_gz(tmp_path / "dynamo-request-trace.000001.jsonl.gz", [_record("b", 2000), _record("d", 4000)])
+        out = tmp_path / "request_trace.jsonl"
+
+        n = process([str(shard0), str(shard1)], str(out))
+
+        assert n == 4
+        assert [r["x_request_id"] for r in _rows(out)] == ["a", "b", "c", "d"]
+
+    def test_plain_file_path_still_accepted(self, tmp_path):
+        from src.ingest.request_trace import process
+
+        plain = tmp_path / "dynamo-request-trace"
+        plain.write_text(_record("a", 1000) + "\n" + _record("b", 2000) + "\n")
+        out = tmp_path / "out.jsonl"
+
+        assert process(str(plain), str(out)) == 2
+        assert [r["x_request_id"] for r in _rows(out)] == ["a", "b"]
+
+    def test_torn_last_line_in_a_shard_is_skipped_not_fatal(self, tmp_path):
+        from src.ingest.request_trace import process
+
+        shard = _write_gz(
+            tmp_path / "dynamo-request-trace.000000.jsonl.gz", [_record("a", 1000), '{"timestamp": 12, "ev']
+        )
+        out = tmp_path / "out.jsonl"
+
+        assert process([str(shard)], str(out)) == 1
+
+    def test_cli_accepts_multiple_inputs(self, tmp_path):
+        from src.ingest.request_trace import main
+
+        shard0 = _write_gz(tmp_path / "dynamo-request-trace.000000.jsonl.gz", [_record("a", 1000)])
+        shard1 = _write_gz(tmp_path / "dynamo-request-trace.000001.jsonl.gz", [_record("b", 2000)])
+        out = tmp_path / "out.jsonl"
+
+        assert main([str(shard0), str(shard1), str(out)]) == 0
+        assert len(_rows(out)) == 2
+
+
+def _args(request_trace_input: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(request_trace="dynamo", request_trace_input=request_trace_input)
+
+
+class TestDiscovery:
+    def test_discovers_rotated_shards_at_the_log_dir_root(self, tmp_path):
+        from src.ingest.ingest import discover_request_trace, run_request_trace
+
+        for i, xid in enumerate(["a", "b", "c"]):
+            _write_gz(tmp_path / f"dynamo-request-trace.{i:06d}.jsonl.gz", [_record(xid, 1000 * (i + 1))])
+        # Unrelated files that share the prefix must not be picked up.
+        (tmp_path / "dynamo-request-trace.lock").write_text("")
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+
+        found = discover_request_trace(tmp_path)
+        assert [Path(p).name for p in found] == [
+            "dynamo-request-trace.000000.jsonl.gz",
+            "dynamo-request-trace.000001.jsonl.gz",
+            "dynamo-request-trace.000002.jsonl.gz",
+        ]
+        assert run_request_trace(_args(), tmp_path, bundle) is True
+        assert [r["x_request_id"] for r in _rows(bundle / "request_trace.jsonl")] == ["a", "b", "c"]
+
+    def test_bare_file_and_uncompressed_shard_are_included(self, tmp_path):
+        from src.ingest.ingest import discover_request_trace
+
+        (tmp_path / "dynamo-request-trace").write_text(_record("a", 1000) + "\n")
+        (tmp_path / "dynamo-request-trace.000000.jsonl").write_text(_record("b", 2000) + "\n")
+        _write_gz(tmp_path / "dynamo-request-trace.000001.jsonl.gz", [_record("c", 3000)])
+
+        assert [Path(p).name for p in discover_request_trace(tmp_path)] == [
+            "dynamo-request-trace",
+            "dynamo-request-trace.000000.jsonl",
+            "dynamo-request-trace.000001.jsonl.gz",
+        ]
+
+    def test_explicit_input_glob_wins_over_discovery(self, tmp_path):
+        from src.ingest.ingest import run_request_trace
+
+        _write_gz(tmp_path / "dynamo-request-trace.000000.jsonl.gz", [_record("ignored", 1000)])
+        custom = tmp_path / "custom"
+        custom.mkdir()
+        _write_gz(custom / "trace.a.jsonl.gz", [_record("x", 1000)])
+        _write_gz(custom / "trace.b.jsonl.gz", [_record("y", 2000)])
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+
+        assert run_request_trace(_args("custom/trace.*.jsonl.gz"), tmp_path, bundle) is True
+        assert [r["x_request_id"] for r in _rows(bundle / "request_trace.jsonl")] == ["x", "y"]
+
+    def test_nothing_found_is_a_skip_not_an_error(self, tmp_path, caplog):
+        import logging
+
+        from src.ingest.ingest import run_request_trace
+
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+
+        with caplog.at_level(logging.INFO, logger="ingest"):
+            assert run_request_trace(_args(), tmp_path, bundle) is False
+        assert not (bundle / "request_trace.jsonl").exists()
+        assert any("no request trace matched" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.parametrize("mode", ["none"])
+    def test_disabled_axis(self, tmp_path, mode):
+        from src.ingest.ingest import run_request_trace
+
+        _write_gz(tmp_path / "dynamo-request-trace.000000.jsonl.gz", [_record("a", 1000)])
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+
+        assert (
+            run_request_trace(SimpleNamespace(request_trace=mode, request_trace_input=None), tmp_path, bundle) is False
+        )


### PR DESCRIPTION
## What

The request-trace axis of the ingest never found its input on real runs. Dynamo's request-trace sink is a *rotating gzip JSONL* appender: with `DYN_REQUEST_TRACE_FILE_PATH=<log_dir>/dynamo-request-trace` (what `observability.enabled` sets via `ANALYTICS_REQUEST_TRACE_ENV`) it writes `dynamo-request-trace.000000.jsonl.gz`, `.000001.jsonl.gz`, ... and never a bare `dynamo-request-trace` file. `run_request_trace` looked only for the bare name.

- `ingest.run_request_trace`: default discovery is now the bare file **plus** `dynamo-request-trace.*.jsonl*` (gz or not, `REQUEST_TRACE_DEFAULT_PATTERNS`); every match is handed to the processor. `--request-trace-input` still overrides.
- `request_trace.process` accepts a path or a list of shard paths, opens `.gz` transparently (`errors="replace"`, so a torn last line in the shard being written when the frontend was killed is skipped, not fatal) and merges the shards before the existing `received_ms` sort. The CLI takes `IN_PATH... OUT_PATH`.
- `docs/component-dashboard.md` names the real input files.

## Evidence

hecate 565811 (2026-09-09, AgentX baseline recipe, `observability.enabled: true`, 8 VR200 nodes). The log dir holds 12 shards and no bare file:

```
129532417 dynamo-request-trace.000000.jsonl.gz
127623635 dynamo-request-trace.000001.jsonl.gz
...
127810520 dynamo-request-trace.000010.jsonl.gz
 55345872 dynamo-request-trace.000011.jsonl.gz
```
(`zcat dynamo-request-trace.000000.jsonl.gz | wc -l` → 10,983 records; first record is a `dynamo.request.trace.v1` / `request_end` event with `session_id`, `x_request_id`, `kv_transfer_estimated_latency_ms`, ...)

and the sweep log:

```
21:22:53 INFO [L2 req-trace] WARN no request trace matched 'dynamo-request-trace' under /lustre/.../565811/logs; skipping
21:37:57 INFO [done] bundle ready in 1318.2s: aiperf=True traces=True metrics=True request_trace=False
```

The same `request_trace=False` appears on 565810 and 565854 (default visibility, no trace written — correct there). Only the observability run lost data.

## Validation

- `pytest tests/test_request_trace.py` → 9 passed: shard merge order across shards, plain file, torn last line, CLI with several inputs, discovery (rotated / bare / uncompressed shard / unrelated `dynamo-request-trace.lock` ignored), explicit glob precedence over discovery, skip path logs the WARN, `--request-trace none`.
- `src/ingest/ingest.py` and `src/ingest/request_trace.py` were already `ruff format`-dirty on `main` (checked with `git show HEAD:<file> | ruff format --check --stdin-filename`), so this diff does not reformat them; the new test file is clean.
- A run of the processor on one real shard of 565811 is in progress; will attach rows/time as a comment.

## Why draft

Scaling caveat worth a reviewer's opinion: `process()` keeps every request's `input_sequence_hashes` in memory until the end to compute `prefix_reuse_ratio` (by design, see the module docstring). Now that the shards are actually read, an hour of AgentX at 8 nodes is ~140k requests × ~1.2k hashes — several GB on the postprocess node. This PR does not change that; if it is a problem in practice the hashes could be reduced per session incrementally instead of held globally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)