### PR TITLE
[SA-Bench] preserve failed request results and measured boundaries

### DIFF
--- a/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
+++ b/src/srtctl/benchmarks/scripts/sa-bench/bench.sh
@@ -188,6 +188,7 @@ mkdir -p "$result_dir"
 # Start profiling before benchmark
 start_all_profiling
 
+benchmark_exit_code=0
 for concurrency in "${CONCURRENCY_LIST[@]}"; do
 
     if [ "$NUM_WARMUP_MULT" -gt 0 ]; then
@@ -207,7 +208,11 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
             --trust-remote-code \
             "${HTTP_CONNECTION_ARGS[@]}" \
             "${CHAT_TEMPLATE_ARGS[@]}" \
-            "${CUSTOM_TOKENIZER_ARGS[@]}"
+            "${CUSTOM_TOKENIZER_ARGS[@]}" || benchmark_exit_code=$?
+        if [[ "$benchmark_exit_code" != 0 ]]; then
+            echo "SA-Bench warmup failed at concurrency $concurrency (rc=$benchmark_exit_code)" >&2
+            break
+        fi
     fi
 
     num_prompts=$((concurrency * NUM_PROMPTS_MULT))
@@ -241,8 +246,12 @@ for concurrency in "${CONCURRENCY_LIST[@]}"; do
         "${CUSTOM_TOKENIZER_ARGS[@]}" \
         "${SLOW_DOWN_ARGS[@]}" \
         "${SLOW_DOWN_EXTRA[@]}" \
-        --save-result --result-dir "$result_dir" --result-filename "$result_filename"
+        --save-result --result-dir "$result_dir" --result-filename "$result_filename" || benchmark_exit_code=$?
     set +x
+    if [[ "$benchmark_exit_code" != 0 ]]; then
+        echo "SA-Bench failed at concurrency $concurrency (rc=$benchmark_exit_code); diagnostics remain in $result_dir" >&2
+        break
+    fi
 
     echo "$(date '+%Y-%m-%d %H:%M:%S')"
     echo "Completed benchmark with concurrency: $concurrency"
@@ -251,4 +260,5 @@ done
 
 stop_all_profiling
 
-echo "SA-Bench complete. Results in $result_dir"
+echo "SA-Bench finished (rc=$benchmark_exit_code). Results in $result_dir"
+exit "$benchmark_exit_code"

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_outcome.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_outcome.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request failure counts and the five-percent benchmark gate."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+MAX_FAILURE_RATE = 0.05
+
+
+class BenchmarkOutcome(TypedDict):
+    status: Literal["passed", "failed"]
+    requested: int
+    completed: int
+    failed: int
+    max_failure_rate: float
+
+
+def benchmark_outcome(requested: int, completed: int) -> BenchmarkOutcome:
+    if type(requested) is not int or type(completed) is not int or requested <= 0 or not 0 <= completed <= requested:
+        raise ValueError("Benchmark request counts must satisfy 0 <= completed <= requested > 0")
+    failed = requested - completed
+    return {
+        "status": "failed" if failed / requested > MAX_FAILURE_RATE else "passed",
+        "requested": requested,
+        "completed": completed,
+        "failed": failed,
+        "max_failure_rate": MAX_FAILURE_RATE,
+    }

--- a/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
+++ b/src/srtctl/benchmarks/scripts/sa-bench/benchmark_serving.py
@@ -71,6 +71,7 @@ try:
 except ImportError:
     from argparse import ArgumentParser as FlexibleArgumentParser
 
+from benchmark_outcome import benchmark_outcome
 from benchmark_utils import convert_to_pytorch_benchmark_format
 from measurement_window import MeasurementWindow
 
@@ -867,6 +868,15 @@ async def benchmark(
             )
             tasks.append(asyncio.create_task(limited_request_func(request_func_input=request_func_input, pbar=pbar)))
         outputs: list[RequestFuncOutput] = await asyncio.gather(*tasks)
+        benchmark_end_time = time.perf_counter()
+        benchmark_end_time_unix = time.time()
+        benchmark_duration = benchmark_end_time - benchmark_start_time
+        if measurement_window is not None:
+            measurement_window.record_boundary(
+                start_unix=benchmark_start_time_unix,
+                end_unix=benchmark_end_time_unix,
+                duration=benchmark_duration,
+            )
     except BaseException:
         if backend == "dynamo" and request_session is not None:
             # A shared pool must outlive every request using it. Preserve the
@@ -903,15 +913,6 @@ async def benchmark(
     if pbar is not None:
         pbar.close()
 
-    benchmark_end_time = time.perf_counter()
-    benchmark_end_time_unix = time.time()
-    benchmark_duration = benchmark_end_time - benchmark_start_time
-    if measurement_window is not None:
-        measurement_window.record_boundary(
-            start_unix=benchmark_start_time_unix,
-            end_unix=benchmark_end_time_unix,
-            duration=benchmark_duration,
-        )
     if backend == "dynamo" and request_session is not None and not request_session.closed:
         await request_session.close()
         # Allow asyncio to finish closing pooled transports before CPU-heavy metrics.
@@ -1295,7 +1296,10 @@ def main(args: argparse.Namespace):
             )
         )
 
-        # Save config and results to json
+        outcome = benchmark_outcome(len(input_requests), benchmark_result["completed"])
+        benchmark_result["benchmark_outcome"] = outcome
+
+        # Failed runs still need request diagnostics for artifact inspection.
         if args.save_result:
             result_json: dict[str, Any] = {}
 
@@ -1306,7 +1310,6 @@ def main(args: argparse.Namespace):
             result_json["model_id"] = model_id
             result_json["tokenizer_id"] = tokenizer_id
             result_json["best_of"] = args.best_of
-            result_json["num_prompts"] = args.num_prompts
 
             # Metadata
             if args.metadata:
@@ -1327,6 +1330,10 @@ def main(args: argparse.Namespace):
             # Record the effective transport mode after both free-form metadata and
             # benchmark output so it cannot disagree with this run.
             result_json["reuse_http_connections"] = args.reuse_http_connections
+            # Dataset limits can exceed the available requests. Keep the
+            # issued count aligned with its outcome without losing CLI intent.
+            result_json["num_prompts"] = outcome["requested"]
+            result_json["requested_num_prompts"] = args.num_prompts
 
             # Save to file
             base_model_id = model_id.split("/")[-1]
@@ -1340,12 +1347,19 @@ def main(args: argparse.Namespace):
                 json.dump(result_json, outfile)
             save_to_pytorch_benchmark_format(args, result_json, file_name)
 
-            if measurement_window is not None:
-                measurement_window.mark_completed(
-                    start_unix=benchmark_result["benchmark_start_time_unix"],
-                    end_unix=benchmark_result["benchmark_end_time_unix"],
-                    duration=benchmark_result["duration"],
-                )
+        if outcome["status"] == "failed":
+            raise SystemExit(
+                f"FAIL: request failure rate {outcome['failed'] / outcome['requested']:.1%} exceeds "
+                f"{outcome['max_failure_rate']:.0%} threshold "
+                f"({outcome['completed']}/{outcome['requested']} completed)"
+            )
+
+        if measurement_window is not None:
+            measurement_window.mark_completed(
+                start_unix=benchmark_result["benchmark_start_time_unix"],
+                end_unix=benchmark_result["benchmark_end_time_unix"],
+                duration=benchmark_result["duration"],
+            )
     except BaseException as exc:
         if measurement_window is not None:
             measurement_window.fail_at_recorded_boundary(f"{type(exc).__name__}: {exc}")

--- a/tests/test_sa_bench_outcome.py
+++ b/tests/test_sa_bench_outcome.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request outcomes survive saved diagnostics and SA-Bench shell cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+from test_sa_bench_http_session import SA_BENCH_DIR, _import_sa_bench_module
+
+
+@pytest.mark.parametrize(
+    ("requested", "completed", "status"), [(20, 19, "passed"), (20, 18, "failed"), (20, 0, "failed")]
+)
+def test_request_failure_threshold(requested: int, completed: int, status: str) -> None:
+    module = _import_sa_bench_module("benchmark_outcome")
+    outcome = module.benchmark_outcome(requested, completed)
+    assert outcome["status"] == status
+    assert outcome["failed"] == requested - completed
+    assert outcome["max_failure_rate"] == 0.05
+
+
+def _main_args(tmp_path: Path) -> Namespace:
+    return Namespace(
+        slow_down_servers=None,
+        seed=0,
+        backend="dynamo",
+        model="model",
+        served_model_name="model",
+        tokenizer="model",
+        tokenizer_mode="auto",
+        base_url="http://localhost:8000",
+        endpoint="/v1/completions",
+        host="localhost",
+        port=8000,
+        trust_remote_code=False,
+        custom_tokenizer=None,
+        use_chat_template=False,
+        dataset_name="custom",
+        dataset_path="requests.jsonl",
+        num_prompts=20,
+        goodput=None,
+        logprobs=None,
+        best_of=1,
+        request_rate=float("inf"),
+        burstiness=1.0,
+        disable_tqdm=True,
+        profile=False,
+        percentile_metrics="ttft,tpot,itl,e2el",
+        metric_percentiles="50,90,99",
+        ignore_eos=True,
+        max_concurrency=20,
+        lora_modules=None,
+        slow_down_sleep_time=1.0,
+        slow_down_wait_time=60.0,
+        reuse_http_connections=False,
+        save_result=True,
+        metadata=None,
+        result_filename="result.json",
+        result_dir=str(tmp_path),
+    )
+
+
+@pytest.mark.parametrize(("sampled", "completed"), [(20, 0), (20, 18), (20, 19), (10, 10)])
+def test_main_saves_diagnostics_and_window_before_failure_gate(
+    monkeypatch, tmp_path: Path, sampled: int, completed: int
+) -> None:
+    _import_sa_bench_module("backend_request_func")
+    dataset = _import_sa_bench_module("benchmark_dataset")
+    module = _import_sa_bench_module("benchmark_serving")
+    window_module = sys.modules["measurement_window"]
+    window_dir = tmp_path / "power/windows"
+    window_dir.mkdir(parents=True)
+    monkeypatch.setenv("SRT_MEASUREMENT_WINDOW_DIR", str(window_dir))
+    monkeypatch.setattr(window_module, "CONTAINER_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(module, "load_tokenizer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(dataset, "sample_custom_requests", lambda **kwargs: [("prompt", 8, 1, None)] * sampled)
+    monkeypatch.setattr(module.gc, "collect", lambda: None)
+    monkeypatch.setattr(module.gc, "freeze", lambda: None)
+    monkeypatch.setattr(module, "save_to_pytorch_benchmark_format", lambda *args, **kwargs: None)
+
+    async def fake_benchmark(**kwargs):
+        window = kwargs["measurement_window"]
+        window.mark_running(100)
+        window.record_boundary(start_unix=100, end_unix=102, duration=2)
+        return {
+            "completed": completed,
+            "duration": 2,
+            "benchmark_start_time_unix": 100,
+            "benchmark_end_time_unix": 102,
+            "errors": ["request failed"] * (sampled - completed),
+        }
+
+    monkeypatch.setattr(module, "run_benchmark_with_cleanup", fake_benchmark)
+    passed = completed >= sampled * 0.95
+    if not passed:
+        with pytest.raises(SystemExit, match="request failure rate"):
+            module.main(_main_args(tmp_path))
+    else:
+        module.main(_main_args(tmp_path))
+    result = json.loads((tmp_path / "result.json").read_text())
+    assert result["benchmark_outcome"]["completed"] == completed
+    assert result["benchmark_outcome"]["requested"] == result["num_prompts"] == sampled
+    assert result["requested_num_prompts"] == 20
+    assert len(result["errors"]) == sampled - completed
+    window = json.loads((window_dir / "result.json").read_text())
+    assert window["status"] == ("completed" if passed else "failed")
+    assert window["benchmark_start_time_unix"] == 100
+    assert window["benchmark_end_time_unix"] == 102
+
+
+def test_all_failed_requests_still_return_finite_diagnostics_and_formal_boundary(tmp_path: Path, monkeypatch) -> None:
+    module = _import_sa_bench_module("benchmark_serving")
+    window = module.MeasurementWindow(str(tmp_path / "window.json"), "result.json", 2)
+    requests = 0
+    clock = [100.0]
+    monkeypatch.setattr(module.time, "perf_counter", lambda: clock[0])
+    monkeypatch.setattr(module.time, "time", lambda: clock[0])
+
+    async def fake_request(request_func_input, pbar=None):
+        nonlocal requests
+        if request_func_input.api_url.endswith("_profile"):
+            if request_func_input.api_url.endswith("/stop_profile"):
+                clock[0] = 500.0
+            return module.RequestFuncOutput(success=True)
+        requests += 1
+        if requests > 1:
+            clock[0] = 102.0
+        return module.RequestFuncOutput(
+            success=requests == 1, output_tokens=1, prompt_len=8, error="" if requests == 1 else "server error"
+        )
+
+    monkeypatch.setitem(module.ASYNC_REQUEST_FUNCS, "dynamo", fake_request)
+    with pytest.warns(UserWarning, match="All requests failed"):
+        result = asyncio.run(
+            module.benchmark(
+                backend="dynamo",
+                api_url="http://localhost/v1/completions",
+                base_url="http://localhost",
+                model_id="model",
+                model_name="model",
+                tokenizer=object(),
+                input_requests=[("prompt", 8, 1, None)] * 2,
+                logprobs=None,
+                best_of=1,
+                request_rate=float("inf"),
+                burstiness=1,
+                disable_tqdm=True,
+                profile=True,
+                selected_percentile_metrics=[],
+                selected_percentiles=[50],
+                ignore_eos=True,
+                goodput_config_dict={},
+                max_concurrency=2,
+                lora_modules=None,
+                measurement_window=window,
+            )
+        )
+    assert result["completed"] == 0
+    assert result["total_output_tokens"] == 0
+    assert result["errors"] == ["server error", "server error"]
+    assert result["benchmark_start_time_unix"] == 100
+    assert result["benchmark_end_time_unix"] == 102
+    assert result["duration"] == 2  # The profiler stop at t=500 is outside the measurement.
+    assert window.fail_at_recorded_boundary("request_gate_failed") is True
+
+
+@pytest.mark.parametrize("failed_stage", ["warmup", "measured"])
+def test_shell_retains_client_exit(tmp_path: Path, failed_stage: str) -> None:
+    binary = tmp_path / "bin"
+    binary.mkdir()
+    calls = tmp_path / "calls.jsonl"
+    python = binary / "python3"
+    python.write_text(f"""#!{sys.executable}
+import json, sys
+if "-c" in sys.argv: sys.exit(0)
+with open({str(calls)!r}, "a") as stream: stream.write(json.dumps(sys.argv[1:]) + "\\n")
+sys.exit(7 if {failed_stage!r} == "warmup" or "--save-result" in sys.argv else 0)
+""")
+    python.chmod(0o755)
+    for name in ("curl", "mkdir"):
+        stub = binary / name
+        stub.write_text("#!/bin/sh\nexit 0\n")
+        stub.chmod(0o755)
+    result = subprocess.run(
+        [
+            "bash",
+            str(SA_BENCH_DIR / "bench.sh"),
+            "http://localhost:8000",
+            "8192",
+            "1024",
+            "2x4",
+            "inf",
+            "/model",
+            "model",
+            "false",
+            "1",
+            "0",
+            "0",
+            "0.8",
+            "10",
+            "2",
+            "",
+            "false",
+            "random",
+            "",
+            "false",
+        ],
+        env={**os.environ, "PATH": f"{binary}:{os.environ['PATH']}", "PROFILE_TYPE": "none"},
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 7, result.stderr
+    recorded = [json.loads(line) for line in calls.read_text().splitlines()]
+    assert len(recorded) == (1 if failed_stage == "warmup" else 2)
+    assert recorded[0][recorded[0].index("--request-rate") + 1] == "250"
+    if failed_stage == "measured":
+        assert "--save-result" in recorded[1]


### PR DESCRIPTION
SA-Bench can report a successful sweep after its client fails, and request failures are not recorded as a structured result. This change saves requested/completed/failed counts before enforcing a 5% failure threshold, propagates warmup and measured-client exit codes, and stops the remaining sweep on failure.

The measured window now ends when the requests finish, excluding profiler teardown. Saved `num_prompts` is the actual sampled request count; `requested_num_prompts` preserves the configured maximum when a custom dataset has fewer rows. The existing measurement-window writer is reused.

### Testing

- `python -m pytest tests/test_sa_bench_outcome.py tests/test_sa_bench_http_session.py tests/test_sa_bench_measurement_window.py`: **69 passed**, including failure diagnostics, shell exit propagation, exact timing, and datasets shorter than the requested maximum. The subsequent commit amendment only changed comments/docstrings.
- `bash -n src/srtctl/benchmarks/scripts/sa-bench/bench.sh`, source Ruff checks, and `git diff --check`: passed.
- Earlier `make check`: 1,947 passed, two failures. Both also fail on untouched base `ed72cbef`: the mock submission assertion in `test_apply_mock.py` and the CPU-affinity test in `test_fingerprint.py` (`os.sched_getaffinity` is absent on macOS). The repository's non-blocking type check emitted diagnostics. The full suite was not repeated after adding the final focused cases.
- CPU-only validation; no Slurm/GPU run or CI dispatch.
