### PR TITLE
fix: deliver Tachometer shutdown to its Slurm step

### DIFF
--- a/src/srtctl/cli/mixins/telemetry_stage.py
+++ b/src/srtctl/cli/mixins/telemetry_stage.py
@@ -24,6 +24,7 @@ from srtctl.core.power.topology import build_expected_devices
 from srtctl.core.processes import ManagedProcess, ProcessRegistry, terminate_and_reap
 from srtctl.core.schema import TelemetryExporterConfig
 from srtctl.core.slurm import start_srun_process
+from srtctl.core.tachometer_process import TachometerProcess, TachometerStep
 from srtctl.core.telemetry import TACHOMETER_STORAGE_PARENT, generate_tachometer_config
 
 if TYPE_CHECKING:
@@ -799,19 +800,16 @@ class TelemetryStageMixin:
         if tachometer.compaction_threads > 0:
             srun_export_env["POLARS_MAX_THREADS"] = str(tachometer.compaction_threads)
 
+        step = TachometerStep.create(self.runtime.log_dir, self.runtime.job_id)
         processes.append(
-            ManagedProcess(
+            TachometerProcess(
                 name="tachometer",
                 popen=start_srun_process(
-                    command=cmd,
+                    command=step.command(cmd),
                     nodelist=[self.runtime.nodes.head],
                     output=str(self.runtime.log_dir / "tachometer.out"),
-                    # Shell-less on purpose: the scraper compacts final.parquet
-                    # on SIGTERM, and srun forwards signals to the task it
-                    # launched. Under the bash wrapper the task is bash, which
-                    # exits without signaling its child — the scraper then dies
-                    # by step SIGKILL with the capture stranded in the arrow
-                    # WAL (hecate job 487539). Env goes via --export instead.
+                    # Record the step then exec the scraper. Cleanup signals
+                    # that step; SIGTERM to srun would SIGKILL its task.
                     use_bash_wrapper=False,
                     srun_export_env=srun_export_env,
                     srun_options=self.runtime.srun_options,
@@ -823,26 +821,22 @@ class TelemetryStageMixin:
                 # benchmark. A dead scraper costs the capture, not the run;
                 # the loss is visible in tachometer.out and the sweep log.
                 critical=False,
+                step=step,
+                shutdown_grace_secs=tachometer.shutdown_grace_secs,
             )
         )
         logger.info("Tachometer started with artifacts under %s", tachometer_dir)
         return processes
 
     def stop_tachometer(self, processes: list[ManagedProcess]) -> None:
-        """Stop Tachometer gracefully so the scraper compacts final.parquet.
-
-        SIGTERM starts the scraper's flush + compact + upload path; anything
-        harder loses everything since the last periodic sync. The scraper gets
-        ``tachometer.shutdown_grace_secs`` to finish compacting before the
-        SIGKILL escalation; the exporter sidecars are plain daemons and keep
-        the registry's default budget. Already-exited processes are skipped,
-        so the registry's later cleanup pass stays a no-op for these.
-        """
-        grace = self.config.observability.tachometer.shutdown_grace_secs
+        """Give the scraper its compaction grace through its exact Slurm step."""
         for process in processes:
+            if isinstance(process, TachometerProcess):
+                process.terminate()
+                continue
             if not process.is_running:
                 continue
-            timeout = grace if process.name == "tachometer" else 10.0
+            timeout = 10.0
             outcome = terminate_and_reap(process.popen, terminate_timeout=timeout, kill_timeout=10.0)
             if outcome.force_killed:
                 logger.warning(
@@ -850,5 +844,5 @@ class TelemetryStageMixin:
                     process.name,
                     timeout,
                 )
-            else:
-                logger.info("%s stopped gracefully", process.name)
+            elif outcome.reaped:
+                logger.info("%s launcher exited with status %s", process.name, process.exit_code)

--- a/src/srtctl/core/tachometer_process.py
+++ b/src/srtctl/core/tachometer_process.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deliver Tachometer's shutdown signal to its task, keeping the srun client alive."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import secrets
+import stat
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from srtctl.core.processes import ManagedProcess
+
+logger = logging.getLogger(__name__)
+
+# Positional arguments preserve the scraper argv without shell interpolation.
+# The shell becomes the scraper; no intermediate shell remains to catch signals.
+_STEP_WRAPPER = """set -euo pipefail
+umask 077
+metadata=$1
+token=$2
+expected_job=$3
+shift 3
+[[ ${SLURM_JOB_ID:-} =~ ^[0-9]+$ && ${SLURM_STEP_ID:-} =~ ^[0-9]+$ ]]
+[[ $SLURM_JOB_ID == "$expected_job" ]]
+set -C
+printf '%s %s %s\\n' "$SLURM_JOB_ID" "$SLURM_STEP_ID" "$token" > "$metadata.tmp"
+ln -- "$metadata.tmp" "$metadata"
+rm -- "$metadata.tmp"
+exec "$@"
+"""
+
+
+@dataclass(frozen=True)
+class TachometerStep:
+    """Private, single-launch handoff from a task in the expected allocation.
+
+    Tachometer runs on the head node (component 0 for heterogeneous jobs).
+    A different component job ID is rejected rather than guessed from offsets.
+    The run log directory must be shared with that node, as for its config.
+    """
+
+    path: Path
+    token: str
+    job_id: str
+
+    @classmethod
+    def create(cls, log_dir: Path, job_id: str) -> TachometerStep:
+        if not re.fullmatch(r"[0-9]+", job_id):
+            raise ValueError("Tachometer requires a numeric Slurm allocation ID")
+        directory = Path(tempfile.mkdtemp(prefix=".tachometer-step-", dir=log_dir))
+        return cls(directory / "identity", secrets.token_hex(16), job_id)
+
+    def command(self, scraper_command: list[str]) -> list[str]:
+        return [
+            "bash",
+            "-c",
+            _STEP_WRAPPER,
+            "tachometer-step",
+            str(self.path),
+            self.token,
+            self.job_id,
+            *scraper_command,
+        ]
+
+    def read(self) -> str:
+        """Return only an owned numeric JOB.STEP from this launch; otherwise fail closed."""
+        directory = self.path.parent.lstat()
+        if not stat.S_ISDIR(directory.st_mode) or directory.st_uid != os.getuid() or directory.st_mode & 0o077:
+            raise ValueError("Tachometer step directory is not private and owned")
+        fd = os.open(self.path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+        with os.fdopen(fd, "r", encoding="ascii") as handle:
+            metadata = os.fstat(handle.fileno())
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.getuid() or metadata.st_mode & 0o077:
+                raise ValueError("Tachometer step identity is not a private owned file")
+            contents = handle.read(256)
+        match = re.fullmatch(r"([0-9]+) ([0-9]+) ([0-9a-f]{32})\n", contents)
+        if match is None or match[1] != self.job_id or match[3] != self.token:
+            raise ValueError("Tachometer step identity does not match this launch")
+        return f"{match[1]}.{match[2]}"
+
+
+@dataclass
+class TachometerProcess(ManagedProcess):
+    """Scoped shutdown also applies when ProcessRegistry calls terminate()."""
+
+    step: TachometerStep | None = None
+    shutdown_grace_secs: float = 120.0
+
+    def _signal_step(self, step_id: str, signal: str) -> bool:
+        try:
+            result = subprocess.run(
+                ["scancel", f"--signal={signal}", step_id],
+                capture_output=True,
+                text=True,
+                timeout=10.0,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.error("Tachometer step %s: scancel %s failed: %s", step_id, signal, exc)
+            return False
+        if result.returncode != 0:
+            logger.error(
+                "Tachometer step %s: scancel %s exited %d: %s", step_id, signal, result.returncode, result.stderr
+            )
+            return False
+        logger.info("Sent SIG%s to Tachometer step %s", signal, step_id)
+        return True
+
+    def terminate(self, timeout: float | None = None) -> None:
+        """Signal the recorded step, wait for compaction, then escalate only that step.
+
+        Never signal the srun client: its SIGTERM handler aborts the remote task
+        with SIGKILL. Unverifiable metadata or a failed scancel leaves the client
+        alive and reports failure instead of risking another step/allocation.
+        """
+        returncode = self.popen.poll()
+        if returncode is not None:
+            if returncode != 0:
+                logger.warning("Tachometer launcher had already exited with status %d", returncode)
+            return
+        try:
+            if self.step is None:
+                raise ValueError("Tachometer has no step identity")
+            step_id = self.step.read()
+        except (OSError, ValueError) as exc:
+            logger.error("Cannot safely stop Tachometer; leaving srun alive: %s", exc)
+            return
+        if not self._signal_step(step_id, "TERM"):
+            return
+        grace = self.shutdown_grace_secs if timeout is None else timeout
+        try:
+            returncode = self.popen.wait(timeout=grace)
+        except subprocess.TimeoutExpired:
+            logger.warning("Tachometer step %s exceeded %.0fs after SIGTERM; capture may be partial", step_id, grace)
+            if not self._signal_step(step_id, "KILL"):
+                return
+            try:
+                returncode = self.popen.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                logger.error("Tachometer launcher was not reaped after step %s SIGKILL", step_id)
+                return
+            logger.warning("Tachometer step %s required SIGKILL; launcher exited with status %d", step_id, returncode)
+            return
+        if returncode != 0:
+            logger.warning(
+                "Tachometer step %s exited with status %d after SIGTERM; inspect %s", step_id, returncode, self.log_file
+            )
+        else:
+            logger.info("Tachometer step %s exited with status 0 after SIGTERM", step_id)

--- a/tests/test_tachometer_process.py
+++ b/tests/test_tachometer_process.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the actual exec wrapper and scoped shutdown without a Slurm allocation."""
+
+import json
+import logging
+import os
+import stat
+import subprocess
+import sys
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from srtctl.core.processes import ProcessRegistry
+from srtctl.core.tachometer_process import TachometerProcess, TachometerStep
+
+
+def run_wrapper(step, *, job="12345", step_id="27", command=None):
+    env = {**os.environ, "SLURM_JOB_ID": job, "SLURM_STEP_ID": step_id}
+    return subprocess.run(
+        step.command(command or [sys.executable, "-c", "pass"]),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+
+def test_wrapper_records_private_identity_and_execs_unchanged_argv(tmp_path):
+    step = TachometerStep.create(tmp_path, "12345")
+    argument = "spaces ' quotes; $(exit 99)"
+    command = [sys.executable, "-c", "import os,sys,json; print(json.dumps([os.getpid(),sys.argv[1:]]))", argument]
+    with subprocess.Popen(
+        step.command(command),
+        env={**os.environ, "SLURM_JOB_ID": "12345", "SLURM_STEP_ID": "27"},
+        stdout=subprocess.PIPE,
+        text=True,
+    ) as launched:
+        output, _ = launched.communicate(timeout=5)
+    assert launched.returncode == 0
+    assert json.loads(output) == [launched.pid, [argument]]
+    assert step.read() == "12345.27"
+    assert stat.S_IMODE(step.path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(step.path.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize("job,step_id", [("", "27"), ("99999", "27"), ("12345", "batch"), ("12345", "")])
+def test_wrapper_rejects_wrong_allocation_or_non_numeric_step_before_exec(tmp_path, job, step_id):
+    step = TachometerStep.create(tmp_path, "12345")
+    result = run_wrapper(step, job=job, step_id=step_id, command=[sys.executable, "-c", "print('started')"])
+    assert result.returncode != 0
+    assert "started" not in result.stdout
+    assert not step.path.exists()
+
+
+def test_wrapper_never_overwrites_a_previous_handoff(tmp_path):
+    step = TachometerStep.create(tmp_path, "12345")
+    assert run_wrapper(step).returncode == 0
+    assert run_wrapper(step, step_id="28").returncode != 0
+    assert step.read() == "12345.27"
+    other_launch = TachometerStep.create(tmp_path, "12345")
+    assert other_launch.path != step.path
+    assert other_launch.token != step.token
+
+
+@pytest.fixture
+def process(tmp_path):
+    step = TachometerStep.create(tmp_path, "12345")
+    assert run_wrapper(step).returncode == 0
+    popen = MagicMock(spec=subprocess.Popen)
+    popen.poll.return_value = None
+    popen.wait.return_value = 0
+    popen.pid = 123
+    proc = TachometerProcess(
+        name="tachometer", popen=popen, step=step, shutdown_grace_secs=45.0, critical=False, log_file=tmp_path / "out"
+    )
+    yield proc
+    # Every path must keep signals away from the srun client.
+    popen.terminate.assert_not_called()
+    popen.kill.assert_not_called()
+    popen.send_signal.assert_not_called()
+
+
+@pytest.fixture
+def signal_command(monkeypatch):
+    runner = MagicMock(return_value=subprocess.CompletedProcess([], 0, "", ""))
+    monkeypatch.setattr("srtctl.core.tachometer_process.subprocess.run", runner)
+    return runner
+
+
+def test_scoped_term_waits_configured_grace_and_checks_status(process, signal_command, caplog):
+    caplog.set_level(logging.INFO)
+    process.terminate()
+    signal_command.assert_called_once_with(
+        ["scancel", "--signal=TERM", "12345.27"], capture_output=True, text=True, timeout=10.0, check=False
+    )
+    process.popen.wait.assert_called_once_with(timeout=45.0)
+    assert "exited with status 0 after SIGTERM" in caplog.text
+    assert "gracefully" not in caplog.text
+
+
+def test_nonzero_exit_cannot_be_reported_as_success(process, signal_command, caplog):
+    caplog.set_level(logging.INFO)
+    process.popen.wait.return_value = 137
+    process.terminate()
+    assert signal_command.call_count == 1
+    assert "exited with status 137 after SIGTERM" in caplog.text
+    assert "status 0" not in caplog.text
+    assert "gracefully" not in caplog.text
+
+
+@pytest.mark.parametrize("returncode", [0, 137])
+def test_already_exited_launcher_is_not_signalled(process, signal_command, caplog, returncode):
+    process.popen.poll.return_value = returncode
+    process.terminate()
+    signal_command.assert_not_called()
+    process.popen.wait.assert_not_called()
+    if returncode:
+        assert "already exited with status 137" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "invalid", ["missing", "stale", "wrong-job", "batch", "symlink", "permissions", "directory", "fifo"]
+)
+def test_invalid_identity_leaves_launcher_and_other_steps_untouched(process, signal_command, caplog, invalid, tmp_path):
+    step = process.step
+    if invalid == "stale":
+        step.path.write_text(f"12345 27 {'0' * 32}\n")
+    elif invalid == "wrong-job":
+        step.path.write_text(f"99999 27 {step.token}\n")
+    elif invalid == "batch":
+        step.path.write_text(f"12345 batch {step.token}\n")
+    elif invalid == "permissions":
+        step.path.chmod(0o644)
+    elif invalid == "directory":
+        step.path.parent.chmod(0o755)
+    else:
+        contents = step.path.read_text()
+        step.path.unlink()
+        if invalid == "symlink":
+            target = tmp_path / "external"
+            target.write_text(contents)
+            target.chmod(0o600)
+            step.path.symlink_to(target)
+        elif invalid == "fifo":
+            os.mkfifo(step.path, 0o600)
+    process.terminate()
+    signal_command.assert_not_called()
+    process.popen.wait.assert_not_called()
+    assert "Cannot safely stop Tachometer" in caplog.text
+
+
+@pytest.mark.parametrize("failure", ["nonzero", "missing-command", "timeout"])
+def test_failed_term_does_not_fall_back_to_client_signals(process, signal_command, caplog, failure):
+    if failure == "nonzero":
+        signal_command.return_value = subprocess.CompletedProcess([], 1, "", "permission denied")
+    else:
+        signal_command.side_effect = (
+            FileNotFoundError("scancel") if failure == "missing-command" else subprocess.TimeoutExpired("scancel", 10)
+        )
+    process.terminate()
+    assert signal_command.call_count == 1
+    process.popen.wait.assert_not_called()
+    assert "scancel TERM" in caplog.text
+
+
+def test_timeout_escalates_only_same_step_after_grace(process, signal_command, caplog):
+    events = []
+
+    def signal(args, **kwargs):
+        events.append(args)
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    def wait(*, timeout):
+        events.append(timeout)
+        if timeout == 45.0:
+            raise subprocess.TimeoutExpired("srun", timeout)
+        return 137
+
+    signal_command.side_effect = signal
+    process.popen.wait.side_effect = wait
+    process.terminate()
+    assert events == [["scancel", "--signal=TERM", "12345.27"], 45.0, ["scancel", "--signal=KILL", "12345.27"], 10.0]
+    assert "required SIGKILL" in caplog.text
+    assert "gracefully" not in caplog.text
+
+
+@pytest.mark.parametrize("failure", ["kill-failed", "reap-timeout"])
+def test_escalation_failure_is_reported_without_client_fallback(process, signal_command, caplog, failure):
+    process.popen.wait.side_effect = subprocess.TimeoutExpired("srun", 45)
+    if failure == "kill-failed":
+        signal_command.side_effect = [
+            subprocess.CompletedProcess([], 0, "", ""),
+            subprocess.CompletedProcess([], 1, "", "failed"),
+        ]
+    process.terminate()
+    assert signal_command.call_count == 2
+    assert "scancel KILL exited 1" in caplog.text if failure == "kill-failed" else "not reaped" in caplog.text
+
+
+def test_registry_cleanup_uses_scoped_stop_and_saved_grace(process, signal_command):
+    registry = ProcessRegistry(job_id="12345")
+    registry.add_process(process)
+    registry.cleanup()
+    assert signal_command.call_args.args[0] == ["scancel", "--signal=TERM", "12345.27"]
+    process.popen.wait.assert_called_once_with(timeout=45.0)
+
+
+def test_repeated_cleanup_after_exit_does_not_signal_stale_step(process, signal_command):
+    process.terminate()
+    process.popen.poll.return_value = 0
+    process.terminate()
+    assert signal_command.call_count == 1
+    assert process.popen.wait.call_args_list == [call(timeout=45.0)]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1213,7 +1213,7 @@ class TestTachometerStageMixin:
             assert call.kwargs["container_image"] in ("dcgm:latest", "node:latest")
             assert call.kwargs["container_mounts"] == {Path(tmp_path): Path("/logs")}
         scraper_call = mock_srun.call_args_list[-1]
-        assert scraper_call.kwargs["command"] == [
+        assert scraper_call.kwargs["command"][7:] == [
             "tachometer-scraper",
             "--config",
             str(tmp_path / "tachometer_config.toml"),
@@ -1224,17 +1224,16 @@ class TestTachometerStageMixin:
         ]
         assert "container_image" not in scraper_call.kwargs
         assert "container_mounts" not in scraper_call.kwargs
-        # Shell-less launch is load-bearing for graceful shutdown: srun
-        # forwards SIGTERM to the task it launched, and the scraper only
-        # compacts final.parquet if IT is that task. Under the bash wrapper
-        # the signal dies with bash and the capture is lost to step SIGKILL
-        # (hecate job 487539). Env must ride --export, not a bash `export`.
+        # Only the dedicated metadata wrapper is allowed; it execs the scraper.
+        assert scraper_call.kwargs["command"][:2] == ["bash", "-c"]
         assert scraper_call.kwargs["use_bash_wrapper"] is False
         assert scraper_call.kwargs["srun_export_env"] == {"POLARS_MAX_THREADS": "4"}
         assert "env_to_set" not in scraper_call.kwargs
         # Telemetry is best-effort by contract: a dead scraper must never
         # tear down the benchmark via the critical-process check.
         assert procs[-1].name == "tachometer"
+        assert procs[-1].step.job_id == "12345"
+        assert procs[-1].shutdown_grace_secs == harness.config.observability.tachometer.shutdown_grace_secs
         assert procs[-1].critical is False
         # Exporter sidecars share the contract: shell-less launch (distroless
         # images have no bash) and non-critical (a dead sidecar never kills
@@ -1620,6 +1619,7 @@ class TestTachometerStageMixin:
                 )
                 self.runtime = MagicMock()
                 self.runtime.log_dir = tmp_path
+                self.runtime.job_id = "12345"
                 self.runtime.nodes.head = "node-a"
                 self.runtime.nodes.het = False
                 self.runtime.srun_options = {}
@@ -1674,19 +1674,23 @@ class TestStopTachometer:
         return stage
 
     @patch("srtctl.cli.mixins.telemetry_stage.terminate_and_reap")
-    def test_scraper_gets_the_shutdown_grace_and_exporters_do_not(self, mock_reap):
+    def test_scraper_uses_scoped_shutdown_and_exporters_keep_default(self, mock_reap):
         from srtctl.core.processes import ManagedProcess, TerminationOutcome
+        from srtctl.core.tachometer_process import TachometerProcess
 
         mock_reap.return_value = TerminationOutcome(reaped=True, force_killed=False)
         exporter = ManagedProcess(name="tachometer_node_exporter", popen=_running_exporter(), critical=False)
-        scraper = ManagedProcess(name="tachometer", popen=_running_exporter(), critical=False)
+
+        scraper = TachometerProcess(name="tachometer", popen=_running_exporter(), critical=False)
+        scraper.terminate = MagicMock()
 
         self._stage(grace=45.0).stop_tachometer([exporter, scraper])
 
         # The scraper compacts final.parquet after SIGTERM and needs the
         # configured grace; the exporter sidecars are plain daemons.
         assert mock_reap.call_args_list[0].kwargs["terminate_timeout"] == 10.0
-        assert mock_reap.call_args_list[1].kwargs["terminate_timeout"] == 45.0
+        assert mock_reap.call_count == 1
+        scraper.terminate.assert_called_once_with()
 
     @patch("srtctl.cli.mixins.telemetry_stage.terminate_and_reap")
     def test_already_exited_processes_are_skipped(self, mock_reap):
@@ -1712,7 +1716,7 @@ class TestBenchmarkWindowTachometerLifecycle:
     @staticmethod
     def _harness(tmp_path, calls):
         from srtctl.cli.mixins.benchmark_stage import BenchmarkStageMixin
-        from srtctl.core.processes import ManagedProcess
+        from srtctl.core.tachometer_process import TachometerProcess
 
         class Stage(BenchmarkStageMixin):
             pass
@@ -1722,7 +1726,7 @@ class TestBenchmarkWindowTachometerLifecycle:
         stage.runtime = MagicMock()
         stage.runtime.log_dir = tmp_path
         stage._wait_for_service_ready = lambda stop_event: True
-        scraper = ManagedProcess(name="tachometer", popen=_running_exporter(), critical=False)
+        scraper = TachometerProcess(name="tachometer", popen=_running_exporter(), critical=False)
         stage.start_tachometer = MagicMock(side_effect=lambda: (calls.append("start"), [scraper])[1])
         stage.stop_tachometer = MagicMock(side_effect=lambda procs: calls.append("stop"))
         return stage, scraper
@@ -1741,6 +1745,23 @@ class TestBenchmarkWindowTachometerLifecycle:
         assert calls == ["start", "script", "stop"]
         registry.add_process.assert_called_once_with(scraper)
         stage.stop_tachometer.assert_called_once_with([scraper])
+
+    def test_benchmark_registration_preserves_scoped_cleanup(self, tmp_path):
+        import threading
+
+        from srtctl.core.processes import ProcessRegistry
+        from srtctl.core.tachometer_process import TachometerProcess
+
+        stage, scraper = self._harness(tmp_path, [])
+        stage._run_benchmark_script = MagicMock(return_value=0)
+        registry = ProcessRegistry(job_id="12345")
+
+        assert stage.run_benchmark(registry, threading.Event(), reporter=None) == 0
+        assert registry._processes["tachometer"] is scraper
+        with patch.object(TachometerProcess, "terminate") as scoped_stop:
+            registry.cleanup()
+        scoped_stop.assert_called_once_with()
+        scraper.popen.terminate.assert_not_called()
 
     def test_capture_stops_even_when_the_script_raises(self, tmp_path):
         import threading


### PR DESCRIPTION
Tachometer shutdown currently sends SIGTERM to the local `srun` client. Slurm25.11.8 aborts the remote task with SIGKILL in response, so the scraper cannot flush and compact its capture. SRT then reports the launcher as having stopped gracefully without checking its exit code. This occurred in Hecate run579709: the scraper step ended0:9 and produced no final artifact.

Record the scraper's exact Slurm job.step in a private file unique to its launch, then exec the scraper with its original arguments. A Tachometer-specific process class signals that recorded step, keeps `srun` alive for the configured compaction grace, and checks the launcher exit code. Timeout escalation targets only the same step. Missing or invalid identity and signal-command failures are reported without falling back to launcher or allocation signals. Registry cleanup uses the same shutdown behavior.

Validation:

- `make check`: 2,178 passed, 2 skipped, 6 deselected. Final focused suite: 154 passed, including the added production-registration regression. Ruff and whitespace checks passed.
- Real Bash wrapper tests verify exec PID, argument preservation, private identity, and allocation validation; shutdown tests cover configured grace, nonzero exit status, invalid/stale metadata, signal failures, registry cleanup, and scoped timeout escalation.
- On Slurm25.11.8, two isolated CPU-only helper steps demonstrated the failure and delivery correction: launcher TERM produced task SIGKILL/exit137; exact-step TERM reached the handler and finished0 after cleanup.
- An additional end-to-end Slurm smoke used the exact committed `TachometerStep.command` and `TachometerProcess.terminate` API. Step579710.37 completed0:0, and seven8-row shards reconciled to56 fully decoded rows in byte-identical local/uploaded final files.
- Three small synthetic-endpoint runs with the exact scraper binary completed0 after exact-step TERM. Final local and uploaded Parquet files matched and fully decoded. The rotating case completed three periodic compactions and reconciled seven8-row shards to56 final rows.

The cluster tests validate the signal mechanism and bounded scraper finalization; they do not certify production-scale compaction or resolve the separate Rust task-quiescence risk. Atomic shard publication is addressed independently by #427. Related open PR #407 by @ishandhanani, "[2.0] The full 2.0 stack: schema v2, services, graceful shutdown, observability, MCP, and the migrator (#386-#406 and after)", also introduces step signaling within its broader v2/services/cleanup migration, using name lookup and a launcher fallback. This patch keeps the main-line fix limited to Tachometer with an exact launch identity; it does not change #407.
