### PR TITLE
fix(power): recognize input rail hwmon labels

### DIFF
--- a/src/cpu-power-exporter/src/main.rs
+++ b/src/cpu-power-exporter/src/main.rs
@@ -57,6 +57,8 @@ const OEM_KINDS: [(&str, &[&str]); 4] = [
             "grace power socket ",
             "total power socket ",
             "total power in uw socket ",
+            "total input power socket ",
+            "total input power in uw socket ",
         ],
     ),
     (
@@ -64,6 +66,8 @@ const OEM_KINDS: [(&str, &[&str]); 4] = [
         &[
             "cpu rail power socket ",
             "cpu rail power in uw socket ",
+            "cpu rail input power socket ",
+            "cpu rail input power in uw socket ",
             "cpu power socket ",
         ],
     ),
@@ -72,10 +76,20 @@ const OEM_KINDS: [(&str, &[&str]); 4] = [
         &[
             "soc rail power socket ",
             "soc rail power in uw socket ",
+            "soc rail input power socket ",
+            "soc rail input power in uw socket ",
             "sysio power socket ",
         ],
     ),
-    ("dram", &["dram power socket ", "dram power in uw socket "]),
+    (
+        "dram",
+        &[
+            "dram power socket ",
+            "dram power in uw socket ",
+            "dram input power socket ",
+            "dram input power in uw socket ",
+        ],
+    ),
 ];
 
 const READ_TIMEOUT: Duration = Duration::from_secs(5);
@@ -730,6 +744,26 @@ mod tests {
         assert_eq!(
             classify_oem("DRAM Power in uW socket 0"),
             ("dram", "0".into())
+        );
+        assert_eq!(
+            classify_oem("Total Input Power in uW socket 0"),
+            ("total", "0".into())
+        );
+        assert_eq!(
+            classify_oem("CPU Rail Input Power in uW socket 1"),
+            ("cpu_rail", "1".into())
+        );
+        assert_eq!(
+            classify_oem("SoC Rail Input Power in uW socket 1"),
+            ("soc", "1".into())
+        );
+        assert_eq!(
+            classify_oem("DRAM Input Power in uW socket 0"),
+            ("dram", "0".into())
+        );
+        assert_eq!(
+            classify_oem("CPU Rail Output Power in uW socket 0"),
+            ("other", String::new())
         );
     }
 

--- a/src/srtctl/core/cpu_power.py
+++ b/src/srtctl/core/cpu_power.py
@@ -127,22 +127,28 @@ class AcpiPowerMeterReader(CpuPowerReader):
         (
             "total",
             "cpuSidePowerUsageW",
-            re.compile(r"\bTotal\s+Power(?:\s+in\s+uW)?\s+socket\s+(\d+)\b", re.IGNORECASE),
+            re.compile(r"\bTotal(?:\s+Input)?\s+Power(?:\s+in\s+uW)?\s+socket\s+(\d+)\b", re.IGNORECASE),
         ),
         (
             "cpu_rail",
             "cpuRailPowerUsageW",
-            re.compile(r"\bCPU\s+Rail\s+Power(?:\s+in\s+uW)?\s+socket\s+(\d+)\b", re.IGNORECASE),
+            re.compile(
+                r"\bCPU\s+Rail(?:\s+Input)?\s+Power(?:\s+in\s+uW)?\s+socket\s+(\d+)\b",
+                re.IGNORECASE,
+            ),
         ),
         (
             "soc",
             "socPowerUsageW",
-            re.compile(r"\bSoC\s+Rail\s+Power(?:\s+in\s+uW)?\s+socket\s+(\d+)\b", re.IGNORECASE),
+            re.compile(
+                r"\bSoC\s+Rail(?:\s+Input)?\s+Power(?:\s+in\s+uW)?\s+socket\s+(\d+)\b",
+                re.IGNORECASE,
+            ),
         ),
         (
             "dram",
             "dramPowerUsageW",
-            re.compile(r"\bDRAM\s+Power(?:\s+in\s+uW)?\s+socket\s+(\d+)\b", re.IGNORECASE),
+            re.compile(r"\bDRAM(?:\s+Input)?\s+Power(?:\s+in\s+uW)?\s+socket\s+(\d+)\b", re.IGNORECASE),
         ),
         # Grace component-rail labels. CPU Power is not the complete Grace
         # socket envelope and therefore must not contribute to total_power_w.

--- a/src/srtctl/core/power/cpu_parser.py
+++ b/src/srtctl/core/power/cpu_parser.py
@@ -14,6 +14,7 @@ when both exist.
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import dataclass
 
 from prometheus_client.parser import text_string_to_metric_families
@@ -21,6 +22,31 @@ from prometheus_client.parser import text_string_to_metric_families
 DCGM_METRIC = "cpu_power_dcgm_watts"
 ACPI_METRIC = "cpu_power_acpi_watts"
 TOTAL_KIND = "total"
+_ACPI_KINDS = {"total", "cpu_rail", "soc", "dram"}
+_ACPI_DOMAIN_PATTERNS = (
+    (
+        "total",
+        re.compile(r"\b(?:Grace|Total(?:\s+Input)?)\s+Power(?:\s+in\s+uW)?\s+Socket\s+(\d+)\b", re.IGNORECASE),
+    ),
+    (
+        "cpu_rail",
+        re.compile(
+            r"\bCPU(?:\s+Rail)?(?:\s+Input)?\s+Power(?:\s+in\s+uW)?\s+Socket\s+(\d+)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "soc",
+        re.compile(
+            r"\b(?:SoC\s+Rail(?:\s+Input)?|SysIO)\s+Power(?:\s+in\s+uW)?\s+Socket\s+(\d+)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "dram",
+        re.compile(r"\bDRAM(?:\s+Input)?\s+Power(?:\s+in\s+uW)?\s+Socket\s+(\d+)\b", re.IGNORECASE),
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -94,10 +120,15 @@ def _parse_acpi(families) -> list[CpuReading]:
             if sample.name != ACPI_METRIC:
                 continue
             labels = sample.labels
+            kind = labels.get("type") or ""
             socket_id = _parse_socket(labels.get("socket"))
+            if socket_id is None or kind not in _ACPI_KINDS:
+                inferred = _classify_acpi_domain(labels.get("oem_info") or "")
+                if inferred is not None:
+                    kind, socket_id = inferred
             # An unclassified rail (the exporter's "other" kind) has no
             # numeric socket, and socket_id is not nullable in the CSV.
-            if socket_id is None:
+            if socket_id is None or kind not in _ACPI_KINDS:
                 continue
             value = sample.value
             if not math.isfinite(value) or value < 0:
@@ -108,7 +139,7 @@ def _parse_acpi(families) -> list[CpuReading]:
                     sensor=labels.get("oem_info") or "",
                     socket_id=socket_id,
                     power_w=value,
-                    kind=labels.get("type") or "",
+                    kind=kind,
                 )
             )
     return readings
@@ -117,6 +148,15 @@ def _parse_acpi(families) -> list[CpuReading]:
 def _sum_by_kind(readings: list[CpuReading], kind: str) -> float | None:
     matching = [reading.power_w for reading in readings if reading.kind == kind]
     return sum(matching) if matching else None
+
+
+def _classify_acpi_domain(oem_info: str) -> tuple[str, int] | None:
+    """Recover the semantic rail and socket from a firmware OEM label."""
+    for kind, pattern in _ACPI_DOMAIN_PATTERNS:
+        match = pattern.search(oem_info)
+        if match is not None:
+            return kind, int(match.group(1))
+    return None
 
 
 def _parse_socket(raw: str | None) -> int | None:

--- a/tests/test_cpu_power.py
+++ b/tests/test_cpu_power.py
@@ -137,6 +137,33 @@ def test_acpi_reader_collects_breakdowns_without_double_counting_total(tmp_path:
     }
 
 
+def test_acpi_reader_collects_input_power_naming_variants(tmp_path: Path) -> None:
+    domains = (
+        (0, "Total Input Power in uW socket 0", 150_000_000),
+        (1, "CPU Rail Input Power in uW socket 0", 70_000_000),
+        (2, "SoC Rail Input Power in uW socket 0", 6_000_000),
+        (3, "DRAM Input Power in uW socket 0", 8_000_000),
+        (4, "CPU Rail Output Power in uW socket 0", 55_000_000),
+    )
+    for hwmon_id, domain, microwatts in domains:
+        _make_acpi_sensor(
+            tmp_path,
+            hwmon_id=hwmon_id,
+            socket_id=0,
+            microwatts=microwatts,
+            domain=domain,
+        )
+
+    reader = AcpiPowerMeterReader(tmp_path)
+
+    assert reader.read_watts() == {
+        "CPU0:cpuSidePowerUsageW": 150.0,
+        "CPU0:cpuRailPowerUsageW": 70.0,
+        "CPU0:socPowerUsageW": 6.0,
+        "CPU0:dramPowerUsageW": 8.0,
+    }
+
+
 def test_acpi_reader_accepts_input_only_hwmon_channel(tmp_path: Path) -> None:
     _make_acpi_sensor(
         tmp_path,

--- a/tests/test_cpu_power_parser.py
+++ b/tests/test_cpu_power_parser.py
@@ -69,6 +69,29 @@ def test_acpi_mode_totals_a_generic_total_power_label_too():
     assert scrape.total_power_w == 88.0
 
 
+def test_acpi_mode_recovers_input_power_labels_from_older_exporter_output():
+    body = (
+        "# HELP cpu_power_acpi_watts x\n"
+        "# TYPE cpu_power_acpi_watts gauge\n"
+        'cpu_power_acpi_watts{sensor="a/0",type="other",socket="",oem_info="Total Input Power in uW socket 0"} 88.0\n'
+        'cpu_power_acpi_watts{sensor="a/1",type="other",socket="",oem_info="CPU Rail Input Power in uW socket 0"} 60.0\n'
+        'cpu_power_acpi_watts{sensor="a/2",type="other",socket="",oem_info="SoC Rail Input Power in uW socket 0"} 8.0\n'
+        'cpu_power_acpi_watts{sensor="a/3",type="other",socket="",oem_info="DRAM Input Power in uW socket 0"} 10.0\n'
+        'cpu_power_acpi_watts{sensor="a/4",type="other",socket="",oem_info="CPU Rail Output Power in uW socket 0"} 50.0\n'
+    )
+
+    scrape = parse_cpu_scrape(body)
+
+    assert scrape.mode == "acpi"
+    assert [(reading.kind, reading.socket_id) for reading in scrape.readings] == [
+        ("total", 0),
+        ("cpu_rail", 0),
+        ("soc", 0),
+        ("dram", 0),
+    ]
+    assert scrape.total_power_w == 88.0
+
+
 def test_acpi_mode_drops_unclassified_rails():
     scrape = parse_cpu_scrape(_acpi_body())
 


### PR DESCRIPTION
## Summary

- recognize firmware hwmon labels that insert `Input` before `Power` in the Rust exporter and Python host reader
- recover rail type and socket from `oem_info` when scraping output produced by older exporter releases
- continue excluding output, energy, and throttle sensors, and derive node totals only from socket-total channels

## Testing

- `uv run ruff check src/srtctl/core/power/cpu_parser.py src/srtctl/core/cpu_power.py tests/test_cpu_power.py tests/test_cpu_power_parser.py`
- `uv run pytest -q tests/test_cpu_power.py tests/test_cpu_power_parser.py tests/test_cpu_power_collector.py` (27 passed)
- `cargo fmt --all -- --check`
- `cargo test --locked --bin cpu-power-exporter` (11 passed)
