### PR TITLE
feat(trtllm-serve): enable iteration metrics by default

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -328,16 +328,18 @@ supported). A recipe can be switched between the two TRT-LLM serving stacks by
 changing only `frontend.type` between `dynamo` and `trtllm_serve`. See the sample
 recipe `recipes/trtllm/b200-fp8/1k1k/stp/ctx1_gen3_tp8_batch1024_eplb0_mtp0_4_trtllm_serve.yaml`.
 
-**Worker metrics default.** srtctl sets `return_perf_metrics: true` in the
-`trtllm_config` section of every mode a `trtllm_serve` recipe uses (prefill and
-decode, or `aggregated`), creating the section when the recipe has none. This is
-a setdefault: an explicit `return_perf_metrics: false` in the recipe wins and is
-warned about. trtllm-serve mounts a worker's `/prometheus/metrics` route only
-when the engine runs with that flag, and TensorRT-LLM's own default is `false`,
-so without it Tachometer's `backend_*` endpoints answer HTTP 404 and the capture
-has no worker-level data. The route carries the per-request series (request
-latency, TTFT, TPOT, queue/prefill/decode time, token counters); it applies
-independently of `observability.enabled`, which keeps its own expansion.
+**Worker metrics defaults.** srtctl sets `return_perf_metrics: true` and
+`enable_iter_perf_stats: true` in the `trtllm_config` section of every mode a
+`trtllm_serve` recipe uses (prefill and decode, or `aggregated`), creating the
+section when absent. These defaults apply independently of `observability.enabled`.
+
+`return_perf_metrics` enables the worker's `/prometheus/metrics` route and
+per-request statistics such as latency and token counters. `enable_iter_perf_stats`
+also enables the PyTorch engine's iteration statistics, including KV-cache occupancy.
+Explicit values for either option are preserved: `return_perf_metrics: false`
+disables the route and produces a configuration warning, while
+`enable_iter_perf_stats: false` disables iteration statistics without disabling
+the route. Use the latter to opt out of iteration-stat collection overhead.
 
 ### vllm frontend
 

--- a/src/srtctl/core/config.py
+++ b/src/srtctl/core/config.py
@@ -701,15 +701,19 @@ def expand_trtllm_serve_defaults(cfg: dict) -> dict:
     ``serve/openai_server.py``, ``register_routes``); TensorRT-LLM's own default
     is ``false``. Tachometer scrapes that route on every run, so without this
     default every trtllm-serve worker endpoint answers HTTP 404 and the capture
-    silently has no worker-level data.
+    silently has no worker-level data. ``enable_iter_perf_stats: true`` also
+    enables the PyTorch backend's iteration statistics, including KV-cache
+    occupancy, on that surface.
 
     Applies to every ``frontend.type: trtllm_serve`` recipe with a TRT-LLM
     backend, independent of ``observability.enabled``. The engine sections for
     the modes the recipe uses (prefill + decode for a disaggregated
     ``resources`` block, ``aggregated`` otherwise) are created when absent, so a
     recipe with no ``trtllm_config`` gets the default too. Every write is a
-    ``setdefault``: an explicit ``return_perf_metrics: false`` in the recipe
-    wins, but is reported loudly. Mutates ``cfg`` in place and returns it.
+    ``setdefault``: explicit values for either engine option are preserved.
+    ``return_perf_metrics: false`` is reported because it disables the route;
+    ``enable_iter_perf_stats: false`` disables iteration statistics independently.
+    Mutates ``cfg`` in place and returns it.
     """
     from srtctl.core.schema import TRTLLM_SERVE_ENGINE_DEFAULTS
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -1439,15 +1439,18 @@ ANALYTICS_ENGINE_CONFIG: dict[str, bool] = {
     "return_perf_metrics": True,
 }
 
-# Engine-config default baked in for every ``frontend.type: trtllm_serve`` run,
+# Engine-config defaults baked in for every ``frontend.type: trtllm_serve`` run,
 # independent of ``observability.enabled``. trtllm-serve registers a worker's
 # Prometheus route (``/prometheus/metrics``) only when the engine runs with
 # ``return_perf_metrics: true`` (TensorRT-LLM ``serve/openai_server.py``,
 # ``register_routes``); TensorRT-LLM's own default is ``false``. Tachometer
 # scrapes that route on every run, so without this default every trtllm-serve
 # worker endpoint answers HTTP 404 and the capture silently has no worker data.
+# The PyTorch backend also needs ``enable_iter_perf_stats`` for iteration-level
+# statistics, including KV-cache occupancy, to populate on that metrics surface.
 TRTLLM_SERVE_ENGINE_DEFAULTS: dict[str, bool] = {
     "return_perf_metrics": True,
+    "enable_iter_perf_stats": True,
 }
 
 

--- a/src/srtctl/core/schema.py
+++ b/src/srtctl/core/schema.py
@@ -2032,7 +2032,7 @@ class SrtConfig:
             return
         if self.frontend.type != "dynamo":
             raise ValidationError("dynamo.sidecar: true requires frontend.type: dynamo")
-        if not isinstance(self.backend, (SGLangProtocol, VLLMProtocol, TRTLLMProtocol)):
+        if not isinstance(self.backend, SGLangProtocol | VLLMProtocol | TRTLLMProtocol):
             raise ValidationError("dynamo.sidecar: true supports sglang, vllm, and trtllm backends only")
         if isinstance(self.backend, VLLMProtocol):
             self.backend.validate_sidecar_dp_config()

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -405,13 +405,12 @@ class TestTrtllmServeDefaults:
     srtctl bakes that default in for every trtllm_serve recipe so Tachometer's
     backend_* endpoints are never a silent 404."""
 
-    def test_return_perf_metrics_defaults_on_without_observability(self):
+    def test_engine_metrics_default_on_without_observability(self):
         out = expand_trtllm_serve_defaults(_trtllm_serve_config())
         for mode in ("prefill", "decode"):
             section = out["backend"]["trtllm_config"][mode]
             assert section["return_perf_metrics"] is True
-            # Only this key is touched; the recipe's own values survive.
-            assert "enable_iter_perf_stats" not in section
+            assert section["enable_iter_perf_stats"] is True
             assert section["max_batch_size"] in (256, 64)
 
     def test_explicit_false_wins_and_warns(self, caplog):
@@ -428,6 +427,7 @@ class TestTrtllmServeDefaults:
         out = expand_trtllm_serve_defaults(cfg)
         for mode in ("prefill", "decode"):
             assert "return_perf_metrics" not in out["backend"]["trtllm_config"][mode]
+            assert "enable_iter_perf_stats" not in out["backend"]["trtllm_config"][mode]
 
     def test_non_trtllm_backend_is_untouched(self):
         cfg = dict(BASE_CONFIG)
@@ -443,8 +443,8 @@ class TestTrtllmServeDefaults:
         del cfg["backend"]["trtllm_config"]
         out = expand_trtllm_serve_defaults(cfg)
         assert out["backend"]["trtllm_config"] == {
-            "prefill": {"return_perf_metrics": True},
-            "decode": {"return_perf_metrics": True},
+            "prefill": {"return_perf_metrics": True, "enable_iter_perf_stats": True},
+            "decode": {"return_perf_metrics": True, "enable_iter_perf_stats": True},
         }
 
     def test_partial_sections_are_completed(self):
@@ -452,7 +452,10 @@ class TestTrtllmServeDefaults:
         del cfg["backend"]["trtllm_config"]["decode"]
         out = expand_trtllm_serve_defaults(cfg)
         assert out["backend"]["trtllm_config"]["prefill"]["return_perf_metrics"] is True
-        assert out["backend"]["trtllm_config"]["decode"] == {"return_perf_metrics": True}
+        assert out["backend"]["trtllm_config"]["decode"] == {
+            "return_perf_metrics": True,
+            "enable_iter_perf_stats": True,
+        }
         assert "aggregated" not in out["backend"]["trtllm_config"]
 
     def test_aggregated_layout_gets_the_default_and_can_opt_out(self, caplog):
@@ -462,6 +465,7 @@ class TestTrtllmServeDefaults:
         cfg["backend"] = {"type": "trtllm", "trtllm_config": {"aggregated": {"max_batch_size": 8}}}
         out = expand_trtllm_serve_defaults(cfg)
         assert out["backend"]["trtllm_config"]["aggregated"]["return_perf_metrics"] is True
+        assert out["backend"]["trtllm_config"]["aggregated"]["enable_iter_perf_stats"] is True
         assert "prefill" not in out["backend"]["trtllm_config"]
 
         cfg["backend"]["trtllm_config"]["aggregated"]["return_perf_metrics"] = False
@@ -480,6 +484,7 @@ class TestTrtllmServeDefaults:
         for mode in ("prefill", "decode"):
             section = getattr(loaded.backend.trtllm_config, mode)
             assert section["return_perf_metrics"] is True
+            assert section["enable_iter_perf_stats"] is True
 
     def test_load_config_applies_the_default(self, tmp_path, monkeypatch):
         """load_config is the path every real entry point uses (srtctl apply,
@@ -497,10 +502,32 @@ class TestTrtllmServeDefaults:
 
         for mode in ("prefill", "decode"):
             assert loaded.backend.get_config_for_mode(mode)["return_perf_metrics"] is True
+            assert loaded.backend.get_config_for_mode(mode)["enable_iter_perf_stats"] is True
+
+    @pytest.mark.parametrize("loader_name", ["from_yaml", "load_config"])
+    @pytest.mark.parametrize("enabled", [False, True])
+    @pytest.mark.parametrize("opted_out", ["return_perf_metrics", "enable_iter_perf_stats"])
+    def test_engine_stat_opt_out_survives_yaml_loaders(self, tmp_path, monkeypatch, loader_name, enabled, opted_out):
+        """Defaults and observability must preserve each opt-out across sweep serialization."""
+        monkeypatch.setattr("srtctl.core.config.load_cluster_config", lambda: None)
+        cfg = _trtllm_serve_config(enabled=enabled)
+        cfg["benchmark"] = {"type": "sa-bench", "concurrencies": [4]}
+        cfg["backend"]["trtllm_config"]["decode"][opted_out] = False
+        loader = SrtConfig.from_yaml if loader_name == "from_yaml" else load_config
+
+        for filename in ("recipe.yaml", "roundtrip.yaml"):
+            path = tmp_path / filename
+            path.write_text(yaml.safe_dump(cfg))
+            loaded = loader(path)
+            for key in ("return_perf_metrics", "enable_iter_perf_stats"):
+                assert loaded.backend.get_config_for_mode("decode")[key] is (key != opted_out)
+                assert loaded.backend.get_config_for_mode("prefill")[key] is True
+            assert loaded.backend.get_config_for_mode("decode")["max_batch_size"] == 64
+            cfg = SrtConfig.Schema().dump(loaded)
 
     def test_observability_expansion_is_unchanged_and_composes(self):
         """observability.enabled still injects both engine keys; the trtllm-serve
-        default only fills return_perf_metrics where nothing else set it."""
+        defaults only fill missing values for those same keys."""
         cfg = _trtllm_serve_config(enabled=True)
         expand_observability(cfg)
         out = expand_trtllm_serve_defaults(cfg)


### PR DESCRIPTION
Withdrawn: Prometheus publication should be enabled by default, while detailed iteration statistics remain opt-in. Main already defaults native `return_perf_metrics: true`, which gates the `/prometheus/metrics` route. This PR additionally enables `enable_iter_perf_stats`, a separate collection option, and is unnecessary for the intended publication default. Matching the previous metrics-rich reference runs did not justify changing this global default. No on/off performance comparison was performed.

The completed reruns used iteration statistics enabled; their results remain evidence about that configuration, not validation of iteration statistics disabled. The independent Tachometer storage (#427), shutdown (#428), and release (#426) fixes remain separate.

Original implementation and validation record:

Native TRT-LLM Serve recipes expose worker metrics by default, but iteration statistics still require explicit `enable_iter_perf_stats: true`. Omitting it can leave iteration and KV-cache occupancy metrics unpopulated, including with `observability.enabled: false`.

Default `enable_iter_perf_stats` to true alongside `return_perf_metrics` in each used native engine section. Preserve independent explicit opt-outs through both YAML loaders, observability expansion, and serialization. Document the opt-out. A separate style commit resolves the pinned-Ruff `isinstance` finding exposed by the required pre-push check.

Validation: `make check` passed with 2,160 tests, 2 skipped, and 6 deselected; 92 final focused tests and pinned pre-commit hooks passed. All six hosted checks pass. Completed full-length Dynamo/native reruns at this exact head with the previous runtime/workload pins and explicit metric-enable overrides removed. Raw Tachometer scans contain every same-engine baseline family: 440 Dynamo and 319 native. Native generated configs enable both defaults; all four leaders and all 28 backend HTTP publishers produce positive, changing detailed gauges.

These runs verify default publication but expose separate capture/quality failures. Both scrapers were killed through srun during teardown; Dynamo also lost a Parquet part to concurrent compaction. #427 fixes part publication and #428 fixes exact-step shutdown; #426 repairs delivery of current scraper binaries. Native per-publisher recurrence and PID-free counter mixing remain quality limitations. The surviving raw captures are not certified complete or valid for every metric's arithmetic.
